### PR TITLE
gui, init: Fixes the 'Blocks Verified' message total

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -450,7 +450,6 @@ bool CTxDB::LoadBlockIndex()
       nBestHeight,
       DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()));
 
-    nLoaded = 0;
     // Verify blocks in the best chain
     int nCheckLevel = gArgs.GetArg("-checklevel", 1);
     int nCheckDepth = gArgs.GetArg( "-checkblocks", 1000);
@@ -460,7 +459,8 @@ bool CTxDB::LoadBlockIndex()
     map<pair<unsigned int, unsigned int>, CBlockIndex*> mapBlockPos;
     for (CBlockIndex* pindex = pindexBest; pindex && pindex->pprev; pindex = pindex->pprev)
     {
-        if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
+        int nCurrentDepth = nBestHeight - pindex->nHeight + 1;
+        if (fRequestShutdown || nCurrentDepth > nCheckDepth)
             break;
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus()))
@@ -470,12 +470,9 @@ bool CTxDB::LoadBlockIndex()
 
         if(fQtActive)
         {
-            if ((pindex->nHeight % 1000) == 0)
+            if ((nCurrentDepth % 1000) == 0)
             {
-                nLoaded +=1000;
-                if (nLoaded > nHighest) nHighest=nLoaded;
-                if (nHighest < nGrandfather) nHighest=nGrandfather;
-                uiInterface.InitMessage(strprintf("%" PRId64 "/%" PRId64 " %s", nLoaded, nHighest, _("Blocks Verified")));
+                uiInterface.InitMessage(strprintf("%" PRId64 "/%" PRId64 " %s", nCurrentDepth, nCheckDepth, _("Blocks Verified")));
             }
         }
 


### PR DESCRIPTION
Fixes the '1000/1000 Blocks Verified' message which previously would show an incorrect denominator.
Previously the total was the total block height, whereas now it is the number of blocks to be verified. The numerator in the message was also often set to 1000 prematurely as this occurred after reaching a block with height divisible by 1000, even if this is the first block.


This also fixes an off-by-one error where 1001 block would be verified rather than 1000, which is the expected default. 
Note that the documentation lists this for the -checkblocks=<n> argument
"How many blocks to check at startup (default: 2500, 0 = all)"
but this does not seem to be accurate as 0 isn't handled and the default is 1000.
This is not handled in this PR