### PR TITLE
qt, build, ci: add optional Qt 6 support

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -59,23 +59,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Install dependencies
-              uses: awalsh128/cache-apt-pkgs-action@v1
-              with:
-                  packages: >-
-                      ${{matrix.deps}}
-                      ccache
-                      cmake
-                      libcurl4-openssl-dev
-                      libssl-dev
-                      libzip-dev
-                      ninja-build
-                      pkgconf
-                      zipcmp
-                      zipmerge
-                      ziptool
-                  version: ${{matrix.tag}}
-            - name: Install Boost dependencies
               run: sudo apt-get install -y --no-install-recommends
+                  ${{matrix.deps}}
+                  ccache
+                  cmake
                   libboost-dev
                   libboost-date-time-dev
                   libboost-exception-dev
@@ -84,6 +71,14 @@ jobs:
                   libboost-serialization-dev
                   libboost-test-dev
                   libboost-thread-dev
+                  libcurl4-openssl-dev
+                  libssl-dev
+                  libzip-dev
+                  ninja-build
+                  pkgconf
+                  zipcmp
+                  zipmerge
+                  ziptool
             - name: Configure
               run: cmake
                   -B ${{github.workspace}}/build -G Ninja

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -17,6 +17,7 @@ jobs:
                     - minimal
                     - no-asm
                     - gui-full
+                    - gui-qt6
                     - system-libs
                 include:
                     - tag: no-asm
@@ -33,6 +34,15 @@ jobs:
                           -DENABLE_QRENCODE=ON
                           -DENABLE_UPNP=ON
                           -DUSE_DBUS=ON
+                    - tag: gui-qt6
+                      deps: >-
+                          qt6-base-dev
+                          qt6-5compat-dev
+                          qt6-tools-dev
+                      options: >-
+                          -DENABLE_GUI=ON
+                          -DUSE_DBUS=ON
+                          -DUSE_QT6=ON
                     - tag: system-libs
                       deps: >-
                           libdb5.3++-dev
@@ -118,6 +128,7 @@ jobs:
                     - minimal
                     - no-asm
                     - gui-full
+                    - gui-qt6
                     - system-libs
                 include:
                     - tag: no-asm
@@ -133,6 +144,13 @@ jobs:
                           -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5
                           -DENABLE_QRENCODE=ON
                           -DENABLE_UPNP=ON
+                    - tag: gui-qt6
+                      deps: >-
+                          qt@6
+                      options: >-
+                          -DENABLE_GUI=ON
+                          -DQt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6
+                          -DUSE_QT6=ON
                     - tag: system-libs
                       deps: >-
                           berkeley-db@5
@@ -209,6 +227,7 @@ jobs:
                     - minimal
                     - no-asm
                     - gui-full
+                    - gui-qt6
                 include:
                     - tag: no-asm
                       deps: null
@@ -223,6 +242,14 @@ jobs:
                           -DENABLE_GUI=ON
                           -DENABLE_QRENCODE=ON
                           -DENABLE_UPNP=ON
