### PR TITLE
rpc: Create getblockbymintime

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -198,6 +198,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblock"               , 1 },
     { "getblockbynumber"       , 0 },
     { "getblockbynumber"       , 1 },
+    { "getblockbymintime"      , 0 },
+    { "getblockbymintime"      , 1 },
     { "getblocksbatch"         , 1 },
     { "getblocksbatch"         , 2 },
     { "getblockhash"           , 0 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -412,6 +412,7 @@ static const CRPCCommand vRPCCommands[] =
     { "getbestblockhash",        &getbestblockhash,        cat_network       },
     { "getblock",                &getblock,                cat_network       },
     { "getblockbynumber",        &getblockbynumber,        cat_network       },
+    { "getblockbymintime",       &getblockbymintime,       cat_network       },
     { "getblocksbatch",          &getblocksbatch,          cat_network       },
     { "getblockcount",           &getblockcount,           cat_network       },
     { "getblockhash",            &getblockhash,            cat_network       },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -227,6 +227,7 @@ extern UniValue getaddednodeinfo(const UniValue& params, bool fHelp);
 extern UniValue getbestblockhash(const UniValue& params, bool fHelp);
 extern UniValue getblock(const UniValue& params, bool fHelp);
 extern UniValue getblockbynumber(const UniValue& params, bool fHelp);
+extern UniValue getblockbymintime(const UniValue& params, bool fHelp);
 extern UniValue getblocksbatch(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getblockcount(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Creates an RPC command to find the block just before or at a given timestamp. Based it off of `getblockbynumber` (with the change in #2289)

I have wanted something like this various times when debugging or writing scripts, so others might find a command like this useful