### PR TITLE
compatibility: Fix qt6 and other warnings

### DIFF
--- a/src/config/gridcoin-config.h.cmake.in
+++ b/src/config/gridcoin-config.h.cmake.in
@@ -14,11 +14,26 @@
 #define COPYRIGHT_YEAR "@COPYRIGHT_YEAR@"
 #define COPYRIGHT_HOLDERS_FINAL "@COPYRIGHT_HOLDERS_FINAL@"
 
+#ifndef ENABLE_SSE41
 #cmakedefine ENABLE_SSE41
+#endif
+
+#ifndef ENABLE_AVX2
 #cmakedefine ENABLE_AVX2
+#endif
+
+#ifndef ENABLE_X86_SHANI
 #cmakedefine ENABLE_X86_SHANI
+#endif
+
+#ifndef ENABLE_ARM_CRC
 #cmakedefine ENABLE_ARM_CRC
+#endif
+
+#ifndef ENABLE_ARM_SHANI
 #cmakedefine ENABLE_ARM_SHANI
+#endif
+
 #cmakedefine USE_ASM
 
 #cmakedefine USE_DBUS

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -10,7 +10,6 @@
 #include "util.h"
 #include "util/threadnames.h"
 #include "net.h"
-#include "txdb.h"
 #include "wallet/walletdb.h"
 #include "banman.h"
 #include "random.h"

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -290,10 +290,12 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    // Generate high-dpi pixmaps
+    // Generate high-dpi pixmaps. This is now wrapped by a macro conditional because these are always
+    // on for Qt 6.0+ and are deprecated.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-
+#endif
     // Initiate the app here to support choosing the data directory.
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);
@@ -390,12 +392,19 @@ int main(int argc, char *argv[])
     // - First load the translator for the base language, without territory
     // - Then load the more specific locale translator
 
+// Near line 394
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QString transPath = QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+#else
+    QString transPath = QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#endif
+
     // Load e.g. qt_de.qm
-    if (qtTranslatorBase.load("qt_" + lang, QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+    if (qtTranslatorBase.load("qt_" + lang, transPath))
         app.installTranslator(&qtTranslatorBase);
 
     // Load e.g. qt_de_DE.qm
-    if (qtTranslator.load("qt_" + lang_territory, QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+    if (qtTranslator.load("qt_" + lang_territory, transPath))
         app.installTranslator(&qtTranslator);
 
     // Load e.g. bitcoin_de.qm (shortcut "de" needs to be defined in bitcoin.qrc)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -313,32 +313,32 @@ void BitcoinGUI::createActions()
     overviewAction = new QAction(tr("&Overview"), tabGroup);
     overviewAction->setToolTip(tr("Show general overview of wallet"));
     overviewAction->setCheckable(true);
-    overviewAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_1));
+    overviewAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_1));
 
     sendCoinsAction = new QAction(tr("&Send"), tabGroup);
     sendCoinsAction->setToolTip(tr("Send coins to a Gridcoin address"));
     sendCoinsAction->setCheckable(true);
-    sendCoinsAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_2));
+    sendCoinsAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_2));
 
     receiveCoinsAction = new QAction(tr("&Receive"), tabGroup);
     receiveCoinsAction->setToolTip(tr("Show the list of addresses for receiving payments"));
     receiveCoinsAction->setCheckable(true);
-    receiveCoinsAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_3));
+    receiveCoinsAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_3));
 
     historyAction = new QAction(tr("&History"), tabGroup);
     historyAction->setToolTip(tr("Browse transaction history"));
     historyAction->setCheckable(true);
-    historyAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_4));
+    historyAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_4));
 
     addressBookAction = new QAction(tr("&Favorites"), tabGroup);
     addressBookAction->setToolTip(tr("Edit the list of stored addresses and labels"));
     addressBookAction->setCheckable(true);
