### PR TITLE
qt: Add thin space thousands separators to coin amounts

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -57,7 +57,11 @@ void BitcoinAmountField::setText(const QString &text)
     if (text.isEmpty())
         amount->clear();
     else
-        amount->setValue(text.toDouble());
+    {
+        QString cleaned = text;
+        cleaned.remove(BitcoinUnits::THIN_SPACE); // Strip thin space thousands separators
+        amount->setValue(cleaned.toDouble());
+    }
 }
 
 void BitcoinAmountField::clear()

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -4,6 +4,7 @@
 #include <QStringList>
 
 static constexpr auto MAX_DIGITS_BTC = 16;
+const QChar BitcoinUnits::THIN_SPACE(0x2009);
 
 BitcoinUnits::BitcoinUnits(QObject *parent):
         QAbstractListModel(parent),
@@ -101,8 +102,15 @@ QString BitcoinUnits::format(int unit, qint64 n, bool fPlus, bool justify)
     qint64 remainder = n_abs % coin;
     QString quotient_str = QString::number(quotient);
 
+    // Insert thin spaces (U+2009) as thousands separators in the integer part
+    for (int i = quotient_str.size() - 3; i > 0; i -= 3) {
+        quotient_str.insert(i, THIN_SPACE);
+    }
+
     if (justify) {
-        quotient_str = quotient_str.rightJustified(MAX_DIGITS_BTC - num_decimals, ' ');
+        int max_digits = MAX_DIGITS_BTC - num_decimals;
+        int max_separators = (max_digits - 1) / 3;
+        quotient_str = quotient_str.rightJustified(max_digits + max_separators, ' ');
     }
 
     QString remainder_str = QString::number(remainder).rightJustified(num_decimals, '0');
@@ -179,7 +187,12 @@ bool BitcoinUnits::parse(int unit, const QString &value, qint64 *val_out)
     if(!valid(unit) || value.isEmpty())
         return false; // Refuse to parse invalid unit or empty string
     int num_decimals = decimals(unit);
