### PR TITLE
build: remove stale generated test data headers from source tree

### DIFF
--- a/src/test/data/CMakeLists.txt
+++ b/src/test/data/CMakeLists.txt
@@ -1,3 +1,23 @@
+# Cleanup: Remove stale generated header files
+# =============================================
+# Prior build methods (and in-source builds) generated .json.h, .bin.h, and
+# .txt.h files directly in the source tree. CMake generates these in the build
+# directory, but stale source-tree copies shadow them via include path ordering,
+# causing the compiler to pick up outdated data.
+file(GLOB STALE_GENERATED_HEADERS
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.json.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.bin.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.txt.h"
+)
+
+if(STALE_GENERATED_HEADERS)
+    message(STATUS "Detected stale generated test data headers in source tree. Cleaning up...")
+    foreach(STALE_FILE ${STALE_GENERATED_HEADERS})
+        message(STATUS "  Removing: ${STALE_FILE}")
+        file(REMOVE "${STALE_FILE}")
+    endforeach()
+endif()
+
 set(JSON_TEST_FILES
     base58_encode_decode.json
     key_io_invalid.json


### PR DESCRIPTION
## Summary

- Add CMake cleanup logic to `src/test/data/CMakeLists.txt` that auto-removes stale `*.json.h`, `*.bin.h`, and `*.txt.h` files from the source tree during configure
- Prior build methods generated these files in-source; CMake generates them in the build directory, but stale source-tree copies shadow them via include path ordering (`CMAKE_SOURCE_DIR/src` before `CMAKE_BINARY_DIR/src`), causing the compiler to pick up outdated test data
- Follows the same pattern as the existing stale MOC file cleanup in `src/qt/CMakeLists.txt`

## Test plan

- [x] Run `cmake -B build -DENABLE_TESTS=ON` with stale `.json.h` files present in `src/test/data/` — verify they are removed and a status message is printed
- [x] Build and run `test_gridcoin` — verify `script_tests` uses the freshly generated headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)