### PR TITLE
build, ci, cd: add official Docker container images

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -335,11 +335,106 @@ jobs:
           retention-days: 5
 
   # ----------------------------------------------------------------------
+  # JOB 2b: ARM64 Cross-Build (for Docker)
+  # ----------------------------------------------------------------------
+  arm64-cross-build:
+    name: Linux ARM64 Cross-Build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add ARM64 Architecture
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo add-apt-repository -y universe
+          sudo add-apt-repository -y multiverse
+          sudo sed -i 's/^Types: deb$/Types: deb\nArchitectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
+          cat <<EOF | sudo tee /etc/apt/sources.list.d/arm64.list
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main universe multiverse restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe multiverse restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main universe multiverse restricted
+          EOF
+          sudo apt-get update
+
+      - name: Install ARM64 Toolchain & Libraries
+        run: |
+          sudo dpkg --remove --force-all libcurl4-openssl-dev libcurl4-gnutls-dev libcups2 libcups2t64 || true
+          sudo apt-get update
+          sudo apt-get -f install -y
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build zipcmp zipmerge ziptool qemu-user-static \
+            g++-aarch64-linux-gnu qt6-base-dev:arm64 qt6-charts-dev:arm64 qt6-svg-dev:arm64 \
+            qt6-l10n-tools:arm64 qt6-tools-dev:arm64 qt6-tools-dev-tools:arm64 \
+            libqt6core5compat6-dev:arm64 libssl-dev:arm64 libzip-dev:arm64 \
+            libcurl4-openssl-dev:arm64 libboost-system-dev:arm64 libboost-filesystem-dev:arm64 \
+            libboost-thread-dev:arm64 libboost-iostreams-dev:arm64 libboost-program-options-dev:arm64 \
+            libboost-serialization-dev:arm64 libboost-chrono-dev:arm64 \
+            libminiupnpc-dev:arm64 libxkbcommon-dev:arm64 \
+            libcups2t64:arm64 \
+            ccache
+
+      - name: Setup Concurrency
+        run: |
+          if [ -z "$CMAKE_BUILD_PARALLEL_LEVEL" ]; then
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)" >> $GITHUB_ENV
+            echo "CTEST_PARALLEL_LEVEL=$(nproc)" >> $GITHUB_ENV
+            echo "Concurrency: Auto-detected $(nproc) cores."
+          else
+            echo "Concurrency: Limit set externally to $CMAKE_BUILD_PARALLEL_LEVEL."
+          fi
+
+      - name: Configure Ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-prod-arm64-${{ github.sha }}
+          restore-keys: ccache-prod-arm64-
+
+      - name: Configure CMake (Cross)
+        env:
+          PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
+        run: |
+          cmake -B build_arm64 -GNinja \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+            -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+            -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu \
+            -DCMAKE_FIND_ROOT_PATH="/usr/lib/aarch64-linux-gnu;/usr/include/aarch64-linux-gnu" \
+            -DCMAKE_SYSROOT=/ \
+            -DENABLE_GUI=ON \
+            -DUSE_QT6=ON \
+            -DQt6_DIR=/usr/lib/aarch64-linux-gnu/cmake/Qt6 \
+            -DENABLE_UPNP=ON \
+            -DDEFAULT_UPNP=ON \
+            -DENABLE_TESTS=OFF \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: cmake --build build_arm64
+
+      - name: Prepare Artifacts
+        run: |
+          mkdir -p dist
+          cp build_arm64/bin/gridcoinresearchd dist/
+          cp build_arm64/bin/gridcoinresearch dist/
+
+      - name: Upload Artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gridcoin-aarch64-linux-gnu
+          path: dist/
+          retention-days: 5
+
+  # ----------------------------------------------------------------------
   # JOB 3: Publish Docker Images
   # ----------------------------------------------------------------------
   docker-publish:
     name: Publish Docker Images
