### PR TITLE
build: cmake build fixes for missing symbols checks and pipe2 detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,9 @@ endif()
 
 # Check symbols
 check_symbol_exists(fork "unistd.h" HAVE_DECL_FORK)
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 check_symbol_exists(pipe2 "unistd.h" HAVE_DECL_PIPE2)
+list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 check_symbol_exists(setsid "unistd.h" HAVE_DECL_SETSID)
 
 check_symbol_exists(le16toh "${ENDIAN_INCLUDES}" HAVE_DECL_LE16TOH)

--- a/src/config/gridcoin-config.h.cmake.in
+++ b/src/config/gridcoin-config.h.cmake.in
@@ -34,6 +34,10 @@
 #cmakedefine HAVE_SYS_ENDIAN_H
 #cmakedefine HAVE_SYS_PRCTL_H
 
+#cmakedefine01 HAVE_DECL_FORK
+#cmakedefine01 HAVE_DECL_PIPE2
+#cmakedefine01 HAVE_DECL_SETSID
+
 #cmakedefine01 HAVE_DECL_LE16TOH
 #cmakedefine01 HAVE_DECL_LE32TOH
 #cmakedefine01 HAVE_DECL_LE64TOH


### PR DESCRIPTION
Fix missing symbols checks and pipe2 detection when using cmake build system.