### PR TITLE
doc: Add quality control checklist and remove trailing whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,7 +248,7 @@ none
  - gui: Translation updates #2599 (@jamescowens)
  - build: update CI for linter and actions version #2606 (@jamescowens)
  - gui: Update translations #2608 (@jamescowens)
- 
+
 ### Removed
  - refactor: remove unused c-string variant of atoi64() #2562 (@barton2526)
  - refactor: Remove unused CDataStream::rdbuf method #2585 (@div72)
@@ -553,9 +553,9 @@ none
  - gui: Show GUI error dialog if command line parsing fails #2218 (@jamescowens)
  - gui: Implement close confirmation. #2216 (@denravonska)
  - build: Use -fstack-reuse=none #2232 (@barton2526)
- 
+
 ### Changed
- - doc: Update build doc #2078 (@iFoggz) 
+ - doc: Update build doc #2078 (@iFoggz)
  - gui: Normalize button and input control appearance #2096 (@cyrossignol)
  - consensus: Implement GetMinimumRequiredConnectionsForStaking #2097 (@jamescowens)
  - refactor: move CTransaction to primitives #2006 (@div72)
@@ -667,7 +667,7 @@ none
  - gui: Avoid refreshing GUI researcher status while out-of-sync #2068 (@cyrossignol)
  - consensus: Reimplement checkpoint-based spam protection #2084 (@cyrossignol)
  - consensus: Verify hardened checkpoints on start up #2087 (@cyrossignol)
- 
+
 ### Changed
  - test: autogenerate data headers #2030 (@div72)
  - doc: Change copyright years to 2021 #2042 (@caraka)
@@ -681,7 +681,7 @@ none
  - log: Adjust logging #2076 (@jamescowens)
  - gui: Change scraper tab to Inconsolata monospace font #2085 (@jamescowens)
  - researcher: Change beacon deferment fix to reference nActiveBeforeSB #2092 (@jamescowens)
- 
+
 ### Removed
  - net: Clean up mandatory protocol version transition #2080 (@cyrossignol)
  - refactor: Remove LessVerbose() function #2089 (@cyrossignol)
@@ -699,7 +699,7 @@ none
  - gui: Fix shutdown response for failed core init #2088 (@cyrossignol)
  - researcher: Fix deferment of beacon renewal in superblock window #2090 (@cyrossignol)
  - gui: Fix typo in beacon status refresh #2091 (@div72)
- 
+
 ## [5.3.0.0] 2021-03-16, mandatory
 ### Fixed
  - consensus, accrual: Fix accrual post hard-fork at 2197000 #2053 (@jamescowens, @div72, @cyrossignol)
@@ -788,7 +788,7 @@ none
  - gui: Adds detection if version is below last mandatory #1939 (@jamescowens)
  - contract: Reimplement legacy administrative contract validation #1943 (@cyrossignol)
  - voting: Add poll choices to "gettransaction" RPC contract output #1948 (@cyrossignol)
- 
+
 ### Changed
  - doc: Fix link in build-openbsd.md #1924 (@Pythonix)
  - voting: Decrease poll duration to 90 days #1936 (@cyrossignol)
@@ -1170,7 +1170,7 @@ none
    - new SB format and packing for bv11
    - new SB contract hashing (native) for bv11
    - changes to accommodate new beacon approach
-   - Implement in memory versioning for team file ETags 
+   - Implement in memory versioning for team file ETags
  - Implement local dynamic team requirement removal and whitelist #1502 (@cyrossignol)
 
 ### Changed
@@ -1352,7 +1352,7 @@ none
  - Stress testing script  (@Foggyx420)
  - refhash command also on Linux (@jamescowens)
  - Documentation for out of source build (@thecharlatan)
- 
+
 ### Changed
  - More accurate time to stake and network weight estimations (@jamescowens)
  - Compressed image files (@Peppernrino)
@@ -1364,7 +1364,7 @@ none
  - Pretty-print rpc output (@denravonska)
  - Logging for debugging reward computation (@tomasbrod)
  - Clean-up beacon manipulation (@Foggyx420)
- 
+
 ### Fixed
  - Building errors on Mac related to SVG framework (@thecharlatan)
  - neural data response
@@ -1385,7 +1385,7 @@ none
  - GUI FAQ (@Lenni)
  - unusable limit from magnitude command (@Foggyx420)
  - cgminer support (@Foggyx420)
