### PR TITLE
[3/3] key, wallet: HD wallets

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -207,11 +207,12 @@ GRIDCOIN_CORE_H = \
     version.h \
     wallet/coincontrol.h \
     wallet/db.h \
+    wallet/diagnose.h \
     wallet/generated_type.h \
-    wallet/walletdb.h \
-    wallet/wallet.h \
     wallet/ismine.h \
-    wallet/diagnose.h
+    wallet/wallet.h \
+    wallet/walletdb.h \
+    wallet/walletutil.h
 
 GRIDCOIN_CORE_CPP = addrdb.cpp \
     addrman.cpp \
@@ -313,11 +314,12 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     util.cpp \
     validation.cpp \
     wallet/db.cpp \
+    wallet/diagnose.cpp \
     wallet/rpcdump.cpp \
     wallet/rpcwallet.cpp \
     wallet/wallet.cpp \
     wallet/walletdb.cpp \
-    wallet/diagnose.cpp
+    wallet/walletutil.cpp
 
 
 obj/build.h: FORCE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,6 +148,7 @@ GRIDCOIN_CORE_H = \
     init.h \
     key.h \
     keystore.h \
+    key_io.h \
     logging.h \
     main.h \
     miner.h \
@@ -263,6 +264,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     init.cpp \
     key.cpp \
     keystore.cpp \
+    key_io.cpp \
     logging.cpp \
     main.cpp \
     miner.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,6 +187,7 @@ GRIDCOIN_CORE_H = \
     txdb.h \
     node/ui_interface.h \
     uint256.h \
+    util/bip32.h \
     util/check.h \
     util/hash_type.h \
     util/macros.h \
@@ -298,6 +299,7 @@ GRIDCOIN_CORE_CPP = addrdb.cpp \
     sync.cpp \
     threadinterrupt.cpp \
     uint256.cpp \
+    util/bip32.cpp \
     util/settings.cpp \
     util/strencodings.cpp \
     util/string.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -38,6 +38,7 @@ GRIDCOIN_TESTS =\
 	test/base58_tests.cpp \
 	test/base64_tests.cpp \
 	test/bignum_tests.cpp \
+	test/bip32_tests.cpp \
 	test/compilerbug_tests.cpp \
 	test/crypto_tests.cpp \
 	test/fs_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,6 +96,8 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,62);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,85);
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1,0); // TODO: What should be the exact value here? 128 + PUBKEY_ADDRESS as 4 bytes?
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
+        base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
         m_is_test_chain = false;
         m_is_mockable_chain = false;
@@ -194,6 +196,8 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1,0); // TODO: What should be the exact value here? 128 + PUBKEY_ADDRESS as 4 bytes?
+        base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
+        base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         m_is_test_chain = true;
         m_is_mockable_chain = false;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,8 +93,9 @@ public:
         assert(genesis.hashMerkleRoot == uint256S("0x5109d5782a26e6a5a5eb76c7867f3e8ddae2bff026632c36afec5dc32ed8ce9f")); */
 
 
-        base58Prefix[PUBKEY_ADDRESS] = 62;
-        base58Prefix[SCRIPT_ADDRESS] = 85;
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,62);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,85);
+        base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1,0); // TODO: What should be the exact value here? 128 + PUBKEY_ADDRESS as 4 bytes?
 
         m_is_test_chain = false;
         m_is_mockable_chain = false;
@@ -190,8 +191,9 @@ public:
         assert(consensus.hashGenesisBlock == uint256S("0x00006e037d7b84104208ecf2a8638d23149d712ea810da604ee2f2cb39bae713"));
         assert(genesis.hashMerkleRoot == uint256S("0x5109d5782a26e6a5a5eb76c7867f3e8ddae2bff026632c36afec5dc32ed8ce9f")); */
 
-        base58Prefix[PUBKEY_ADDRESS] = 111;
-        base58Prefix[SCRIPT_ADDRESS] = 196;
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1,0); // TODO: What should be the exact value here? 128 + PUBKEY_ADDRESS as 4 bytes?
 
         m_is_test_chain = true;
         m_is_mockable_chain = false;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -39,6 +39,7 @@ public:
     enum Base58Type {
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
+        SECRET_KEY,
 
         MAX_BASE58_TYPES
     };
@@ -64,7 +65,7 @@ public:
     uint64_t AssumedBlockchainSize() const { return m_assumed_blockchain_size; }
     /** Return the network string */
     std::string NetworkIDString() const { return strNetworkID; }
-    const unsigned char& Base58Prefix(Base58Type type) const { return base58Prefix[type]; }
+    const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
 protected:
     CChainParams() {}
@@ -73,7 +74,7 @@ protected:
     CMessageHeader::MessageStartChars pchMessageStart;
     int nDefaultPort;
     uint64_t m_assumed_blockchain_size;
-    unsigned char base58Prefix[MAX_BASE58_TYPES];
+    std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     std::string strNetworkID;
     // CBlock genesis;
     bool m_is_test_chain;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -40,6 +40,8 @@ public:
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
         SECRET_KEY,
+        EXT_PUBLIC_KEY,
+        EXT_SECRET_KEY,
 
         MAX_BASE58_TYPES
     };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -448,8 +448,6 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RESEARCHER);
 
     // Wallet
-    argsman.AddArg("-upgradewallet", "Upgrade wallet to latest format",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-keypool=<n>", "Set key pool size to <n> (default: 100)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-rescan", "Rescan the block chain for missing wallet transactions",
@@ -617,6 +615,8 @@ void SetupServerArgs()
 
     // This is hidden because it defaults to true and should NEVER be changed unless you know what you are doing.
     hidden_args.emplace_back("-flushwallet");
+
+    hidden_args.emplace_back("-upgradewallet");
 
     SetupChainParamsBaseOptions(argsman);
 
@@ -1271,17 +1271,6 @@ bool AppInit2(ThreadHandlerPtr threads)
         }
         else
             strErrors << _("Error loading wallet.dat") << "\n";
-    }
-
-    // Upgrade to HD if explicit upgrade
-    if (gArgs.GetBoolArg("-upgradewallet", false)) {
-        LOCK(pwalletMain->cs_wallet);
-
-        if (pwalletMain->IsLocked()) return InitError("Cannot apply wallet upgrade while the wallet is encrypted.");
-
-        std::string error = "";
-        pwalletMain->UpgradeWallet(gArgs.GetArg("-upgradewallet", 0), error);
-        if (!error.empty()) return InitError(error);
     }
 
     if (fFirstRun)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -448,7 +448,7 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RESEARCHER);
 
     // Wallet
