### PR TITLE
build: Implement Alpine CI

### DIFF
--- a/.github/workflows/cmake_distros.yml
+++ b/.github/workflows/cmake_distros.yml
@@ -52,6 +52,12 @@ jobs:
             prep_cmd: "apt-get update && apt-get install -y sudo git"
             build_args: ""
 
+          - distro: Alpine Linux (Edge)
+            image: alpine:latest
+            # Alpine needs bash installed explicitly because scripts use /bin/bash shebang
+            prep_cmd: "apk update && apk add bash sudo git"
+            build_args: ""
+
     steps:
       - uses: actions/checkout@v4
 
@@ -66,10 +72,13 @@ jobs:
 
           MOUNT_PATH="${HOST_WORKSPACE:-${{ github.workspace }}}"
 
+          # FIX: Use /bin/sh instead of /bin/bash for the initial entrypoint.
+          # Alpine (and others) always have /bin/sh, but Alpine does NOT have /bin/bash by default.
+          # The prep_cmd will install bash for the build scripts.
           docker run --rm \
             -v "$MOUNT_PATH":/mnt/host_source:ro \
             ${{ matrix.image }} \
-            /bin/bash -c " \
+            /bin/sh -c " \
               ${{ matrix.prep_cmd }} && \
               \
               mkdir -p /work && \
@@ -85,5 +94,7 @@ jobs:
                   SKIP_DEPS=false \
                   USE_CCACHE=false \
                   CLEAN_BUILD=true \
+                  WITH_GUI=true \
+                  USE_QT6=true \
                   PARALLEL=${CMAKE_BUILD_PARALLEL_LEVEL:-4} \
                   ${{ matrix.build_args }}"

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -14,6 +14,11 @@ define $(package)_set_vars
   $(package)_cflags_arm_linux = $(GCCFLAGS)
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess . && \
+  cp -f $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef
@@ -23,5 +28,5 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install
 endef

--- a/doc/build.md
+++ b/doc/build.md
@@ -9,7 +9,7 @@ for various build targets:
 | :--- | :--- | :--- | :--- |
 | **Linux (Native)** | CMake | **Stable** | This file |
 | **Linux (Static)** | CMake (depends) | **Stable** | This file |
-| **Linux Alpine (MUSL) ** | CMake | **Experimental** | This file |
+| **Linux Alpine (MUSL)** | CMake | **Experimental** | This file |
 | **Windows (Cross)**| CMake (depends) | **Stable** | This file |
 | **Windows via WSL**| CMake (depends) | **Stable** | [build-windows-wsl.md](build-windows-wsl.md) |
 | **macOS** | CMake | **Stable** | [build-macos.md](build-macos.md) |
@@ -97,7 +97,7 @@ repeated compilations.
 
 -----
 
-## 1\. Linux Native Build
+## 1\. Linux Native Build (also works for Linux Alpine (MUSL))
 
 This procedure uses your operating system's installed libraries (OpenSSL, Boost, Qt, etc.). It creates a dynamically linked executable.
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -9,6 +9,7 @@ for various build targets:
 | :--- | :--- | :--- | :--- |
 | **Linux (Native)** | CMake | **Stable** | This file |
 | **Linux (Static)** | CMake (depends) | **Stable** | This file |
+| **Linux Alpine (MUSL) ** | CMake | **Experimental** | This file |
 | **Windows (Cross)**| CMake (depends) | **Stable** | This file |
 | **Windows via WSL**| CMake (depends) | **Stable** | [build-windows-wsl.md](build-windows-wsl.md) |
 | **macOS** | CMake | **Stable** | [build-macos.md](build-macos.md) |

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -285,6 +285,20 @@ install_deps() {
             append_wine wine
             ;;
 
+        alpine)
+            # Base Build Tools
+            # 'build-base' is Alpine's build-essential.
+            # 'linux-headers' often needed. 'bash' is needed for these scripts.
+            # 'libexecinfo-dev' is sometimes needed for backtraces on musl.
+            append_base build-base cmake git curl ccache doxygen graphviz bison linux-headers xxd bash
+
+            # Libraries
+            append_base boost-dev openssl-dev libevent-dev miniupnpc-dev libqrencode-dev libzip-dev curl-dev
+
+            # Qt6 Packages
+            append_qt qt6-qtbase-dev qt6-qttools-dev qt6-qtcharts-dev qt6-qtsvg-dev qt6-qt5compat-dev
+            ;;
+
         *)
             echo "Error: Unsupported distribution '$OS'."
             return 1
@@ -367,6 +381,10 @@ install_deps() {
             ;;
         arch|manjaro)
             sudo pacman -S --noconfirm $PKGS_TO_INSTALL
