### PR TITLE
consensus, autogreylist: Fix autogreylisting flutter

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -71,6 +71,7 @@ public:
         consensus.BlockV13Height = std::numeric_limits<int>::max();
         consensus.PollV3Height = 2671700;
         consensus.ProjectV2Height = 2671700;
+        consensus.AutoGreylistAuditHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
@@ -192,6 +193,7 @@ public:
         consensus.BlockV13Height = 2870000;
         consensus.PollV3Height = 1944820;
         consensus.ProjectV2Height = 1944820;
+        consensus.AutoGreylistAuditHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -171,6 +171,12 @@ inline bool IsProjectV2Enabled(int nHeight)
     return nHeight >= Params().GetConsensus().ProjectV2Height;
 }
 
+inline bool IsAutoGreylistAuditEnabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate testing.
+    return nHeight >= gArgs.GetArg("-autogreylistauditheight", Params().GetConsensus().AutoGreylistAuditHeight);
+}
+
 inline bool IsSuperblockV3Enabled(int nHeight)
 {
     // The argument driven override temporarily here to facilitate testing.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -42,6 +42,8 @@ struct Params {
     int ProjectV2Height;
     /** Block height at which project v4 contracts are allowed */
     int ProjectV4Height;
+    /** Height at which the benefit of the doubt logic is enabled for autogreylist evaluation */
+    int AutoGreylistAuditHeight;
     /**
       * @brief The default GRC paid for a constant block reward.
       *

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -449,6 +449,9 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
         return;
     }
 
+    // [Added] Determine the flag based on the height of the superblock being processed.
+    bool use_benefit_of_doubt = IsAutoGreylistAuditEnabled(superblock_ptr_in.m_height);
+
     unsigned int superblock_count = 0;
 
     // Notice the superblock_ptr_in m_projects_all_cpid_total_credits MUST ALREADY BE POPULATED to record the TC state into
@@ -545,23 +548,26 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
 
             auto project = superblock_ptr->m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits.find(iter.m_name);
 
-                   // This record MUST be found, because for the record to be in the whitelist, it must have at least a first record.
+            // This record MUST be found, because for the record to be in the whitelist, it must have at least a first record.
             auto project_first_active = project_first_actives.find(iter.m_name);
 
-                   // The purpose of this time comparison is to ONLY post greylist candidate entry (updates) for superblocks that are
-                   // equal to or after the first entry date. Remember we are going backwards here. There cannot be entries held against
-                   // a whitelisted project from before it was ever whitelisted. This check is required to ensure the greylist rules work
-                   // correctly for newly whitelisted projects that are within the 40 day window for WAS and 20 day window for ZCD.
+            // The purpose of this time comparison is to ONLY post greylist candidate entry (updates) for superblocks that are
+            // equal to or after the first entry date. Remember we are going backwards here. There cannot be entries held against
+            // a whitelisted project from before it was ever whitelisted. This check is required to ensure the greylist rules work
+            // correctly for newly whitelisted projects that are within the 40 day window for WAS and 20 day window for ZCD.
             if (project_first_active != project_first_actives.end()
                 && superblock_ptr.m_timestamp >= project_first_active->second->m_timestamp) {
                 if (project != superblock_ptr->m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits.end()) {
                     // Update greylist candidate entry with the total credit for each project present in superblock.
-                    greylist_entry->second.UpdateGreylistCandidateEntry(project->second, superblock_count);
+                    // [Changed] Pass use_benefit_of_doubt
+                    greylist_entry->second.UpdateGreylistCandidateEntry(project->second, superblock_count, use_benefit_of_doubt);
                 } else {
                     // Record updated greylist candidate entry with nullopt total credit. This is for a project that is in the
                     // whitelist, but does not have a project entry in this superblock. This would be because the scrapers could
                     // not converge on the project for this superblock.
-                    greylist_entry->second.UpdateGreylistCandidateEntry(std::optional<uint64_t>(std::nullopt), superblock_count);
+                    // [Changed] Pass use_benefit_of_doubt
+                    greylist_entry->second.UpdateGreylistCandidateEntry(std::optional<uint64_t>(std::nullopt), superblock_count,
+                                                                        use_benefit_of_doubt);
                 }
             }
         }

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -606,6 +606,17 @@ void AutoGreylist::RefreshWithAndUpdateSuperblock(Superblock& superblock) EXCLUS
             superblock.m_project_status.m_project_status.insert(std::make_pair(project.m_name, project.m_status));
         }
     }
+
+    // Invalidate m_superblock_hash so that Refresh() re-evaluates with the actual on-chain superblock. The evaluation
+    // above used a candidate superblock bound to pindexBest, which may be past the most recent superblock block height.
+    // When pindexBest > SB height, the just-staked superblock appears as a historical entry (sb_from_baseline == 1) with
+    // identical TC to the candidate (built from stale convergence), producing a false ZCD. Since the quorum hash excludes
+    // m_project_status, the candidate hash equals the on-chain superblock hash, causing Refresh() to false cache-hit and
+    // perpetuate the inflated ZCD. Resetting here forces Refresh() to re-evaluate at the correct baseline height.
+    {
+        LOCK(autogreylist_lock);
+        m_superblock_hash = Superblock().GetHash();
+    }
 }
 
 void AutoGreylist::Reset()

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -647,8 +647,8 @@ public:
         //!
         //! \param total_credit
         //! \param sb_from_baseline
-        //!
-        void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline)
+        //! \param use_benefit_of_doubt Flag to enable the benefit of the doubt logic for the head superblock.
+        void UpdateGreylistCandidateEntry(std::optional<uint64_t> total_credit, uint8_t sb_from_baseline, bool use_benefit_of_doubt)
         {
             if (sb_from_baseline > 0) {
                 // ZCD part. Remember we are going backwards, so if total_credit is greater than or equal to
@@ -658,7 +658,20 @@ public:
                     // If total credit is greater than the bookmark, this means that (going forward in time) credit actually
                     // declined, so we must add a day for the credit decline (going forward in time). If total credit
                     // is std::nullopt, then this means no statistics available, which also is a ZCD.
-                    if ((total_credit && total_credit >= m_TC_bookmark) || !total_credit){
+
+                    // [Added] Benefit of the Doubt Exception
+                    // If the initial bookmark (Head/Candidate) is missing, that means the project is missing from
+                    // the CURRENT superblock (the baseline). This is likely a transient local scraper failure on
+                    // the staking node. We give the "benefit of the doubt" for this one specific interval
+                    // (sb_from_baseline == 1) to prevent a single node's connection issue from forcing
+                    // a greylist event.
+                    bool head_scraper_failure = false;
+
+                    if (use_benefit_of_doubt) {
+                        head_scraper_failure = (sb_from_baseline == 1 && !m_TC_initial_bookmark);
+                    }
+
+                    if (!head_scraper_failure && ((total_credit && total_credit >= m_TC_bookmark) || !total_credit)){
                         ++m_zcd_20_SB_count;
                     }
                 }

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1377,4 +1377,159 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
     delete whitelist_index_entry;
 }
 
+BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
+{
+    /**
+     * This test exercises the "Benefit of the Doubt" logic in the AutoGreylist system. When a staking node's scraper
+     * fails to reach a project, the head superblock is missing the project's total credit entry. Without the
+     * benefit-of-doubt fix, std::optional comparison semantics cause the valid historical SB at sb_from_baseline == 1
+     * to be counted as a false ZCD (because any engaged optional >= nullopt in C++17). The fix suppresses this false
+     * ZCD at the head position.
+     *
+     * The test also verifies the "deferred penalty": once a good SB becomes the new head and the bad SB ages to
+     * sb_from_baseline == 1, the missing data is correctly counted as a ZCD.
+     *
+     * Scenario A (benefit-of-doubt ON, head missing):
+     *   Head (nullopt) -> SB-1 (TC=1000) -> SB-2 (TC=500)
+     *   Expected: ZCD = 0 (false ZCD suppressed at sb==1)
+     *
+     * Scenario A' (benefit-of-doubt OFF, same data):
+     *   Expected: ZCD = 1 (false ZCD counted at sb==1)
+     *
+     * Scenario B (deferred penalty, good head after bad SB):
+     *   Head (TC=2000) -> SB-1 (nullopt) -> SB-2 (TC=1000) -> SB-3 (TC=500)
+     *   Expected: ZCD = 1 (nullopt at sb==1 correctly counted, benefit-of-doubt does not apply
+     *   because head has data)
+     */
+
+    GRC::Whitelist& whitelist = GRC::GetWhitelist();
+
+    std::shared_ptr<GRC::AutoGreylist> auto_greylist = GRC::GetAutoGreylistCache();
+
+    whitelist.Reset();
+
+    int height = 0;
+    int64_t time = 0;
+
+    // Add a project for testing.
+    AddProjectEntry(3, "bod_test", "http://bod.test", false, height, time, true);
+
+    // Create dummy CBlockIndex for the whitelist entry.
+    CBlockIndex* whitelist_index_entry = new CBlockIndex;
+
+    ++height;
+    ++time;
+
+    // ---- Build the superblock chain: SB1(TC=500), SB2(TC=1000), SB3(nullopt), SB4(TC=2000) ----
+
+    auto unit_test_blocks = std::make_shared<std::map<int, std::pair<CBlockIndex*, GRC::SuperblockPtr>>>();
+
+    CBlockIndex* index_ptr = whitelist_index_entry;
+    CBlockIndex* index_ptr_prev = nullptr;
+
+    // Helper to build a superblock at the next height.
+    auto build_sb = [&](std::optional<uint64_t> tc) {
+        index_ptr_prev = index_ptr;
+        index_ptr = new CBlockIndex;
+        index_ptr->nHeight = height;
+        index_ptr->nTime = time;
+        index_ptr->MarkAsSuperblock();
+        index_ptr->pprev = index_ptr_prev;
+
+        GRC::Superblock superblock = GRC::Superblock();
+
+        if (tc) {
+            superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits
+                .insert(std::make_pair("bod_test", *tc));
+        }
+
+        GRC::SuperblockPtr superblock_ptr = GRC::SuperblockPtr();
+        superblock_ptr.Replace(superblock);
+        superblock_ptr.Rebind(index_ptr);
+
+        unit_test_blocks->insert(std::make_pair(height, std::make_pair(index_ptr, superblock_ptr)));
+
+        ++height;
+        ++time;
+    };
+
+    build_sb(500);    // SB at height 1: TC = 500
+    build_sb(1000);   // SB at height 2: TC = 1000
+    build_sb({});     // SB at height 3: TC = nullopt (scraper failure)
+    build_sb(2000);   // SB at height 4: TC = 2000
+
+    // ---- Scenario A: Benefit-of-doubt ON, head is the bad SB (nullopt at height 3) ----
+    // Head: nullopt -> sb_from_baseline==1: TC=1000 -> sb_from_baseline==2: TC=500
+    // Expected: ZCD = 0 (benefit-of-doubt suppresses false ZCD at sb==1)
+
+    gArgs.ForceSetArg("-autogreylistauditheight", "0");
+
+    auto_greylist->Reset();
+
+    // Use SB at height 3 (nullopt) as the head.
+    auto head_iter = unit_test_blocks->find(3);
+    auto_greylist->RefreshWithSuperblock(head_iter->second.second, unit_test_blocks);
+
+    {
+        auto greylist_candidate = auto_greylist->begin()->second;
+
+        LogPrintf("info: %s: Scenario A (BoD ON, head missing) - ZCD = %u (expected 0)",
+                  "it_applies_benefit_of_doubt_correctly", greylist_candidate.m_zcd_20_SB_count);
+
+        BOOST_CHECK_EQUAL(greylist_candidate.m_zcd_20_SB_count, 0);
+    }
+
+    // ---- Scenario A': Same data, benefit-of-doubt OFF ----
+    // Expected: ZCD = 1 (TC=1000 >= nullopt bookmark at sb==1 -> false ZCD counted)
+
+    gArgs.ForceSetArg("-autogreylistauditheight", ToString(std::numeric_limits<int>::max()));
+
+    auto_greylist->Reset();
+
+    auto_greylist->RefreshWithSuperblock(head_iter->second.second, unit_test_blocks);
+
+    {
+        auto greylist_candidate = auto_greylist->begin()->second;
+
+        LogPrintf("info: %s: Scenario A' (BoD OFF, head missing) - ZCD = %u (expected 1)",
+                  "it_applies_benefit_of_doubt_correctly", greylist_candidate.m_zcd_20_SB_count);
+
+        BOOST_CHECK_EQUAL(greylist_candidate.m_zcd_20_SB_count, 1);
+    }
+
+    // ---- Scenario B: Deferred penalty — bad SB ages past head, benefit-of-doubt ON ----
+    // Head: TC=2000 -> sb_from_baseline==1: nullopt -> sb_from_baseline==2: TC=1000 -> sb_from_baseline==3: TC=500
+    // Expected: ZCD = 1 (nullopt at sb==1 correctly counted; benefit-of-doubt does NOT apply because head has data)
+
+    gArgs.ForceSetArg("-autogreylistauditheight", "0");
+
+    auto_greylist->Reset();
+
+    // Use SB at height 4 (TC=2000) as the head.
+    head_iter = unit_test_blocks->find(4);
+    auto_greylist->RefreshWithSuperblock(head_iter->second.second, unit_test_blocks);
+
+    {
+        auto greylist_candidate = auto_greylist->begin()->second;
+
+        LogPrintf("info: %s: Scenario B (BoD ON, deferred penalty) - ZCD = %u (expected 1)",
+                  "it_applies_benefit_of_doubt_correctly", greylist_candidate.m_zcd_20_SB_count);
+
+        BOOST_CHECK_EQUAL(greylist_candidate.m_zcd_20_SB_count, 1);
+    }
+
+    // ---- Cleanup ----
+
+    // Restore default (disabled) state.
+    gArgs.ForceSetArg("-autogreylistauditheight", ToString(std::numeric_limits<int>::max()));
+
+    for (auto& iter : *unit_test_blocks) {
+        delete iter.second.first;
+    }
+
+    unit_test_blocks->clear();
+
+    delete whitelist_index_entry;
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Fix AutoGreylist flickering via "Benefit of the Doubt" logic and quiescent period cache fix                                                                    
                                                                                                                                                                 
### Summary                                                                                                                                                        
                                                                                                                                                                 
  - Prevent single-node scraper failure from triggering false greylisting at the head superblock position. When a staking node's local scraper cannot reach a  project, the candidate superblock is missing that project's total credit entry. Without this fix, the std::optional comparison semantics cause a valid historical superblock to be misinterpreted as a Zero Credit Day (ZCD) — because any engaged optional compares >= to nullopt. The "Benefit of the Doubt" logic detects when the head superblock has no data for a project (sb_from_baseline == 1 && !m_TC_initial_bookmark) and skips the ZCD increment for that single interval. The penalty is deferred — once the bad superblock ages into history, it is counted normally. Activation is gated by a configurable AutoGreylistAuditHeight consensus parameter.
  - Fix false ZCD inflation during the scraper quiescent period. After a superblock stakes, the scraper completes one final loop before going quiescent, triggering ScraperHousekeeping() which calls RefreshWithAndUpdateSuperblock(). The candidate superblock is bound to pindexBest (which has advanced past the superblock block height), causing the just-staked superblock to appear as a historical entry at sb_from_baseline == 1 with identical total credit — producing a false ZCD. Because the quorum hash excludes m_project_status, the candidate hash collides with the on-chain superblock hash, and Refresh() returns early with the inflated count. This persists for the entire quiescent period until scrapers wake up. The fix invalidates m_superblock_hash at the end of RefreshWithAndUpdateSuperblock(), forcing Refresh() to re-evaluate with the on-chain superblock at its correct baseline height.

 ### Test plan

  - On an isolated testnet fork with AutoGreylistAuditHeight activated, block one scraper node's access to a project and have that node stake — verify the project does not receive a false ZCD via the "Benefit of the Doubt" logic
  - Block two of three scraper nodes — verify the project correctly drops out of convergence after the 48-hour statistics retention window flushes
  - After a superblock stakes and scrapers go quiescent, run getautogreylist true true — verify no duplicate total credit entry at sb_from_baseline 0/1 and no inflated ZCD count
  - Verify the fix does not affect actual superblock staking — at staking time, fresh convergence data produces correct ZCD counts and project status
  - Unit test it_applies_benefit_of_doubt_correctly passes all three scenarios.
  
#### Actual isolated testnet fork of three nodes with AutoGreylistAuditHeight activated passes all tests.
 
#### There will be a testnet mandatory with this height set with 2 weeks worth of block height via a separate PR.
 
#### On mainnet this height will be coincident with the v13 block height when the mandatory height for mainnet is set.