-    addressBookAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
+    addressBookAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_5));
 
     votingAction = new QAction(tr("&Voting"), tabGroup);
     votingAction->setToolTip(tr("Voting"));
     votingAction->setCheckable(true);
-    votingAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_6));
+    votingAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_6));
 
     bxAction = new QAction(tr("&Block Explorer"), this);
     bxAction->setStatusTip(tr("Block Explorer"));
@@ -381,7 +381,7 @@ void BitcoinGUI::createActions()
 
     quitAction = new QAction(tr("E&xit"), this);
     quitAction->setToolTip(tr("Quit application"));
-    quitAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
+    quitAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q));
     quitAction->setMenuRole(QAction::QuitRole);
 
     aboutAction = new QAction(tr("&About Gridcoin"), this);
@@ -433,7 +433,7 @@ void BitcoinGUI::createActions()
     resetblockchainAction->setToolTip(tr("Remove blockchain data and start chain from zero"));
 
     m_mask_values_action = new QAction(tr("&Mask values"), this);
-    m_mask_values_action->setShortcut(QKeySequence((Qt::CTRL | Qt::SHIFT) + Qt::Key_M));
+    m_mask_values_action->setShortcut(QKeySequence((Qt::CTRL | Qt::SHIFT) | Qt::Key_M));
     m_mask_values_action->setStatusTip(tr("Mask the values in the Overview screen"));
     m_mask_values_action->setCheckable(true);
 
@@ -1583,7 +1583,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         unlockWalletAction->setVisible(false);
         unlockWalletAction->setShortcut(QKeySequence());
         lockWalletAction->setVisible(true);
-        lockWalletAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_7));
+        lockWalletAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_7));
         encryptWalletAction->setEnabled(false);
         break;
     case WalletModel::Locked:
@@ -1592,7 +1592,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setChecked(true);
         changePassphraseAction->setEnabled(true);
         unlockWalletAction->setVisible(true);
-        unlockWalletAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_7));
+        unlockWalletAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_7));
         lockWalletAction->setVisible(false);
         lockWalletAction->setShortcut(QKeySequence());
         encryptWalletAction->setEnabled(false);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -87,8 +87,16 @@ OptionsDialog::OptionsDialog(QWidget* parent)
         /** check if the locale name consists of 2 parts (language_country) */
         if(langStr.contains("_"))
         {
+            QString countryName;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+            countryName = locale.nativeTerritoryName();
+#else
+            countryName = locale.nativeCountryName();
+#endif
+
             /** display language strings as "native language - native country (locale name)", e.g. "Deutsch - Deutschland (de)" */
-            ui->lang->addItem(locale.nativeLanguageName() + QString(" - ") + locale.nativeCountryName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
+            ui->lang->addItem(locale.nativeLanguageName() + QString(" - ") + countryName + QString(" (") + langStr + QString(")"), QVariant(langStr));
         }
         else
         {
@@ -255,7 +263,7 @@ void OptionsDialog::setMapper()
         mapper->addMapping(ui->minimizeOnClose, OptionsModel::MinimizeOnClose);
     }
     mapper->addMapping(ui->confirmOnClose, OptionsModel::ConfirmOnClose);
-#endif    
+#endif
 
     /* Display */
     mapper->addMapping(ui->lang, OptionsModel::Language);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -48,7 +48,11 @@ SendCoinsDialog::SendCoinsDialog(QWidget* parent)
     connect(ui->coinControlPushButton, &QPushButton::clicked, this, &SendCoinsDialog::coinControlButtonClicked);
     connect(ui->coinControlConsolidateWizardPushButton, &QPushButton::clicked, this, &SendCoinsDialog::coinControlConsolidateWizardButtonClicked);
     connect(ui->coinControlResetPushButton, &QPushButton::clicked, this, &SendCoinsDialog::coinControlResetButtonClicked);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0) // strictly it's 6.7+ for checkStateChanged
