### PR TITLE
linter: Fix include circular dependency linter false positives

### DIFF
--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -3,9 +3,18 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/licenses/mit-license.php.
 
+import argparse
 import sys
 import re
 from typing import Dict, List, Set
+
+parser = argparse.ArgumentParser(description='Detect circular dependencies among source modules.')
+parser.add_argument('--headers-only', action='store_true',
+                    help='Only consider #include edges originating from header files. '
+                         'This detects true header-to-header cycles while ignoring '
+                         'module-level cycles caused by .cpp implementation includes.')
+parser.add_argument('files', nargs='*', help='Source files to analyze')
+args = parser.parse_args()
 
 MAPPING = {
     'core_read.cpp': 'core_io.cpp',
@@ -38,7 +47,7 @@ deps: Dict[str, Set[str]] = dict()
 RE = re.compile("^#include [<\"](.*)[\">]")
 
 # Iterate over files, and create list of modules
-for arg in sys.argv[1:]:
+for arg in args.files:
     module = module_name(arg)
     if module is None:
         print("Ignoring file %s (does not constitute module)\n" % arg)
@@ -49,6 +58,8 @@ for arg in sys.argv[1:]:
 # Iterate again, and build list of direct dependencies for each module
 # TODO: implement support for multiple include directories
 for arg in sorted(files.keys()):
+    if args.headers_only and not arg.endswith('.h'):
+        continue
     module = files[arg]
     with open(arg, 'r', encoding="utf8") as f:
         for line in f:

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -19,7 +19,6 @@ LINTALL=$(basename "${BASH_SOURCE[0]}")
 EXIT_CODE=0
 
 IGNORE_EXIT=(
-  "lint-circular-dependencies.sh"
 )
 
 for f in "${SCRIPTDIR}"/lint-*.sh; do

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -16,7 +16,7 @@ EXIT_CODE=0
 CIRCULAR_DEPENDENCIES=()
 
 IFS=$'\n'
-for CIRC in $(cd src && ../contrib/devtools/circular-dependencies.py {*,*/*,*/*/*}.{h,cpp} | sed -e 's/^Circular dependency: //'); do
+for CIRC in $(cd src && ../contrib/devtools/circular-dependencies.py --headers-only {*,*/*,*/*/*}.{h,cpp} | sed -e 's/^Circular dependency: //'); do
     CIRCULAR_DEPENDENCIES+=( "$CIRC" )
     IS_EXPECTED_CIRC=0
     for EXPECTED_CIRC in "${EXPECTED_CIRCULAR_DEPENDENCIES[@]}"; do

--- a/test/lint/lint-shell-locale.sh
+++ b/test/lint/lint-shell-locale.sh
@@ -16,7 +16,7 @@ for SHELL_SCRIPT in $(git ls-files -- "*.sh" | grep -vE "src/(secp256k1|univalue
     if grep -q "# This script is intentionally locale dependent by not setting \"export LC_ALL=C\"" "${SHELL_SCRIPT}"; then
         continue
     fi
-    FIRST_NON_COMMENT_LINE=$(grep -vE '^(#.*)?$' "${SHELL_SCRIPT}" | head -1)
+    FIRST_NON_COMMENT_LINE=$(grep -vE -m 1 '^(#.*)?$' "${SHELL_SCRIPT}")
     if [[ ${FIRST_NON_COMMENT_LINE} != "export LC_ALL=C" && ${FIRST_NON_COMMENT_LINE} != "export LC_ALL=C.UTF-8" ]]; then
         echo "Missing \"export LC_ALL=C\" (to avoid locale dependence) as first non-comment non-empty line in ${SHELL_SCRIPT}"
         EXIT_CODE=1


### PR DESCRIPTION
### Summary                                                                                                                                                        
                                                                                                                                                                 
  - Add --headers-only flag to circular-dependencies.py that restricts cycle detection to header-to-header include edges, eliminating 103 false positives caused by normal module-level cross-references (A.cpp includes B.h, B.cpp includes A.h)                                                                               
  - Use --headers-only in lint-circular-dependencies.sh so the linter enforces real header layering                                                              
  - Remove lint-circular-dependencies.sh from the IGNORE_EXIT list in lint-all.sh, making it a real CI gate again                                                
                                                                                                                                                                 
### Motivation                                                                                                                                                     
                                                                                                                                                                 
  The script (inherited from Bitcoin Core) treats foo.h and foo.cpp as a single "module". This is useful for Bitcoin Core's librarification/process-separation goals, but for Gridcoin's interconnected subsystems (scraper, beacon, tally, superblock, contracts) it produces only false positives. With --headers-only, the linter catches genuine problems (header include cycles that break compilation or create fragile include-order dependencies) while ignoring harmless implementation-level cross-references. If we later want to go down the road of strict "module" enforcement, we can adopt Bitcoin's exception list and strict module checking.                                                                                                                       

### Test plan

  - cd src && ../contrib/devtools/circular-dependencies.py --headers-only {*,*/*,*/*/*}.{h,cpp} reports zero cycles
  - cd src && ../contrib/devtools/circular-dependencies.py {*,*/*,*/*/*}.{h,cpp} still reports 103 cycles (backward compat)
  - test/lint/lint-circular-dependencies.sh passes
  - test/lint/lint-all.sh no longer exempts circular dependencies
  
  These tests are satisfied by the passing of CI and a clean linter log.
  
This PR also fixes the broken pipe errors on the running of the linter seen in the CI logs.

Closes #2160.
