### PR TITLE
voting: fix unprotected chain state reads during vote tallying

### DIFF
--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -613,6 +613,8 @@ private:
     //!
     static bool IsInMainChain(const CBlockHeader& header)
     {
+        LOCK(cs_main);
+
         const auto iter = mapBlockIndex.find(header.GetHash());
 
         if (iter == mapBlockIndex.end()) {
@@ -1201,9 +1203,16 @@ PollResultOption PollResult::BuildFor(const PollReference& poll_ref)
         VoteCounter counter(txdb, result.m_poll);
 
         if (result.m_poll.IncludesMagnitudeWeight()) {
-            counter.EnableMagnitudeWeight(
-                ResolveSuperblockForPoll(result.m_poll),
-                ResolveMoneySupplyForPoll(result.m_poll));
+            SuperblockPtr superblock;
+            uint64_t supply;
+
+            {
+                LOCK(cs_main);
+                superblock = ResolveSuperblockForPoll(result.m_poll);
+                supply = ResolveMoneySupplyForPoll(result.m_poll);
+            }
+
+            counter.EnableMagnitudeWeight(std::move(superblock), supply);
         }
 
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: number of votes = %u for poll %s",

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -219,13 +219,21 @@ UniValue VoteDetailsToJson(const PollResult& result)
 
 UniValue VoteDetailsToJson(const PollReference& poll_ref)
 {
+    GetPollRegistry().registry_traversal_in_progress = true;
+
     try {
         if (const PollResultOption result = PollResult::BuildFor(poll_ref)) {
+            GetPollRegistry().registry_traversal_in_progress = false;
+
             return VoteDetailsToJson(*result);
         }
     } catch (InvalidDuetoReorgFork& e) {
+        GetPollRegistry().registry_traversal_in_progress = false;
+
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk due to reorg in progress during inquiry.");
     }
+
+    GetPollRegistry().registry_traversal_in_progress = false;
 
     throw JSONRPCError(RPC_INTERNAL_ERROR, "Failed to load poll from disk.");
 }


### PR DESCRIPTION
## Summary

- Add `LOCK(cs_main)` to `VoteResolver::IsInMainChain()` which reads `mapBlockIndex` and checks `pindex->IsInMainChain()` (dependent on `pnext`/`pindexBest`) without any lock, allowing concurrent reorgs to produce inconsistent chain membership results during vote weight resolution.
- Add scoped `LOCK(cs_main)` around `ResolveSuperblockForPoll()` and `ResolveMoneySupplyForPoll()` in `BuildFor()` so both resolve from the same chain tip. Previously a new block connecting between the two calls could produce an inconsistent magnitude weight factor.
- Add missing `registry_traversal_in_progress` flag to `VoteDetailsToJson()` (`getvotedetails` RPC) to match the existing pattern in `PollResultToJson()`, enabling reorg detection during that code path.

No lock ordering issues: `BuildFor()` is called without `cs_poll_registry` held in all code paths (GUI and RPC both use scoped `WITH_LOCK` to look up the `PollReference`, releasing before calling `BuildFor`), and the established lock order is `cs_main` → `cs_poll_registry`. Within `VoteResolver`, both `cs_tx_val_commit_to_disk` and `cs_wallet` are acquired and released in their own scoped blocks before `IsInMainChain()` is reached.

## Test plan

- [x] Verify clean build on Linux
- [x] Run `getpollresults` and `getvotedetails` RPCs against active and finished polls
- [x] Confirm no deadlocks under normal operation and during reorgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)