-    argsman.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u)", DEFAULT_KEYPOOL_SIZE),
+    argsman.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u for HD, %u for pre-HD wallets)", DEFAULT_KEYPOOL_SIZE, DEFAULT_KEYPOOL_SIZE_PRE_HD),
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-rescan", "Rescan the block chain for missing wallet transactions",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1275,6 +1275,8 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     if (gArgs.GetBoolArg("-upgradewallet", fFirstRun))
     {
+        if (pwalletMain->IsLocked()) return InitError("Cannot apply wallet upgrade while the wallet is encrypted.");
+
         int nMaxVersion = gArgs.GetArg("-upgradewallet", 0);
         if (nMaxVersion == 0) // the -upgradewallet without argument case
         {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1292,7 +1292,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     // Upgrade to HD if explicit upgrade
     if (gArgs.GetBoolArg("-upgradewallet", false)) {
         LOCK(pwalletMain->cs_wallet);
-        if (pwalletMain->CanSupportFeature(FEATURE_HD) && pwalletMain->GetHDChain().masterKeyID.IsNull()) {
+        if (pwalletMain->CanSupportFeature(FEATURE_HD) && !pwalletMain->IsHDEnabled()) {
             CPubKey masterPubKey = pwalletMain->GenerateNewHDMasterKey();
             if (!pwalletMain->SetHDMasterKey(masterPubKey)) {
                 return InitError(_("Storing master key failed"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -448,7 +448,7 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::RESEARCHER);
 
     // Wallet
-    argsman.AddArg("-keypool=<n>", "Set key pool size to <n> (default: 100)",
+    argsman.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u)", DEFAULT_KEYPOOL_SIZE),
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-rescan", "Rescan the block chain for missing wallet transactions",
                    ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);

--- a/src/key.h
+++ b/src/key.h
@@ -68,6 +68,13 @@ public:
         keydata.resize(32);
     }
 
+    friend bool operator==(const CKey& a, const CKey& b)
+    {
+        return a.fCompressed == b.fCompressed &&
+            a.size() == b.size() &&
+            memcmp(a.keydata.data(), b.keydata.data(), a.size()) == 0;
+    }
+
     //! Initialize using begin and end iterators to byte data.
     template <typename T>
     void Set(const T pbegin, const T pend, bool fCompressedIn)
@@ -128,6 +135,9 @@ public:
      */
     bool SignCompact(const uint256& hash, std::vector<unsigned char>& vchSig) const;
 
+    //! Derive BIP32 child key.
+    bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const;
+
     /**
      * Verify thoroughly whether a private key and a public key match.
      * This is done using a different mechanism than just regenerating it.
@@ -136,6 +146,29 @@ public:
 
     //! Load private key and check that public key matches.
     bool Load(const CPrivKey& privkey, const CPubKey& vchPubKey, bool fSkipCheck);
+};
+
+struct CExtKey {
+    unsigned char nDepth;
+    unsigned char vchFingerprint[4];
+    unsigned int nChild;
+    ChainCode chaincode;
+    CKey key;
+
+    friend bool operator==(const CExtKey& a, const CExtKey& b)
+    {
+        return a.nDepth == b.nDepth &&
+            memcmp(a.vchFingerprint, b.vchFingerprint, sizeof(vchFingerprint)) == 0 &&
+            a.nChild == b.nChild &&
+            a.chaincode == b.chaincode &&
+            a.key == b.key;
+    }
+
+    void Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const;
+    void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
+    bool Derive(CExtKey& out, unsigned int nChild) const;
+    CExtPubKey Neuter() const;
+    void SetSeed(Span<const std::byte> seed);
 };
 
 /** Initialize the elliptic curve support. May not be called twice without calling ECC_Stop first. */

--- a/src/key.h
+++ b/src/key.h
@@ -85,7 +85,7 @@ public:
 
     //! Simple read-only vector-like interface.
     unsigned int size() const { return (fValid ? keydata.size() : 0); }
-    const unsigned char* data() const { return keydata.data(); }
+    const std::byte* data() const { return reinterpret_cast<const std::byte*>(keydata.data()); }
     const unsigned char* begin() const { return keydata.data(); }
     const unsigned char* end() const { return keydata.data() + size(); }
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2014-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <key_io.h>
+
+#include <base58.h>
+// #include <bech32.h>
+#include <util/strencodings.h>
+
+#include <algorithm>
+#include <assert.h>
+#include <string.h>
+
+CExtPubKey DecodeExtPubKey(const std::string& str)
+{
+    CExtPubKey key;
+    std::vector<unsigned char> data;
+    if (DecodeBase58Check(str, data, 78)) {
+        const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_PUBLIC_KEY);
+        if (data.size() == BIP32_EXTKEY_SIZE + prefix.size() && std::equal(prefix.begin(), prefix.end(), data.begin())) {
+            key.Decode(data.data() + prefix.size());
+        }
+    }
+    return key;
+}
+
+std::string EncodeExtPubKey(const CExtPubKey& key)
+{
+    std::vector<unsigned char> data = Params().Base58Prefix(CChainParams::EXT_PUBLIC_KEY);
+    size_t size = data.size();
+    data.resize(size + BIP32_EXTKEY_SIZE);
+    key.Encode(data.data() + size);
+    std::string ret = EncodeBase58Check(data);
+    return ret;
+}
+
+CExtKey DecodeExtKey(const std::string& str)
+{
+    CExtKey key;
+    std::vector<unsigned char> data;
+    if (DecodeBase58Check(str, data, 78)) {
+        const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_SECRET_KEY);
+        if (data.size() == BIP32_EXTKEY_SIZE + prefix.size() && std::equal(prefix.begin(), prefix.end(), data.begin())) {
+            key.Decode(data.data() + prefix.size());
+        }
+    }
+    return key;
+}
+
+std::string EncodeExtKey(const CExtKey& key)
+{
+    std::vector<unsigned char> data = Params().Base58Prefix(CChainParams::EXT_SECRET_KEY);
+    size_t size = data.size();
+    data.resize(size + BIP32_EXTKEY_SIZE);
+    key.Encode(data.data() + size);
+    std::string ret = EncodeBase58Check(data);
+    memory_cleanse(data.data(), data.size());
+    return ret;
+}

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KEY_IO_H
+#define BITCOIN_KEY_IO_H
+
+#include <chainparams.h>
+#include <key.h>
+#include <pubkey.h>
+
+#include <string>
+
+CExtKey DecodeExtKey(const std::string& str);
+std::string EncodeExtKey(const CExtKey& extkey);
+CExtPubKey DecodeExtPubKey(const std::string& str);
+std::string EncodeExtPubKey(const CExtPubKey& extpubkey);
+
+#endif // BITCOIN_KEY_IO_H

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -234,3 +234,10 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     }
     return true;
 }
+
+bool HaveKey(const CKeyStore& store, const CKey& key)
+{
+    CKey key2;
+    key2.Set(key.begin(), key.end(), !key.IsCompressed());
+    return store.HaveKey(key.GetPubKey().GetID()) || store.HaveKey(key2.GetPubKey().GetID());
+}

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -185,4 +185,7 @@ public:
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;
 };
 