+    connect(ui->coinControlChangeCheckBox, &QCheckBox::checkStateChanged, this, &SendCoinsDialog::coinControlChangeChecked);
+#else
     connect(ui->coinControlChangeCheckBox, &QCheckBox::stateChanged, this, &SendCoinsDialog::coinControlChangeChecked);
+#endif
     connect(ui->coinControlChangeEdit, &QLineEdit::textEdited, this, &SendCoinsDialog::coinControlChangeEdited);
 
     // Coin Control: clipboard actions

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -2,7 +2,7 @@
 
 #include "transactiontablemodel.h"
 #include "transactionrecord.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <QDateTime>
 
@@ -13,7 +13,7 @@ const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromSecsSinceEpoch
 // Last date that can be represented (far in the future)
 const QDateTime TransactionFilterProxy::MAX_DATE = QDateTime::fromSecsSinceEpoch(0xFFFFFFFF);
 
-//Halford 1-2-2015 
+//Halford 1-2-2015
 TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     QSortFilterProxyModel(parent),
     dateFrom(MIN_DATE),
@@ -55,29 +55,33 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     return true;
 }
 
+// Note that invalidateFilter() is just a deprecated alias for invalidate(), so these have been changed to invalidate()
+// to silence the compiler warnings for Qt 6+.
+// TODO: Redesign to narrow scope of invalidation.
+
 void TransactionFilterProxy::setDateRange(const QDateTime &from, const QDateTime &to)
 {
     this->dateFrom = from;
     this->dateTo = to;
-    invalidateFilter();
+    invalidate();
 }
 
 void TransactionFilterProxy::setAddressPrefix(const QString &addrPrefix)
 {
     this->addrPrefix = addrPrefix;
-    invalidateFilter();
+    invalidate();
 }
 
 void TransactionFilterProxy::setTypeFilter(quint32 modes)
 {
     this->typeFilter = modes;
-    invalidateFilter();
+    invalidate();
 }
 
 void TransactionFilterProxy::setMinAmount(qint64 minimum)
 {
     this->minAmount = minimum;
-    invalidateFilter();
+    invalidate();
 }
 
 void TransactionFilterProxy::setLimit(int limit)
@@ -94,7 +98,7 @@ int TransactionFilterProxy::getLimit()
 void TransactionFilterProxy::setShowInactive(bool showInactive)
 {
     this->showInactive = showInactive;
-    invalidateFilter();
+    invalidate();
 }
 
 int TransactionFilterProxy::rowCount(const QModelIndex &parent) const

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -265,7 +265,7 @@ void PollTableModel::refresh()
                  __func__);
     }
 
-    QtConcurrent::run([this]() {
+    (void) QtConcurrent::run([this]() {
         RenameThread("PollTableModel_refresh");
         util::ThreadSetInternalName("PollTableModel_refresh");
 

--- a/src/qt/voting/votingpage.cpp
+++ b/src/qt/voting/votingpage.cpp
@@ -61,7 +61,7 @@ VotingPage::VotingPage(QWidget* parent)
     ui->activePollsTab->setPollFilterFlags(PollFilterFlag::ACTIVE);
     ui->finishedPollsTab->setPollFilterFlags(PollFilterFlag::FINISHED);
 
-    m_filter_action->setShortcut(Qt::CTRL + Qt::Key_F);
+    m_filter_action->setShortcut(Qt::CTRL | Qt::Key_F);
     ui->filterLineEdit->addAction(m_filter_action.get(), QLineEdit::LeadingPosition);
     ui->cardsToggleButton->hide();
     ui->sortButton->setMenu(new PollSortMenu(this));


### PR DESCRIPTION
This is a cleanup PR to fix compiler warnings related to Qt6+ changes and also a few minor issues with gridcoin-config.h.cmake.in redefinition of SSE41 and similar flags where they have already been defined from cmake arguments. It is currently based on the depends_qt6 branch, so will include all of those commits as well until depends_qt6 is merged into development.