-    QStringList parts = value.split(".");
+
+    // Strip thin space thousands separators before parsing
+    QString cleaned = value;
+    cleaned.remove(THIN_SPACE);
+
+    QStringList parts = cleaned.split(".");
 
     if(parts.size() > 2)
     {

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -52,6 +52,8 @@ public:
     static QString formatOverviewRounded(qint64 amount, bool privacy = false);
     //! Parse string to coin amount
     static bool parse(int unit, const QString &value, qint64 *val_out);
+    //! Thin space (U+2009) used as thousands separator in formatted amounts
+    static const QChar THIN_SPACE;
     ///@}
 
     //! @name AbstractListModel implementation

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -491,19 +491,25 @@ void CoinControlDialog::clipboardQuantity()
 // copy label "Amount" to clipboard
 void CoinControlDialog::clipboardAmount()
 {
-    QApplication::clipboard()->setText(ui->coinControlAmountLabel->text().left(ui->coinControlAmountLabel->text().indexOf(" ")));
+    QString text = ui->coinControlAmountLabel->text().left(ui->coinControlAmountLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // copy label "Fee" to clipboard
 void CoinControlDialog::clipboardFee()
 {
-    QApplication::clipboard()->setText(ui->coinControlFeeLabel->text().left(ui->coinControlFeeLabel->text().indexOf(" ")));
+    QString text = ui->coinControlFeeLabel->text().left(ui->coinControlFeeLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // copy label "After fee" to clipboard
 void CoinControlDialog::clipboardAfterFee()
 {
-    QApplication::clipboard()->setText(ui->coinControlAfterFeeLabel->text().left(ui->coinControlAfterFeeLabel->text().indexOf(" ")));
+    QString text = ui->coinControlAfterFeeLabel->text().left(ui->coinControlAfterFeeLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // copy label "Bytes" to clipboard
@@ -521,7 +527,9 @@ void CoinControlDialog::clipboardLowOutput()
 // copy label "Change" to clipboard
 void CoinControlDialog::clipboardChange()
 {
-    QApplication::clipboard()->setText(ui->coinControlChangeLabel->text().left(ui->coinControlChangeLabel->text().indexOf(" ")));
+    QString text = ui->coinControlChangeLabel->text().left(ui->coinControlChangeLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // treeview: sort

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -19,7 +19,13 @@
 #include "guiconstants.h"
 #include "gridcoin/voting/fwd.h"
 
+#include <functional>
+
 #include <QAbstractItemDelegate>
+#include <QApplication>
+#include <QClipboard>
+#include <QLabel>
+#include <QMenu>
 #include <QPainter>
 
 #define DECORATION_SIZE 40
@@ -173,6 +179,31 @@ OverviewPage::OverviewPage(QWidget *parent) :
     showOutOfSyncWarning(true);
 
     showHideMRCToolButton();
+
+    // Set up right-click "Copy amount" context menus on balance labels
+    auto setupCopyMenu = [this](QLabel* label, std::function<qint64()> getAmount) {
+        label->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(label, &QWidget::customContextMenuRequested, this, [this, label, getAmount](const QPoint& pos) {
+            if (m_privacy) return;
+            QMenu menu;
+            menu.addAction(tr("Copy amount"), this, [this, getAmount]() {
+                int unit = walletModel->getOptionsModel()->getDisplayUnit();
+                QString text = BitcoinUnits::format(unit, getAmount());
+                text.remove(BitcoinUnits::THIN_SPACE);
+                QApplication::clipboard()->setText(text);
+            });
+            menu.exec(label->mapToGlobal(pos));
+        });
+    };
+
+    setupCopyMenu(ui->headerBalanceLabel, [this]() { return currentBalance; });
+    setupCopyMenu(ui->balanceLabel, [this]() { return currentBalance; });
+    setupCopyMenu(ui->stakeLabel, [this]() { return currentStake; });
+    setupCopyMenu(ui->unconfirmedLabel, [this]() { return currentUnconfirmedBalance; });
+    setupCopyMenu(ui->immatureLabel, [this]() { return currentImmatureBalance; });
+    setupCopyMenu(ui->totalLabel, [this]() {
+        return currentBalance + currentStake + currentUnconfirmedBalance + currentImmatureBalance;
+    });
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -405,19 +405,25 @@ void SendCoinsDialog::coinControlClipboardQuantity()
 // Coin Control: copy label "Amount" to clipboard
 void SendCoinsDialog::coinControlClipboardAmount()
 {
-    QApplication::clipboard()->setText(ui->coinControlAmountLabel->text().left(ui->coinControlAmountLabel->text().indexOf(" ")));
+    QString text = ui->coinControlAmountLabel->text().left(ui->coinControlAmountLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // Coin Control: copy label "Fee" to clipboard
 void SendCoinsDialog::coinControlClipboardFee()
 {
-    QApplication::clipboard()->setText(ui->coinControlFeeLabel->text().left(ui->coinControlFeeLabel->text().indexOf(" ")));
+    QString text = ui->coinControlFeeLabel->text().left(ui->coinControlFeeLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // Coin Control: copy label "After fee" to clipboard
 void SendCoinsDialog::coinControlClipboardAfterFee()
 {
-    QApplication::clipboard()->setText(ui->coinControlAfterFeeLabel->text().left(ui->coinControlAfterFeeLabel->text().indexOf(" ")));
+    QString text = ui->coinControlAfterFeeLabel->text().left(ui->coinControlAfterFeeLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // Coin Control: copy label "Bytes" to clipboard
@@ -435,7 +441,9 @@ void SendCoinsDialog::coinControlClipboardLowOutput()
 // Coin Control: copy label "Change" to clipboard
 void SendCoinsDialog::coinControlClipboardChange()
 {
-    QApplication::clipboard()->setText(ui->coinControlChangeLabel->text().left(ui->coinControlChangeLabel->text().indexOf(" ")));
+    QString text = ui->coinControlChangeLabel->text().left(ui->coinControlChangeLabel->text().indexOf(" "));
+    text.remove(BitcoinUnits::THIN_SPACE);
+    QApplication::clipboard()->setText(text);
 }
 
 // Coin Control: settings menu - coin control enabled/disabled by user

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(test_gridcoin-qt
     test_main.cpp
+    bitcoinunitstests.cpp
     uritests.cpp
 )
 

--- a/src/qt/test/bitcoinunitstests.cpp
+++ b/src/qt/test/bitcoinunitstests.cpp
@@ -1,0 +1,68 @@
+#include "bitcoinunitstests.h"
+#include "../bitcoinunits.h"
+
+void BitcoinUnitsTests::formatTests()
+{
+    const QChar ts = BitcoinUnits::THIN_SPACE;
+
+    // Small amounts (no thousands separator expected)
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 0), QString("0.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 100000000), QString("1.00"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 99900000000LL), QString("999.00"));
+
+    // 4-digit integer part: one thin space separator
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 100000000000LL),
+             QString("1") + ts + QString("000.00"));
+
+    // 5-digit integer part
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 1234500000000LL),
+             QString("12") + ts + QString("345.00"));
+
+    // 7-digit integer part: two thin space separators
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 123456789012345LL),
+             QString("1") + ts + QString("234") + ts + QString("567.89012345"));
+
+    // Negative amount
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, -123456789012345LL),
+             QString("-1") + ts + QString("234") + ts + QString("567.89012345"));
+
+    // Plus sign
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::BTC, 123456789012345LL, true),
+             QString("+1") + ts + QString("234") + ts + QString("567.89012345"));
+
+    // mBTC unit with separators
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::mBTC, 100000000000LL),
+             QString("1") + ts + QString("000") + ts + QString("000.00"));
+
+    // uBTC unit with separators
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::uBTC, 100000000000LL),
+             QString("1") + ts + QString("000") + ts + QString("000") + ts + QString("000.00"));
+}
+
+void BitcoinUnitsTests::parseTests()
+{
+    const QChar ts = BitcoinUnits::THIN_SPACE;
+    qint64 val;
+
+    // Parse plain value (no separators)
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, "1234.56", &val));
+    QCOMPARE(val, 123456000000LL);
+
+    // Parse value with thin space separators (as produced by format)
+    QString formatted = QString("1") + ts + QString("234.56");
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, formatted, &val));
+    QCOMPARE(val, 123456000000LL);
+
+    // Round-trip: format then parse
+    qint64 original = 123456789012345LL;
+    QString str = BitcoinUnits::format(BitcoinUnits::BTC, original);
+    qint64 parsed;
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::BTC, str, &parsed));
+    QCOMPARE(parsed, original);
+
+    // Round-trip with mBTC
+    original = 100000000000LL;
+    str = BitcoinUnits::format(BitcoinUnits::mBTC, original);
+    QVERIFY(BitcoinUnits::parse(BitcoinUnits::mBTC, str, &parsed));
+    QCOMPARE(parsed, original);
+}

