### PR TITLE
Correct Chinese translation of the word "share" on voting page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Missing rewards will be reimbursed, #552 (@Foggyx420).
  - Fix minor UI typos, #661 (@Erkan-Yilmaz).
  - Fix stake modifier, #686 (@tomasbrod).
+ - Improve boost-1.66.0 compatibility, #800 (@denravonska).
+ - Fix crash in diagnostics dialog, #794 (@Foggyx420).
 
 ### Changed
  - Changed versioning extraction from git. Test builds can no longer be used to
@@ -45,6 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  - Fix voting sorting issues, #610 (@MagixInTheAir).
  - Improve wallet backup, #610 (@Foggyx420).
  - Update seed nodes, #783 (@barton2526).
+ - Auto upgrades are now opt-in via the "autoupgrade" flag, #796 (@denravonska).
+ - Clean up seed nodes, #783 (@barton2526).
 
 ### Removed
  - Remove CSV exporter which used unreliable data, #759 (@denravonska).

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -703,8 +703,8 @@ void ThreadRPCServer(void* parg)
 }
 
 // Forward declaration required for RPCListen
-template <typename Protocol, typename SocketAcceptorService>
-static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol, SocketAcceptorService> > acceptor,
+template <typename Protocol>
+static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor,
                              ssl::context& context,
                              bool fUseSSL,
                              AcceptedConnection* conn,
@@ -713,8 +713,8 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol, 
 /**
  * Sets up I/O resources to accept and handle a new connection.
  */
-template <typename Protocol, typename SocketAcceptorService>
-static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol, SocketAcceptorService> > acceptor,
+template <typename Protocol>
+static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor,
                    ssl::context& context,
                    const bool fUseSSL)
 {
@@ -724,7 +724,7 @@ static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol, SocketA
     acceptor->async_accept(
             conn->sslStream.lowest_layer(),
             conn->peer,
-            boost::bind(&RPCAcceptHandler<Protocol, SocketAcceptorService>,
+            boost::bind(&RPCAcceptHandler<Protocol>,
                 acceptor,
                 boost::ref(context),
                 fUseSSL,
@@ -735,8 +735,8 @@ static void RPCListen(boost::shared_ptr< basic_socket_acceptor<Protocol, SocketA
 /**
  * Accept and handle incoming connection.
  */
-template <typename Protocol, typename SocketAcceptorService>
-static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol, SocketAcceptorService> > acceptor,
+template <typename Protocol>
+static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> > acceptor,
                              ssl::context& context,
                              const bool fUseSSL,
                              AcceptedConnection* conn,
@@ -813,7 +813,7 @@ void ThreadRPCServer2(void* parg)
     assert(rpc_io_service == NULL);
     rpc_io_service = new asio::io_service();
 
-    ssl::context context(*rpc_io_service, ssl::context::sslv23);
+    ssl::context context(ssl::context::sslv23);
     if (fUseSSL)
     {
         context.set_options(ssl::context::no_sslv2);
@@ -829,7 +829,7 @@ void ThreadRPCServer2(void* parg)
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH");
-        SSL_CTX_set_cipher_list(context.impl(), strCiphers.c_str());
+        SSL_CTX_set_cipher_list(context.native_handle(), strCiphers.c_str());
     }
 
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
@@ -1125,7 +1125,7 @@ Object CallRPC(const string& strMethod, const Array& params)
     // Connect to localhost
     bool fUseSSL = GetBoolArg("-rpcssl");
     asio::io_service io_service;
-    ssl::context context(io_service, ssl::context::sslv23);
+    ssl::context context(ssl::context::sslv23);
     context.set_options(ssl::context::no_sslv2);
     asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_service, context);
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);

--- a/src/global_objects_noui.hpp
+++ b/src/global_objects_noui.hpp
@@ -11,8 +11,6 @@ extern bool bCPIDsLoaded;
 extern bool bProjectsInitialized;
 extern bool bNetAveragesLoaded;
 extern bool bForceUpdate;
-extern bool bCheckedForUpgrade;
-extern bool bCheckedForUpgradeLive;
 extern bool bGlobalcomInitialized;
 extern bool bGridcoinGUILoaded;
 

--- a/src/main.h
+++ b/src/main.h
@@ -100,7 +100,7 @@ inline uint32_t IsV9Enabled(int nHeight)
 {
     return fTestNet
             ? nHeight >=  399000
-            : nHeight >= 2000000;
+            : nHeight >= 1144000;
 }
 
 inline int GetSuperblockAgeSpacing(int nHeight)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -129,9 +129,6 @@ extern int CreateRestorePoint();
 extern int DownloadBlocks();
 void GetGlobalStatus();
 
-extern int UpgradeClient();
-extern void CheckForUpgrade();
-
 bool IsConfigFileEmpty();
 void HarvestCPIDs(bool cleardata);
 extern int RestartClient();
@@ -471,20 +468,20 @@ void qtSetSessionInfo(std::string defaultgrcaddress, std::string cpid, double ma
     #endif
 }
 
-void CheckForUpgrade()
+bool IsUpgradeAvailable()
 {
-            if (!bGlobalcomInitialized) return;
+   if (!bGlobalcomInitialized)
+      return false;
 
-            if (bCheckedForUpgrade == false && !fTestNet && bProjectsInitialized)
-            {
-                int nNeedsUpgrade = 0;
-                bCheckedForUpgrade = true;
-                #ifdef WIN32
-                    nNeedsUpgrade = globalcom->dynamicCall("ClientNeedsUpgrade()").toInt();
-                #endif
-                printf("Needs upgraded %f\r\n",(double)nNeedsUpgrade);
-                if (nNeedsUpgrade) UpgradeClient();
-            }
+   bool upgradeAvailable = false;
+   if (!fTestNet)
+   {
+#ifdef WIN32
+      upgradeAvailable = globalcom->dynamicCall("ClientNeedsUpgrade()").toInt();
+#endif
+   }
+
+   return upgradeAvailable;
 }
 
 

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -1301,7 +1301,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="+10"/>
         <source>Share Type: </source>
-        <translation>分享类型：</translation>
+        <translation>计票方式：</translation>
     </message>
     <message>
         <location line="+23"/>
@@ -3176,7 +3176,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="+1"/>
         <source>Share Type</source>
-        <translation>分享类型</translation>
+        <translation>计票方式</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -3197,7 +3197,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="+1"/>
         <source>Total Shares</source>
-        <translation>总分享次数</translation>
+        <translation>总票数</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -3227,7 +3227,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="+2"/>
         <source>Share Type.</source>
-        <translation>分享类型。</translation>
+        <translation>计票方式。</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -3242,7 +3242,7 @@ This label turns red, if the priority is smaller than &quot;medium&quot;.
     <message>
         <location line="+2"/>
         <source>Total Shares.</source>
-        <translation>总分享数。</translation>
+        <translation>总票数。</translation>
     </message>
     <message>
         <location line="+2"/>


### PR DESCRIPTION
Currently in the Chinese translation, the word "share" is translated as "to make joint use of", rather than "a unit of account".

This PR proposes translating "Share Type" as "The way we count votes", and "Total Shares" as "Total votes", as the direct translation of "share" in Chinese implies that it's the stock of a corporation rather than the right to vote.