### PR TITLE
staking: fix mandatory sidestake miscounting when staker address matches

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -880,9 +880,17 @@ private:
                             return error("%s: FAILED: coinstake output has invalid destination.");
                         }
 
+                        // Skip outputs to the coinstake destination. When a mandatory sidestake address matches
+                        // the staker's address, the miner suppresses the dedicated sidestake output and returns
+                        // the funds via the normal coinstake split outputs instead. Without this check, the
+                        // validator would miscount those split outputs as mandatory sidestakes.
+                        if (output_destination == coinstake_destination) {
+                            continue;
+                        }
+
                         std::vector<GRC::SideStake_ptr> mandatory_sidestake
                             = GRC::GetSideStakeRegistry().TryActive(output_destination,
-                                                                    GRC::SideStake::FilterFlag::MANDATORY);;
+                                                                    GRC::SideStake::FilterFlag::MANDATORY);
 
                         // The output is deemed to match if the destination matches AND the computed allocation matches or exceeds
                         // what is required by the mandatory sidestake. Note that the test uses the GRC::Allocation class, which


### PR DESCRIPTION
## Summary

- When a mandatory sidestake destination matches the staker's own address, the miner correctly suppresses the dedicated sidestake output and returns the funds via normal coinstake split outputs. However, the validator's mandatory sidestake counting loop did not skip outputs to the coinstake destination, causing it to miscount stake split outputs as mandatory sidestakes.
- This caused block rejection with `"The number of mandatory sidestakes in the coinstake is N, which is above the limit of 4"` when stake splitting produced more than 4 outputs to the staker's address.
- Also fixes a harmless double semicolon on a `TryActive()` call.

## Context

Found during HTLC integration testing on an isolated 3-node testnet. The staker's address happened to be the same as the sole mandatory sidestake address in the testnet's protocol registry. With stake splitting enabled, the validator miscounted 5 stake split outputs as mandatory sidestakes and rejected the staker's own blocks.

Not currently triggered on mainnet (no protocol-defined mandatory sidestakes exist yet), but would affect any future deployment of mandatory sidestakes.

## Test plan

- [x] Verified fix on isolated 3-node testnet — node that was previously failing to stake due to this error now stakes successfully
- [x] Code review of the change against the miner's equivalent logic (`SplitCoinStakeOutput` in `miner.cpp:1005-1006`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)