### PR TITLE
gui: Fix build failures with -Werror=odr,lto-type-mismatch in notificator

### DIFF
--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -37,10 +37,8 @@ QObject(_parent),
 parent(_parent),
 programName(_programName),
 mode(None),
-trayIcon(_trayIcon)
-#ifdef USE_DBUS
-    ,interface(nullptr)
-#endif
+trayIcon(_trayIcon),
+interface(nullptr)
 {
     if(_trayIcon && _trayIcon->supportsMessages())
     {

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -6,9 +6,7 @@
 
 QT_BEGIN_NAMESPACE
 class QSystemTrayIcon;
-#ifdef USE_DBUS
 class QDBusInterface;
-#endif
 QT_END_NAMESPACE
 
 /** Cross-platform desktop notification client. */
@@ -54,11 +52,9 @@ private:
     QString programName;
     Mode mode;
     QSystemTrayIcon *trayIcon;
-#ifdef USE_DBUS
     QDBusInterface *interface;
 
     void notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
-#endif
     void notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout);
 #ifdef Q_OS_MAC
     void notifyMacUserNotificationCenter(const QString &title, const QString &text);


### PR DESCRIPTION
The Notificator class had inconsistent definitions across translation units due to conditional compilation of the QDBusInterface member and its forward declaration.  This violated the One Definition Rule (ODR) and triggered -Werror=odr and -Werror=lto-type-mismatch errors.

Move QDBusInterface forward declaration outside #ifdef USE_DBUS and unconditionally include the interface member in the class definition.

The DBus method implementations remain conditionally compiled, preserving build configuration flexibility while ensuring consistent class layout across all translation units.

Fixes: #2835