### PR TITLE
qt, doc: Add transaction type tooltips, Help menu links, and docs (closes #2808)

### DIFF
--- a/doc/transaction-types.md
+++ b/doc/transaction-types.md
@@ -1,0 +1,79 @@
+# Gridcoin Transaction Types
+
+This document explains the transaction type labels shown in the Gridcoin wallet's
+transaction history and overview pages.
+
+## Regular Transactions
+
+| Label | Description |
+|-------|-------------|
+| **Sent to** | Funds you manually sent to another address. Requires an unlocked wallet. |
+| **Received with** | Funds received at one of your labeled addresses. |
+| **Received from** | Funds received from an address not in your address book. |
+| **Payment to yourself** | A transaction that sends funds back to your own wallet (e.g. UTXO consolidation or change). |
+
+## Staking Rewards
+
+These transactions are generated automatically when your wallet stakes a block.
+Your wallet must be encrypted and unlocked for staking only (or fully unlocked)
+for staking to occur, but staking transactions are created by the staking process
+itself — they are not manual sends.
+
+| Label | Description |
+|-------|-------------|
+| **Mined - PoS** | You earned a Proof of Stake reward by staking a block. |
+| **Mined - PoS+RR** | You earned a Proof of Stake reward combined with BOINC research rewards by staking a block. |
+| **Mined - Superblock** | You earned a reward by staking a superblock (the periodic consensus snapshot of network research statistics). |
+| **Mined - Orphaned** | You staked a block, but it was orphaned — another block at the same height was accepted by the network instead. No funds were gained or lost. |
+| **Mined - Unknown** | A mined transaction whose specific type could not be determined. This should not normally appear. |
+
+## Side Stakes
+
+Side stakes are automatic reward distributions configured by stakers. When you
+stake a block, a portion of your reward can be automatically sent to configured
+side stake addresses (e.g. for pool operators, foundations, or personal
+distribution). **These are not manual transactions.**
+
+| Label | Description |
+|-------|-------------|
+| **PoS Side Stake Received** | You received a side stake allocation from another staker's Proof of Stake reward. |
+| **PoS+RR Side Stake Received** | You received a side stake allocation from another staker's research reward. |
+| **PoS Side Stake Sent** | Your Proof of Stake staking reward automatically allocated this side stake to a configured address. **No manual send occurred.** This transaction is normal even when your wallet is locked for staking only. |
+| **PoS+RR Side Stake Sent** | Your research staking reward automatically allocated this side stake to a configured address. **No manual send occurred.** This transaction is normal even when your wallet is locked for staking only. |
+
+> **Note:** "Side Stake Sent" transactions are the most common source of user
+> confusion. They appear as outgoing transactions, but they are automatically
+> created as part of the staking process — the wallet does not need to be fully
+> unlocked for them to occur. If you see these transactions and did not configure
+> side stakes yourself, check your `gridcoinresearch.conf` for `sidestake=`
+> entries, or look in Settings > Options > Staking for configured side stakes.
+> Mandatory network-level side stakes (e.g. the Gridcoin foundation address) are
+> applied automatically to all stakers.
+
+## MRC (Manual Rewards Claim)
+
+MRC allows researchers who are not actively staking to claim their accrued BOINC
+research rewards. The researcher submits an MRC request, and the next staker
+includes it in their block, paying the researcher from the coinbase.
+
+| Label | Description |
+|-------|-------------|
+| **Manual Rewards Claim Request** | You submitted an MRC request to claim your accrued research rewards. This is a user-initiated transaction. |
+| **MRC Payment Received** | You received a research reward payment because a staker included your MRC claim in their block. |
+| **MRC Payment Sent** | Your staked block automatically paid an MRC claim to a researcher. **No manual send occurred.** This transaction is normal even when your wallet is locked for staking only. |
+
+> **Note:** Like "Side Stake Sent," "MRC Payment Sent" can appear as an outgoing
+> transaction from a locked wallet. This is expected behavior — when your wallet
+> stakes a block that contains pending MRC claims, it automatically pays those
+> claims as part of the block reward distribution.
+
+## Contract Transactions
+
+These transactions record on-chain governance and identity actions.
+
+| Label | Description |
+|-------|-------------|
+| **Beacon Advertisement** | A transaction that advertises or renews your beacon, linking your BOINC CPID to your wallet address for research reward eligibility. |
+| **Poll** | A transaction that creates an on-chain governance poll. |
+| **Vote** | A transaction that records your vote on an on-chain poll. |
+| **Message** | A transaction that records an on-chain message. |

--- a/doc/transaction-types.md
+++ b/doc/transaction-types.md
@@ -77,3 +77,9 @@ These transactions record on-chain governance and identity actions.
 | **Poll** | A transaction that creates an on-chain governance poll. |
 | **Vote** | A transaction that records your vote on an on-chain poll. |
 | **Message** | A transaction that records an on-chain message. |
+
+## Other
+
+| Label | Description |
+|-------|-------------|
+| *(unlabeled)* | A transaction with mixed inputs and outputs that could not be broken down into individual payees. This is uncommon in normal wallet usage. |

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -360,6 +360,18 @@ void BitcoinGUI::createActions()
     boincAction->setStatusTip(tr("Gridcoin rewards distributed computing with BOINC"));
     boincAction->setMenuRole(QAction::TextHeuristicRole);
 
+    openWikiAction = new QAction(tr("Gridcoin &Wiki"), this);
+    openWikiAction->setStatusTip(tr("Open the Gridcoin Wiki"));
+    openWikiAction->setMenuRole(QAction::TextHeuristicRole);
+
+    openFaqAction = new QAction(tr("&FAQ"), this);
+    openFaqAction->setStatusTip(tr("Open the Gridcoin FAQ"));
+    openFaqAction->setMenuRole(QAction::TextHeuristicRole);
+
+    openGuidesAction = new QAction(tr("&Guides"), this);
+    openGuidesAction->setStatusTip(tr("Open the Gridcoin Guides"));
+    openGuidesAction->setMenuRole(QAction::TextHeuristicRole);
+
     // We use lambdas here to squash the argument to showNormalIfMinized.
     connect(overviewAction, &QAction::triggered, this, [this]{ this->showNormalIfMinimized(); });
     connect(overviewAction, &QAction::triggered, this, &BitcoinGUI::gotoOverviewPage);
@@ -378,6 +390,9 @@ void BitcoinGUI::createActions()
     connect(exchangeAction, &QAction::triggered, this, &BitcoinGUI::exchangeClicked);
     connect(boincAction, &QAction::triggered, this, &BitcoinGUI::boincStatsClicked);
     connect(chatAction, &QAction::triggered, this, &BitcoinGUI::chatClicked);
+    connect(openWikiAction, &QAction::triggered, this, &BitcoinGUI::openWikiClicked);
+    connect(openFaqAction, &QAction::triggered, this, &BitcoinGUI::openFaqClicked);
+    connect(openGuidesAction, &QAction::triggered, this, &BitcoinGUI::openGuidesClicked);
 
     quitAction = new QAction(tr("E&xit"), this);
     quitAction->setToolTip(tr("Quit application"));
@@ -596,6 +611,10 @@ void BitcoinGUI::createMenuBar()
     community->addAction(websiteAction);
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
+    help->addAction(openWikiAction);
+    help->addAction(openFaqAction);
+    help->addAction(openGuidesAction);
+    help->addSeparator();
     help->addAction(openRPCConsoleAction);
     help->addSeparator();
     help->addAction(diagnosticsAction);
@@ -1428,6 +1447,21 @@ void BitcoinGUI::websiteClicked()
 void BitcoinGUI::exchangeClicked()
 {
     QDesktopServices::openUrl(QUrl("https://gridcoin.us/exchange.htm#GridcoinWallet"));
+}
+
+void BitcoinGUI::openWikiClicked()
+{
+    QDesktopServices::openUrl(QUrl("https://gridcoin.us/wiki/"));
+}
+
+void BitcoinGUI::openFaqClicked()
+{
+    QDesktopServices::openUrl(QUrl("https://gridcoin.us/wiki/faq.html"));
+}
+
+void BitcoinGUI::openGuidesClicked()
+{
+    QDesktopServices::openUrl(QUrl("https://gridcoin.us/guides/"));
 }
 
 void BitcoinGUI::peersClicked()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -158,6 +158,9 @@ private:
     QAction *snapshotAction;
     QAction *resetblockchainAction;
     QAction *m_mask_values_action;
+    QAction *openWikiAction;
+    QAction *openFaqAction;
+    QAction *openGuidesAction;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
@@ -264,6 +267,9 @@ private slots:
     void snapshotClicked();
     void resetblockchainClicked();
     void setPrivacy();
+    void openWikiClicked();
+    void openFaqClicked();
+    void openGuidesClicked();
     bool tryQuit();
 
 #ifndef Q_OS_MAC

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -653,6 +653,8 @@ QString TransactionTableModel::formatTxTypeExplanation(const TransactionRecord *
         return tr("On-chain message transaction.");
     case TransactionRecord::MRC:
         return tr("Manual Rewards Claim request submitted to the network.");
+    case TransactionRecord::Other:
+        return tr("Transaction with mixed inputs and outputs.");
     default:
         return QString();
     }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -596,7 +596,66 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
     {
         tooltip += QString(" ") + formatTxToAddress(rec, true);
     }
+
+    QString explanation = formatTxTypeExplanation(rec);
+    if (!explanation.isEmpty()) {
+        tooltip += QString(": ") + explanation;
+    }
+
     return tooltip;
+}
+
+QString TransactionTableModel::formatTxTypeExplanation(const TransactionRecord *rec) const
+{
+    if (rec->type == TransactionRecord::Generated) {
+        switch (rec->status.generated_type) {
+        case GRC::MinedType::POS:
+            return tr("Earned by staking a block (Proof of Stake).");
+        case GRC::MinedType::POR:
+            return tr("Earned by staking a block with BOINC research rewards (Proof of Stake + Research Rewards).");
+        case GRC::MinedType::SUPERBLOCK:
+            return tr("Earned by staking a superblock.");
+        case GRC::MinedType::ORPHANED:
+            return tr("This staked block was orphaned and did not become part of the chain.");
+        case GRC::MinedType::POS_SIDE_STAKE_RCV:
+            return tr("Side stake received from another staker's Proof of Stake reward.");
+        case GRC::MinedType::POR_SIDE_STAKE_RCV:
+            return tr("Side stake received from another staker's research reward.");
+        case GRC::MinedType::POS_SIDE_STAKE_SEND:
+            return tr("Your staking reward automatically allocated this side stake; no manual send occurred.");
+        case GRC::MinedType::POR_SIDE_STAKE_SEND:
+            return tr("Your research staking reward automatically allocated this side stake; no manual send occurred.");
+        case GRC::MinedType::MRC_RCV:
+            return tr("MRC payment received from a staker who included your MRC claim.");
+        case GRC::MinedType::MRC_SEND:
+            return tr("Your staked block automatically paid this MRC claim; no manual send occurred.");
+        default:
+            return tr("Mined transaction of unknown type.");
+        }
+    }
+
+    switch (rec->type) {
+    case TransactionRecord::SendToAddress:
+    case TransactionRecord::SendToOther:
+        return tr("Funds sent to another address.");
+    case TransactionRecord::RecvWithAddress:
+    case TransactionRecord::RecvFromOther:
+        return tr("Funds received.");
+    case TransactionRecord::SendToSelf:
+        return tr("Payment to yourself (e.g. change consolidation).");
+    case TransactionRecord::BeaconAdvertisement:
+        return tr("Beacon advertisement linking your CPID to your wallet.");
+    case TransactionRecord::Poll:
+        return tr("On-chain poll creation transaction.");
+    case TransactionRecord::Vote:
+        return tr("On-chain vote transaction.");
+    case TransactionRecord::Message:
+        return tr("On-chain message transaction.");
+    case TransactionRecord::MRC:
+        return tr("Manual Rewards Claim request submitted to the network.");
+    default:
+        return QString();
+    }
 }
 
 QVariant TransactionTableModel::data(const QModelIndex &index, int role) const

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -73,6 +73,7 @@ private:
     QString formatTxToAddress(const TransactionRecord *wtx, bool tooltip) const;
     QString formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed=true) const;
     QString formatTooltip(const TransactionRecord *rec) const;
+    QString formatTxTypeExplanation(const TransactionRecord *rec) const;
     QVariant txStatusDecoration(const TransactionRecord *wtx) const;
     QVariant txAddressDecoration(const TransactionRecord *wtx) const;
 


### PR DESCRIPTION
## Summary
- Add contextual tooltip explanations for all 22 transaction type/subtype combinations when hovering over transaction rows in the history and overview pages — especially clarifying that "Side Stake Sent" and "MRC Payment Sent" are automatic staking actions, not manual sends
- Add Wiki, FAQ, and Guides links to the Help menu opening gridcoin.us documentation pages
- Add `doc/transaction-types.md` as a user-facing reference document explaining every transaction type label

## Test plan
- [ ] Hover over each transaction type in the history page and verify the tooltip shows the type explanation
- [ ] Verify tooltip also appears on the overview page recent transactions
- [ ] Click each new Help menu item (Wiki, FAQ, Guides) and verify the correct URL opens in a browser
- [ ] Verify `doc/transaction-types.md` content matches the tooltip explanations
- [ ] Build and run lint checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)