### PR TITLE
build: Add multiple depends source fallback capability and Fix configure.ac changes for boost >=1.89

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1075,14 +1075,11 @@ define(MINIMUM_REQUIRED_BOOST, 1.60.0)
 define(MINIMUM_BOOST_SYSTEM_HEADER, 1.89.0)
 
 dnl Check for Boost libs
-dnl For Boost >= 1.89.0, Boost::System is header nly, so we only link to it if we're using a version that doesn't match Boost >= 1.89
+dnl For Boost >= 1.89.0, Boost::System is header only, so we only link to it if we're using a version that doesn't match Boost >= 1.89
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
-AX_BOOST_BASE([MINIMUM_BOOST_SYSTEM_HEADER], [
-    BOOST_SYSTEM_IS_HEADER="1"
-], [
-    BOOST_SYSTEM_IS_HEADER="0"
-    AX_BOOST_SYSTEM
-])
+
+dnl Check whether Boost >= MINIMUM_BOOST_SYSTEM_HEADER so we know if Boost.System is header-only AC_MSG_CHECKING([for boostlib >= $MINIMUM_BOOST_SYSTEM_HEADER]) AX_BOOST_BASE([MINIMUM_BOOST_SYSTEM_HEADER], [BOOST_SYSTEM_IS_HEADER="1"], [BOOST_SYSTEM_IS_HEADER="0"]) AC_MSG_RESULT([$BOOST_SYSTEM_IS_HEADER])
+
 AX_BOOST_FILESYSTEM
 AX_BOOST_ZLIB
 AX_BOOST_IOSTREAMS

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -10,7 +10,8 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATHS ?= https://bitcoincore.org/depends-sources https://gridcoin-depends-backup-sources.s3.us-east-1.amazonaws.com
+
 
 C_STANDARD ?= gnu11
 CXX_STANDARD ?= c++17

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -29,9 +29,16 @@ define fetch_file_inner
 endef
 
 define fetch_file
-    ( test -f $$($(1)_source_dir)/$(4) || \
-    ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
-      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
+    ( \
+      test -f $$($(1)_source_dir)/$(4) || \
+      ( \
+        $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) \
+        $(foreach fallback_url,$(FALLBACK_DOWNLOAD_PATHS), \
+          || (echo "Primary download failed, trying fallback: $(fallback_url)" && $(call fetch_file_inner,$(1),$(fallback_url),$(3),$(4),$(5))) \
+        ) \
+        || (echo "All fallbacks failed for $(3)." && exit 1) \
+      ) \
+    )
 endef
 
 define int_get_build_recipe_hash

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,9 +1,9 @@
 package=boost
 GCCFLAGS?=
-$(package)_version=1.81.0
+$(package)_version=1.89.0
 $(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
 $(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.gz
-$(package)_sha256_hash=205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6
+$(package)_sha256_hash=9de758db755e8330a01d995b0a24d09798048400ac25c03fc5ea9be364b13c93
 $(package)_dependencies=zlib
 
 define $(package)_set_vars


### PR DESCRIPTION
This is a fix for https://github.com/gridcoin-community/Gridcoin-Research/pull/2823. It also adds multiple fallback source capability for depends source file downloads. The current secondary fallback is set to the project lead's AWS S3 source bucket.

Closes #2820.