### PR TITLE
researcher: fix stale GUI status after beacon activation via superblock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1514,6 +1514,11 @@ bool TryLoadSuperblock(
                     block.GetHash(),
                     pindex->nHeight);
 
+        // A beacon activation may change the researcher's eligibility status,
+        // so mark the context dirty to refresh the cached status on the next
+        // Researcher::Refresh() call.
+        GRC::Researcher::MarkDirty();
+
         // Notify the GUI if present that beacons have changed.
         uiInterface.BeaconChanged();
     }


### PR DESCRIPTION
## Summary
- Mark the researcher context dirty after `ActivatePending()` in superblock processing so the existing `Researcher::Refresh()` call at the end of `GridcoinConnectBlock()` reloads the cached status
- Fixes the GUI researcher widget showing "Staking Only - No active beacon" after a superblock activates a pending beacon, even though magnitude and staking info update correctly

## Root Cause
The researcher status text is set in `StoreResearcher()`, which only runs when the researcher context is reloaded. After `ActivatePending()`, the beacon registry is updated but the cached `Researcher` object's `Status()` still returns `NO_BEACON`. Methods like `Eligible()` and `Magnitude()` query the registry directly and work fine, but the status text remains stale.

`Researcher::Refresh()` is already called at the end of `GridcoinConnectBlock()` but only triggers a reload when `g_researcher_dirty` is true. Adding `Researcher::MarkDirty()` after `ActivatePending()` closes the gap.

## Test plan
- [x] Deploy to testnet, advertise a beacon, wait for superblock activation
- [x] Verify the GUI researcher status updates from "No active beacon" to "Eligible for Research Rewards" without requiring `resetcpids` or wallet restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)