### PR TITLE
gui: Allow fractional scaling with Qt6

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -295,6 +295,10 @@ int main(int argc, char *argv[])
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#else
+    // QT6: Disable scale factor rounding. This ensures that if a user manually
+    // sets QT_FONT_DPI or uses fractional scaling, icons/windows scale smoothly.
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
     // Initiate the app here to support choosing the data directory.
     Q_INIT_RESOURCE(bitcoin);


### PR DESCRIPTION
Qt6 rounds GUI scaling to the nearest integer. This may not be appropriate with all displays and configurations, where fractional scaling, such as 1.6, might be present due to the combination of font size, display size, and the global scaling selection.

Note that on some displays an environment variable setting, such as QT_FONT_DPI=\<x\>, where x is the screen dpi, may be needed due to the differences between Qt5 and Qt6 and how it deals with X sessions. This will not be necessary in Wayland I think.

I explored lots of different approaches to doing this automatically in code, and all are "hacky" and ugly.

