### PR TITLE
build: suppress CMake error for src/secp256k1 subdirectory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,9 @@ endif()
 if(SYSTEM_SECP256K1)
     set(LIBSECP256K1 PkgConfig::SECP256K1)
 else()
+    # workarounds for libsecp256k1 v0.3.0
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
     set(SECP256K1_BUILD_SHARED OFF)
     set(SECP256K1_BUILD_STATIC ON)


### PR DESCRIPTION
> Changed in version 3.27: Compatibility with versions of CMake older than 3.5 is deprecated. Calls to cmake_minimum_required(VERSION) or cmake_policy(VERSION) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.27 and above.