--- a/src/qt/test/bitcoinunitstests.h
+++ b/src/qt/test/bitcoinunitstests.h
@@ -1,0 +1,16 @@
+#ifndef BITCOIN_QT_TEST_BITCOINUNITSTESTS_H
+#define BITCOIN_QT_TEST_BITCOINUNITSTESTS_H
+
+#include <QTest>
+#include <QObject>
+
+class BitcoinUnitsTests : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void formatTests();
+    void parseTests();
+};
+
+#endif // BITCOIN_QT_TEST_BITCOINUNITSTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -1,6 +1,7 @@
 #include <QTest>
 #include <QObject>
 
+#include "bitcoinunitstests.h"
 #include "uritests.h"
 
 #if defined(QT_STATICPLUGIN)
@@ -23,8 +24,12 @@ int main(int argc, char *argv[])
 {
     bool fInvalid = false;
 
-    URITests test1;
+    BitcoinUnitsTests test1;
     if (QTest::qExec(&test1) != 0)
+        fInvalid = true;
+
+    URITests test2;
+    if (QTest::qExec(&test2) != 0)
         fInvalid = true;
 
     return fInvalid;


### PR DESCRIPTION
## Summary
- Adds Unicode thin space (U+2009) as locale-neutral thousands separators in the integer part of formatted coin amounts, per SI/BIPM convention (closes #1040)
- Updates `parse()` to strip thin spaces so copy-paste and input round-trips work correctly
- Adds `BitcoinUnitsTests` (format + parse coverage) to the Qt test suite
- Adds right-click "Copy amount" context menu to all overview page balance labels (available, stake, unconfirmed, immature, total, and the header balance)
- Fixes thin space handling in `BitcoinAmountField::setText()` and coin control clipboard copy functions

The copy feature was added because the thin space separators, while visually correct, break an informal workflow where users could previously select a balance label's text and paste it directly into the send amount field. The `QDoubleSpinBox` used by the send amount input rejects the thin space characters before `BitcoinUnits::parse()` is ever called, so stripping them in `parse()` alone is not sufficient for that path. Rather than fighting Qt's internal spinbox validation, we added a proper "Copy amount" action that copies a clean numeric value (thin spaces stripped, no unit suffix) to the clipboard. The context menu is suppressed when privacy mode is active.

The same thin space issue also broke the consolidate unspent wizard: `BitcoinAmountField::setText()` passes the formatted string through `QString::toDouble()`, which returns 0 when thin spaces are present, causing the send amount to show as zero. This was fixed by stripping thin spaces before the `toDouble()` conversion. The coin control clipboard copy functions in both `CoinControlDialog` and `SendCoinsDialog` were also updated to strip thin spaces so that copied values are clean and paste correctly.

## Test plan
- [x] All existing tests pass (`gridcoin_tests` + `gridcoin_qt_tests`)
- [x] New `BitcoinUnitsTests::formatTests()` verifies separators for 1-7 digit integers, negative values, plus signs, and all unit types (GRC, mGRC, μGRC)
- [x] New `BitcoinUnitsTests::parseTests()` verifies parsing plain values, values with thin spaces, and format→parse round-trips
- [x] Lint checks pass (whitespace, include guards)
- [x] Manual verification in GUI: overview, transaction list, send/receive dialogs display separators correctly
- [x] Manual verification: right-click balance labels, "Copy amount" copies clean numeric value
- [x] Manual verification: right-click suppressed in privacy mode
- [x] Manual verification: consolidate unspent wizard populates send amount correctly
- [x] Manual verification: coin control clipboard copies produce clean values

🤖 Generated with [Claude Code](https://claude.com/claude-code)