- - deprecated menu items (@jamescowens) 
+ - deprecated menu items (@jamescowens)
 
 ## [3.7.13.0] 2018-06-02, leisure
 ### Fixed
@@ -1401,7 +1401,7 @@ none
 ### Added
  - Neural Report RPC command #1063 (@tomasbrod).
  - GUI wallet redign with new icons and purple native style (@skcin).
- 
+
 ### Changed
  - Switch to autotools and Depends from Bitcoin #487 (@thecharlatan).
  - Clean and update docs for new build system, remove outdated #828 (@thecharlatan).
@@ -1423,7 +1423,7 @@ none
  - Upgrade menu #1094 (@jamescowens).
  - Acid test functions #871 (@tomasbrod).
  - Qt4 support #801 (@denravonska).
- 
+
 ## [3.7.11.0] 2018-03-15, leisure
 ### Fixed
  - Fix wallet being locked while flushing. It now requires a clean shutdown
@@ -1585,7 +1585,7 @@ Internal test version used to sort out the forks.
  - Fix an issue where multiple beacons could be advertised in rapid
    succession #604 (@Foggyx420).
  - Stake weight in the UI will no longer include old DPOR weght #602
-   (@Foggyx420). 
+   (@Foggyx420).
  - Fix stake modifier mismatch which caused nodes to get stuck on first
    V8 block #581 (@tomasbrod).
  - Fix beacon auto advertisement issue when done automatically #580 (@Foggyx420).
@@ -1651,7 +1651,7 @@ Internal test version used to sort out the forks.
 
 ## [3.6.0.0] - 2017-08-14
 ### Fixed
- - Fix a crash when starting up as a new user #488 (@Foggyx420, 
+ - Fix a crash when starting up as a new user #488 (@Foggyx420,
    @denravonska).
  - Fix an out of memory crash when syncing from 0 #508 (@tomasbrod).
 
@@ -1659,7 +1659,7 @@ Internal test version used to sort out the forks.
 ### Changed
  - Staking cleanup #301 (@tomasbrod). This also solves several other issues:
  - UI:
-    - Wallet window can now be made smaller #384 (@skcin). 
+    - Wallet window can now be made smaller #384 (@skcin).
     - Interest and Research subsidy visible in getmininginfo (@tomasbrod).
     - External links now use HTTPS where possible, and the code has been cleaned
       up #339 (@skcin).
@@ -1669,7 +1669,7 @@ Internal test version used to sort out the forks.
    the Bitcoin source tree: Arabic, Belarusian, Bulgarian, Greek, Persian,
    Hebrew, Hindi, Japanese, Georgian, Kirghiz, Serbian, Thai, Ukrainian,
    Urdu and Chinese.
- - Don't print the "Bootup" and "Signing block" messages unless fDebug (@tomasbrod). 
+ - Don't print the "Bootup" and "Signing block" messages unless fDebug (@tomasbrod).
  - Print beacons as they are loaded and debug3=true (@tomasbrod).
  - Show superblock information in getblock (@tomasbrod).
  - Code cleanup (@skcin).
@@ -1684,7 +1684,7 @@ Internal test version used to sort out the forks.
  - Client no longer has to be restarted for a beacon to activate #253
    (@Foggyx420).
  - Fixed a coin age bug which made it hard to stake on testnet (@denravonska)
- - Fixed reloading of polls in the voting GUI #431 (@skcin) 
+ - Fixed reloading of polls in the voting GUI #431 (@skcin)
  - Fix crash when listing receivedby on addresses with no transactions,
    #456 (@denravonska).
  - Fix buffer overflow in TX message unscambling #468 (@tomasbrod).
@@ -1801,7 +1801,7 @@ Internal test version used to sort out the forks.
 - Add man pages to doc folder #135 (@caraka).
 
 ### Changed
- - Windows are now resizable 
+ - Windows are now resizable
  - Replace Windows voting dialog with the new dialog.
  - Update Gridcoin icon on Windows.
  - Enable C++11.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Communication Channels
 ----------------------
 
 Most communication about Gridcoin Research development happens on Slack, in the
