### PR TITLE
gui: Fix display of polls with no votes yet

### DIFF
--- a/src/rpcvoting.cpp
+++ b/src/rpcvoting.cpp
@@ -82,8 +82,14 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
     json.pushKV("votes", (uint64_t)poll_ref.Votes().size());
     json.pushKV("invalid_votes", (uint64_t)result.m_invalid_votes);
     json.pushKV("total_weight", ValueFromAmount(result.m_total_weight));
-    json.pushKV("top_choice_id", (uint64_t)result.Winner());
-    json.pushKV("top_choice", result.WinnerLabel());
+
+    if (!result.m_votes.empty()) {
+        json.pushKV("top_choice_id", (uint64_t)result.Winner());
+        json.pushKV("top_choice", result.WinnerLabel());
+    } else {
+        json.pushKV("top_choice_id", NullUniValue);
+        json.pushKV("top_choice", NullUniValue);
+    }
 
     UniValue responses(UniValue::VARR);
 


### PR DESCRIPTION
This fixes issues for the display of poll results in the GUI when a poll does not have any votes submitted for it yet. The result table displayed blank cells for polls with no accumulated voting weight and the dialog shows a misleading "best answer".

Closes #1827.