### PR TITLE
poll, voting: Unable to create a "protocol development" poll? Issue #2785

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -99,7 +99,26 @@ install_deps() {
             append_base libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libqrencode-dev libzip-dev libcurl4-openssl-dev zipcmp zipmerge ziptool
 
             # Qt6 Packages (Qt5 names are not defined here as most are EOL)
-            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev libqt6core5compat6-dev
+            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev
+
+            # The Qt6Core5Compat dev package was renamed across the Debian/Ubuntu
+            # family in mid-2026:
+            #   - Debian Sid (and forky/trixie) ship only `qt6-5compat-dev`;
+            #     the older `libqt6core5compat6-dev` was dropped.
+            #   - Ubuntu Noble (24.04) ships both -- `libqt6core5compat6-dev` is
+            #     a transitional that pulls in `qt6-5compat-dev`.
+            #   - Ubuntu Jammy (22.04) ships only `libqt6core5compat6-dev`.
+            # Detect which name is available in the current apt cache and use
+            # that. Apt-cache is already populated by this point in the CI
+            # runners (the OS-detect block above triggered an `apt update`
+            # transitively) and on bare-metal dev systems this falls through
+            # to whichever name resolves. `-q -q` keeps the detection quiet on
+            # the success path.
+            if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
+                append_qt qt6-5compat-dev
+            else
+                append_qt libqt6core5compat6-dev
+            fi
 
             # Windows Cross-Compile Tools
             # NOTE: We only append NSIS here. The MinGW compiler (g++-mingw-w64-x86-64)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -73,6 +73,7 @@ public:
         consensus.ProtocolVersionGracePeriod = 900 * 7; // ~6.5 days
         consensus.PollV3Height = 2671700;
         consensus.ProjectV2Height = 2671700;
+        consensus.PollMultiAddressHeight = std::numeric_limits<int>::max();
         consensus.AutoGreylistAuditHeight = 3989800;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
@@ -197,6 +198,7 @@ public:
         consensus.ProtocolVersionGracePeriod = 900 * 21; // ~19.6 days — extended because v14 fork preceded deployment
         consensus.PollV3Height = 1944820;
         consensus.ProjectV2Height = 1944820;
+        consensus.PollMultiAddressHeight = std::numeric_limits<int>::max();
         consensus.AutoGreylistAuditHeight = 3111000;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -164,6 +164,13 @@ inline bool IsProjectV2Enabled(int nHeight)
     return nHeight >= Params().GetConsensus().ProjectV2Height;
 }
 
+inline bool IsPollMultiAddressEnabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate testing.
+
+    return nHeight >= gArgs.GetArg("-pollmultiaddressheight", Params().GetConsensus().PollMultiAddressHeight);
+}
+
 inline bool IsAutoGreylistAuditEnabled(int nHeight)
 {
     return nHeight >= Params().GetConsensus().AutoGreylistAuditHeight;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -166,8 +166,8 @@ inline bool IsProjectV2Enabled(int nHeight)
 
 inline bool IsPollMultiAddressEnabled(int nHeight)
 {
-    // The argument driven override temporarily here to facilitate testing.
-
+    // The argument-driven override is temporary, to facilitate testing on the
+    // isolated testnet before the activation height is set in chainparams.
     return nHeight >= gArgs.GetArg("-pollmultiaddressheight", Params().GetConsensus().PollMultiAddressHeight);
 }
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -47,6 +47,8 @@ struct Params {
     int PollV3Height;
     /** Block height at which project v2 contracts are allowed */
     int ProjectV2Height;
+    /** Block height at which poll multi-address eligibility claims are required */
+    int PollMultiAddressHeight;
     /** Block height at which project v4 contracts are allowed */
     int ProjectV4Height;
     /** Height at which the benefit of the doubt logic is enabled for autogreylist evaluation */

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1302,7 +1302,7 @@ CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& c
     SelectFinalInputs<PollPayload>(*pwallet, tx);
     PollPayload& poll_payload = tx.vContracts.back().SharePayload().As<PollPayload>();
 
-    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: tx contract payload claim with %u address(es), poll title %s.",
+    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: tx contract payload claim with %" PRIszu " address(es), poll title %s.",
              __func__,
              poll_payload.m_claim.m_balance_claim.m_address_claims.size(),
              poll_payload.m_poll.m_title

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -1257,7 +1257,7 @@ PollBuilder PollBuilder::AddAdditionalField(Poll::AdditionalField field)
     return std::move(*this);
 }
 
-CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version)
+CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pwallet) {
         throw VotingError(_("No wallet available."));

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -635,6 +635,10 @@ public:
     //!
     PollEligibilityClaim BuildClaim(const Poll& poll) const
     {
+        if (!IsPollMultiAddressEnabled(nBestHeight)) {
+            return BuildV1Claim(poll);
+        }
+
         PollEligibilityClaim claim;
         claim.m_version = 2;
 
@@ -744,6 +748,66 @@ public:
 
 private:
     const CWallet& m_wallet; //!< Supplies balance context and signing keys.
+
+    //!
+    //! \brief Generate a v1 single-address poll eligibility claim.
+    //!
+    //! Used before PollMultiAddressHeight activation to maintain backward
+    //! compatibility with nodes that do not understand v2 claims.
+    //!
+    //! \param poll Poll contract to generate the claim for.
+    //!
+    PollEligibilityClaim BuildV1Claim(const Poll& poll) const
+    {
+        std::vector<COutput> outputs;
+        m_wallet.AvailableCoins(outputs, true, nullptr, true);
+
+        // Group outputs by address
+        std::map<CKeyID, AddressOutputs> outputs_by_address;
+        for (const auto& output : outputs) {
+            if (output.tx->vout[output.i].nValue < COIN) continue;
+            if (!output.tx->IsTrusted() || !output.tx->IsConfirmed()) continue;
+
+            CTxDestination dest;
+            if (!ExtractDestination(output.tx->vout[output.i].scriptPubKey, dest)) continue;
+
+            const CKeyID* keyId = std::get_if<CKeyID>(&dest);
+            if (!keyId) continue;
+
+            auto it = outputs_by_address.find(*keyId);
+            if (it == outputs_by_address.end()) {
+                it = outputs_by_address.emplace(*keyId, AddressOutputs(*keyId)).first;
+            }
+            it->second.m_outpoints.emplace_back(output.tx->GetHash(), output.i);
+            it->second.m_total_amount += output.tx->vout[output.i].nValue;
+        }
+
+        // Find the first address with balance >= POLL_REQUIRED_BALANCE
+        const AddressClaimBuilder address_builder(m_wallet);
+        for (auto& [key_id, addr_outputs] : outputs_by_address) {
+            if (addr_outputs.m_total_amount < POLL_REQUIRED_BALANCE) continue;
+
+            // Trim to MAX_OUTPOINTS if needed
+            if (addr_outputs.m_outpoints.size() > PollEligibilityClaim::MAX_OUTPOINTS) {
+                addr_outputs.m_outpoints.resize(PollEligibilityClaim::MAX_OUTPOINTS);
+            }
+
+            if (auto claim_option = address_builder.TryBuildClaim(std::move(addr_outputs))) {
+                PollEligibilityClaim claim;
+                claim.m_version = 1;
+                claim.m_balance_claim.m_address_claims.push_back(std::move(*claim_option));
+
+                LogPrint(LogFlags::VOTE, "%s: Built v1 poll claim for address %s",
+                    __func__, EncodeDestination(key_id));
+
+                return claim;
+            }
+        }
+
+        throw VotingError(strprintf(
+            _("No single address has the required %s GRC balance to create a poll."),
+            FormatMoney(POLL_REQUIRED_BALANCE)));
+    }
 }; // PollClaimBuilder
 
 //!

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -633,7 +633,7 @@ public:
     //!
     //! \param poll Poll contract to generate the claim for.
     //!
-    PollEligibilityClaim BuildClaim(const Poll& poll) const
+    PollEligibilityClaim BuildClaim(const Poll& poll) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (!IsPollMultiAddressEnabled(nBestHeight)) {
             return BuildV1Claim(poll);

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -635,30 +635,88 @@ public:
     //!
     PollEligibilityClaim BuildClaim(const Poll& poll) const
     {
-        const AddressClaimBuilder builder(m_wallet);
         PollEligibilityClaim claim;
+        claim.m_version = 2;
 
-        for (auto& address : CoinPicker(m_wallet).PickCoins()) {
-            // Addresses are sorted in descending order by amount. We can exit
-            // early when we find an address less than the required amount:
-            if (address.m_total_amount < POLL_REQUIRED_BALANCE) {
-                break;
-            }
+        // STEP 1: Get ALL outputs, sort GLOBALLY by size (same as votes)
+        std::vector<COutput> outputs;
+        m_wallet.AvailableCoins(outputs, true, nullptr, true);
 
-            if (!TryTrimAddress(address)) {
-                continue;
-            }
+        const auto descending_by_amount = [](const COutput& a, const COutput& b) {
+            return a.tx->vout[a.i].nValue > b.tx->vout[b.i].nValue;
+        };
+        std::sort(outputs.begin(), outputs.end(), descending_by_amount);
 
-            if (auto claim_option = builder.TryBuildClaim(std::move(address))) {
-                claim.m_address_claim = std::move(*claim_option);
-                return claim;
+        LogPrint(LogFlags::VOTE, "%s: wallet supplied %" PRIszu " outputs",
+            __func__, outputs.size());
+
+        // STEP 2: Select top outputs (up to MAX_OUTPOINTS)
+        std::map<CKeyID, std::vector<COutPoint>> selected_by_address;
+        CAmount total_amount = 0;
+        size_t outpoint_count = 0;
+
+        for (const auto& output : outputs) {
+            if (outpoint_count >= PollEligibilityClaim::MAX_OUTPOINTS) break;
+
+            // Filter same as votes: >= 1 GRC, confirmed, P2PKH only
+            if (output.tx->vout[output.i].nValue < COIN) break;
+            if (!output.tx->IsTrusted() || !output.tx->IsConfirmed()) continue;
+
+            CTxDestination dest;
+            if (!ExtractDestination(output.tx->vout[output.i].scriptPubKey, dest)) continue;
+
+            const CKeyID* keyId = std::get_if<CKeyID>(&dest);
+            if (!keyId) continue;
+
+            // Add to selection
+            selected_by_address[*keyId].emplace_back(output.tx->GetHash(), output.i);
+            total_amount += output.tx->vout[output.i].nValue;
+            ++outpoint_count;
+
+            LogPrint(LogFlags::VOTE,
+                "  selected output for address %s: %s GRC (total: %s)",
+                EncodeDestination(*keyId),
+                FormatMoney(output.tx->vout[output.i].nValue),
+                FormatMoney(total_amount));
+
+            // Early exit if we have enough
+            if (total_amount >= POLL_REQUIRED_BALANCE) break;
+        }
+
+        // STEP 3: Verify sufficient balance
+        if (total_amount < POLL_REQUIRED_BALANCE) {
+            throw VotingError(strprintf(
+                _("Wallet balance of %s in top %s UTXOs is less than required %s GRC."),
+                FormatMoney(total_amount),
+                ToString(outpoint_count),
+                FormatMoney(POLL_REQUIRED_BALANCE)));
+        }
+
+        // STEP 4: Build address claims (same as votes)
+        const AddressClaimBuilder address_builder(m_wallet);
+        claim.m_balance_claim.m_address_claims.reserve(selected_by_address.size());
+
+        for (auto& [key_id, outpoints] : selected_by_address) {
+            AddressOutputs addr_outputs(key_id);
+            addr_outputs.m_outpoints = std::move(outpoints);
+
+            if (auto claim_option = address_builder.TryBuildClaim(std::move(addr_outputs))) {
+                claim.m_balance_claim.m_address_claims.emplace_back(
+                    std::move(*claim_option));
             }
         }
 
-        throw VotingError(strprintf(
-            _("No address contains %s GRC in %s UTXOs or fewer."),
-            FormatMoney(POLL_REQUIRED_BALANCE),
-            ToString(PollEligibilityClaim::MAX_OUTPOINTS)));
+        // STEP 5: Sort address claims
+        std::sort(claim.m_balance_claim.m_address_claims.begin(),
+                  claim.m_balance_claim.m_address_claims.end());
+
+        LogPrint(LogFlags::VOTE, "%s: Built poll claim: %s addresses, %s UTXOs, %s GRC",
+            __func__,
+            ToString(claim.m_balance_claim.m_address_claims.size()),
+            ToString(outpoint_count),
+            FormatMoney(total_amount));
+
+        return claim;
     }
 
     //!
@@ -674,54 +732,18 @@ public:
         const ClaimMessage message = PackPollMessage(payload.m_poll, tx);
         const AddressClaimBuilder builder(m_wallet);
 
-        return builder.SignClaim(payload.m_claim.m_address_claim, message);
-    }
-
-private:
-    const CWallet& m_wallet; //!< Supplies balance context and signing keys.
-
-    //!
-    //! \brief Remove outputs from the address until the address fits into a
-    //! poll address claim or until the total claimed amount for the address
-    //! falls below the required threshold.
-    //!
-    //! \param address The intermediate address container to trim.
-    //!
-    //! \return \c false if the trimmed amount for the address does not meet
-    //! the balance requirement for a poll.
-    //!
-    static bool TryTrimAddress(AddressOutputs& address)
-    {
-        std::vector<COutPoint>& outpoints = address.m_outpoints;
-        std::vector<CAmount>& amounts = address.m_amounts;
-
-        while (outpoints.size() > PollEligibilityClaim::MAX_OUTPOINTS) {
-            address.m_total_amount -= amounts.back();
-
-            if (address.m_total_amount < POLL_REQUIRED_BALANCE) {
-                LogPrint(LogFlags::VOTE, "%s: exceeded max outputs for %s",
-                    __func__,
-                    EncodeDestination(address.m_key_id));
-
+        // Sign all address claims in the balance claim
+        for (auto& address_claim : payload.m_claim.m_balance_claim.m_address_claims) {
+            if (!builder.SignClaim(address_claim, message)) {
                 return false;
             }
-
-            outpoints.pop_back();
-            amounts.pop_back();
-        }
-
-        // Trim any remaining outputs that we don't need to satisfy the balance
-        // requirement for the poll:
-        //
-        while (address.m_total_amount - amounts.back() > POLL_REQUIRED_BALANCE) {
-            outpoints.pop_back();
-            amounts.pop_back();
-
-            address.m_total_amount -= amounts.back();
         }
 
         return true;
     }
+
+private:
+    const CWallet& m_wallet; //!< Supplies balance context and signing keys.
 }; // PollClaimBuilder
 
 //!
@@ -1216,9 +1238,9 @@ CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& c
     SelectFinalInputs<PollPayload>(*pwallet, tx);
     PollPayload& poll_payload = tx.vContracts.back().SharePayload().As<PollPayload>();
 
-    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: tx contract payload claim address %s, poll title %s.",
+    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: tx contract payload claim with %u address(es), poll title %s.",
              __func__,
-             EncodeDestination(poll_payload.m_claim.m_address_claim.m_public_key.GetID()),
+             poll_payload.m_claim.m_balance_claim.m_address_claims.size(),
              poll_payload.m_poll.m_title
              );
 

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -229,7 +229,7 @@ public:
     //!
     //! \throws VotingError If the constructed poll is malformed.
     //!
-    CWalletTx BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version);
+    CWalletTx BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 private:
     std::unique_ptr<Poll> m_poll;    //!< The poll under construction.

--- a/src/gridcoin/voting/claims.cpp
+++ b/src/gridcoin/voting/claims.cpp
@@ -94,7 +94,9 @@ bool MagnitudeClaim::VerifySignature(
 
 void PollEligibilityClaim::ExpandDummySignatures()
 {
-    m_address_claim.m_signature.resize(SIGNATURE_BYTES_ESTIMATE);
+    for (auto& claim : m_balance_claim.m_address_claims) {
+        claim.m_signature.resize(SIGNATURE_BYTES_ESTIMATE);
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/src/gridcoin/voting/claims.h
+++ b/src/gridcoin/voting/claims.h
@@ -358,6 +358,7 @@ public:
     bool WellFormed() const
     {
         return m_version > 0 && m_version <= CURRENT_VERSION
+            && !m_balance_claim.m_address_claims.empty()
             && m_balance_claim.WellFormed()
             && TotalOutpoints() <= MAX_OUTPOINTS;
     }
@@ -369,8 +370,12 @@ public:
     //!
     CAmount RequiredBurnAmount() const
     {
-        // A scaled fee based on the number of claimed outputs:
-        return m_balance_claim.RequiredBurnAmount();
+        // Poll eligibility: per-UTXO fee only, no per-address overhead
+        CAmount amount = 0;
+        for (const auto& claim : m_balance_claim.m_address_claims) {
+            amount += claim.RequiredBurnAmount();
+        }
+        return amount;
     }
 
     //!
@@ -387,14 +392,17 @@ public:
         READWRITE(m_version);
 
         if (m_version == 1) {
-            // Legacy: single address claim (v1)
-            AddressClaim single_address_claim;
-            READWRITE(single_address_claim);
-
             if (ser_action.ForRead()) {
-                // Convert v1 (single address) to v2 (balance claim) format
+                AddressClaim single_address_claim;
+                READWRITE(single_address_claim);
                 m_balance_claim.m_address_claims.clear();
                 m_balance_claim.m_address_claims.push_back(std::move(single_address_claim));
+            } else {
+                // Write the actual first address claim
+                AddressClaim single_address_claim = !m_balance_claim.m_address_claims.empty()
+                    ? m_balance_claim.m_address_claims[0]
+                    : AddressClaim{};
+                READWRITE(single_address_claim);
             }
         } else {
             // Version 2+: multiple addresses via balance claim

--- a/src/gridcoin/voting/claims.h
+++ b/src/gridcoin/voting/claims.h
@@ -305,7 +305,7 @@ public:
     //! ensure that the serialization/deserialization routines also handle all
     //! of the previous versions.
     //!
-    static constexpr uint16_t CURRENT_VERSION = 1;
+    static constexpr uint16_t CURRENT_VERSION = 2;
 
     //!
     //! \brief The maximum number of unspent outputs that a poll can claim.
@@ -320,16 +320,30 @@ public:
     uint16_t m_version; //!< Version of the serialized claim format.
 
     //!
-    //! \brief Testifies that a participant owns an address with an unspent
-    //! balance great enough to create a poll.
+    //! \brief Testifies that a participant owns the unspent balance across
+    //! one or more addresses that is great enough to create a poll.
     //!
-    AddressClaim m_address_claim;
+    BalanceClaim m_balance_claim;
 
     //!
     //! \brief Initialize an empty, invalid poll eligibility claim.
     //!
     PollEligibilityClaim() : m_version(CURRENT_VERSION)
     {
+    }
+
+    //!
+    //! \brief Get the total number of outpoints across all address claims.
+    //!
+    //! \return The total count of outpoints claimed.
+    //!
+    size_t TotalOutpoints() const
+    {
+        size_t total = 0;
+        for (const auto& addr_claim : m_balance_claim.m_address_claims) {
+            total += addr_claim.m_outpoints.size();
+        }
+        return total;
     }
 
     //!
@@ -344,8 +358,8 @@ public:
     bool WellFormed() const
     {
         return m_version > 0 && m_version <= CURRENT_VERSION
-            && m_address_claim.WellFormed()
-            && m_address_claim.m_outpoints.size() <= MAX_OUTPOINTS;
+            && m_balance_claim.WellFormed()
+            && TotalOutpoints() <= MAX_OUTPOINTS;
     }
 
     //!
@@ -356,7 +370,7 @@ public:
     CAmount RequiredBurnAmount() const
     {
         // A scaled fee based on the number of claimed outputs:
-        return m_address_claim.RequiredBurnAmount();
+        return m_balance_claim.RequiredBurnAmount();
     }
 
     //!
@@ -371,7 +385,21 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(m_version);
-        READWRITE(m_address_claim);
+
+        if (m_version == 1) {
+            // Legacy: single address claim (v1)
+            AddressClaim single_address_claim;
+            READWRITE(single_address_claim);
+
+            if (ser_action.ForRead()) {
+                // Convert v1 (single address) to v2 (balance claim) format
+                m_balance_claim.m_address_claims.clear();
+                m_balance_claim.m_address_claims.push_back(std::move(single_address_claim));
+            }
+        } else {
+            // Version 2+: multiple addresses via balance claim
+            READWRITE(m_balance_claim);
+        }
     }
 }; // PollEligibilityClaim
 

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -368,6 +368,7 @@ PollReference::PollReference()
     : m_txid(uint256{})
     , m_payload_version(0)
     , m_type(PollType::UNKNOWN)
+    , m_weight_type(PollWeightType::UNKNOWN)
     , m_ptitle(nullptr)
     , m_timestamp(0)
     , m_duration_days(0)
@@ -1088,6 +1089,17 @@ bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
         return false;
     }
 
+    // Reject v2+ claims before multi-address activation (bidirectional enforcement)
+    if (!IsPollMultiAddressEnabled(ctx.m_pindex->nHeight)
+        && payload->m_claim.m_version >= 2) {
+        DoS = 25;
+        LogPrint(LogFlags::CONTRACT,
+            "%s: rejected v2 poll claim before multi-address activation at height %d",
+            __func__,
+            ctx.m_pindex->nHeight);
+        return false;
+    }
+
     // Enforce multi-address claims at PollMultiAddressHeight
     if (IsPollMultiAddressEnabled(ctx.m_pindex->nHeight)
         && payload->m_claim.m_version < 2) {
@@ -1152,6 +1164,7 @@ void PollRegistry::AddPoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(
         poll_ref.m_title = poll_title;
         poll_ref.m_payload_version = payload->m_version;
         poll_ref.m_type = payload->m_poll.m_type.Value();
+        poll_ref.m_weight_type = payload->m_poll.m_weight_type.Value();
         poll_ref.m_timestamp = ctx.m_tx.nTime;
         poll_ref.m_duration_days = payload->m_poll.m_duration_days;
 
@@ -1242,7 +1255,13 @@ void PollRegistry::DeletePoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIR
 
     int64_t poll_time = payload->m_poll.m_timestamp;
 
-    PollReference* poll_ref = TryBy(payload->m_poll.m_title);
+    PollReference* poll_ref = TryBy(ToLower(payload->m_poll.m_title));
+
+    if (!poll_ref) {
+        LogPrint(BCLog::LogFlags::VOTE, "%s: poll \"%s\" not found in registry.",
+                 __func__, payload->m_poll.m_title);
+        return;
+    }
 
     if (poll_ref) {
         // Note this reference will effectively disappear once this function exits, but this is ok, because there will

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -178,7 +178,18 @@ public:
         const ClaimMessage message = PackPollMessage(payload.m_poll, tx);
 
         try {
-            return VerifyClaim(payload.m_claim.m_address_claim, message);
+            if (payload.m_claim.m_version == 1) {
+                // Legacy single address (converted by serialization)
+                if (payload.m_claim.m_balance_claim.m_address_claims.size() != 1) {
+                    return false;
+                }
+                return VerifyAddressClaim(
+                    payload.m_claim.m_balance_claim.m_address_claims[0],
+                    message);
+            } else {
+                // Version 2+: multiple addresses
+                return VerifyBalanceClaim(payload.m_claim.m_balance_claim, message);
+            }
         } catch (const InvalidPollError& e) {
             LogPrint(LogFlags::VOTE, "%s: bad poll claim", __func__);
             return false;
@@ -187,6 +198,36 @@ public:
 
 private:
     CTxDB& m_txdb; //!< Used to resolve unspent amount claims.
+
+    //!
+    //! \brief Determine whether the balance claim (multiple addresses)
+    //! establishes eligibility for creating the poll.
+    //!
+    //! \param claim   The balance claim to verify minimum balance for.
+    //! \param message Serialized context for claim signature verification.
+    //!
+    //! \return \c true If the resolved amount for the claim meets the
+    //! minimum balance requirement to create a poll.
+    //!
+    bool VerifyBalanceClaim(const BalanceClaim& claim, const ClaimMessage& message)
+    {
+        CAmount total_amount = 0;
+
+        for (const auto& address_claim : claim.m_address_claims) {
+            if (!address_claim.VerifySignature(message)) {
+                LogPrint(LogFlags::VOTE, "%s: bad address signature", __func__);
+                return false;
+            }
+
+            const CTxDestination address = address_claim.m_public_key.GetID();
+
+            for (const auto& txo : address_claim.m_outpoints) {
+                total_amount += Resolve(txo, address);
+            }
+        }
+
+        return total_amount >= POLL_REQUIRED_BALANCE;
+    }
 
     //!
     //! \brief Determine whether the address claim establishes eligibility for
@@ -198,7 +239,7 @@ private:
     //! \return \c true If the resolved amount for the claim meets the
     //! minimum balance requirement to create a poll.
     //!
-    bool VerifyClaim(const AddressClaim& claim, const ClaimMessage& message)
+    bool VerifyAddressClaim(const AddressClaim& claim, const ClaimMessage& message)
     {
         if (!claim.VerifySignature(message)) {
             LogPrint(LogFlags::VOTE, "%s: bad address signature", __func__);
@@ -1042,10 +1083,19 @@ bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
 
     const auto payload = ctx->SharePayloadAs<PollPayload>();
 
-    // This is why we had to introduce BlockValidate, and this is critical
-    // to ensure that v2 poll payloads are not allowed in blocks for the v3
-    // height and beyond.
+    // Enforce v3 polls at PollV3Height
     if (IsPollV3Enabled(ctx.m_pindex->nHeight) && payload->m_version < 3) {
+        return false;
+    }
+
+    // Enforce multi-address claims at PollMultiAddressHeight
+    if (IsPollMultiAddressEnabled(ctx.m_pindex->nHeight)
+        && payload->m_claim.m_version < 2) {
+        DoS = 25;
+        LogPrint(LogFlags::CONTRACT,
+            "%s: rejected v1 poll claim after multi-address activation at height %d",
+            __func__,
+            ctx.m_pindex->nHeight);
         return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -673,6 +673,13 @@ void SetupServerArgs()
     hidden_args.emplace_back("-scrapersleep");
     hidden_args.emplace_back("-activebeforesb");
 
+    // Feature-specific consensus-height test overrides. Each entry pairs with a
+    // gArgs.GetArg(...) call in the corresponding IsXxxEnabled helper in
+    // chainparams.h. Registering them here suppresses the "argument not
+    // registered" startup warning when an isolated-testnet node sets the
+    // height via the override.
+    hidden_args.emplace_back("-pollmultiaddressheight");
+
     // This puts hidden options in the form of -clear<type>history, where <type> is the contract types that have a
     // registry with a backing db. This is currently beacon, project, protocol, and scraper, with sidestakes starting
     // at V13 height.

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -291,7 +291,7 @@ UniValue PollClaimToJson(const PollEligibilityClaim& claim)
     UniValue json(UniValue::VOBJ);
 
     json.pushKV("version", (uint64_t)claim.m_version);
-    json.pushKV("address_claim", AddressClaimToJson(claim.m_address_claim));
+    json.pushKV("balance_claim", BalanceClaimToJson(claim.m_balance_claim));
 
     return json;
 }


### PR DESCRIPTION
# Implementation Proposal: Multi-Address Poll Eligibility Claims

## Problem Summary

Currently, `PollEligibilityClaim` only supports a **single address**, while `VoteWeightClaim` supports **multiple addresses**. This causes poll creation to fail when a user has 100K+ GRC spread across multiple addresses, even though they meet the balance requirement.

**Example failure case:**
- User has 120K GRC total
- Spread across 5 addresses (24K each)
- No single address has 100K → **Poll creation fails** ❌

## Proposed Solution

Replicate the "general attestation algorithm for votes" by:
1. Sorting **all UTXOs globally** by size (largest first)
2. Taking the top N UTXOs (up to `MAX_OUTPOINTS = 250`)
3. Grouping by address for signing
4. Supporting **multiple addresses** in the claim (like votes)