-`#development` channel on TeamGridcoin. The invite link is in 
+`#development` channel on TeamGridcoin. The invite link is in
 [the main README](README.md#community).
 
 Discussion about code base improvements happens in GitHub issues and on pull
@@ -141,7 +141,7 @@ references to any discussions (for example other tickets or discussions).
 ### Work in Progress Changes and Requests for Comments
 
 If a pull request is not to be considered for merging (yet), please
-prefix the title with [WIP], mark the pull request as draft or 
+prefix the title with [WIP], mark the pull request as draft or
 use [Tasks Lists](https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists)
 in the body of the pull request to indicate tasks are pending.
 
@@ -262,7 +262,7 @@ In general, all pull requests must:
 
 Patches that change Gridcoin consensus rules are considerably more involved than
 normal because they affect the entire ecosystem and so must be preceded by
-extensive discussions. While each case will be different, 
+extensive discussions. While each case will be different,
 one should be prepared to expend more time and effort than for
 other kinds of patches because of increased peer review and consensus building
 requirements.

--- a/clinerules/06-quality-control-checklist.md
+++ b/clinerules/06-quality-control-checklist.md
@@ -1,0 +1,407 @@
+# Quality Control Checklist for Gridcoin Contributions
+
+## Purpose
+
+This checklist ensures contributions meet quality standards before submission. Use it as a pre-commit and pre-PR review guide to catch common issues early.
+
+---
+
+## Documentation Changes
+
+### Before Committing
+
+- [ ] **No trailing whitespace**
+  - Check: `grep -En '[[:space:]]+$' *.md`
+  - Should return nothing
+  - Fix: `sed -i 's/[[:space:]]*$//' *.md` (or `sed -i '' 's/[[:space:]]*$//' *.md` on macOS)
+
+- [ ] **No tab characters in markdown**
+  - Run: `grep -n $'\t' *.md`
+  - Should return nothing
+
+- [ ] **Code examples use 4 spaces (not tabs)**
+  - Check all code blocks for consistent indentation
+
+- [ ] **Cross-references are valid**
+  - All links to other files/sections work correctly
+  - No broken internal links
+
+- [ ] **Examples have been tested**
+  - Command examples run without errors
+  - Code examples compile/work as shown
+
+- [ ] **Follows Baby Steps philosophy**
+  - Changes are focused and incremental
+  - Each change has clear purpose
+
+### Before Submitting PR
+
+- [ ] **Run full lint suite**
+  - From repo root: `test/lint/lint-all.sh`
+  - Or run full local CI: `contrib/devtools/run-local-ci.sh`
+  - All checks pass
+
+- [ ] **Changes documented appropriately**
+  - Updated relevant .md files
+  - Added to changelog if significant
+
+- [ ] **README.md updated (if needed)**
+  - New files listed in appropriate section
+  - Table of contents reflects changes
+
+---
+
+## Code Changes
+
+### Before Committing
+
+- [ ] **Follows coding standards**
+  - See `01-coding.md` for style guide
+  - ANSI/Allman block style
+  - 4-space indentation, no tabs
+  - Modern variable naming: `lower_snake_case` for locals, `m_` prefix for members, `UPPER_SNAKE_CASE` for global constants
+  - Legacy Hungarian notation only for consistency within existing modules
+
+- [ ] **Comments explain "why", not just "what"**
+  - Complex logic has explanatory comments
+  - Non-obvious decisions documented
+
+- [ ] **One substantive change per commit**
+  - Each commit represents one logical change
+  - No mixing unrelated changes
+
+- [ ] **Lock order respected**
+  - Always: `cs_main` → `cs_wallet`
+  - No potential deadlocks introduced
+  - Tip: Compile with `-DDEBUG_LOCKORDER` to detect violations at runtime
+
+- [ ] **No trailing whitespace in code**
+  - Check: `grep -En '[[:space:]]+$' *.cpp *.h`
+  - Fix: `sed -i 's/[[:space:]]*$//' *.cpp *.h` (or `sed -i '' 's/[[:space:]]*$//' *.cpp *.h` on macOS)
+  - Clean up before commit
+
+- [ ] **No debug code left in**
+  - Remove temporary print statements
+  - Remove commented-out debugging code
+
+### Before Submitting PR
+
+- [ ] **Unit tests added/updated**
+  - New features have test coverage
+  - Changed features have updated tests
+  - All tests pass: `./src/test/test_gridcoinresearch`
+
+- [ ] **Manual testing completed**
+  - Tested on testnet first
+  - Verified expected behavior
+  - Checked edge cases
+
+- [ ] **Documentation updated**
+  - Code comments added/updated
+  - User-facing docs updated if needed
+  - RPC help text accurate
+
+- [ ] **CHANGELOG.md entry added**
+  - For user-facing changes
+  - Clear description of change
+  - Proper category (Added/Changed/Fixed/etc.)
+
+- [ ] **Consensus changes properly gated**
+  - Height-gated activation if needed
+  - Version bumps if appropriate
+  - Community coordination planned
+
+---
+
+## Consensus Changes (Critical)
+
+### Special Requirements
+
+- [ ] **Community approval obtained**
+  - Discussed on Discord/GitHub
+  - General agreement on approach
+
+- [ ] **Hard fork planning complete**
+  - Activation height determined
+  - Upgrade timeline communicated
+
+- [ ] **Extensive testing performed**
+  - Tested on testnet extensively
+  - Multiple scenarios verified
+  - Edge cases examined
+
+- [ ] **Documentation comprehensive**
+  - CHANGELOG.md updated
+  - Release notes prepared
+  - Migration guide written (if needed)
+
+- [ ] **Backward compatibility considered**
+  - Old blocks still validate correctly
+  - Database migrations handled
+  - Network protocol compatible
+
+---
+
+## GUI Changes
+
+### Before Committing
+
+- [ ] **UI files properly formatted**
+  - .ui files valid XML
+  - Consistent styling applied
+
+- [ ] **Signals/slots connected correctly**
+  - No memory leaks (proper cleanup)
+  - Thread safety maintained
+
+- [ ] **Strings marked for translation**
+  - User-facing strings use `tr()`
+  - No hardcoded English text
+
+### Before Submitting PR
+
+- [ ] **Tested on target platforms**
+  - Windows, Linux, macOS (if possible)
+  - Different screen resolutions
+  - High DPI displays
+
+- [ ] **Accessibility considered**
+  - Tab order logical
+  - Keyboard shortcuts work
+  - Screen reader friendly
+
+---
+
+## RPC Changes
+
+### Before Committing
+
+- [ ] **Help text complete and accurate**
+  - All parameters documented
+  - Return values explained
+  - Examples provided
+
+- [ ] **Parameter validation implemented**
+  - Invalid inputs rejected gracefully
+  - Clear error messages
+
+- [ ] **Proper locking used**
+  - Appropriate locks acquired
+  - Locks released properly
+
+### Before Submitting PR
+
+- [ ] **Backward compatibility maintained**
+  - Existing functionality unchanged
+  - New parameters optional (if possible)
+
+- [ ] **Examples tested**
+  - CLI examples work
+  - RPC examples work
+
+---
+
+## Contract Changes
+
+### Before Committing
+
+- [ ] **Contract type properly registered**
+  - Added to enum
+  - Dispatcher updated
+  - Handler implemented
+
+- [ ] **Validation comprehensive**
+  - Well-formed checks complete
+  - Block-context validation correct
+  - DoS scoring appropriate
+
+- [ ] **Burn fee appropriate**
+  - Fee amount reasonable
+  - Prevents spam
+
+### Before Submitting PR
+
+- [ ] **Registry persistence working**
+  - Database operations correct
+  - Reorg handling proper
+  - Migration path clear
+
+- [ ] **Tests comprehensive**
+  - Unit tests for validation
+  - Integration tests for workflow
+  - Edge cases covered
+
+---
+
+## Performance Changes
+
+### Before Committing
+
+- [ ] **Profiling data supports change**
+  - Identified actual bottleneck
+  - Measured improvement
+
+- [ ] **No premature optimization**
+  - Change addresses real issue
+  - Complexity justified
+
+### Before Submitting PR
+
+- [ ] **Benchmarks show improvement**
+  - Before/after measurements
+  - Multiple test cases
+  - No regressions elsewhere
+
+- [ ] **Memory usage considered**
+  - No significant increase
+  - Leaks addressed
+
+---
+
+## General Best Practices
+
+### Code Quality
+
+- [ ] **No compiler warnings**
+  - Clean build with warnings enabled
+  - No suppressed warnings without reason
+
+- [ ] **No magic numbers**
+  - Constants named meaningfully
+  - Values explained in comments
+
+- [ ] **Error handling complete**
+  - All error paths handled
+  - Resources cleaned up properly
+
+- [ ] **Logging appropriate**
+  - Important events logged
+  - Debug logging for troubleshooting
+  - No excessive logging
+
+### Git Practices
+
+- [ ] **Commit message clear**
+  - First line: concise summary
+  - Body: explains why, not just what
+  - References issues if applicable
+
+- [ ] **Commits atomic**
+  - Each commit buildable
+  - Each commit testable
+  - No "fix previous commit" commits in PR
+
+- [ ] **Branch up to date**
+  - Rebased on target branch (typically `development`; check PR target)
+  - Conflicts resolved
+  - Tests still pass
+
+---
+
+## Pre-Submission Final Check
+
+### Required Actions
+
+- [ ] **All lint checks pass**
+  ```bash
+  test/lint/lint-all.sh
+  ```
+
+- [ ] **All tests pass**
+  ```bash
+  cmake --build . --target test_gridcoinresearch
+  ./src/test/test_gridcoinresearch
+  ```
+
+- [ ] **No trailing whitespace anywhere**
+  ```bash
+  # Check for documentation
+  grep -rEn '[[:space:]]+$' clinerules/*.md
+
+  # Check for code
+  grep -rEn '[[:space:]]+$' src/*.cpp src/*.h
+
+  # Fix documentation (recursive)
+  find clinerules/ -name "*.md" -type f -exec sed -i 's/[[:space:]]*$//' {} +
+  # On macOS: find clinerules/ -name "*.md" -type f -exec sed -i '' 's/[[:space:]]*$//' {} +
+
+  # Fix code (recursive)
+  find src/ \( -name "*.cpp" -o -name "*.h" \) -type f -exec sed -i 's/[[:space:]]*$//' {} +
+  # On macOS: find src/ \( -name "*.cpp" -o -name "*.h" \) -type f -exec sed -i '' 's/[[:space:]]*$//' {} +
+  ```
+
+- [ ] **Clean build on multiple platforms**
+  - At minimum: your development platform
+  - Ideally: Windows, Linux, macOS
+
+### PR Description
+
+- [ ] **Clear title**
+  - Summarizes change in one line
+
+- [ ] **Comprehensive description**
+  - What: what changes were made
+  - Why: motivation for changes
+  - How: approach taken
+
+- [ ] **Testing notes included**
+  - How to test the changes
+  - Expected results
+  - Edge cases to check
+
+- [ ] **Screenshots if GUI**
+  - Before/after comparisons
+  - Different states shown
+
+---
+
+## Remember: Baby Steps
+
+This checklist may seem extensive, but remember:
+
+1. **One change at a time**: Focus on one substantive improvement
+2. **Test as you go**: Don't wait until the end
+3. **Document immediately**: Write docs while context is fresh
+4. **Ask for help**: Better to ask than to guess
+5. **Process is product**: Taking time to do it right IS the work
+
+---
+
+## Related Documentation
+
+- **Coding Standards**: `01-coding.md`
+- **Common Tasks**: `05-common-tasks.md`
+- **Architecture**: `02-architecture-overview.md`
+- **Testing**: `05-common-tasks.md` (Section 6: Working with the Test Suite)
+
+---
+
+## Quick Reference Commands
+
+```bash
+# Run all linters
+test/lint/lint-all.sh
+
+# Run unit tests
+./src/test/test_gridcoinresearch
+
+# Check for trailing whitespace
+grep -rEn '[[:space:]]+$' --include="*.cpp" --include="*.h" src/
+grep -rEn '[[:space:]]+$' --include="*.md" clinerules/
+
+# Remove trailing whitespace
+find src/ \( -name "*.cpp" -o -name "*.h" \) -type f -exec sed -i 's/[[:space:]]*$//' {} +
+find clinerules/ -name "*.md" -type f -exec sed -i 's/[[:space:]]*$//' {} +
+# On macOS: add '' after -i (e.g., sed -i '' 's/[[:space:]]*$//')
+
+# Find tab characters
+grep -rn $'\t' --include="*.cpp" --include="*.h" src/
+
+# Build with warnings
+cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra" ..
+cmake --build .
+```
+
+---
+
+**Use this checklist to ensure your contributions are high-quality and ready for review!**


### PR DESCRIPTION
This PR adds a quality control checklist to the clinerules specifically to catch formatting and trailing whitespace issues. 

The checklist (clinerules/06-quality-control-checklist.md) is meant to be a handy pre-commit and pre-PR reference that should help new joiners get their AI Assistants primed for submitting quality commits.

The idea is to catch common issues before they get caught by linter.

While putting this together the QCC found some trailing whitespace in CHANGELOG.md and CONTRIBUTING.md. 
So I went ahead and cleaned those up as an example of it's usage.

  Changes

  - New file: clinerules/06-quality-control-checklist.md — quality control checklist for contributions
  - Whitespace cleanup: Removed trailing whitespace from CHANGELOG.md (38 lines) and CONTRIBUTING.md (6 lines)