+            ;;
+        alpine)
+            sudo apk update
+            sudo apk add $PKGS_TO_INSTALL
             ;;
     esac
 }

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -290,7 +290,7 @@ install_deps() {
             # 'build-base' is Alpine's build-essential.
             # 'linux-headers' often needed. 'bash' is needed for these scripts.
             # 'libexecinfo-dev' is sometimes needed for backtraces on musl.
-            append_base build-base cmake git curl ccache doxygen graphviz bison linux-headers xxd bash
+            append_base build-base cmake git curl ccache doxygen graphviz bison linux-headers xxd bash autoconf automake libtool perl
 
             # Libraries
             append_base boost-dev openssl-dev libevent-dev miniupnpc-dev libqrencode-dev libzip-dev curl-dev

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -231,24 +231,33 @@ target_link_libraries(gridcoinresearch PRIVATE
 
 # Linux Static Math Lib Workaround
 if(UNIX AND NOT APPLE AND DEFINED DEP_LIB)
-# 1. The "Imposter" Math Target
-    # We must link against the system's SHARED libm to avoid static linking issues with glibc.
-    # Detect the location: OpenSUSE/Fedora use /lib64, Ubuntu/Debian use /lib/x86_64-linux-gnu.
+    # 1. The "Imposter" Math Target
+    # We must link against the system's SHARED libm to avoid static linking issues.
+
+    # Detect the location:
     if(EXISTS "/lib64/libm.so.6")
+        # RHEL / CentOS / Fedora / OpenSUSE
         set(SYSTEM_LIBM "/lib64/libm.so.6")
     elseif(EXISTS "/lib/x86_64-linux-gnu/libm.so.6")
+        # Debian / Ubuntu
         set(SYSTEM_LIBM "/lib/x86_64-linux-gnu/libm.so.6")
+    elseif(EXISTS "/usr/lib/libm.so")
+        # Alpine Linux (Musl)
+        set(SYSTEM_LIBM "/usr/lib/libm.so")
     else()
-        # Fallback: Ask CMake to find it (though this might return a .a if we aren't careful)
-        find_library(SYSTEM_LIBM NAMES m.so.6 m)
+        # Fallback: Ask CMake to find it.
+        # We use CMAKE_FIND_ROOT_PATH_BOTH to allow breaking out of the cross-compile
+        # sandbox to find the host system's libm.
+        find_library(SYSTEM_LIBM NAMES m.so.6 m libm.so CMAKE_FIND_ROOT_PATH BOTH)
     endif()
 
     if(SYSTEM_LIBM)
+        message(STATUS "Using System Math Lib: ${SYSTEM_LIBM}")
         add_library(m SHARED IMPORTED GLOBAL)
         set_target_properties(m PROPERTIES IMPORTED_LOCATION "${SYSTEM_LIBM}")
         target_link_libraries(gridcoinresearch PRIVATE m)
     else()
-        message(FATAL_ERROR "Could not find system libm.so.6. Required for static builds.")
+        message(FATAL_ERROR "Could not find system libm.so.6 (or libm.so). Required for static builds.")
     endif()
 
     # 2. THE AUTOMATED MANUAL FIX

--- a/src/scrypt.cpp
+++ b/src/scrypt.cpp
@@ -6,10 +6,10 @@
  * modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
+ * notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -29,6 +29,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <vector>
 
 #include "util.h"
 #include "scrypt.h"
@@ -167,14 +168,14 @@ uint256 scrypt(const void* data, size_t datalen, const void* salt, size_t saltle
 
 uint256 scrypt_hash(const void* input, size_t inputlen)
 {
-    unsigned char scratchpad[SCRYPT_BUFFER_SIZE];
-    return scrypt_nosalt(input, inputlen, scratchpad);
+    static thread_local std::vector<unsigned char> scratchpad(SCRYPT_BUFFER_SIZE);
+    return scrypt_nosalt(input, inputlen, scratchpad.data());
 }
 
 uint256 scrypt_salted_hash(const void* input, size_t inputlen, const void* salt, size_t saltlen)
 {
-    unsigned char scratchpad[SCRYPT_BUFFER_SIZE];
-    return scrypt(input, inputlen, salt, saltlen, scratchpad);
+    static thread_local std::vector<unsigned char> scratchpad(SCRYPT_BUFFER_SIZE);
+    return scrypt(input, inputlen, salt, saltlen, scratchpad.data());
 }
 
 uint256 scrypt_salted_multiround_hash(const void* input, size_t inputlen, const void* salt, size_t saltlen, const unsigned int nRounds)
@@ -193,7 +194,6 @@ uint256 scrypt_salted_multiround_hash(const void* input, size_t inputlen, const 
 
 uint256 scrypt_blockhash(const void* input)
 {
-    unsigned char scratchpad[SCRYPT_BUFFER_SIZE];
-    return scrypt_nosalt(input, 80, scratchpad);
+    static thread_local std::vector<unsigned char> scratchpad(SCRYPT_BUFFER_SIZE);
+    return scrypt_nosalt(input, 80, scratchpad.data());
 }
-


### PR DESCRIPTION
This PR implements Alpine Linux in CI. It also makes some minor modifications to depends and the src/qt/CMakeLists.txt to allow a successful depends build in Alpine to produce a MUSL statically linked binary.

Alpine MUSL binaries were successfully compiling and passing the unit tests, but a real run of the wallet in Alpine was resulting in segfaults. This was tracked down to an issue in scrypt.cpp where the scratchpad was too large for MUSL's default stack size (~128 kB). Rather than trying to adjust the stack size, it was better to refactor scrypt.cpp to get the scratchpad off the stack. This buffer is now a `static thread_local` vector, moving the storage to the heap.