+                    - tag: gui-qt6
+                      deps: >-
+                          qt6-base:p
+                          qt6-5compat:p
+                          qt6-tools:p
+                      options: >-
+                          -DENABLE_GUI=ON
+                          -DUSE_QT6=ON
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,10 @@ option(ENABLE_QRENCODE  "Enable generation of QR Codes for receiving payments" O
 option(ENABLE_UPNP      "Enable UPnP port mapping support" OFF)
 option(DEFAULT_UPNP     "Turn UPnP on startup" OFF)
 option(USE_DBUS         "Enable DBus support" OFF)
+option(USE_QT6          "Use Qt 6 instead of Qt 5" OFF)
 
 # Bundled packages
-option(SYSTEM_BDB	    "Find system installation of Berkeley DB CXX 5.3" OFF)
+option(SYSTEM_BDB       "Find system installation of Berkeley DB CXX 5.3" OFF)
 option(SYSTEM_LEVELDB   "Find system installation of leveldb" OFF)
 option(SYSTEM_SECP256K1 "Find system installation of libsecp256k1 with pkg-config" OFF)
 option(SYSTEM_UNIVALUE  "Find system installation of Univalue with pkg-config" OFF)
@@ -114,20 +115,24 @@ option(BUNDLED_BOOST    "Use the bundled version of Boost" ${HUNTER_ENABLED})
 option(BUNDLED_CURL     "Use the bundled version of cURL" ${HUNTER_ENABLED})
 option(BUNDLED_LIBZIP   "Use the bundled version of libzip" ${HUNTER_ENABLED})
 option(BUNDLED_OPENSSL  "Use the bundled version of OpenSSL" ${HUNTER_ENABLED})
-option(BUNDLED_QT       "Use the bundled version of Qt" ${HUNTER_ENABLED})
+option(BUNDLED_QT5      "Use the bundled version of Qt 5" ${HUNTER_ENABLED})
 
 
 # Handle dependencies
 # ===================
 
 set(QT5_MINIMUM_VERSION 5.9.5)
-set(QT5_COMPONENTS Concurrent Core Gui LinguistTools Network Widgets)
-set(QT5_HUNTER_COMPONENTS qtbase qttools)
+set(QT6_MINIMUM_VERSION 6.2.0)
+set(QT_COMPONENTS Core Concurrent Gui LinguistTools Network Widgets)
+set(QT_HUNTER_COMPONENTS qtbase qttools)
+if(USE_QT6)
+    list(APPEND QT_COMPONENTS Core5Compat)
+endif()
 if(USE_DBUS)
-    list(APPEND QT5_COMPONENTS DBus)
+    list(APPEND QT_COMPONENTS DBus)
 endif()
 if(ENABLE_TESTS)
-    list(APPEND QT5_COMPONENTS Test)
+    list(APPEND QT_COMPONENTS Test)
 endif()
 
 set(BOOST_MINIMUM_VERSION 1.63.0)
@@ -199,24 +204,30 @@ if(USE_ASM)
 endif()
 
 if(ENABLE_GUI)
-    if(BUNDLED_QT)
-        hunter_add_package(Qt COMPONENTS ${QT5_HUNTER_COMPONENTS})
+    if(USE_QT6)
+        find_package(Qt6 ${QT6_MINIMUM_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
+        set(QT Qt6)
+    else()
+        if(BUNDLED_QT5)
+            hunter_add_package(Qt COMPONENTS ${QT_HUNTER_COMPONENTS})
+        endif()
+        find_package(Qt5 ${QT5_MINIMUM_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
+        set(QT Qt5)
+
+        # Compatibility macros
+        if(Qt5Core_VERSION VERSION_LESS 5.15.0)
+            macro(qt_create_translation)
+                qt5_create_translation(${ARGN})
+            endmacro()
+
+            macro(qt_add_translation)
+                qt5_add_translation(${ARGN})
+            endmacro()
+        endif()
     endif()
-    find_package(Qt5 ${QT5_MINIMUM_VERSION} COMPONENTS ${QT5_COMPONENTS} REQUIRED)
 
     if(ENABLE_QRENCODE)
         pkg_check_modules(QRENCODE REQUIRED IMPORTED_TARGET libqrencode)
-    endif()
-
-    # Compatibility macros
-    if(Qt5Core_VERSION VERSION_LESS 5.15.0)
-        macro(qt_create_translation)
-            qt5_create_translation(${ARGN})
-        endmacro()
-
-        macro(qt_add_translation)
-            qt5_add_translation(${ARGN})
-        endmacro()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ if(USE_ASM)
 endif()
 
 if(ENABLE_GUI)
+    set(QT_MACOS_DISABLE_DARK_MODE False)
     if(USE_QT6)
         find_package(Qt6 ${QT6_MINIMUM_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
         set(QT Qt6)
@@ -213,6 +214,10 @@ if(ENABLE_GUI)
         endif()
         find_package(Qt5 ${QT5_MINIMUM_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)
         set(QT Qt5)
+
+        if(Qt5Core_VERSION VERSION_LESS 5.12.0)
+            set(QT_MACOS_DISABLE_DARK_MODE True)
+        endif()
 
         # Compatibility macros
         if(Qt5Core_VERSION VERSION_LESS 5.15.0)

--- a/share/qt/Info.plist.cmake.in
+++ b/share/qt/Info.plist.cmake.in
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.9">
+<dict>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.8.0</string>
+
+  <key>LSArchitecturePriority</key>
+  <array>
+    <string>x86_64</string>
+  </array>
+
+  <key>CFBundleIconFile</key>
+  <string>gridcoin.icns</string>
+
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+
+  <key>CFBundleGetInfoString</key>
+  <string>@PROJECT_VERSION@, Copyright © 2009-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@</string>
+
+  <key>CFBundleShortVersionString</key>
+  <string>@PROJECT_VERSION@</string>
+
+  <key>CFBundleVersion</key>
+  <string>@PROJECT_VERSION@</string>
+
+  <key>CFBundleSignature</key>
+  <string>????</string>
+
+  <key>CFBundleExecutable</key>
+  <string>gridcoinresearch</string>
+
+  <key>CFBundleName</key>
+  <string>Gridcoin</string>
+
+  <key>LSHasLocalizedDisplayName</key>
+  <true/>
+
+  <key>CFBundleIdentifier</key>
+  <string>world.gridcoin.Gridcoin-Qt</string>
+
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>CFBundleURLName</key>
+      <string>world.gridcoin.GridcoinPayment</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>gridcoin</string>
+      </array>
+    </dict>
+  </array>
+
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>world.gridcoin.paymentrequest</string>
+      <key>UTTypeDescription</key>
+      <string>Gridcoin payment request</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.mime-type</key>
+        <string>application/x-gridcoin-payment-request</string>
+        <key>public.filename-extension</key>
+        <array>
+          <string>gridcoinpaymentrequest</string>
+        </array>
+      </dict>
+    </dict>
+  </array>
+
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>world.gridcoin.paymentrequest</string>
+      </array>
+      <key>LSHandlerRank</key>
+      <string>Owner</string>
+    </dict>
+  </array>
+
+  <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+
+  <key>NSHighResolutionCapable</key>
+    <string>True</string>
+
+  <key>LSApplicationCategoryType</key>
+    <string>public.app-category.finance</string>
+
+  <key>NSRequiresAquaSystemAppearance</key>
+    <string>@QT_MACOS_DISABLE_DARK_MODE@</string>
+</dict>
+</plist>

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -133,6 +133,7 @@ QT_MOC_CPP = \
   qt/moc_bitcoinaddressvalidator.cpp \
   qt/moc_bitcoinamountfield.cpp \
   qt/moc_bitcoingui.cpp \
+  qt/moc_bitcoinunits.cpp \
   qt/moc_clicklabel.cpp \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
@@ -173,6 +174,7 @@ QT_MOC_CPP = \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_updatedialog.cpp \
+  qt/moc_upgradeqt.cpp \
   qt/moc_walletmodel.cpp \
   qt/researcher/moc_projecttablemodel.cpp \
   qt/researcher/moc_researchermodel.cpp \

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -141,13 +141,20 @@ set_source_files_properties(
 # =================
 
 target_link_libraries(gridcoinqt PUBLIC
-    Qt5::Concurrent
-    Qt5::Core
-    Qt5::Gui
-    Qt5::Network
-    Qt5::Widgets
+    ${QT}::Core
+    ${QT}::Concurrent
+    ${QT}::Gui
+    ${QT}::Network
+    ${QT}::Widgets
     gridcoin_util
 )
+
+if(USE_QT6)
+    target_link_libraries(gridcoinqt PUBLIC ${QT}::Core5Compat)
+endif()
+if(USE_DBUS)
+    target_link_libraries(gridcoinqt PUBLIC ${QT}::DBus)
+endif()
 
 if(APPLE)
     target_link_libraries(gridcoinqt PUBLIC
@@ -161,10 +168,6 @@ endif()
 
 target_compile_definitions(gridcoinqt PUBLIC HAVE_CONFIG_H)
 target_compile_definitions(gridcoinqt PUBLIC QT_DISABLE_DEPRECATED_UP_TO=0x050F00)
-
-if(USE_DBUS)
-    target_link_libraries(gridcoinqt PUBLIC Qt5::DBus)
-endif()
 
 if(ENABLE_UPNP)
     if(DEFAULT_UPNP)
@@ -184,7 +187,7 @@ add_executable(gridcoinresearch WIN32 MACOSX_BUNDLE bitcoin.cpp)
 
 target_link_libraries(gridcoinresearch PRIVATE
     ${RUNTIME_LIBS}
-    Qt5::Widgets
+    ${QT}::Widgets
     gridcoin_util
     gridcoinqt
 )

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -183,13 +183,25 @@ add_dependencies(gridcoinqt gridcoinqt_l10n)
 # Application
 # ===========
 
-add_executable(gridcoinresearch WIN32 MACOSX_BUNDLE bitcoin.cpp)
+add_executable(gridcoinresearch bitcoin.cpp)
+
+set(MACOSX_BUNDLE_RESOURCE_FILES res/icons/gridcoin.icns)
+if(APPLE)
+    target_sources(gridcoinresearch PRIVATE ${MACOSX_BUNDLE_RESOURCE_FILES})
+endif()
 
 target_link_libraries(gridcoinresearch PRIVATE
     ${RUNTIME_LIBS}
     ${QT}::Widgets
     gridcoin_util
     gridcoinqt
+)
+
+set_target_properties(gridcoinresearch PROPERTIES
+    WIN32_EXECUTABLE TRUE
+    MACOSX_BUNDLE TRUE
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/share/qt/Info.plist.cmake.in"
+    RESOURCE ${MACOSX_BUNDLE_RESOURCE_FILES}
 )
 
 if(UNIX AND NOT APPLE)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -160,6 +160,7 @@ elseif(WIN32)
 endif()
 
 target_compile_definitions(gridcoinqt PUBLIC HAVE_CONFIG_H)
+target_compile_definitions(gridcoinqt PUBLIC QT_DISABLE_DEPRECATED_UP_TO=0x050F00)
 
 if(USE_DBUS)
     target_link_libraries(gridcoinqt PUBLIC Qt5::DBus)

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -202,7 +202,7 @@ void AddressBookPage::on_signMessageButton_clicked()
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
     QString addr;
 
-    for (QModelIndex index : indexes) {
+    for (QModelIndex index : std::as_const(indexes)) {
         QVariant address = index.data();
         addr = address.toString();
     }
@@ -216,7 +216,7 @@ void AddressBookPage::on_verifyMessageButton_clicked()
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
     QString addr;
 
-    for (QModelIndex index : indexes) {
+    for (QModelIndex index : std::as_const(indexes)) {
         QVariant address = index.data();
         addr = address.toString();
     }
@@ -308,7 +308,7 @@ void AddressBookPage::done(int retval)
     // Figure out which address was selected, and return it
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 
-    for (QModelIndex index : indexes) {
+    for (QModelIndex index : std::as_const(indexes)) {
         QVariant address = table->model()->data(index);
         returnValue = address.toString();
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -52,6 +52,7 @@
 #endif
 
 #include <QApplication>
+#include <QGuiApplication>
 #include <QFontDatabase>
 #include <QMainWindow>
 #include <QMenuBar>
@@ -77,8 +78,10 @@
 #include <QDesktopServices> // for opening URLs
 #include <QUrl>
 #include <QStyle>
-#include <QDesktopWidget>
 #include <QSettings>
+#include <QAction>
+#include <QActionGroup>
+#include <QScreen>
 
 #include <boost/lexical_cast.hpp>
 
@@ -119,8 +122,8 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
 
     if (!restoreGeometry(settings.value(window_geometry_key).toByteArray())) {
         // Restore failed (perhaps missing setting), center the window
-        setGeometry(QStyle::alignedRect(Qt::LeftToRight,Qt::AlignCenter,QDesktopWidget().availableGeometry(this).size()
-                                        * 0.4,QDesktopWidget().availableGeometry(this)));
+        setGeometry(QStyle::alignedRect(Qt::LeftToRight,Qt::AlignCenter,QGuiApplication::primaryScreen()->availableGeometry().size()
+                                        * 0.4,QGuiApplication::primaryScreen()->availableGeometry()));
     }
 
     QFontDatabase::addApplicationFont(":/fonts/inter-bold");
@@ -430,7 +433,7 @@ void BitcoinGUI::createActions()
     resetblockchainAction->setToolTip(tr("Remove blockchain data and start chain from zero"));
 
     m_mask_values_action = new QAction(tr("&Mask values"), this);
-    m_mask_values_action->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_M));
+    m_mask_values_action->setShortcut(QKeySequence((Qt::CTRL | Qt::SHIFT) + Qt::Key_M));
     m_mask_values_action->setStatusTip(tr("Mask the values in the Overview screen"));
     m_mask_values_action->setCheckable(true);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -78,6 +78,7 @@
 #include <QUrl>
 #include <QStyle>
 #include <QDesktopWidget>
+#include <QSettings>
 
 #include <boost/lexical_cast.hpp>
 
@@ -1277,10 +1278,11 @@ void BitcoinGUI::incomingTransaction(const QModelIndex & parent, int start, int 
                                  "Amount: %2\n"
                                  "Type: %3\n"
                                  "Address: %4")
-                              .arg(date)
-                              .arg(BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), amount, true))
-                              .arg(type)
-                              .arg(address), icon);
+                              .arg(date,
+                                   BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), amount, true),
+                                   type,
+                                   address),
+                              icon);
     }
 }
 
@@ -1526,7 +1528,7 @@ void BitcoinGUI::dropEvent(QDropEvent *event)
     {
         int nValidUrisFound = 0;
         QList<QUrl> uris = event->mimeData()->urls();
-        for (const QUrl& uri : uris) {
+        for (const QUrl& uri : std::as_const(uris)) {
             if (sendCoinsPage->handleURI(uri.toString()))
                 nValidUrisFound++;
         }
@@ -1728,7 +1730,8 @@ QString BitcoinGUI::GetEstimatedStakingFrequency(unsigned int nEstimateTime)
         }
     }
 
-    text = tr("%1 times per %2").arg(QString(RoundToString(frequency, 2).c_str())).arg(unit);
+    text = tr("%1 times per %2").arg(QString(RoundToString(frequency, 2).c_str()),
+                                     unit);
 
     return text;
 }
@@ -1745,9 +1748,9 @@ void BitcoinGUI::updateStakingIcon(
     {
         labelStakingIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_staking_yes_" + sSheet));
         labelStakingIcon->setToolTip(tr("Staking.<br>Your weight is %1<br>Network weight is %2<br><b>Estimated</b> staking frequency is %3.")
-                                     .arg(QString::number(coin_weight, 'f', 0))
-                                     .arg(QString::number(net_weight, 'f', 0))
-                                     .arg(GetEstimatedStakingFrequency(etts_days)));
+                                     .arg(QString::number(coin_weight, 'f', 0),
+                                          QString::number(net_weight, 'f', 0),
+                                          GetEstimatedStakingFrequency(etts_days)));
     }
     else if (coin_weight == 0.0)
     {
@@ -1759,8 +1762,8 @@ void BitcoinGUI::updateStakingIcon(
     {
         labelStakingIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_staking_no_" + sSheet));
         labelStakingIcon->setToolTip(tr("Not staking currently: %1, <b>Estimated</b> staking frequency is %2.")
-                                     .arg(clientModel->getMinerWarnings())
-                                     .arg(GetEstimatedStakingFrequency(etts_days)));
+                                     .arg(clientModel->getMinerWarnings(),
+                                          GetEstimatedStakingFrequency(etts_days)));
     }
 }
 
@@ -1847,18 +1850,18 @@ void BitcoinGUI::updateScraperIcon(int scraperEventtype, int status)
                                             "Scrapers included: %3. \n"
                                             "Scraper(s) excluded: %4. \n"
                                             "Scraper(s) not publishing: %5.")
-                                         .arg(QString(DateTimeStrFormat("%x %H:%M:%S", nConvergenceTime).c_str()))
-                                         .arg(qsExcludedProjects)
-                                         .arg(qsIncludedScrapers)
-                                         .arg(qsExcludedScrapers)
-                                         .arg(qsScrapersNotPublishing));
+                                         .arg(QString(DateTimeStrFormat("%x %H:%M:%S", nConvergenceTime).c_str()),
+                                              qsExcludedProjects,
+                                              qsIncludedScrapers,
+                                              qsExcludedScrapers,
+                                              qsScrapersNotPublishing));
         }
         else
         {
             labelScraperIcon->setToolTip(tr("Scraper: Convergence achieved, date/time %1 UTC. \n"
                                             " Project(s) excluded: %2.")
-                                         .arg(QString(DateTimeStrFormat("%x %H:%M:%S", nConvergenceTime).c_str()))
-                                         .arg(qsExcludedProjects));
+                                         .arg(QString(DateTimeStrFormat("%x %H:%M:%S", nConvergenceTime).c_str()),
+                                              qsExcludedProjects));
         }
     }
     else if ((scraperEventtype == (int)scrapereventtypes::Convergence  || scraperEventtype == (int)scrapereventtypes::SBContract)

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -9,6 +9,8 @@
 */
 class BitcoinUnits: public QAbstractListModel
 {
+    Q_OBJECT
+
 public:
     explicit BitcoinUnits(QObject *parent);
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -620,7 +620,7 @@ void CoinControlDialog::updateLabels(WalletModel *model,
     bool fLowOutput = false;
     bool fDust = false;
     CTransaction txDummy;
-    for (const qint64& amount : *payAmounts) {
+    for (const qint64& amount : std::as_const(*payAmounts)) {
         nPayAmount += amount;
 
         if (amount > 0)
@@ -749,8 +749,8 @@ void CoinControlDialog::updateLabels(WalletModel *model,
 
     // tool tips
     l5->setToolTip(tr("This label turns red, if the transaction size is bigger than 10000 bytes.\n\n This means a fee of at least %1 per kb is required.\n\n Can vary +/- 1 Byte per input.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
-    l7->setToolTip(tr("This label turns red, if any recipient receives an amount smaller than %1.\n\n This means a fee of at least %2 is required. \n\n Amounts below 0.546 times the minimum relay fee are shown as DUST.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)).arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
-    l8->setToolTip(tr("This label turns red, if the change is smaller than %1.\n\n This means a fee of at least %2 is required.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)).arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
+    l7->setToolTip(tr("This label turns red, if any recipient receives an amount smaller than %1.\n\n This means a fee of at least %2 is required. \n\n Amounts below 0.546 times the minimum relay fee are shown as DUST.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT), BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
+    l8->setToolTip(tr("This label turns red, if the change is smaller than %1.\n\n This means a fee of at least %2 is required.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT), BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
     dialog->findChild<QLabel *>("coinControlBytesTextLabel")    ->setToolTip(l5->toolTip());
     dialog->findChild<QLabel *>("coinControlLowOutputTextLabel")->setToolTip(l7->toolTip());
     dialog->findChild<QLabel *>("coinControlChangeTextLabel")   ->setToolTip(l8->toolTip());
@@ -833,7 +833,7 @@ void CoinControlDialog::updateView()
             if (!(sAddress == sWalletAddress)) // change
             {
                 // tooltip from where the change comes from
-                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel).arg(sWalletAddress));
+                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel, sWalletAddress));
                 itemOutput->setText(COLUMN_LABEL, tr("(change)"));
                 itemOutput->setText(COLUMN_CHANGE_BOOL, QString::number(1));
             }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -769,7 +769,7 @@ void CoinControlDialog::updateView()
     ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox
     ui->treeWidget->setAlternatingRowColors(!treeMode);
     QFlags<Qt::ItemFlag> flgCheckbox=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
-    QFlags<Qt::ItemFlag> flgTristate=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
+    QFlags<Qt::ItemFlag> flgTristate=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsAutoTristate;
 
     int nDisplayUnit = BitcoinUnits::BTC;
     if (model && model->getOptionsModel())

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -526,7 +526,7 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
     ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox
     ui->treeWidget->setAlternatingRowColors(!treeMode);
     QFlags<Qt::ItemFlag> flgCheckbox=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable;
-    QFlags<Qt::ItemFlag> flgTristate=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
+    QFlags<Qt::ItemFlag> flgTristate=Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsAutoTristate;
 
     int nDisplayUnit = BitcoinUnits::BTC;
 

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -356,7 +356,7 @@ void ConsolidateUnspentWizardSelectInputsPage::updateLabels()
     // nPayAmount
     qint64 nPayAmount = 0;
     CTransaction txDummy;
-    for (const auto& amount: *payAmounts)
+    for (const auto& amount: std::as_const(*payAmounts))
     {
         nPayAmount += amount;
 
@@ -593,7 +593,7 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
             if (!(sAddress == sWalletAddress)) // change
             {
                 // tooltip from where the change comes from
-                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel).arg(sWalletAddress));
+                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel, sWalletAddress));
                 itemOutput->setText(COLUMN_LABEL, tr("(change)"));
                 itemOutput->setText(COLUMN_CHANGE_BOOL, QString::number(1));
             }

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -6,7 +6,8 @@
 #define BITCOIN_QT_DIAGNOSTICSDIALOG_H
 
 #include <QDialog>
-#include <QtNetwork>
+#include <QtNetwork/QTcpSocket>
+#include <QtNetwork/QUdpSocket>
 #include <QtWidgets/QLabel>
 
 #include <string>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -97,8 +97,8 @@ QString formatNiceTimeOffset(qint64 secs)
         qint64 years = secs / YEAR_IN_SECONDS;
         qint64 remainder = secs % YEAR_IN_SECONDS;
         timeBehindText = QObject::tr("%1 and %2")
-            .arg(QObject::tr("%n year(s)", "", years))
-            .arg(QObject::tr("%n week(s)","", round_half_up(remainder, WEEK_IN_SECONDS)));
+            .arg(QObject::tr("%n year(s)", "", years),
+                 QObject::tr("%n week(s)","", round_half_up(remainder, WEEK_IN_SECONDS)));
     }
 
     return timeBehindText;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -19,6 +19,8 @@
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QThread>
+#include <QStandardPaths>
+#include <QRegExp>
 
 #ifdef WIN32
 #ifdef _WIN32_IE

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -301,8 +301,8 @@ void OverviewPage::setHeight(int height, int height_of_peers, bool in_sync)
         percent_progress = height * 100 / height_of_peers;
 
         text += QString(" of %1 (%2\%)")
-                .arg(QString::number(height_of_peers))
-                .arg(QString::number(percent_progress));
+                .arg(QString::number(height_of_peers),
+                     QString::number(percent_progress));
     }
 
     ui->blocksLabel->setText(text);

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -83,7 +83,7 @@ public:
         // build index map
         mapNodeRows.clear();
         int row = 0;
-        for (const CNodeCombinedStats& stats : cachedNodeStats)
+        for (const CNodeCombinedStats& stats : std::as_const(cachedNodeStats))
             mapNodeRows.insert(std::pair<NodeId, int>(stats.nodeStats.id, row++));
     }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -17,7 +17,6 @@
 #include <QThread>
 #include <QTextEdit>
 #include <QUrl>
-#include <QDesktopWidget>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
@@ -273,7 +272,11 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
         case Qt::Key_PageDown:
             if(obj == ui->lineEdit)
             {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                QApplication::postEvent(ui->messagesWidget, keyevt->clone());
+#else
                 QApplication::postEvent(ui->messagesWidget, new QKeyEvent(*keyevt));
+#endif
                 return true;
             }
             break;
@@ -286,7 +289,11 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
                   ((mod & Qt::ShiftModifier) && key == Qt::Key_Insert)))
             {
                 ui->lineEdit->setFocus();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                QApplication::postEvent(ui->lineEdit, keyevt->clone());
+#else
                 QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
+#endif
                 return true;
             }
         }

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -9,8 +9,8 @@ set_target_properties(test_gridcoin-qt PROPERTIES
 
 target_link_libraries(test_gridcoin-qt PRIVATE
     ${RUNTIME_LIBS}
-    Qt5::Test
-    Qt5::Widgets
+    ${QT}::Test
+    ${QT}::Widgets
     gridcoin_util
     gridcoinqt
 )

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -151,10 +151,10 @@ void TrafficGraphWidget::updateRates()
     }
 
     float tmax = 0.0f;
-    for (float f : vSamplesIn) {
+    for (float f : std::as_const(vSamplesIn)) {
         if(f > tmax) tmax = f;
     }
-    for (float f : vSamplesOut) {
+    for (float f : std::as_const(vSamplesOut)) {
         if(f > tmax) tmax = f;
     }
     fMax = tmax;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -172,7 +172,7 @@ public:
                     {
                         parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex+toInsert.size()-1);
                         int insert_idx = lowerIndex;
-                        for (const TransactionRecord& rec : toInsert) {
+                        for (const TransactionRecord& rec : std::as_const(toInsert)) {
                             cachedWallet.insert(insert_idx, rec);
                             insert_idx += 1;
                         }

--- a/src/qt/upgradeqt.cpp
+++ b/src/qt/upgradeqt.cpp
@@ -6,7 +6,10 @@
 #include "gridcoin/upgrade.h"
 #include "util.h"
 
-#include <QtWidgets>
+#include <QApplication>
+#include <QMainWindow>
+#include <QAction>
+#include <QMenuBar>
 #include <QProgressDialog>
 #include <QMessageBox>
 #include <QPixmap>

--- a/src/qt/upgradeqt.h
+++ b/src/qt/upgradeqt.h
@@ -22,6 +22,8 @@ class QProgressDialog;
 
 class UpgradeQt : QObject
 {
+    Q_OBJECT
+
 public:
     //!
     //! \brief Constructor.

--- a/src/qt/voting/additionalfieldstablemodel.cpp
+++ b/src/qt/voting/additionalfieldstablemodel.cpp
@@ -6,7 +6,6 @@
 #include "qt/voting/additionalfieldstablemodel.h"
 #include "qt/voting/votingmodel.h"
 
-#include <QtConcurrentRun>
 #include <QStringList>
 
 using namespace GRC;

--- a/src/qt/voting/polldetails.cpp
+++ b/src/qt/voting/polldetails.cpp
@@ -36,8 +36,8 @@ PollDetails::~PollDetails()
 void PollDetails::setItem(const PollItem& poll_item)
 {
     ui->dateRangeLabel->setText(QStringLiteral("%1 → %2")
-        .arg(GUIUtil::dateTimeStr(poll_item.m_start_time))
-        .arg(GUIUtil::dateTimeStr(poll_item.m_expiration)));
+        .arg(GUIUtil::dateTimeStr(poll_item.m_start_time),
+             GUIUtil::dateTimeStr(poll_item.m_expiration)));
 
     ui->titleLabel->setText(poll_item.m_title);
     ui->urlLabel->setText(QStringLiteral("<a href=\"%1\">%1</a>").arg(poll_item.m_url));

--- a/src/qt/voting/pollresultchoiceitem.cpp
+++ b/src/qt/voting/pollresultchoiceitem.cpp
@@ -24,8 +24,8 @@ QString CalculateBarStyle(const double ratio)
         (1 - ratio) * BAR_START_COLOR.blue() + ratio * BAR_END_COLOR.blue());
 
     return QString(CHUNK_STYLE_TEMPLATE)
-        .arg(BAR_START_COLOR.name())
-        .arg(end_color.name());
+        .arg(BAR_START_COLOR.name(),
+             end_color.name());
 }
 } // Anonymous namespace
 

--- a/src/qt/voting/polltab.cpp
+++ b/src/qt/voting/polltab.cpp
@@ -32,7 +32,7 @@ QString PollWaitMessage()
 
 QString FullRefreshMessage()
 {
-    return QStringLiteral("%1 %2").arg(RefreshMessage()).arg(PollWaitMessage());
+    return QStringLiteral("%1 %2").arg(RefreshMessage(), PollWaitMessage());
 }
 } // Anonymous namespace
 

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -7,16 +7,16 @@
 
 #include "uint256.h"
 #include "gridcoin/voting/filter.h"
+#include "qt/voting/votingmodel.h"
 
 #include <memory>
 #include <QSortFilterProxyModel>
 #include <QMutex>
 
-class PollItem;
-class VotingModel;
-
 class PollTableDataModel : public QAbstractTableModel
 {
+    Q_OBJECT
+
 public:
     PollTableDataModel();
 

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -302,9 +302,9 @@ void PollWizardDetailsPage::initializePage()
 
     if (type_id == (int) GRC::PollType::PROJECT) {
         ui->titleField->setText(QStringLiteral("[%1] %2 %3")
-            .arg(poll_type.m_name)
-            .arg(field("projectPollAddRemoveState").toString())
-            .arg(field("projectName").toString()));
+            .arg(poll_type.m_name,
+                 field("projectPollAddRemoveState").toString(),
+                 field("projectName").toString()));
         ui->responseTypeList->setCurrentIndex(0); // Yes/No/Abstain
         ui->responseTypeList->setDisabled(true);
 

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -15,14 +15,11 @@
 #include <QObject>
 #include <vector>
 #include <QVariant>
+#include <QStringList>
 
 namespace GRC {
 class PollRegistry;
 }
-
-QT_BEGIN_NAMESPACE
-class QStringList;
-QT_END_NAMESPACE
 
 class ClientModel;
 class OptionsModel;

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -14,7 +14,11 @@
 
 // If we don't want a message to be processed by Qt, return true and set result to
 // the value that the window procedure should return. Otherwise return false.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult)
+#else
 bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult)
+#endif
 {
        Q_UNUSED(eventType);
 

--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -17,7 +17,11 @@ class WinShutdownMonitor : public QAbstractNativeEventFilter
 {
 public:
     /** Implements QAbstractNativeEventFilter interface for processing Windows messages */
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    bool nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult);
+#else
     bool nativeEventFilter(const QByteArray &eventType, void *pMessage, long *pnResult);
+#endif
 
     /** Register the reason for blocking shutdown on Windows to allow clean client exit */
     static void registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId);


### PR DESCRIPTION
Introduce `USE_QT6` CMake option to build the GUI with Qt 6 instead of Qt 5. Most of porting work was done with the assistance of [Clazy](https://invent.kde.org/sdk/clazy/) and somewhat carefully reading the docs.

No functional changes are required.

## Rationale

Qt5 upstream (Qt Company) OSS support ended on 2020-12-08[^1]. Since then, bugs are only fixed if reproduced in Qt6 first, then backported. Since then, public availability of commercial 5.15 LTS releases is delayed by 1 year, including repository access for cherry-picking.

The last official LTS release will be this April/May:
https://www.qt.io/blog/qt-5.15-extended-support-for-subscription-license-holders
https://wiki.qt.io/Qt_5.15_Release#Release_Plan

Public availability of this release will be 1 year later, in April/May 2026. There will be no Qt5 releases or bugfixes going forward.

KDE's Qt5PatchCollection has no clear EOL date[^2], but since most of KDE has moved to Qt 6, it wouldn't last for long. And this work relies on Qt company's upstream commits anyway.

Some distros already stopped accepting new packages that use Qt 5, and began actively cleaning packages with no plans for porting to Qt 6.

[^1]: https://www.qt.io/blog/qt-offering-changes-2020
[^2]: https://community.kde.org/Qt5PatchCollection#For_how_long_will_this_be_maintained?