+/** Checks if a CKey is in the given CKeyStore compressed or otherwise*/
+bool HaveKey(const CKeyStore& store, const CKey& key);
+
 #endif

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -230,6 +230,66 @@ bool CPubKey::Decompress() {
     return true;
 }
 
+bool CPubKey::Derive(CPubKey& pubkeyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const {
+    assert(IsValid());
+    assert((nChild >> 31) == 0);
+    assert(size() == COMPRESSED_SIZE);
+    unsigned char out[64];
+    BIP32Hash(cc, nChild, *begin(), begin()+1, out);
+    memcpy(ccChild.begin(), out+32, 32);
+    secp256k1_pubkey pubkey;
+    assert(secp256k1_context_verify && "secp256k1_context_verify must be initialized to use CPubKey.");
+    if (!secp256k1_ec_pubkey_parse(secp256k1_context_verify, &pubkey, vch, size())) {
+        return false;
+    }
+    if (!secp256k1_ec_pubkey_tweak_add(secp256k1_context_verify, &pubkey, out)) {
+        return false;
+    }
+    unsigned char pub[COMPRESSED_SIZE];
+    size_t publen = COMPRESSED_SIZE;
+    secp256k1_ec_pubkey_serialize(secp256k1_context_verify, pub, &publen, &pubkey, SECP256K1_EC_COMPRESSED);
+    pubkeyChild.Set(pub, pub + publen);
+    return true;
+}
+
+void CExtPubKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const {
+    code[0] = nDepth;
+    memcpy(code+1, vchFingerprint, 4);
+    WriteBE32(code+5, nChild);
+    memcpy(code+9, chaincode.begin(), 32);
+    assert(pubkey.size() == CPubKey::COMPRESSED_SIZE);
+    memcpy(code+41, pubkey.begin(), CPubKey::COMPRESSED_SIZE);
+}
+
+void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE]) {
+    nDepth = code[0];
+    memcpy(vchFingerprint, code+1, 4);
+    nChild = ReadBE32(code+5);
+    memcpy(chaincode.begin(), code+9, 32);
+    pubkey.Set(code+41, code+BIP32_EXTKEY_SIZE);
+    if ((nDepth == 0 && (nChild != 0 || ReadLE32(vchFingerprint) != 0)) || !pubkey.IsFullyValid()) pubkey = CPubKey();
+}
+
+void CExtPubKey::EncodeWithVersion(unsigned char code[BIP32_EXTKEY_WITH_VERSION_SIZE]) const
+{
+    memcpy(code, version, 4);
+    Encode(&code[4]);
+}
+
+void CExtPubKey::DecodeWithVersion(const unsigned char code[BIP32_EXTKEY_WITH_VERSION_SIZE])
+{
+    memcpy(version, code, 4);
+    Decode(&code[4]);
+}
+
+bool CExtPubKey::Derive(CExtPubKey &out, unsigned int _nChild) const {
+    out.nDepth = nDepth + 1;
+    CKeyID id = pubkey.GetID();
+    memcpy(out.vchFingerprint, &id, 4);
+    out.nChild = _nChild;
+    return pubkey.Derive(out.pubkey, out.chaincode, _nChild, chaincode);
+}
+
 /* static */ bool CPubKey::CheckLowS(const std::vector<unsigned char>& vchSig) {
     secp256k1_ecdsa_signature sig;
     assert(secp256k1_context_verify && "secp256k1_context_verify must be initialized to use CPubKey.");

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -184,6 +184,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sethdseed"              , 0 },
     { "signrawtransaction"     , 1 },
     { "signrawtransaction"     , 2 },
+    { "upgradewallet"          , 0 },
     { "walletpassphrase"       , 1 },
     { "walletpassphrase"       , 2 },
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -181,6 +181,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmany"               , 2 },
     { "sendtoaddress"          , 1 },
     { "settxfee"               , 0 },
+    { "sethdseed"              , 0 },
     { "signrawtransaction"     , 1 },
     { "signrawtransaction"     , 2 },
     { "walletpassphrase"       , 1 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -341,6 +341,7 @@ static const CRPCCommand vRPCCommands[] =
     { "settxfee",                &settxfee,                cat_wallet        },
     { "signmessage",             &signmessage,             cat_wallet        },
     { "signrawtransaction",      &signrawtransaction,      cat_wallet        },
+    { "upgradewallet",           &upgradewallet,           cat_wallet        },
     { "validateaddress",         &validateaddress,         cat_wallet        },
     { "validatepubkey",          &validatepubkey,          cat_wallet        },
     { "verifymessage",           &verifymessage,           cat_wallet        },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -337,6 +337,7 @@ static const CRPCCommand vRPCCommands[] =
     { "sendrawtransaction",      &sendrawtransaction,      cat_wallet        },
     { "sendtoaddress",           &sendtoaddress,           cat_wallet        },
     { "setaccount",              &setaccount,              cat_wallet        },
+    { "sethdseed",               &sethdseed,               cat_wallet        },
     { "settxfee",                &settxfee,                cat_wallet        },
     { "signmessage",             &signmessage,             cat_wallet        },
     { "signrawtransaction",      &signrawtransaction,      cat_wallet        },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -153,6 +153,7 @@ extern UniValue sendmany(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue sendtoaddress(const UniValue& params, bool fHelp);
 extern UniValue setaccount(const UniValue& params, bool fHelp);
+extern UniValue sethdseed(const UniValue& params, bool fHelp);
 extern UniValue settxfee(const UniValue& params, bool fHelp);
 extern UniValue signmessage(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -157,6 +157,7 @@ extern UniValue sethdseed(const UniValue& params, bool fHelp);
 extern UniValue settxfee(const UniValue& params, bool fHelp);
 extern UniValue signmessage(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
+extern UniValue upgradewallet(const UniValue& params, bool fHelp);
 extern UniValue validateaddress(const UniValue& params, bool fHelp);
 extern UniValue validatepubkey(const UniValue& params, bool fHelp);
 extern UniValue verifymessage(const UniValue& params, bool fHelp);

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2013-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include <clientversion.h>
+#include <key.h>
+#include <key_io.h>
+#include <streams.h>
+#include <util/strencodings.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+struct TestDerivation {
+    std::string pub;
+    std::string prv;
+    unsigned int nChild;
+};
+
+struct TestVector {
+    std::string strHexMaster;
+    std::vector<TestDerivation> vDerive;
+
+    explicit TestVector(std::string strHexMasterIn) : strHexMaster(strHexMasterIn) {}
+
+    TestVector& operator()(std::string pub, std::string prv, unsigned int nChild) {
+        vDerive.push_back(TestDerivation());
+        TestDerivation &der = vDerive.back();
+        der.pub = pub;
+        der.prv = prv;
+        der.nChild = nChild;
+        return *this;
+    }
+};
+
+TestVector test1 =
+  TestVector("000102030405060708090a0b0c0d0e0f")
+    ("xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+     "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+     0x80000000)
+    ("xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+     "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+     1)
+    ("xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
+     "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+     0x80000002)
+    ("xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+     "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+     2)
+    ("xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+     "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+     1000000000)
+    ("xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
+     "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
+     0);
+
+TestVector test2 =
+  TestVector("fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542")
+    ("xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+     "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
+     0)
+    ("xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
+     "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
+     0xFFFFFFFF)
+    ("xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a",
+     "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+     1)
+    ("xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon",
+     "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
+     0xFFFFFFFE)
+    ("xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL",
+     "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+     2)
+    ("xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
+     "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
+     0);
+
+TestVector test3 =
+  TestVector("4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be")
+    ("xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13",
+     "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6",
+      0x80000000)
+    ("xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y",
+     "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
+      0);
+
+TestVector test4 =
+  TestVector("3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678")
+    ("xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa",
+     "xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv",
+     0x80000000)
+    ("xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m",
+     "xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G",
+     0x80000001)
+    ("xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt",
+     "xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1",
+     0);
+
+const std::vector<std::string> TEST5 = {
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6LBpB85b3D2yc8sfvZU521AAwdZafEz7mnzBBsz4wKY5fTtTQBm",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGTQQD3dC4H2D5GBj7vWvSQaaBv5cxi9gafk7NF3pnBju6dwKvH",
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Txnt3siSujt9RCVYsx4qHZGc62TG4McvMGcAUjeuwZdduYEvFn",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ",
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6N8ZMMXctdiCjxTNq964yKkwrkBJJwpzZS4HS2fxvyYUA4q2Xe4",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fEQ3Qen6J",
+    "xprv9s2SPatNQ9Vc6GTbVMFPFo7jsaZySyzk7L8n2uqKXJen3KUmvQNTuLh3fhZMBoG3G4ZW1N2kZuHEPY53qmbZzCHshoQnNf4GvELZfqTUrcv",
+    "xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ",
+    "xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN",
+    "xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8",
+    "DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHGMQzT7ayAmfo4z3gY5KfbrZWZ6St24UVf2Qgo6oujFktLHdHY4",
+    "DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHPmHJiEDXkTiJTVV9rHEBUem2mwVbbNfvT2MTcAqj3nesx8uBf9",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD5SDKr24z3aiUvKr9bJpdrcLg1y3G",
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY",
+    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHL"
+};
+
+void RunTest(const TestVector& test)
+{
+    std::vector<unsigned char> seed{ParseHex(test.strHexMaster)};
+    CExtKey key;
+    CExtPubKey pubkey;
+    key.SetSeed(MakeByteSpan(seed));
+    pubkey = key.Neuter();
+    for (const TestDerivation &derive : test.vDerive) {
+        unsigned char data[74];
+        key.Encode(data);
+        pubkey.Encode(data);
+
+        // Test private key
+        BOOST_CHECK(EncodeExtKey(key) == derive.prv);
+        BOOST_CHECK(DecodeExtKey(derive.prv) == key); //ensure a base58 decoded key also matches
+
+        // Test public key
+        BOOST_CHECK(EncodeExtPubKey(pubkey) == derive.pub);
+        BOOST_CHECK(DecodeExtPubKey(derive.pub) == pubkey); //ensure a base58 decoded pubkey also matches
+
+        // Derive new keys
+        CExtKey keyNew;
+        BOOST_CHECK(key.Derive(keyNew, derive.nChild));
+        CExtPubKey pubkeyNew = keyNew.Neuter();
+        if (!(derive.nChild & 0x80000000)) {
+            // Compare with public derivation
+            CExtPubKey pubkeyNew2;
+            BOOST_CHECK(pubkey.Derive(pubkeyNew2, derive.nChild));
+            BOOST_CHECK(pubkeyNew == pubkeyNew2);
+        }
+        key = keyNew;
+        pubkey = pubkeyNew;
+    }
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(bip32_tests)
+
+BOOST_AUTO_TEST_CASE(bip32_test1) {
+    RunTest(test1);
+}
+
+BOOST_AUTO_TEST_CASE(bip32_test2) {
+    RunTest(test2);
+}
+
+BOOST_AUTO_TEST_CASE(bip32_test3) {
+    RunTest(test3);
+}
+
+BOOST_AUTO_TEST_CASE(bip32_test4) {
+    RunTest(test4);
+}
+
+BOOST_AUTO_TEST_CASE(bip32_test5) {
+    for (const auto& str : TEST5) {
+        auto dec_extkey = DecodeExtKey(str);
+        auto dec_extpubkey = DecodeExtPubKey(str);
+        BOOST_CHECK_MESSAGE(!dec_extkey.key.IsValid(), "Decoding '" + str + "' as xprv should fail");
+        BOOST_CHECK_MESSAGE(!dec_extpubkey.pubkey.IsValid(), "Decoding '" + str + "' as xpub should fail");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -59,6 +59,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_V8ShouldBeEnabledOnBlock312000InTestnet)
     BOOST_CHECK(IsV8Enabled(311999) == false);
     BOOST_CHECK(IsV8Enabled(312000) == true);
     fTestNet = was_testnet;
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <sstream>
+#include <stdio.h>
+#include <tinyformat.h>
+#include <util/bip32.h>
+#include <util/strencodings.h>
+
+
+bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)
+{
+    std::stringstream ss(keypath_str);
+    std::string item;
+    bool first = true;
+    while (std::getline(ss, item, '/')) {
+        if (item.compare("m") == 0) {
+            if (first) {
+                first = false;
+                continue;
+            }
+            return false;
+        }
+        // Finds whether it is hardened
+        uint32_t path = 0;
+        size_t pos = item.find("'");
+        if (pos != std::string::npos) {
+            // The hardened tick can only be in the last index of the string
+            if (pos != item.size() - 1) {
+                return false;
+            }
+            path |= 0x80000000;
+            item = item.substr(0, item.size() - 1); // Drop the last character which is the hardened tick
+        }
+
+        // Ensure this is only numbers
+        if (item.find_first_not_of( "0123456789" ) != std::string::npos) {
+            return false;
+        }
+        uint32_t number;
+        if (!ParseUInt32(item, &number)) {
+            return false;
+        }
+        path |= number;
+
+        keypath.push_back(path);
+        first = false;
+    }
+    return true;
+}
+
+std::string FormatHDKeypath(const std::vector<uint32_t>& path)
+{
+    std::string ret;
+    for (auto i : path) {
+        ret += strprintf("/%i", (i << 1) >> 1);
+        if (i >> 31) ret += '\'';
+    }
+    return ret;
+}
+
+std::string WriteHDKeypath(const std::vector<uint32_t>& keypath)
+{
+    return "m" + FormatHDKeypath(keypath);
+}

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_BIP32_H
+#define BITCOIN_UTIL_BIP32_H
+
+#include <string>
+#include <vector>
+
+/** Parse an HD keypaths like "m/7/0'/2000". */
+[[nodiscard]] bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath);
+
+/** Write HD keypaths as strings */
+std::string WriteHDKeypath(const std::vector<uint32_t>& keypath);
+std::string FormatHDKeypath(const std::vector<uint32_t>& path);
+
+#endif // BITCOIN_UTIL_BIP32_H

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -202,6 +202,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
     int64_t nTimeBegin = pindexBest->nTime;
 
     bool fGood = true;
+    bool found_hd_seed = false;
 
     while (file.good()) {
         std::string line;
@@ -237,6 +238,9 @@ UniValue importwallet(const UniValue& params, bool fHelp)
                 fLabel = false;
             if (vstr[nStr] == "reserve=1")
                 fLabel = false;
+            if (vstr[nStr] == "hdmaster=1") {
+                found_hd_seed = true;
+            }
             if (boost::algorithm::starts_with(vstr[nStr], "label=")) {
                 strLabel = DecodeDumpString(vstr[nStr].substr(6));
                 fLabel = true;
@@ -268,6 +272,11 @@ UniValue importwallet(const UniValue& params, bool fHelp)
 
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
+
+    if (found_hd_seed) {
+        return "Warning: Encountered and imported inactive HD seed during the import. Use the 'sethdseed false <key>'"
+               "RPC command if you wish to activate it.";
+    }
 
     return NullUniValue;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2078,14 +2078,15 @@ UniValue keypoolrefill(const UniValue& params, bool fHelp)
                 "Fills the keypool.\n"
                 + HelpRequiringPassphrase());
 
-    unsigned int nSize = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    unsigned int default_size = pwalletMain->IsHDEnabled() ? DEFAULT_KEYPOOL_SIZE : DEFAULT_KEYPOOL_SIZE_PRE_HD;
+    unsigned int nSize = max(gArgs.GetArg("-keypool", default_size), (int64_t)0);
     if (params.size() > 0) {
         if (params[0].get_int() < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size");
         nSize = (unsigned int) params[0].get_int();
     }
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     EnsureWalletIsUnlocked();
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2667,3 +2667,71 @@ UniValue burn(const UniValue& params, bool fHelp)
 
     return wtx.GetHash().GetHex();
 }
+
+UniValue sethdseed(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 2) {
+        throw std::runtime_error(
+            "sethdseed ( \"newkeypool\" \"seed\" )\n"
+            "\nSet or generate a new HD wallet seed. Non-HD wallets will not be upgraded to being a HD wallet. Wallets that are already\n"
+            "HD will have a new HD seed set so that new keys added to the keypool will be derived from this new seed.\n"
+            "\nNote that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet seed.\n"
+            "\nArguments:\n"
+            "1. \"newkeypool\"         (boolean, optional, default=true) Whether to flush old unused addresses, including change addresses, from the keypool and regenerate it.\n"
+            "                             If true, the next address from getnewaddress and change address from getrawchangeaddress will be from this new seed.\n"
+            "                             If false, addresses (including change addresses if the wallet already had HD Chain Split enabled) from the existing\n"
+            "                             keypool will be used until it has been depleted.\n"
+            "2. \"seed\"               (string, optional) The WIF private key to use as the new HD seed; if not provided a random seed will be used.\n"
+            "                             The seed value can be retrieved using the dumpwallet command. It is the private key marked hdmaster=1\n"
+        );
+    }
+
+    if (IsInitialBlockDownload()) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot set a new HD seed while still in Initial Block Download");
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    // Do not do anything to non-HD wallets
+    if (!pwalletMain->IsHDEnabled()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot set a HD seed on a non-HD wallet. Start with -upgradewallet in order to upgrade a non-HD wallet to HD");
+    }
+
+    EnsureWalletIsUnlocked();
+
+    bool flush_key_pool = true;
+    if (!params[0].isNull()) {
+        flush_key_pool = params[0].get_bool();
+    }
+
+    CPubKey master_pub_key;
+    if (params[1].isNull()) {
+        master_pub_key = pwalletMain->GenerateNewHDMasterKey();
+    } else {
+        CKey key;
+        CBitcoinSecret vchSecret;
+
+        if (!vchSecret.SetString(params[1].get_str())) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+        }
+
+        bool fCompressed;
+        CSecret secret = vchSecret.GetSecret(fCompressed);
+        key.Set(secret.begin(), secret.end(), fCompressed);
+
+        if (!key.IsValid()) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+        }
+
+        if (HaveKey(*pwalletMain, key)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Already have this key (either as an HD seed or as a loose private key)");
+        }
+
+        master_pub_key = pwalletMain->DeriveNewMasterHDKey(key);
+    }
+
+    pwalletMain->SetHDMasterKey(master_pub_key);
+    if (flush_key_pool) pwalletMain->NewKeyPool();
+
+    return NullUniValue;
+}

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2078,7 +2078,7 @@ UniValue keypoolrefill(const UniValue& params, bool fHelp)
                 "Fills the keypool.\n"
                 + HelpRequiringPassphrase());
 
-    unsigned int nSize = max(gArgs.GetArg("-keypool", 100), (int64_t)0);
+    unsigned int nSize = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
     if (params.size() > 0) {
         if (params[0].get_int() < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2724,7 +2724,7 @@ UniValue sethdseed(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
         }
 
-        if (HaveKey(*pwalletMain, key)) {
+        if (false && HaveKey(*pwalletMain, key)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Already have this key (either as an HD seed or as a loose private key)");
         }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2735,3 +2735,30 @@ UniValue sethdseed(const UniValue& params, bool fHelp)
 
     return NullUniValue;
 }
+
+UniValue upgradewallet(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1) {
+        throw std::runtime_error(
+                "upgradewallet [version]\n"
+                "\n"
+                "Upgrade the wallet. Upgrades to the latest version if no version number is specified\n"
+                "New keys may be generated and a new wallet backup will need to be made.\n"
+                "\n"
+                "[version] - The version number to upgrade to. Default is the latest wallet version."
+        );
+    }
+
+    EnsureWalletIsUnlocked();
+
+    int version = 0;
+    if (!params[0].isNull()) {
+        version = params[0].get_int();
+    }
+
+    std::string error;
+    if (!pwalletMain->UpgradeWallet(version, error)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, error);
+    }
+    return error;
+}

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2435,7 +2435,7 @@ bool CWallet::NewKeyPool()
         if (IsLocked())
             return false;
 
-        int64_t nKeys = max(gArgs.GetArg("-keypool", 100), (int64_t)0);
+        int64_t nKeys = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
         for (int i = 0; i < nKeys; i++)
         {
             int64_t nIndex = i+1;
@@ -2462,7 +2462,7 @@ bool CWallet::TopUpKeyPool(unsigned int nSize)
         if (nSize > 0)
             nTargetSize = nSize;
         else
-            nTargetSize = max(gArgs.GetArg("-keypool", 100), (int64_t)0);
+            nTargetSize = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
 
         while (setKeyPool.size() < (nTargetSize + 1))
         {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2435,7 +2435,8 @@ bool CWallet::NewKeyPool()
         if (IsLocked())
             return false;
 
-        int64_t nKeys = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
+        unsigned int default_size = IsHDEnabled() ? DEFAULT_KEYPOOL_SIZE : DEFAULT_KEYPOOL_SIZE_PRE_HD;
+        int64_t nKeys = max(gArgs.GetArg("-keypool", default_size), (int64_t)0);
         for (int i = 0; i < nKeys; i++)
         {
             int64_t nIndex = i+1;
@@ -2459,10 +2460,12 @@ bool CWallet::TopUpKeyPool(unsigned int nSize)
 
         // Top up key pool
         unsigned int nTargetSize;
-        if (nSize > 0)
+        if (nSize > 0) {
             nTargetSize = nSize;
-        else
-            nTargetSize = max(gArgs.GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
+        } else {
+            unsigned int default_size = IsHDEnabled() ? DEFAULT_KEYPOOL_SIZE : DEFAULT_KEYPOOL_SIZE_PRE_HD;
+            nTargetSize = max(gArgs.GetArg("-keypool", default_size), (int64_t)0);
+        }
 
         while (setKeyPool.size() < (nTargetSize + 1))
         {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -83,7 +83,7 @@ CPubKey CWallet::GenerateNewKey() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     CKeyMetadata metadata(nCreationTime);
 
     // use HD key derivation if HD was enabled during wallet creation
-    if (!hdChain.masterKeyID.IsNull()) {
+    if (IsHDEnabled()) {
         // for now we use a fixed keypath scheme of m/0'/0'/k
         CKey key;                      //master key seed (256bit)
         CExtKey masterKey;             //hd master key
@@ -400,7 +400,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         Unlock(strWalletPassphrase);
 
         // if we are using HD, replace the HD master key (seed) with a new one
-        if (!hdChain.masterKeyID.IsNull()) {
+        if (IsHDEnabled()) {
             CKey key;
             CPubKey masterPubKey = GenerateNewHDMasterKey();
             if (!SetHDMasterKey(masterPubKey))
@@ -700,7 +700,11 @@ CPubKey CWallet::GenerateNewHDMasterKey()
 {
     CKey key;
     key.MakeNewKey(true);
+    return DeriveNewMasterHDKey(key);
+}
 
+CPubKey CWallet::DeriveNewMasterHDKey(const CKey& key)
+{
     int64_t nCreationTime = GetTime();
     CKeyMetadata metadata(nCreationTime);
 
@@ -751,6 +755,11 @@ bool CWallet::SetHDChain(const CHDChain& chain, bool memonly)
 
     hdChain = chain;
     return true;
+}
+
+bool CWallet::IsHDEnabled() const
+{
+    return !hdChain.masterKeyID.IsNull();
 }
 
 int64_t CWalletTx::GetTxTime() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -37,6 +37,8 @@ bool fConfChange;
 unsigned int nDerivationMethodIndex;
 extern std::atomic<int64_t> g_nTimeBestReceived;
 
+const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
+
 namespace {
 struct CompareValueOnly
 {
@@ -74,24 +76,68 @@ CPubKey CWallet::GenerateNewKey() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     bool fCompressed = CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
 
-    CKey key;
-    key.MakeNewKey(fCompressed);
+    CKey secret;
+
+    // Create new metadata
+    int64_t nCreationTime = GetAdjustedTime();
+    CKeyMetadata metadata(nCreationTime);
+
+    // use HD key derivation if HD was enabled during wallet creation
+    if (!hdChain.masterKeyID.IsNull()) {
+        // for now we use a fixed keypath scheme of m/0'/0'/k
+        CKey key;                      //master key seed (256bit)
+        CExtKey masterKey;             //hd master key
+        CExtKey accountKey;            //key at m/0'
+        CExtKey externalChainChildKey; //key at m/0'/0'
+        CExtKey childKey;              //key at m/0'/0'/<n>'
+
+        // try to get the master key
+        if (!GetKey(hdChain.masterKeyID, key))
+            throw std::runtime_error("CWallet::GenerateNewKey(): Master key not found");
+
+        masterKey.SetSeed(key);
+
+        // derive m/0'
+        // use hardened derivation (child keys >= 0x80000000 are hardened after bip32)
+        masterKey.Derive(accountKey, BIP32_HARDENED_KEY_LIMIT);
+
+        // derive m/0'/0'
+        accountKey.Derive(externalChainChildKey, BIP32_HARDENED_KEY_LIMIT);
+
+        // derive child key at next index, skip keys already known to the wallet
+        do
+        {
+            // always derive hardened keys
+            // childIndex | BIP32_HARDENED_KEY_LIMIT = derive childIndex in hardened child-index-range
+            // example: 1 | BIP32_HARDENED_KEY_LIMIT == 0x80000001 == 2147483649
+            externalChainChildKey.Derive(childKey, hdChain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
+            metadata.hdKeypath     = "m/0'/0'/" + ToString(hdChain.nExternalChainCounter) + "'";
+            metadata.hdMasterKeyID = hdChain.masterKeyID;
+            // increment childkey index
+            hdChain.nExternalChainCounter++;
+        } while(HaveKey(childKey.key.GetPubKey().GetID()));
+        secret = childKey.key;
+
+        // update the chain model in the database
+        if (!CWalletDB(strWalletFile).WriteHDChain(hdChain))
+            throw std::runtime_error("CWallet::GenerateNewKey(): Writing HD chain model failed");
+    } else {
+        secret.MakeNewKey(fCompressed);
+    }
 
     // Compressed public keys were introduced in version 0.6.0
     if (fCompressed)
         SetMinVersion(FEATURE_COMPRPUBKEY);
 
-    CPubKey pubkey = key.GetPubKey();
+    CPubKey pubkey = secret.GetPubKey();
 
-    // Create new metadata
-    int64_t nCreationTime =  GetAdjustedTime();
-    mapKeyMetadata[pubkey.GetID()] = CKeyMetadata(nCreationTime);
+    mapKeyMetadata[pubkey.GetID()] = metadata;
     if (!nTimeFirstKey || nCreationTime < nTimeFirstKey)
         nTimeFirstKey = nCreationTime;
 
-    if (!AddKey(key))
+    if (!AddKey(secret))
         throw std::runtime_error("CWallet::GenerateNewKey() : AddKey failed");
-    return key.GetPubKey();
+    return pubkey;
 }
 
 bool CWallet::AddKey(const CKey& key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
@@ -352,6 +398,15 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
         Lock();
         Unlock(strWalletPassphrase);
+
+        // if we are using HD, replace the HD master key (seed) with a new one
+        if (!hdChain.masterKeyID.IsNull()) {
+            CKey key;
+            CPubKey masterPubKey = GenerateNewHDMasterKey();
+            if (!SetHDMasterKey(masterPubKey))
+                return false;
+        }
+
         NewKeyPool();
         Lock();
 
@@ -639,6 +694,63 @@ bool CWallet::IsChange(const CTxOut& txout) const
             return true;
     }
     return false;
+}
+
+CPubKey CWallet::GenerateNewHDMasterKey()
+{
+    CKey key;
+    key.MakeNewKey(true);
+
+    int64_t nCreationTime = GetTime();
+    CKeyMetadata metadata(nCreationTime);
+
+    // calculate the pubkey
+    CPubKey pubkey = key.GetPubKey();
+    assert(key.VerifyPubKey(pubkey));
+
+    // set the hd keypath to "m" -> Master, refers the masterkeyid to itself
+    metadata.hdKeypath     = "m";
+    metadata.hdMasterKeyID = pubkey.GetID();
+
+    {
+        LOCK(cs_wallet);
+
+        // mem store the metadata
+        mapKeyMetadata[pubkey.GetID()] = metadata;
+
+        // write the key&metadata to the database
+        if (!AddKey(key))
+            throw std::runtime_error(std::string(__func__)+": AddKeyPubKey failed");
+    }
+
+    return pubkey;
+}
+
+bool CWallet::SetHDMasterKey(const CPubKey& pubkey)
+{
+    LOCK(cs_wallet);
+
+    // ensure this wallet.dat can only be opened by clients supporting HD
+    SetMinVersion(FEATURE_HD);
+
+    // store the keyid (hash160) together with
+    // the child index counter in the database
+    // as a hdchain object
+    CHDChain newHdChain;
+    newHdChain.masterKeyID = pubkey.GetID();
+    SetHDChain(newHdChain, false);
+
+    return true;
+}
+
+bool CWallet::SetHDChain(const CHDChain& chain, bool memonly)
+{
+    LOCK(cs_wallet);
+    if (!memonly && !CWalletDB(strWalletFile).WriteHDChain(chain))
+        throw runtime_error("SetHDChain(): writing chain failed");
+
+    hdChain = chain;
+    return true;
 }
 
 int64_t CWalletTx::GetTxTime() const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -36,6 +36,8 @@ class CCoinControl;
 
 MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
 
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+
 /** A key pool entry */
 class CKeyPool
 {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -41,7 +41,9 @@ enum WalletFeature
     FEATURE_BASE = 10500, // the earliest version new wallets supports (only useful for getinfo's clientversion output)
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
-    FEATURE_LATEST = 60000
+
+    FEATURE_HD = 5040001, // Hierarchical key derivation after BIP32 (HD Wallet)
+    FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
 };
 
 /** A key pool entry */
@@ -94,6 +96,9 @@ private:
 
     // the maximum wallet format version: memory-only variable that specifies to what version this wallet may be upgraded
     int nWalletMaxVersion GUARDED_BY(cs_wallet);
+
+    /* the HD chain data model (external chain counters) */
+    CHDChain hdChain;
 
 public:
     /// Main wallet lock.
@@ -422,6 +427,16 @@ public:
      * @note called with lock cs_wallet held.
      */
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx, ChangeType status)> NotifyTransactionChanged;
+
+    /* Set the HD chain model (chain child index counters) */
+    bool SetHDChain(const CHDChain& chain, bool memonly);
+    const CHDChain& GetHDChain() { return hdChain; }
+
+    /* Generates a new HD master key (will not be activated) */
+    CPubKey GenerateNewHDMasterKey();
+
+    /* Set the current HD master key (will reset the chain child index counters) */
+    bool SetHDMasterKey(const CPubKey& key);
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -42,8 +42,8 @@ enum WalletFeature
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
 
-    FEATURE_HD = 5040001, // Hierarchical key derivation after BIP32 (HD Wallet)
-    FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
+    FEATURE_HD = 5030311, // 5040001
+    FEATURE_LATEST = FEATURE_HD
 };
 
 /** A key pool entry */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -432,8 +432,14 @@ public:
     bool SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() { return hdChain; }
 
+    /* Returns true if HD is enabled */
+    bool IsHDEnabled() const;
+
     /* Generates a new HD master key (will not be activated) */
     CPubKey GenerateNewHDMasterKey();
+
+    /* Derives a new HD master key (will not be activated) */
+    CPubKey DeriveNewMasterHDKey(const CKey& key);
 
     /* Set the current HD master key (will reset the chain child index counters) */
     bool SetHDMasterKey(const CPubKey& key);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -36,7 +36,8 @@ class CCoinControl;
 
 MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
 
-static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
+static const unsigned int DEFAULT_KEYPOOL_SIZE_PRE_HD = 1000;
 
 /** A key pool entry */
 class CKeyPool

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -401,6 +401,16 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             ssValue >> pwallet->nOrderPosNext;
         }
+        else if (strType == "hdchain")
+        {
+            CHDChain chain;
+            ssValue >> chain;
+            if (!pwallet->SetHDChain(chain, true))
+            {
+                strErr = "Error reading wallet database: SetHDChain failed";
+                return false;
+            }
+        }
     } catch (...)
     {
         return false;
@@ -729,7 +739,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
             string strType, strErr;
             bool fReadOK = ReadKeyValue(&dummyWallet, ssKey, ssValue,
                                         wss, strType, strErr);
-            if (!IsKeyType(strType))
+            if (!IsKeyType(strType) && strType != "hdchain")
                 continue;
             if (!fReadOK)
             {
@@ -751,4 +761,10 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
 bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename)
 {
     return CWalletDB::Recover(dbenv, filename, false);
+}
+
+bool CWalletDB::WriteHDChain(const CHDChain& chain)
+{
+    nWalletDBUpdated++;
+    return Write(std::string("hdchain"), chain);
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -24,12 +24,42 @@ enum DBErrors
     DB_NEED_REWRITE
 };
 
+/* simple HD chain data model */
+class CHDChain
+{
+public:
+    uint32_t nExternalChainCounter;
+    CKeyID masterKeyID; //!< master key hash160
+
+    static const int VERSION_HD_BASE = 1;
+    static const int CURRENT_VERSION = VERSION_HD_BASE;
+    int nVersion;
+
+    CHDChain() { SetNull(); }
+
+    SERIALIZE_METHODS(CHDChain, obj)
+    {
+        READWRITE(obj.nVersion, obj.nExternalChainCounter, obj.masterKeyID);
+    }
+
+    void SetNull()
+    {
+        nVersion = CHDChain::CURRENT_VERSION;
+        nExternalChainCounter = 0;
+        masterKeyID.SetNull();
+    }
+};
+
 class CKeyMetadata
 {
 public:
-    static const int CURRENT_VERSION=1;
+    static const int VERSION_BASIC=1;
+    static const int VERSION_WITH_HDDATA=10;
+    static const int CURRENT_VERSION=VERSION_WITH_HDDATA;
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
+    std::string hdKeypath; //optional HD/bip32 keypath
+    CKeyID hdMasterKeyID; //id of the HD masterkey used to derive this key
 
     CKeyMetadata()
     {
@@ -37,7 +67,7 @@ public:
     }
     CKeyMetadata(int64_t nCreateTime_)
     {
-        nVersion = CKeyMetadata::CURRENT_VERSION;
+        SetNull();
         nCreateTime = nCreateTime_;
     }
 
@@ -48,12 +78,19 @@ public:
     {
         READWRITE(nVersion);
         READWRITE(nCreateTime);
+        if (this->nVersion >= VERSION_WITH_HDDATA)
+        {
+            READWRITE(hdKeypath);
+            READWRITE(hdMasterKeyID);
+        }
     }
 
     void SetNull()
     {
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
+        hdKeypath.clear();
+        hdMasterKeyID.SetNull();
     }
 };
 
@@ -190,6 +227,9 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
+
+    //! write the hdchain model (external chain child index counter)
+    bool WriteHDChain(const CHDChain& chain);
 };
 
 #endif // BITCOIN_WALLET_WALLETDB_H

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <wallet/walletutil.h>
+
+#include <array>
+
+namespace wallet {
+bool IsFeatureSupported(int wallet_version, int feature_version)
+{
+    return wallet_version >= feature_version;
+}
+
+WalletFeature GetClosestWalletFeature(int version)
+{
+    static constexpr std::array wallet_features{FEATURE_LATEST, FEATURE_HD, FEATURE_COMPRPUBKEY, FEATURE_WALLETCRYPT, FEATURE_BASE};
+    for (const WalletFeature& wf : wallet_features) {
+        if (version >= wf) return wf;
+    }
+    return static_cast<WalletFeature>(0);
+}
+} // namespace wallet

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -14,7 +14,7 @@ enum WalletFeature
     FEATURE_WALLETCRYPT = 40000, // wallet encryption
     FEATURE_COMPRPUBKEY = 60000, // compressed public keys
 
-    FEATURE_HD = 5040001, // Hierarchical key derivation after BIP32 (HD Wallet)
+    FEATURE_HD = 5040101, // Hierarchical key derivation after BIP32 (HD Wallet)
 
     FEATURE_LATEST = FEATURE_HD
 };

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_WALLETUTIL_H
+#define BITCOIN_WALLET_WALLETUTIL_H
+
+namespace wallet {
+/** (client) version numbers for particular wallet features */
+enum WalletFeature
+{
+    FEATURE_BASE = 10500, // the earliest version new wallets supports (only useful for getwalletinfo's clientversion output)
+
+    FEATURE_WALLETCRYPT = 40000, // wallet encryption
+    FEATURE_COMPRPUBKEY = 60000, // compressed public keys
+
+    FEATURE_HD = 5040001, // Hierarchical key derivation after BIP32 (HD Wallet)
+
+    FEATURE_LATEST = FEATURE_HD
+};
+
+bool IsFeatureSupported(int wallet_version, int feature_version);
+WalletFeature GetClosestWalletFeature(int version);
+
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_WALLETUTIL_H


### PR DESCRIPTION
Adds HD wallet support. Introduces two new RPCs: sethdseed and upgradewallet(previously a cli argument).

This PR does not introduce BIP39/seed phrases support.

## Upgrade Instructions

Old pre-HD wallets will not automatically be upgraded and will continue to work as normal. HD can be enabled for old wallets like this:

1. Unlock wallet if locked.
2. Call `upgradewallet` (5040101 can be given as a second argument if the wallet is not meant to be fully upgraded; does not affect anything for now.)
3. Wait. (The generation and the flush of the keys might take a few minutes.)

Note: New wallets are automatically created as HD wallets and do not need to be updated.
Note 2: Unused keys in the key pool will be removed when doing this action. When dealing with multiple out of sync wallet.dat files caution must be taken care as losing the other files can cause loss of keys/funds.

## Backup/Restore Instructions

A backup of the wallet.dat file is enough as the seed is contained in the file. Alternatively the private key associated with the seed can be backed up like this:

1. Do a walletdump. (`walletdump <file>`)
2. Get the key marked with hdmaster=1 or hdseed=1 in the file.
3. Backup that key.

and restored with:
`sethdseed true {key}`

Note: This operation can also take a few minutes.
Note 2: The wallet dump files contain unencrypted private keys and should be removed after the backup.
Note 3: If the sethdseed command is used from a shell, cleaning the shell's $HISTFILE might be a good idea.

## Testing checklist
- [x] Ability to re-create private keys from a given seed.
- [x] Old wallets are able to generate private keys without an issue.
- [x] Receiving and sending is not impacted.

Fixes #570.
Fixes #2325.