### PR TITLE
rpc: fix allow check for ::1

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -501,7 +501,8 @@ bool ClientAllowed(const boost::asio::ip::address& address)
     // Make sure that IPv4-compatible and IPv4-mapped IPv6 addresses are treated as IPv4 addresses
     if (address.is_v6()
      && (address.to_v6() <= boost::asio::ip::make_address_v6("::ffff:ffff")
-      || address.to_v6().is_v4_mapped())) {
+      || address.to_v6().is_v4_mapped())
+     && !(address.to_v6() == asio::ip::address_v6::loopback() || address.to_v6() == asio::ip::make_address_v6("::"))) {
         auto address6 = address.to_v6();
         auto bytes = address6.to_bytes();
 


### PR DESCRIPTION
See `curl --data '{"method": "getinfo"}' http://'[::1]':15715/` for before and after a91d529389e88bc7ebe0795e7a2925026d498b1e.