-    needs: [depends-builds]
+    needs: [depends-builds, arm64-cross-build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -354,17 +449,29 @@ jobs:
           name: gridcoin-x86_64-pc-linux-gnu
           path: artifacts/amd64
 
+      - name: Download ARM64 Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gridcoin-aarch64-linux-gnu
+          path: artifacts/arm64
+
       - name: Stage Binaries
         run: |
           cd contrib/docker
-          mkdir -p bin/amd64
+          mkdir -p bin/amd64 bin/arm64
 
           mkdir -p /tmp/amd64-extract
           tar -xzf ../../artifacts/amd64/*.tar.gz -C /tmp/amd64-extract --strip-components=1
           cp /tmp/amd64-extract/bin/gridcoinresearchd bin/amd64/
           cp /tmp/amd64-extract/bin/gridcoinresearch bin/amd64/
 
-          chmod +x bin/amd64/gridcoin*
+          cp ../../artifacts/arm64/gridcoinresearchd bin/arm64/
+          cp ../../artifacts/arm64/gridcoinresearch bin/arm64/
+
+          chmod +x bin/amd64/gridcoin* bin/arm64/gridcoin*
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -388,7 +495,7 @@ jobs:
         with:
           context: contrib/docker
           file: contrib/docker/Dockerfile.headless
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/gridcoinresearchd:${{ steps.version.outputs.version }}
@@ -399,7 +506,7 @@ jobs:
         with:
           context: contrib/docker
           file: contrib/docker/Dockerfile.gui
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/gridcoinresearch:${{ steps.version.outputs.version }}

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -335,7 +335,67 @@ jobs:
           retention-days: 5
 
   # ----------------------------------------------------------------------
-  # JOB 2b: ARM64 Cross-Build (for Docker)
+  # JOB 2b: AMD64 Native Build (for Docker)
+  # ----------------------------------------------------------------------
+  amd64-native-build:
+    name: Linux AMD64 Native Build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          source ./install_dependencies.sh
+          install_deps native true true
+
+      - name: Setup Concurrency
+        run: |
+          if [ -z "$CMAKE_BUILD_PARALLEL_LEVEL" ]; then
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)" >> $GITHUB_ENV
+            echo "CTEST_PARALLEL_LEVEL=$(nproc)" >> $GITHUB_ENV
+            echo "Concurrency: Auto-detected $(nproc) cores."
+          else
+            echo "Concurrency: Limit set externally to $CMAKE_BUILD_PARALLEL_LEVEL."
+          fi
+
+      - name: Configure Ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-prod-amd64-native-${{ github.sha }}
+          restore-keys: ccache-prod-amd64-native-
+
+      - name: Configure CMake
+        run: |
+          cmake -B build_native \
+            -DENABLE_GUI=ON \
+            -DUSE_QT6=ON \
+            -DENABLE_UPNP=ON \
+            -DDEFAULT_UPNP=ON \
+            -DENABLE_TESTS=OFF \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: cmake --build build_native
+
+      - name: Prepare Artifacts
+        run: |
+          mkdir -p dist
+          cp build_native/bin/gridcoinresearchd dist/
+          cp build_native/bin/gridcoinresearch dist/
+
+      - name: Upload Artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gridcoin-x86_64-linux-gnu
+          path: dist/
+          retention-days: 5
+
+  # ----------------------------------------------------------------------
+  # JOB 2c: ARM64 Cross-Build (for Docker)
   # ----------------------------------------------------------------------
   arm64-cross-build:
     name: Linux ARM64 Cross-Build
@@ -434,7 +494,7 @@ jobs:
   # ----------------------------------------------------------------------
   docker-publish:
     name: Publish Docker Images
-    needs: [depends-builds, arm64-cross-build]
+    needs: [amd64-native-build, arm64-cross-build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -446,7 +506,7 @@ jobs:
       - name: Download x86_64 Build Artifact
         uses: actions/download-artifact@v4
         with:
-          name: gridcoin-x86_64-pc-linux-gnu
+          name: gridcoin-x86_64-linux-gnu
           path: artifacts/amd64
 
       - name: Download ARM64 Build Artifact
@@ -460,10 +520,8 @@ jobs:
           cd contrib/docker
           mkdir -p bin/amd64 bin/arm64
 
-          mkdir -p /tmp/amd64-extract
-          tar -xzf ../../artifacts/amd64/*.tar.gz -C /tmp/amd64-extract --strip-components=1
-          cp /tmp/amd64-extract/bin/gridcoinresearchd bin/amd64/
-          cp /tmp/amd64-extract/bin/gridcoinresearch bin/amd64/
+          cp ../../artifacts/amd64/gridcoinresearchd bin/amd64/
+          cp ../../artifacts/amd64/gridcoinresearch bin/amd64/
 
           cp ../../artifacts/arm64/gridcoinresearchd bin/arm64/
           cp ../../artifacts/arm64/gridcoinresearch bin/arm64/

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -146,16 +146,11 @@ jobs:
         run: |
           echo "Checking binaries for unexpected shared library dependencies..."
 
-          # 1. Define the Allowlist (Regex)
-          # We expect ONLY:
-          # - linux-vdso.so.1 (Kernel interface)
-          # - libm.so.6 (Math)
-          # - libc.so.6 (C Runtime)
-          # - ld-linux-x86-64.so.2 (Dynamic Loader)
-          ALLOWED='linux-vdso\.so|libm\.so|libc\.so|ld-linux-x86-64'
+          # Use readelf -d to inspect NEEDED entries from the ELF dynamic section.
+          # Allowed shared libraries: libc.so.6 and libm.so.6 only.
+          ALLOWED='libc\.so|libm\.so'
 
-          # 2. Identify binaries to check (Corrected Paths)
-          # We check both the GUI (src/qt/) and Daemon (src/)
+          # Check both the GUI (src/qt/) and Daemon (src/)
           BINARIES="${{ matrix.build_dir }}/src/qt/gridcoinresearch ${{ matrix.build_dir }}/src/gridcoinresearchd"
 
           fail_count=0
@@ -165,10 +160,9 @@ jobs:
               echo "------------------------------------------------"
               echo "Scanning: $bin"
 
-              # Run ldd, strip whitespace
-              # grep -vE removes the allowed lines.
-              # Any output remaining represents a LEAK (a dynamic dependency).
-              LEAKS=$(ldd "$bin" | grep -vE "$ALLOWED" | sed 's/^[ \t]*//' || true)
+              # Extract NEEDED entries from ELF dynamic section
+              NEEDED=$(readelf -d "$bin" 2>/dev/null | grep '(NEEDED)' | sed 's/.*\[//;s/\]//' || true)
+              LEAKS=$(echo "$NEEDED" | grep -vE "$ALLOWED" | grep -v '^$' || true)
 
               if [ -n "$LEAKS" ]; then
                 echo "::error::NON-HERMETIC DEPENDENCY DETECTED!"
@@ -176,7 +170,7 @@ jobs:
                 echo "$LEAKS"
                 fail_count=$((fail_count+1))
               else
-                echo "✅ Verified hermetic."
+                echo "Verified hermetic. NEEDED: $(echo $NEEDED | tr '\n' ' ')"
               fi
             else
               # Warn but don't fail immediately if a binary is missing (e.g. GUI disabled)
@@ -341,7 +335,78 @@ jobs:
           retention-days: 5
 
   # ----------------------------------------------------------------------
-  # JOB 3: Deploy (GitHub Release)
+  # JOB 3: Publish Docker Images
+  # ----------------------------------------------------------------------
+  docker-publish:
+    name: Publish Docker Images
+    needs: [depends-builds]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download x86_64 Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gridcoin-x86_64-pc-linux-gnu
+          path: artifacts/amd64
+
+      - name: Stage Binaries
+        run: |
+          cd contrib/docker
+          mkdir -p bin/amd64
+
+          mkdir -p /tmp/amd64-extract
+          tar -xzf ../../artifacts/amd64/*.tar.gz -C /tmp/amd64-extract --strip-components=1
+          cp /tmp/amd64-extract/bin/gridcoinresearchd bin/amd64/
+          cp /tmp/amd64-extract/bin/gridcoinresearch bin/amd64/
+
+          chmod +x bin/amd64/gridcoin*
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Version from Tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Build and Push Headless Image
+        uses: docker/build-push-action@v6
+        with:
+          context: contrib/docker
+          file: contrib/docker/Dockerfile.headless
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/gridcoinresearchd:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/gridcoinresearchd:latest
+
+      - name: Build and Push GUI Image
+        uses: docker/build-push-action@v6
+        with:
+          context: contrib/docker
+          file: contrib/docker/Dockerfile.gui
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/gridcoinresearch:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/gridcoinresearch:latest
+
+  # ----------------------------------------------------------------------
+  # JOB 4: Deploy (GitHub Release)
   # ----------------------------------------------------------------------
   deploy:
     name: Create Release

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -470,6 +470,9 @@ jobs:
 
           chmod +x bin/amd64/gridcoin* bin/arm64/gridcoin*
 
+          echo "Staged binaries:"
+          file bin/amd64/* bin/arm64/*
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/contrib/docker/.dockerignore
+++ b/contrib/docker/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+docker-compose*.yml
+.env*

--- a/contrib/docker/.env.example
+++ b/contrib/docker/.env.example
@@ -1,5 +1,6 @@
-# Host path for persistent blockchain/wallet data
-GRIDCOIN_DATA_DIR=~/.GridcoinResearch
+# Host path for persistent blockchain/wallet data.
+# Use an absolute path or $HOME -- tilde (~) is not expanded in .env files.
+GRIDCOIN_DATA_DIR=$HOME/.GridcoinResearch
 
 # Port mappings (defaults match mainnet)
 P2P_PORT=32749

--- a/contrib/docker/.env.example
+++ b/contrib/docker/.env.example
@@ -1,0 +1,9 @@
+# Host path for persistent blockchain/wallet data
+GRIDCOIN_DATA_DIR=~/.GridcoinResearch
+
+# Port mappings (defaults match mainnet)
+P2P_PORT=32749
+RPC_PORT=15715
+
+# For GUI: set your DISPLAY (usually auto-detected)
+# DISPLAY=:0

--- a/contrib/docker/Dockerfile.gui
+++ b/contrib/docker/Dockerfile.gui
@@ -1,0 +1,51 @@
+FROM ubuntu:24.04
+
+ARG UID=1000
+ARG GID=1000
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gosu \
+        openssl \
+        libxcb1 \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-randr0 \
+        libxcb-render-util0 \
+        libxcb-render0 \
+        libxcb-shape0 \
+        libxcb-shm0 \
+        libxcb-sync1 \
+        libxcb-xfixes0 \
+        libxcb-xinerama0 \
+        libxcb-xkb1 \
+        libxcb-cursor0 \
+        libxkbcommon0 \
+        libxkbcommon-x11-0 \
+        libfontconfig1 \
+        libfreetype6 \
+        fontconfig \
+        fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/* \
+    && userdel -r ubuntu 2>/dev/null || true \
+    && groupadd -f -g ${GID} gridcoin \
+    && useradd -u ${UID} -g gridcoin -d /home/gridcoin -m -s /bin/bash gridcoin
+
+COPY entrypoint.sh /entrypoint.sh
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /entrypoint.sh /healthcheck.sh
+
+COPY bin/amd64/gridcoinresearchd /usr/local/bin/
+COPY bin/amd64/gridcoinresearch /usr/local/bin/
+
+VOLUME ["/home/gridcoin/.GridcoinResearch"]
+
+# P2P port (mainnet)
+EXPOSE 32749
+
+HEALTHCHECK --interval=60s --timeout=10s --start-period=300s --retries=3 \
+    CMD ["/healthcheck.sh"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["gridcoinresearchd"]

--- a/contrib/docker/Dockerfile.gui
+++ b/contrib/docker/Dockerfile.gui
@@ -33,29 +33,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd -f -g ${GID} gridcoin \
     && useradd -u ${UID} -g gridcoin -d /home/gridcoin -m -s /bin/bash gridcoin
 
-# Install runtime libraries for dynamically-linked arm64 binary
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends \
-            libboost-filesystem1.83.0 \
-            libboost-thread1.83.0 \
-            libboost-iostreams1.83.0 \
-            libboost-serialization1.83.0 \
-            libboost-date-time1.83.0 \
-            libboost-chrono1.83.0 \
-            libboost-program-options1.83.0 \
-            libssl3t64 \
-            libcurl4t64 \
-            libzip4t64 \
-            libminiupnpc17 \
-            libqt6core6t64 \
-            libqt6gui6t64 \
-            libqt6widgets6t64 \
-            libqt6network6t64 \
-            libqt6charts6 \
-            libqt6svg6 \
-            libqt6core5compat6 \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
+# Install runtime libraries for dynamically-linked binaries (both architectures)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libboost-filesystem1.83.0 \
+        libboost-thread1.83.0 \
+        libboost-iostreams1.83.0 \
+        libboost-serialization1.83.0 \
+        libboost-date-time1.83.0 \
+        libboost-chrono1.83.0 \
+        libboost-program-options1.83.0 \
+        libssl3t64 \
+        libcurl4t64 \
+        libzip4t64 \
+        libminiupnpc17 \
+        libqt6core6t64 \
+        libqt6gui6t64 \
+        libqt6widgets6t64 \
+        libqt6network6t64 \
+        libqt6charts6 \
+        libqt6svg6 \
+        libqt6core5compat6 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/contrib/docker/Dockerfile.gui
+++ b/contrib/docker/Dockerfile.gui
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04
 
+ARG TARGETARCH
 ARG UID=1000
 ARG GID=1000
 
@@ -32,12 +33,36 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd -f -g ${GID} gridcoin \
     && useradd -u ${UID} -g gridcoin -d /home/gridcoin -m -s /bin/bash gridcoin
 
+# Install runtime libraries for dynamically-linked arm64 binary
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            libboost-filesystem1.83.0 \
+            libboost-thread1.83.0 \
+            libboost-iostreams1.83.0 \
+            libboost-serialization1.83.0 \
+            libboost-date-time1.83.0 \
+            libboost-chrono1.83.0 \
+            libboost-program-options1.83.0 \
+            libssl3t64 \
+            libcurl4t64 \
+            libzip4t64 \
+            libminiupnpc17 \
+            libqt6core6t64 \
+            libqt6gui6t64 \
+            libqt6widgets6t64 \
+            libqt6network6t64 \
+            libqt6charts6 \
+            libqt6svg6 \
+            libqt6core5compat6 \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /entrypoint.sh /healthcheck.sh
 
-COPY bin/amd64/gridcoinresearchd /usr/local/bin/
-COPY bin/amd64/gridcoinresearch /usr/local/bin/
+COPY bin/${TARGETARCH}/gridcoinresearchd /usr/local/bin/
+COPY bin/${TARGETARCH}/gridcoinresearch /usr/local/bin/
 
 VOLUME ["/home/gridcoin/.GridcoinResearch"]
 

--- a/contrib/docker/Dockerfile.headless
+++ b/contrib/docker/Dockerfile.headless
@@ -1,0 +1,30 @@
+FROM ubuntu:24.04
+
+ARG UID=1000
+ARG GID=1000
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gosu \
+        openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && userdel -r ubuntu 2>/dev/null || true \
+    && groupadd -f -g ${GID} gridcoin \
+    && useradd -u ${UID} -g gridcoin -d /home/gridcoin -m -s /bin/bash gridcoin
+
+COPY entrypoint.sh /entrypoint.sh
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /entrypoint.sh /healthcheck.sh
+
+COPY bin/amd64/gridcoinresearchd /usr/local/bin/
+
+VOLUME ["/home/gridcoin/.GridcoinResearch"]
+
+# P2P port (mainnet)
+EXPOSE 32749
+
+HEALTHCHECK --interval=60s --timeout=10s --start-period=300s --retries=3 \
+    CMD ["/healthcheck.sh"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["gridcoinresearchd"]

--- a/contrib/docker/Dockerfile.headless
+++ b/contrib/docker/Dockerfile.headless
@@ -13,22 +13,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd -f -g ${GID} gridcoin \
     && useradd -u ${UID} -g gridcoin -d /home/gridcoin -m -s /bin/bash gridcoin
 
-# Install runtime libraries for dynamically-linked arm64 binary
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends \
-            libboost-filesystem1.83.0 \
-            libboost-thread1.83.0 \
-            libboost-iostreams1.83.0 \
-            libboost-serialization1.83.0 \
-            libboost-date-time1.83.0 \
-            libboost-chrono1.83.0 \
-            libboost-program-options1.83.0 \
-            libssl3t64 \
-            libcurl4t64 \
-            libzip4t64 \
-            libminiupnpc17 \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
+# Install runtime libraries for dynamically-linked binaries (both architectures)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libboost-filesystem1.83.0 \
+        libboost-thread1.83.0 \
+        libboost-iostreams1.83.0 \
+        libboost-serialization1.83.0 \
+        libboost-date-time1.83.0 \
+        libboost-chrono1.83.0 \
+        libboost-program-options1.83.0 \
+        libssl3t64 \
+        libcurl4t64 \
+        libzip4t64 \
+        libminiupnpc17 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/contrib/docker/Dockerfile.headless
+++ b/contrib/docker/Dockerfile.headless
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04
 
+ARG TARGETARCH
 ARG UID=1000
 ARG GID=1000
 
@@ -12,11 +13,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd -f -g ${GID} gridcoin \
     && useradd -u ${UID} -g gridcoin -d /home/gridcoin -m -s /bin/bash gridcoin
 
+# Install runtime libraries for dynamically-linked arm64 binary
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            libboost-filesystem1.83.0 \
+            libboost-thread1.83.0 \
+            libboost-iostreams1.83.0 \
+            libboost-serialization1.83.0 \
+            libboost-date-time1.83.0 \
+            libboost-chrono1.83.0 \
+            libboost-program-options1.83.0 \
+            libssl3t64 \
+            libcurl4t64 \
+            libzip4t64 \
+            libminiupnpc17 \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod +x /entrypoint.sh /healthcheck.sh
 
-COPY bin/amd64/gridcoinresearchd /usr/local/bin/
+COPY bin/${TARGETARCH}/gridcoinresearchd /usr/local/bin/
 
 VOLUME ["/home/gridcoin/.GridcoinResearch"]
 

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -11,10 +11,11 @@ Official Docker images for running Gridcoin as a headless daemon or with the Qt 
 
 Both images support `linux/amd64` and `linux/arm64`.
 
-**Note:** The amd64 images use statically-linked binaries and are smaller (~100 MB). The arm64
-images use dynamically-linked binaries (cross-compiled with system libraries) and include
-runtime shared libraries, making them larger (~200-300 MB). The Docker container provides
-the hermetic environment for arm64 instead of static linking.
+**Note:** The amd64 images use statically-linked binaries and are smaller (~95 MB headless,
+~143 MB GUI). The arm64 images use dynamically-linked binaries (cross-compiled with system
+libraries) and include runtime shared libraries, making them larger (~134 MB headless,
+~438 MB GUI). The Docker container provides the hermetic environment for arm64 instead of
+static linking.
 
 ## Quick Start
 
@@ -30,13 +31,18 @@ docker run -d \
   ghcr.io/gridcoin-community/gridcoinresearchd:latest
 ```
 
+For RPC access, see [Exchange Deployment](#exchange-deployment) -- always bind the RPC
+port to `127.0.0.1` to avoid exposing credentials to the network.
+
 ### GUI
 
 ```bash
 docker pull ghcr.io/gridcoin-community/gridcoinresearch:latest
 
-# Allow X11 connections (run on host)
-xhost +local:docker
+# Allow X11 connections for the current local user only (run on host).
+# Avoid broad commands like 'xhost +local:' which allow any local container
+# to connect to your X server (keystroke capture, input injection).
+xhost +SI:localuser:$(id -un)
 
 docker run -d \
   --name gridcoin-gui \

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,230 @@
+# Gridcoin Docker Images
+
+Official Docker images for running Gridcoin as a headless daemon or with the Qt GUI.
+
+## Images
+
+| Image | Description |
+|-------|-------------|
+| `ghcr.io/gridcoin-community/gridcoinresearchd` | Headless daemon only |
+| `ghcr.io/gridcoin-community/gridcoinresearch` | Daemon + Qt GUI |
+
+Both images currently support `linux/amd64`. ARM64 support is planned for a future release
+once the depends build system supports aarch64 cross-compilation.
+
+## Quick Start
+
+### Headless (Daemon)
+
+```bash
+docker pull ghcr.io/gridcoin-community/gridcoinresearchd:latest
+
+docker run -d \
+  --name gridcoin \
+  -v ~/.GridcoinResearch:/home/gridcoin/.GridcoinResearch \
+  -p 32749:32749 \
+  ghcr.io/gridcoin-community/gridcoinresearchd:latest
+```
+
+### GUI
+
+```bash
+docker pull ghcr.io/gridcoin-community/gridcoinresearch:latest
+
+# Allow X11 connections (run on host)
+xhost +local:docker
+
+docker run -d \
+  --name gridcoin-gui \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+  -v ~/.GridcoinResearch:/home/gridcoin/.GridcoinResearch \
+  -p 32749:32749 \
+  ghcr.io/gridcoin-community/gridcoinresearch:latest \
+  gridcoinresearch
+```
+
+## Docker Compose
+
+### Headless + BOINC
+
+```bash
+cd contrib/docker
+cp .env.example .env
+# Edit .env to set GRIDCOIN_DATA_DIR
+
+docker compose up -d
+```
+
+This starts both the Gridcoin daemon and a BOINC client with a shared data volume,
+allowing Gridcoin to read BOINC statistics for research reward eligibility.
+
+### GUI + BOINC
+
+```bash
+cd contrib/docker
+cp .env.example .env
+# Edit .env to set GRIDCOIN_DATA_DIR and DISPLAY
+
+docker compose -f docker-compose.gui.yml up -d
+```
+
+## Data Persistence
+
+All blockchain data, wallet files, and configuration are stored in the data directory
+mounted at `/home/gridcoin/.GridcoinResearch` inside the container. This is a standard
+bind mount -- the same directory layout as a bare-metal installation.
+
+**Back up your wallet:** The wallet file is at `<data-dir>/wallet.dat`. Back it up
+regularly, especially before upgrading.
+
+## Configuration
+
+### Auto-Generated Config
+
+On first run, if no `gridcoinresearch.conf` exists, the entrypoint creates one with:
+- `server=1` (RPC server enabled)
+- Random `rpcpassword` (generated via `openssl rand -hex 32`)
+- `rpcallowip` entries for localhost and Docker internal networks
+- `printtoconsole=1` (forced for Docker log visibility)
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRIDCOIN_DATA_DIR` | `./.gridcoin` | Host path for persistent data |
+| `P2P_PORT` | `32749` | Host P2P port mapping |
+| `RPC_PORT` | `15715` | Host RPC port mapping |
+| `DISPLAY` | (none) | X11 display for GUI |
+
+### Custom Config
+
+Edit `<data-dir>/gridcoinresearch.conf` directly, or pass arguments to the daemon:
+
+```bash
+docker run -d \
+  --name gridcoin \
+  -v ~/.GridcoinResearch:/home/gridcoin/.GridcoinResearch \
+  ghcr.io/gridcoin-community/gridcoinresearchd:latest \
+  -testnet -debug=net
+```
+
+## Exchange Deployment
+
+For exchange integration, enable the RPC port and configure credentials:
+
+```bash
+docker run -d \
+  --name gridcoin \
+  -v /data/gridcoin:/home/gridcoin/.GridcoinResearch \
+  -p 32749:32749 \
+  -p 127.0.0.1:15715:15715 \
+  ghcr.io/gridcoin-community/gridcoinresearchd:latest
+```
+
+The auto-generated config enables `server=1` with a random password. Retrieve it:
+
+```bash
+docker exec gridcoin grep rpcpassword /home/gridcoin/.GridcoinResearch/gridcoinresearch.conf
+```
+
+Key RPC methods for exchanges:
+- `getnewaddress` -- generate deposit addresses
+- `sendtoaddress` -- process withdrawals
+- `listtransactions` / `listsinceblock` -- track deposits
+- `getblockchaininfo` -- monitor sync status
+- `walletnotify` / `blocknotify` -- real-time transaction/block notifications
+
+Transaction index is always enabled (no `-txindex` flag needed).
+
+**Note:** Gridcoin uses plaintext `rpcuser`/`rpcpassword` (hashed `rpcauth` is not
+supported). Docker network isolation (binding RPC to 127.0.0.1 only) mitigates this.
+
+## GUI Display Server Notes
+
+The GUI image includes the Qt XCB (X11) platform plugin.
+
+- **X11 sessions:** Work directly with the X11 socket mount shown above
+- **Wayland sessions:** Work via XWayland, which is enabled by default on GNOME, KDE
+  Plasma, Sway, and other major Wayland compositors
+- **Pure Wayland (no XWayland):** Not supported
+
+## Building Locally
+
+Build static binaries using the `depends/` system, then create Docker images:
+
+```bash
+# 1. Build static binaries
+cmake -B build_depends \
+  --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake \
+  -DSTATIC_LIBS=ON -DENABLE_GUI=ON -DENABLE_TESTS=OFF \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build_depends -j$(nproc)
+
+# 2. Stage binaries
+cd contrib/docker
+mkdir -p bin/amd64
+cp ../../build_depends/src/gridcoinresearchd bin/amd64/
+cp ../../build_depends/src/qt/gridcoinresearch bin/amd64/
+
+# 3. Build images
+docker build -f Dockerfile.headless -t gridcoin-headless .
+docker build -f Dockerfile.gui -t gridcoin-gui .
+```
+
+## Ports
+
+| Port | Protocol | Network | Description |
+|------|----------|---------|-------------|
+| 32749 | TCP | Mainnet | P2P |
+| 15715 | TCP | Mainnet | RPC |
+| 32748 | TCP | Testnet | P2P |
+| 25715 | TCP | Testnet | RPC |
+
+## Security Model
+
+The images follow defense-in-depth principles:
+
+- **Non-root execution:** The daemon runs as user `gridcoin` (UID/GID 1000) via `gosu`
+- **Read-only filesystem:** `read_only: true` in docker-compose (writable data dir via volume)
+- **Dropped capabilities:** `cap_drop: ALL` removes all Linux capabilities
+- **No privilege escalation:** `no-new-privileges` security option
+- **Private tmp:** `tmpfs` mount for `/tmp`
+- **Minimal base image:** `ubuntu:24.04` with only `ca-certificates`, `gosu`,
+  and `openssl` installed (GUI adds X11 libraries)
+- **Config permissions:** `gridcoinresearch.conf` created with mode `0600`
+
+## Troubleshooting
+
+### Container won't start
+
+Check logs:
+```bash
+docker logs gridcoin
+```
+
+### GUI shows "could not connect to display"
+
+1. Ensure `DISPLAY` is set: `echo $DISPLAY`
+2. Allow Docker X11 access: `xhost +local:docker`
+3. Verify X11 socket exists: `ls /tmp/.X11-unix/`
+
+### Sync is slow
+
+This is normal for initial blockchain download. Monitor progress:
+```bash
+docker exec gridcoin gridcoinresearchd getblockchaininfo
+```
+
+### Permission denied on data directory
+
+The container runs as UID/GID 1000. Ensure your data directory is owned by the same:
+```bash
+sudo chown -R 1000:1000 ~/.GridcoinResearch
+```
+
+Or build with custom UID/GID:
+```bash
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+  -f Dockerfile.headless -t gridcoin-headless .
+```

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -11,11 +11,9 @@ Official Docker images for running Gridcoin as a headless daemon or with the Qt 
 
 Both images support `linux/amd64` and `linux/arm64`.
 
-**Note:** The amd64 images use statically-linked binaries and are smaller (~95 MB headless,
-~143 MB GUI). The arm64 images use dynamically-linked binaries (cross-compiled with system
-libraries) and include runtime shared libraries, making them larger (~134 MB headless,
-~438 MB GUI). The Docker container provides the hermetic environment for arm64 instead of
-static linking.
+Both architectures use dynamically-linked binaries built with Ubuntu 24.04 system libraries.
+The Docker container provides the hermetic runtime environment (consistent library versions)
+instead of static linking.
 
 ## Quick Start
 
@@ -95,7 +93,14 @@ regularly, especially before upgrading.
 On first run, if no `gridcoinresearch.conf` exists, the entrypoint creates one with:
 - `server=1` (RPC server enabled)
 - Random `rpcpassword` (generated via `openssl rand -hex 32`)
-- `rpcallowip` entries for localhost and Docker internal networks
+- `rpcallowip` wildcard entries for localhost and private networks (`10.*.*.*`,
+  `172.*.*.*`, `192.168.*.*`). Gridcoin uses wildcard matching for `rpcallowip` (not
+  CIDR notation). Note: `172.*.*.*` is broader than RFC 1918's `172.16.0.0/12` because
+  the wildcard syntax cannot express subnet boundaries; this is acceptable since these
+  entries only affect traffic that reaches the container's network interfaces. The
+  presence of any `rpcallowip` entry causes the RPC server to listen on all interfaces
+  inside the container (not just loopback), which is required for Docker port forwarding
+  to work.
 - `printtoconsole=1` (forced for Docker log visibility)
 
 ### Environment Variables
@@ -161,23 +166,25 @@ The GUI image includes the Qt XCB (X11) platform plugin.
 
 ## Building Locally
 
-Build static binaries using the `depends/` system, then create Docker images:
+Build dynamically-linked binaries with system libraries, then create Docker images:
 
 ```bash
-# 1. Build static binaries
-cmake -B build_depends \
-  --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake \
-  -DSTATIC_LIBS=ON -DENABLE_GUI=ON -DENABLE_TESTS=OFF \
-  -DCMAKE_BUILD_TYPE=Release
-cmake --build build_depends -j$(nproc)
+# 1. Install build dependencies (Ubuntu 24.04)
+source ./install_dependencies.sh
+install_deps native true true
 
-# 2. Stage binaries
+# 2. Build
+cmake -B build -DENABLE_GUI=ON -DUSE_QT6=ON -DENABLE_TESTS=OFF \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+
+# 3. Stage binaries
 cd contrib/docker
 mkdir -p bin/amd64
-cp ../../build_depends/src/gridcoinresearchd bin/amd64/
-cp ../../build_depends/src/qt/gridcoinresearch bin/amd64/
+cp ../../build/bin/gridcoinresearchd bin/amd64/
+cp ../../build/bin/gridcoinresearch bin/amd64/
 
-# 3. Build images
+# 4. Build images
 docker build -f Dockerfile.headless -t gridcoin-headless .
 docker build -f Dockerfile.gui -t gridcoin-gui .
 ```
@@ -197,11 +204,12 @@ The images follow defense-in-depth principles:
 
 - **Non-root execution:** The daemon runs as user `gridcoin` (UID/GID 1000) via `gosu`
 - **Read-only filesystem:** `read_only: true` in docker-compose (writable data dir via volume)
-- **Dropped capabilities:** `cap_drop: ALL` removes all Linux capabilities
+- **Dropped capabilities:** `cap_drop: ALL` then `cap_add` restores only CHOWN,
+  DAC_OVERRIDE, FOWNER, SETUID, SETGID (minimum for entrypoint bootstrap and `gosu`)
 - **No privilege escalation:** `no-new-privileges` security option
 - **Private tmp:** `tmpfs` mount for `/tmp`
-- **Minimal base image:** `ubuntu:24.04` with only `ca-certificates`, `gosu`,
-  and `openssl` installed (GUI adds X11 libraries)
+- **Minimal base image:** `ubuntu:24.04` with only runtime dependencies installed
+  (GUI adds Qt6 and X11 libraries)
 - **Config permissions:** `gridcoinresearch.conf` created with mode `0600`
 
 ## Troubleshooting
@@ -216,7 +224,7 @@ docker logs gridcoin
 ### GUI shows "could not connect to display"
 
 1. Ensure `DISPLAY` is set: `echo $DISPLAY`
-2. Allow Docker X11 access: `xhost +local:docker`
+2. Allow X11 access for the current user: `xhost +SI:localuser:$(id -un)`
 3. Verify X11 socket exists: `ls /tmp/.X11-unix/`
 
 ### Sync is slow

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -9,8 +9,12 @@ Official Docker images for running Gridcoin as a headless daemon or with the Qt 
 | `ghcr.io/gridcoin-community/gridcoinresearchd` | Headless daemon only |
 | `ghcr.io/gridcoin-community/gridcoinresearch` | Daemon + Qt GUI |
 
-Both images currently support `linux/amd64`. ARM64 support is planned for a future release
-once the depends build system supports aarch64 cross-compilation.
+Both images support `linux/amd64` and `linux/arm64`.
+
+**Note:** The amd64 images use statically-linked binaries and are smaller (~100 MB). The arm64
+images use dynamically-linked binaries (cross-compiled with system libraries) and include
+runtime shared libraries, making them larger (~200-300 MB). The Docker container provides
+the hermetic environment for arm64 instead of static linking.
 
 ## Quick Start
 

--- a/contrib/docker/docker-compose.gui.yml
+++ b/contrib/docker/docker-compose.gui.yml
@@ -15,11 +15,17 @@ services:
       - "${P2P_PORT:-32749}:32749"
     read_only: true
     tmpfs:
-      - /tmp
+      - /tmp/gridcoin
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
 
   boinc:
     image: boinc/client:latest

--- a/contrib/docker/docker-compose.gui.yml
+++ b/contrib/docker/docker-compose.gui.yml
@@ -13,6 +13,9 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
     ports:
       - "${P2P_PORT:-32749}:32749"
+    read_only: true
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/contrib/docker/docker-compose.gui.yml
+++ b/contrib/docker/docker-compose.gui.yml
@@ -1,0 +1,29 @@
+services:
+  gridcoin-gui:
+    image: ghcr.io/gridcoin-community/gridcoinresearch:latest
+    container_name: gridcoin-gui
+    restart: unless-stopped
+    stop_grace_period: 120s
+    command: ["gridcoinresearch"]
+    environment:
+      - DISPLAY=${DISPLAY}
+    volumes:
+      - ${GRIDCOIN_DATA_DIR:-./.gridcoin}:/home/gridcoin/.GridcoinResearch
+      - boinc-data:/var/lib/boinc:ro
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
+    ports:
+      - "${P2P_PORT:-32749}:32749"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  boinc:
+    image: boinc/client:latest
+    container_name: boinc
+    restart: unless-stopped
+    volumes:
+      - boinc-data:/var/lib/boinc
+
+volumes:
+  boinc-data:

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  gridcoin:
+    image: ghcr.io/gridcoin-community/gridcoinresearchd:latest
+    container_name: gridcoin
+    restart: unless-stopped
+    stop_grace_period: 120s
+    volumes:
+      - ${GRIDCOIN_DATA_DIR:-./.gridcoin}:/home/gridcoin/.GridcoinResearch
+      - boinc-data:/var/lib/boinc:ro
+    ports:
+      - "${P2P_PORT:-32749}:32749"                       # P2P
+      # - "127.0.0.1:${RPC_PORT:-15715}:15715"           # RPC (uncomment if needed)
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  boinc:
+    image: boinc/client:latest
+    container_name: boinc
+    restart: unless-stopped
+    volumes:
+      - boinc-data:/var/lib/boinc
+    # GPU passthrough (uncomment if needed):
+    # devices:
+    #   - /dev/dri:/dev/dri
+
+volumes:
+  boinc-data:

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
 
   boinc:
     image: boinc/client:latest

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+export LC_ALL=C
+
+set -e
+
+DATA_DIR="/home/gridcoin/.GridcoinResearch"
+CONF_FILE="${DATA_DIR}/gridcoinresearch.conf"
+
+# Ensure the data directory exists and is owned by gridcoin
+mkdir -p "${DATA_DIR}"
+chown -R gridcoin:gridcoin "${DATA_DIR}"
+
+# Bootstrap config if it doesn't exist
+if [ ! -f "${CONF_FILE}" ]; then
+    echo "Creating default gridcoinresearch.conf..."
+    cat > "${CONF_FILE}" <<EOF
+server=1
+rpcuser=gridcoinrpc
+rpcpassword=$(openssl rand -hex 32)
+rpcallowip=127.0.0.1
+rpcallowip=10.0.0.0/8
+rpcallowip=172.16.0.0/12
+rpcallowip=192.168.0.0/16
+EOF
+    chown gridcoin:gridcoin "${CONF_FILE}"
+    chmod 0600 "${CONF_FILE}"
+fi
+
+# Force printtoconsole=1 for Docker log visibility
+if grep -q '^printtoconsole=' "${CONF_FILE}"; then
+    sed -i 's/^printtoconsole=.*/printtoconsole=1/' "${CONF_FILE}"
+else
+    echo "printtoconsole=1" >> "${CONF_FILE}"
+fi
+
+# If first arg starts with '-', prepend the daemon binary
+if [ "${1:0:1}" = '-' ]; then
+    set -- gridcoinresearchd "$@"
+fi
+
+# Drop privileges for Gridcoin binaries
+if [ "$1" = 'gridcoinresearchd' ] || [ "$1" = 'gridcoinresearch' ]; then
+    exec gosu gridcoin:gridcoin "$@"
+fi
+
+# Allow arbitrary commands (e.g. bash for debugging)
+exec "$@"

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -19,11 +19,15 @@ server=1
 rpcuser=gridcoinrpc
 rpcpassword=$(openssl rand -hex 32)
 rpcallowip=127.0.0.1
-# Docker internal networks -- allows RPC from linked containers.
-# Customize these for production; see README for details.
-rpcallowip=10.0.0.0/8
-rpcallowip=172.16.0.0/12
-rpcallowip=192.168.0.0/16
+# Allow RPC from Docker networks. Any rpcallowip entry causes the daemon
+# to bind on all interfaces (required for Docker port forwarding).
+# Host-side access is restricted by -p 127.0.0.1:15715:15715.
+# Gridcoin uses wildcard matching (not CIDR), so 172.*.*.* is broader
+# than RFC 1918's 172.16-31.x.x -- acceptable since only Docker network
+# traffic can reach the container's interfaces.
+rpcallowip=10.*.*.*
+rpcallowip=172.*.*.*
+rpcallowip=192.168.*.*
 EOF
     chown gridcoin:gridcoin "${CONF_FILE}"
     chmod 0600 "${CONF_FILE}"

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -19,6 +19,8 @@ server=1
 rpcuser=gridcoinrpc
 rpcpassword=$(openssl rand -hex 32)
 rpcallowip=127.0.0.1
+# Docker internal networks -- allows RPC from linked containers.
+# Customize these for production; see README for details.
 rpcallowip=10.0.0.0/8
 rpcallowip=172.16.0.0/12
 rpcallowip=192.168.0.0/16

--- a/contrib/docker/healthcheck.sh
+++ b/contrib/docker/healthcheck.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export LC_ALL=C
+
+gridcoinresearchd getblockchaininfo > /dev/null 2>&1 || exit 1


### PR DESCRIPTION
## Summary

- Add headless (`gridcoinresearchd`) and GUI (`gridcoinresearch`) Docker images built on `ubuntu:24.04`, published to ghcr.io as multi-arch (amd64 + arm64) on tagged releases
- Add amd64 native build and arm64 cross-compilation jobs to the CI production workflow for Docker image creation
- Include BOINC orchestration via docker-compose, security hardening (non-root, read-only fs, cap_drop ALL), and auto-generated config with random RPC credentials

Closes #2766.

## Architecture: Symmetric Dynamic Linking

Both amd64 and arm64 images use dynamically-linked binaries built with Ubuntu 24.04 system
libraries. The Docker container itself provides the hermetic runtime environment (consistent
library versions across deployments) rather than static linking.

| | amd64 | arm64 |
|---|---|---|
| **Build method** | Native build with system libraries | Cross-compile with system libraries |
| **Linking** | Dynamic (boost, openssl, curl, Qt6, etc.) | Dynamic (boost, openssl, curl, Qt6, etc.) |
| **Hermeticity** | Docker container provides hermetic environment | Docker container provides hermetic environment |

The `depends/` static build continues to be used for the release tarball and Windows
installer via the existing `depends-builds` and `deploy` jobs.

## Historical Context: Why Dynamic Instead of Static?

This PR originally used a mixed approach: statically-linked binaries (from the `depends/`
build system) for amd64, and dynamically-linked binaries for arm64 (because `depends/`
cannot cross-compile for aarch64 due to boost.context selecting x86_64-specific assembly).

During testing, the statically-linked amd64 GUI binary consistently segfaulted (exit code
139 / SIGSEGV) when run inside the Docker container, despite working perfectly on bare
metal. The crash occurred during Qt's xcb platform plugin initialization:

```
qt.qpa.xcb: could not connect to display
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
This application failed to start because no Qt platform plugin could be initialized.
```

Debugging revealed a **Heisenbug**: running the binary under `strace` (which uses `ptrace`)
prevented the crash entirely — the binary would successfully fall back from the abstract X11
socket (isolated by Docker's network namespace) to the filesystem socket at
`/tmp/.X11-unix/X0` and run normally. Without `ptrace`, the process crashed before the
fallback could execute. This was reproducible with both CI-built and locally-built static
binaries.

Multiple container-level fixes were attempted (fontconfig paths, locale settings, ldconfig
triggers, `--net=host`, `--ipc=host`, installing `libunwind8`) — none resolved the
underlying issue. The crash is specific to statically-linked Qt xcb plugin initialization
in a container environment and is masked by the timing changes that `ptrace` introduces.

Rather than chase a fragile fix that could break with any Qt or kernel update, we switched
amd64 to dynamically-linked binaries — the same approach already proven reliable on arm64.
This makes both architectures consistent and eliminates the entire class of "static binary
doesn't work in container" problems. The modest increase in image size is an acceptable
trade-off for reliability, and the `depends/` static builds remain available for the
release tarball.

## New files

| File | Purpose |
|------|---------|
| `contrib/docker/Dockerfile.headless` | Daemon-only image on ubuntu:24.04 |
| `contrib/docker/Dockerfile.gui` | Daemon + Qt GUI image with X11/XCB libraries |
| `contrib/docker/entrypoint.sh` | Config bootstrap, printtoconsole enforcement, privilege drop via gosu |
| `contrib/docker/healthcheck.sh` | Docker HEALTHCHECK via `getblockchaininfo` RPC |
| `contrib/docker/docker-compose.yml` | Headless + BOINC orchestration |
| `contrib/docker/docker-compose.gui.yml` | GUI + BOINC with X11 socket mount |
| `contrib/docker/.env.example` | Environment variable template |
| `contrib/docker/.dockerignore` | Build context exclusions |
| `contrib/docker/README.md` | Usage docs: quick start, exchange deployment, security model |

## Testing Results

All four image variants built via CI (tag `5.4.9.10-docker_test_6`) and tested locally:

| Image | Arch | Size | Daemon | RPC | GUI | Sync |
|-------|------|------|:---:|:---:|:---:|:---:|
| `gridcoinresearchd` | amd64 | 112 MB | OK | OK | n/a | OK |
| `gridcoinresearchd` | arm64 | 134 MB | OK | OK | n/a | OK |
| `gridcoinresearch` | amd64 | 411 MB | OK | OK | OK | OK |
| `gridcoinresearch` | arm64 | 437 MB | OK | OK | OK | OK |

**Tests performed:**
- Pulled and ran all four images (arm64 via QEMU on x86_64 host)
- Verified daemon starts, connects to peers, and syncs blocks on both architectures
- Verified RPC responds (`getblockcount`) on both architectures
- Verified entrypoint bootstraps config with random RPC password and `printtoconsole=1`
- Verified amd64 GUI launches with X11 display forwarding (Qt window renders correctly)
- Verified arm64 GUI launches with X11 display forwarding (Qt window renders correctly)
- Verified `ldd` shows no missing shared libraries on dynamically-linked binaries
- Verified docker-compose: BOINC volume shared between containers (read-only from Gridcoin)
- Full CI pipeline passes: all build jobs + Docker publish + release creation

## Test plan

- [x] Verify arm64 cross-build job completes in CI
- [x] Verify amd64 native build job completes in CI
- [x] Verify docker-publish job builds and pushes multi-arch images
- [x] Local headless image (amd64): daemon starts, RPC responds, syncs
- [x] Local headless image (arm64): daemon starts, RPC responds, syncs
- [x] Local GUI image (amd64): Qt window renders, daemon runs, RPC responds
- [x] Local GUI image (arm64): Qt window renders, daemon runs, RPC responds
- [x] docker-compose: BOINC volume sharing, config bootstrap, read-only mount verified
- [x] Exchange mode: RPC accessible from host via 127.0.0.1:15715, not exposed externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
