### PR TITLE
qt: add v3 beacon ownership proof GUI wizard page

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -1166,6 +1166,19 @@ std::vector<std::string> GetProjectsExternalAdapterRequired()
     return split(EXTERNAL_ADAPTER_PROJECTS, "|");
 }
 
+std::set<std::string> GetProjectsWithOwnershipProofSupport()
+{
+    LOCK(cs_ProjectPublicKeys);
+
+    std::set<std::string> urls;
+
+    for (const auto& entry : g_project_public_keys) {
+        urls.insert(entry.first);
+    }
+
+    return urls;
+}
+
 
 /** Username and password data utility class for accessing project stats that have implemented usernam and password
  * protection for stats downloads to satisfy GDPR requirements

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -9,6 +9,8 @@
 #include <cmath>
 #include <algorithm>
 #include <cctype>
+#include <set>
+#include <string>
 #include <vector>
 #include <map>
 
@@ -262,5 +264,8 @@ unsigned int NumScrapersForSupermajority(unsigned int nScraperCount);
 
 /** Gets a vector of projects that require an external adapter for the scrapers to pull statistics. */
 std::vector<std::string> GetProjectsExternalAdapterRequired();
+
+/** Returns the set of project master URLs for which ownership proof public keys are available. */
+std::set<std::string> GetProjectsWithOwnershipProofSupport();
 
 #endif // GRIDCOIN_SCRAPER_SCRAPER_H

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(gridcoinqt STATIC
     researcher/researcherwizardpoolpage.cpp
     researcher/researcherwizardpoolsummarypage.cpp
     researcher/researcherwizardprojectspage.cpp
+    researcher/researcherwizardownershipproofpage.cpp
     researcher/researcherwizardsummarypage.cpp
     rpcconsole.cpp
     sendcoinsdialog.cpp

--- a/src/qt/forms/researcherwizard.ui
+++ b/src/qt/forms/researcherwizard.ui
@@ -69,6 +69,14 @@
   <widget class="ResearcherWizardNoncruncherPage" name="NoncruncherPage"/>
   <widget class="ResearcherWizardPoolPage" name="poolPage"/>
   <widget class="ResearcherWizardPoolSummaryPage" name="poolSummaryPage"/>
+  <widget class="ResearcherWizardOwnershipProofPage" name="ownershipProofPage">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+  </widget>
  </widget>
  <customwidgets>
   <customwidget>
@@ -129,6 +137,12 @@
    <class>ResearcherWizardPoolSummaryPage</class>
    <extends>QWizardPage</extends>
    <header>researcher/researcherwizardpoolsummarypage.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ResearcherWizardOwnershipProofPage</class>
+   <extends>QWizardPage</extends>
+   <header>researcher/researcherwizardownershipproofpage.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/qt/forms/researcherwizardbeaconpage.ui
+++ b/src/qt/forms/researcherwizardbeaconpage.ui
@@ -90,56 +90,80 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="verificationMethodWrapper" native="true">
-     <layout class="QVBoxLayout" name="verificationMethodLayout">
-      <item>
-       <widget class="QLabel" name="verificationMethodLabel">
-        <property name="text">
-         <string>Choose verification method:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::NoTextInteraction</set>
-        </property>
-       </widget>
-      </item>
-      <item alignment="Qt::AlignHCenter">
-       <widget class="QRadioButton" name="v2RadioButton">
-        <property name="text">
-         <string>Classic verification (change BOINC username)</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item alignment="Qt::AlignHCenter">
-       <widget class="QRadioButton" name="v3RadioButton">
-        <property name="text">
-         <string>Account ownership proof (recommended if available)</string>
-        </property>
-       </widget>
-      </item>
-      <item alignment="Qt::AlignHCenter">
-       <widget class="QLabel" name="v3UnavailableLabel">
-        <property name="text">
-         <string notr="true"/>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::NoTextInteraction</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QHBoxLayout" name="verificationMethodOuterLayout">
+     <item>
+      <spacer name="verificationMethodLeftSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QWidget" name="verificationMethodWrapper" native="true">
+       <layout class="QVBoxLayout" name="verificationMethodLayout">
+        <item>
+         <widget class="QLabel" name="verificationMethodLabel">
+          <property name="text">
+           <string>Choose verification method:</string>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::NoTextInteraction</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="v2RadioButton">
+          <property name="text">
+           <string>Classic verification (change BOINC username)</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="v3RadioButton">
+          <property name="text">
+           <string>Account ownership proof (recommended if available)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="v3UnavailableLabel">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::NoTextInteraction</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verificationMethodRightSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item alignment="Qt::AlignHCenter">
     <widget class="QPushButton" name="sendBeaconButton">

--- a/src/qt/forms/researcherwizardbeaconpage.ui
+++ b/src/qt/forms/researcherwizardbeaconpage.ui
@@ -89,6 +89,58 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QWidget" name="verificationMethodWrapper" native="true">
+     <layout class="QVBoxLayout" name="verificationMethodLayout">
+      <item>
+       <widget class="QLabel" name="verificationMethodLabel">
+        <property name="text">
+         <string>Choose verification method:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::NoTextInteraction</set>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QRadioButton" name="v2RadioButton">
+        <property name="text">
+         <string>Classic verification (change BOINC username)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QRadioButton" name="v3RadioButton">
+        <property name="text">
+         <string>Account ownership proof (recommended if available)</string>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="v3UnavailableLabel">
+        <property name="text">
+         <string notr="true"/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::NoTextInteraction</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item alignment="Qt::AlignHCenter">
     <widget class="QPushButton" name="sendBeaconButton">
      <property name="sizePolicy">

--- a/src/qt/forms/researcherwizardownershipproofpage.ui
+++ b/src/qt/forms/researcherwizardownershipproofpage.ui
@@ -1,0 +1,396 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ResearcherWizardOwnershipProofPage</class>
+ <widget class="QWizardPage" name="ResearcherWizardOwnershipProofPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>BOINC Account Ownership Proof</string>
+  </property>
+  <property name="title">
+   <string>BOINC Account Ownership Proof</string>
+  </property>
+  <property name="subTitle">
+   <string>Prove ownership of a BOINC account by obtaining a cryptographic signature from a supporting project website.</string>
+  </property>
+  <layout class="QVBoxLayout" name="ownershipProofPageLayout">
+   <item>
+    <widget class="QScrollArea" name="contentScrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <widget class="QWidget" name="contentScrollAreaContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>596</width>
+        <height>700</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="contentLayout">
+       <item>
+        <widget class="QLabel" name="pubkeyHeaderLabel">
+         <property name="text">
+          <string>Your beacon public key:</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="pubkeyLayout">
+         <property name="leftMargin">
+          <number>16</number>
+         </property>
+         <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+          <widget class="QLabel" name="pubkeyLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <family>Monospace</family>
+            </font>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+          <widget class="QPushButton" name="copyPubKeyButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Copy the beacon public key to the system clipboard</string>
+           </property>
+           <property name="text">
+            <string>&amp;Copy</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../bitcoin.qrc">
+             <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="pubkeySpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="sectionSpacer1">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>6</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="projectListHeaderLabel">
+         <property name="text">
+          <string>Projects supporting account ownership proof:</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="projectListLabel">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="indent">
+          <number>16</number>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="sectionSpacer2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>6</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="step1Label">
+         <property name="text">
+          <string>1. Sign in to one of the projects listed above and visit the account ownership proof page.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="step2Label">
+         <property name="text">
+          <string>2. Enter your beacon public key (shown above) where the project asks for it.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="step3Label">
+         <property name="text">
+          <string>3. Copy the entire XML block the project returns and paste it below:</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="ownershipProofXmlEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>120</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>Monospace</family>
+          </font>
+         </property>
+         <property name="placeholderText">
+          <string>Paste the ownership proof XML here...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="sendLayout">
+         <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+          <widget class="QPushButton" name="sendBeaconButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&amp;Send Beacon</string>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignLeft|Qt::AlignVCenter">
+          <widget class="QLabel" name="statusIconLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::NoTextInteraction</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="statusLabel">
+           <property name="text">
+            <string notr="true"/>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextSelectableByMouse</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="sendSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="sectionSpacer3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="rememberLabel">
+         <property name="text">
+          <string>&lt;html&gt;
+&lt;head/&gt;
+&lt;body&gt;
+&lt;h4 style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;
+&lt;span style=&quot; font-size:medium; font-weight:600;&quot;&gt;Remember:&lt;/span&gt;
+&lt;/h4&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 0;&quot;&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The network only needs to verify the ownership proof from a single project even when you participate in multiple projects. &lt;/li&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A beacon expires after six months pass. &lt;/li&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:0px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A beacon becomes eligible for renewal after five months pass. The wallet will remind you to renew the beacon. &lt;/li&gt;
+&lt;li style=&quot; margin-top:6px; margin-bottom:12px; margin-left:15px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This method does not require changing your BOINC username. &lt;/li&gt;
+&lt;/ul&gt;
+&lt;/body&gt;
+&lt;/html&gt;</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="footerSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <key_io.h>
+#include "chainparams.h"
 #include "main.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/boinc.h"
@@ -12,7 +13,9 @@
 #include "gridcoin/researcher.h"
 #include "gridcoin/scraper/scraper.h"
 #include "gridcoin/superblock.h"
+#include "gridcoin/support/xml.h"
 #include "node/ui_interface.h"
+#include "util/strencodings.h"
 
 #include "qt/bitcoinunits.h"
 #include "qt/guiutil.h"
@@ -784,8 +787,133 @@ BeaconStatus ResearcherModel::advertiseBeacon()
     return MapAdvertiseBeaconError(result.Error());
 }
 
+bool ResearcherModel::isV14Enabled() const
+{
+    return IsV14Enabled(nBestHeight);
+}
+
+bool ResearcherModel::hasV3CapableProjects() const
+{
+    return !GetProjectsWithOwnershipProofSupport().empty();
+}
+
+std::vector<std::pair<QString, QString>> ResearcherModel::buildV3ProjectList() const
+{
+    const std::set<std::string> v3_urls = GetProjectsWithOwnershipProofSupport();
+
+    if (v3_urls.empty()) {
+        return {};
+    }
+
+    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(
+        ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED);
+
+    std::vector<std::pair<QString, QString>> result;
+
+    for (const auto& project : whitelist) {
+        std::string base_url = project.BaseUrl();
+
+        // Normalize: ensure trailing slash for comparison.
+        if (!base_url.empty() && base_url.back() != '/') {
+            base_url += '/';
+        }
+
+        if (v3_urls.count(base_url) > 0) {
+            result.emplace_back(
+                QString::fromStdString(project.DisplayName()),
+                QString::fromStdString(project.DisplayUrl()));
+        }
+    }
+
+    return result;
+}
+
+QString ResearcherModel::generateBeaconKeyForV3()
+{
+    const CpidOption cpid = m_researcher->Id().TryCpid();
+
+    if (!cpid) {
+        return QString();
+    }
+
+    AdvertiseBeaconResult result = GenerateBeaconKey(*cpid);
+
+    if (auto public_key = result.TryPublicKey()) {
+        m_cached_beacon_pubkey_hex = QString::fromStdString(HexStr(*public_key));
+        return m_cached_beacon_pubkey_hex;
+    }
+
+    return QString();
+}
+
+BeaconStatus ResearcherModel::advertiseBeaconV3(const QString& ownership_proof_xml)
+{
+    const CpidOption cpid = m_researcher->Id().TryCpid();
+
+    if (!cpid) {
+        return BeaconStatus::NO_CPID;
+    }
+
+    const std::string xml = ownership_proof_xml.toStdString();
+
+    const std::string master_url = ExtractXML(xml, "<master_url>", "</master_url>");
+    const std::string msg = ExtractXML(xml, "<msg>", "</msg>");
+    const std::string sig_b64 = ExtractXML(xml, "<signature>", "</signature>");
+
+    if (master_url.empty() || msg.empty() || sig_b64.empty()) {
+        return BeaconStatus::ERROR_TX_FAILED;
+    }
+
+    // Parse the msg field: "{account_id} {beacon_public_key_hex}"
+    const size_t space_pos = msg.find(' ');
+
+    if (space_pos == std::string::npos || space_pos + 1 >= msg.size()) {
+        return BeaconStatus::ERROR_TX_FAILED;
+    }
+
+    uint32_t account_id = 0;
+    if (!ParseUInt32(msg.substr(0, space_pos), &account_id) || account_id == 0) {
+        return BeaconStatus::ERROR_TX_FAILED;
+    }
+
+    const std::string public_key_hex = msg.substr(space_pos + 1);
+    const std::vector<uint8_t> pubkey_bytes = ParseHex(public_key_hex);
+    CPubKey beacon_pubkey(pubkey_bytes);
+
+    if (!beacon_pubkey.IsValid()) {
+        return BeaconStatus::ERROR_TX_FAILED;
+    }
+
+    if (!pwalletMain->HaveKey(beacon_pubkey.GetID())) {
+        return BeaconStatus::ERROR_MISSING_KEY;
+    }
+
+    bool b64_invalid = false;
+    const std::vector<uint8_t> rsa_sig_bytes = DecodeBase64(sig_b64.c_str(), &b64_invalid);
+
+    if (b64_invalid || rsa_sig_bytes.empty()) {
+        return BeaconStatus::ERROR_TX_FAILED;
+    }
+
+    Beacon beacon(beacon_pubkey);
+    OwnershipProof proof;
+    proof.m_master_url = master_url;
+    proof.m_account_id = account_id;
+    proof.m_rsa_signature = rsa_sig_bytes;
+
+    AdvertiseBeaconResult result = SendBeaconContractV3(*cpid, beacon, std::move(proof));
+
+    return MapAdvertiseBeaconError(result.Error());
+}
+
+QString ResearcherModel::cachedBeaconPubKeyHex() const
+{
+    return m_cached_beacon_pubkey_hex;
+}
+
 void ResearcherModel::onWizardClose()
 {
+    m_cached_beacon_pubkey_hex.clear();
     m_wizard_open = false;
 }
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -16,6 +16,7 @@
 #include "gridcoin/support/xml.h"
 #include "node/ui_interface.h"
 #include "util/strencodings.h"
+#include <util/string.h>
 
 #include "qt/bitcoinunits.h"
 #include "qt/guiutil.h"
@@ -141,6 +142,8 @@ QString ResearcherModel::mapBeaconStatus(const BeaconStatus status)
             return tr("Current beacon is not renewable yet.");
         case BeaconStatus::ERROR_TX_FAILED:
             return tr("Unable to send beacon transaction. See debug.log");
+        case BeaconStatus::ERROR_INVALID_PROOF_XML:
+            return tr("Invalid ownership proof XML. Verify the pasted content.");
         case BeaconStatus::ERROR_WALLET_LOCKED:
             return tr("Unlock wallet fully to send a beacon transaction.");
         case BeaconStatus::NO_BEACON:
@@ -181,6 +184,7 @@ QIcon ResearcherModel::mapBeaconStatusIcon(const BeaconStatus status) const
         case BeaconStatus::ERROR_MISSING_KEY:        return make_icon(danger);
         case BeaconStatus::ERROR_NOT_NEEDED:         return make_icon(success);
         case BeaconStatus::ERROR_TX_FAILED:          return make_icon(danger);
+        case BeaconStatus::ERROR_INVALID_PROOF_XML: return make_icon(danger);
         case BeaconStatus::ERROR_WALLET_LOCKED:      return make_icon(danger);
         case BeaconStatus::NO_BEACON:                return make_icon(inactive);
         case BeaconStatus::NO_CPID:                  return make_icon(inactive);
@@ -832,6 +836,8 @@ QString ResearcherModel::generateBeaconKeyForV3()
 {
     const CpidOption cpid = m_researcher->Id().TryCpid();
 
+    // The wizard flow requires a CPID before reaching the beacon page, so
+    // this is not reachable in practice. Defensive check only.
     if (!cpid) {
         return QString();
     }
@@ -856,24 +862,24 @@ BeaconStatus ResearcherModel::advertiseBeaconV3(const QString& ownership_proof_x
 
     const std::string xml = ownership_proof_xml.toStdString();
 
-    const std::string master_url = ExtractXML(xml, "<master_url>", "</master_url>");
-    const std::string msg = ExtractXML(xml, "<msg>", "</msg>");
-    const std::string sig_b64 = ExtractXML(xml, "<signature>", "</signature>");
+    const std::string master_url = TrimString(ExtractXML(xml, "<master_url>", "</master_url>"));
+    const std::string msg = TrimString(ExtractXML(xml, "<msg>", "</msg>"));
+    const std::string sig_b64 = TrimString(ExtractXML(xml, "<signature>", "</signature>"));
 
     if (master_url.empty() || msg.empty() || sig_b64.empty()) {
-        return BeaconStatus::ERROR_TX_FAILED;
+        return BeaconStatus::ERROR_INVALID_PROOF_XML;
     }
 
     // Parse the msg field: "{account_id} {beacon_public_key_hex}"
     const size_t space_pos = msg.find(' ');
 
     if (space_pos == std::string::npos || space_pos + 1 >= msg.size()) {
-        return BeaconStatus::ERROR_TX_FAILED;
+        return BeaconStatus::ERROR_INVALID_PROOF_XML;
     }
 
     uint32_t account_id = 0;
     if (!ParseUInt32(msg.substr(0, space_pos), &account_id) || account_id == 0) {
-        return BeaconStatus::ERROR_TX_FAILED;
+        return BeaconStatus::ERROR_INVALID_PROOF_XML;
     }
 
     const std::string public_key_hex = msg.substr(space_pos + 1);
@@ -881,7 +887,7 @@ BeaconStatus ResearcherModel::advertiseBeaconV3(const QString& ownership_proof_x
     CPubKey beacon_pubkey(pubkey_bytes);
 
     if (!beacon_pubkey.IsValid()) {
-        return BeaconStatus::ERROR_TX_FAILED;
+        return BeaconStatus::ERROR_INVALID_PROOF_XML;
     }
 
     if (!pwalletMain->HaveKey(beacon_pubkey.GetID())) {
@@ -892,7 +898,7 @@ BeaconStatus ResearcherModel::advertiseBeaconV3(const QString& ownership_proof_x
     const std::vector<uint8_t> rsa_sig_bytes = DecodeBase64(sig_b64.c_str(), &b64_invalid);
 
     if (b64_invalid || rsa_sig_bytes.empty()) {
-        return BeaconStatus::ERROR_TX_FAILED;
+        return BeaconStatus::ERROR_INVALID_PROOF_XML;
     }
 
     Beacon beacon(beacon_pubkey);

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -6,8 +6,10 @@
 #define GRIDCOIN_QT_RESEARCHER_RESEARCHERMODEL_H
 
 #include <memory>
+#include <vector>
 #include "amount.h"
 #include <QObject>
+#include <QString>
 #include <optional>
 
 QT_BEGIN_NAMESPACE
@@ -137,6 +139,14 @@ public:
 
     std::vector<ProjectRow> buildProjectTable(bool extended = true) const;
 
+    // V3 beacon ownership proof support
+    bool isV14Enabled() const;
+    bool hasV3CapableProjects() const;
+    std::vector<std::pair<QString, QString>> buildV3ProjectList() const;
+    QString generateBeaconKeyForV3();
+    BeaconStatus advertiseBeaconV3(const QString& ownership_proof_xml);
+    QString cachedBeaconPubKeyHex() const;
+
 private:
     GRC::ResearcherPtr m_researcher;
     std::unique_ptr<GRC::Beacon> m_beacon;
@@ -148,6 +158,7 @@ private:
     bool m_split_cpid;
     bool m_privacy_enabled;
     QString m_theme_suffix;
+    QString m_cached_beacon_pubkey_hex;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_QT_RESEARCHER_RESEARCHERMODEL_H
 
 #include <memory>
+#include <utility>
 #include <vector>
 #include "amount.h"
 #include <QObject>
@@ -39,6 +40,7 @@ enum class BeaconStatus
     ERROR_MISSING_KEY,
     ERROR_NOT_NEEDED,
     ERROR_TX_FAILED,
+    ERROR_INVALID_PROOF_XML,
     ERROR_WALLET_LOCKED,
     NO_BEACON,
     NO_CPID,

--- a/src/qt/researcher/researcherwizard.cpp
+++ b/src/qt/researcher/researcherwizard.cpp
@@ -45,6 +45,7 @@ ResearcherWizard::ResearcherWizard(
     ui->NoncruncherPage->setModel(researcher_model);
     ui->poolPage->setModel(researcher_model, wallet_model);
     ui->poolSummaryPage->setModel(researcher_model);
+    ui->ownershipProofPage->setModel(researcher_model, wallet_model);
 
     // This enables the "help me choose" button on the modes page to switch the
     // current page to the details page. Because the modes page cannot navigate

--- a/src/qt/researcher/researcherwizard.h
+++ b/src/qt/researcher/researcherwizard.h
@@ -31,6 +31,7 @@ public:
         PageNoncruncher,
         PagePool,
         PagePoolSummary,
+        PageOwnershipProof,
     };
 
     //!

--- a/src/qt/researcher/researcherwizardbeaconpage.cpp
+++ b/src/qt/researcher/researcherwizardbeaconpage.cpp
@@ -158,7 +158,7 @@ void ResearcherWizardBeaconPage::advertiseBeacon()
 
         m_v3_key_generated = true;
         updateBeaconStatus(tr("Beacon key generated. Press \"Next\" to continue."));
-        emit completeChanged();
+        refresh();
         return;
     }
 
@@ -196,5 +196,5 @@ void ResearcherWizardBeaconPage::onVerificationMethodToggled()
         ui->sendBeaconButton->setText(tr("&Advertise Beacon"));
     }
 
-    emit completeChanged();
+    refresh();
 }

--- a/src/qt/researcher/researcherwizardbeaconpage.cpp
+++ b/src/qt/researcher/researcherwizardbeaconpage.cpp
@@ -17,6 +17,8 @@ ResearcherWizardBeaconPage::ResearcherWizardBeaconPage(QWidget *parent)
     , ui(new Ui::ResearcherWizardBeaconPage)
     , m_researcher_model(nullptr)
     , m_wallet_model(nullptr)
+    , m_v3_selected(false)
+    , m_v3_key_generated(false)
 {
     ui->setupUi(this);
 }
@@ -40,6 +42,8 @@ void ResearcherWizardBeaconPage::setModel(
     connect(m_researcher_model, &ResearcherModel::researcherChanged, this, &ResearcherWizardBeaconPage::refresh);
     connect(m_researcher_model, &ResearcherModel::beaconChanged, this, &ResearcherWizardBeaconPage::refresh);
     connect(ui->sendBeaconButton, &QPushButton::clicked, this, &ResearcherWizardBeaconPage::advertiseBeacon);
+    connect(ui->v2RadioButton, &QRadioButton::toggled, this, &ResearcherWizardBeaconPage::onVerificationMethodToggled);
+    connect(ui->v3RadioButton, &QRadioButton::toggled, this, &ResearcherWizardBeaconPage::onVerificationMethodToggled);
 }
 
 void ResearcherWizardBeaconPage::initializePage()
@@ -48,17 +52,47 @@ void ResearcherWizardBeaconPage::initializePage()
         return;
     }
 
+    m_v3_selected = false;
+    m_v3_key_generated = false;
+
+    const bool v14_active = m_researcher_model->isV14Enabled();
+    const bool v3_projects = m_researcher_model->hasV3CapableProjects();
+    const bool v3_available = v14_active && v3_projects;
+
+    ui->v3RadioButton->setEnabled(v3_available);
+    ui->v2RadioButton->setChecked(true);
+
+    if (!v14_active) {
+        ui->v3UnavailableLabel->setText(
+            tr("Account ownership proof requires block version 14 (not yet active)."));
+        ui->v3UnavailableLabel->setVisible(true);
+    } else if (!v3_projects) {
+        ui->v3UnavailableLabel->setText(
+            tr("No whitelisted projects currently support account ownership proof."));
+        ui->v3UnavailableLabel->setVisible(true);
+    } else {
+        ui->v3UnavailableLabel->setVisible(false);
+    }
+
     refresh();
 }
 
 bool ResearcherWizardBeaconPage::isComplete() const
 {
+    if (m_v3_selected && m_v3_key_generated) {
+        return true;
+    }
+
     return m_researcher_model->hasActiveBeacon()
         || m_researcher_model->hasPendingBeacon();
 }
 
 int ResearcherWizardBeaconPage::nextId() const
 {
+    if (m_v3_selected && m_v3_key_generated) {
+        return ResearcherWizard::PageOwnershipProof;
+    }
+
     if (m_researcher_model->needsBeaconAuth()) {
         return ResearcherWizard::PageAuth;
     }
@@ -82,13 +116,18 @@ void ResearcherWizardBeaconPage::refresh()
     if (m_researcher_model->outOfSync()) {
         ui->sendBeaconButton->setVisible(false);
         ui->continuePromptWrapper->setVisible(false);
+        ui->verificationMethodWrapper->setVisible(false);
     } else {
-        ui->sendBeaconButton->setVisible(isEnabled());
-        ui->continuePromptWrapper->setVisible(!isEnabled());
+        const bool enabled = isEnabled();
+        ui->sendBeaconButton->setVisible(enabled && !m_v3_key_generated);
+        ui->continuePromptWrapper->setVisible(!enabled && !m_v3_key_generated);
+        ui->verificationMethodWrapper->setVisible(enabled);
     }
 
-    updateBeaconStatus(m_researcher_model->formatBeaconStatus());
-    updateBeaconIcon(m_researcher_model->getBeaconStatusIcon());
+    if (!m_v3_key_generated) {
+        updateBeaconStatus(m_researcher_model->formatBeaconStatus());
+        updateBeaconIcon(m_researcher_model->getBeaconStatusIcon());
+    }
 
     emit completeChanged();
 }
@@ -106,6 +145,24 @@ void ResearcherWizardBeaconPage::advertiseBeacon()
         return;
     }
 
+    if (m_v3_selected) {
+        // V3 path: generate the key only. The actual beacon send happens
+        // on the ownership proof page after the user pastes the XML.
+        const QString pubkey_hex = m_researcher_model->generateBeaconKeyForV3();
+
+        if (pubkey_hex.isEmpty()) {
+            updateBeaconStatus(ResearcherModel::mapBeaconStatus(BeaconStatus::ERROR_MISSING_KEY));
+            updateBeaconIcon(m_researcher_model->mapBeaconStatusIcon(BeaconStatus::ERROR_MISSING_KEY));
+            return;
+        }
+
+        m_v3_key_generated = true;
+        updateBeaconStatus(tr("Beacon key generated. Press \"Next\" to continue."));
+        emit completeChanged();
+        return;
+    }
+
+    // V2 path: advertise beacon immediately.
     BeaconStatus status = m_researcher_model->advertiseBeacon();
 
     if (status == BeaconStatus::ACTIVE) {
@@ -126,4 +183,18 @@ void ResearcherWizardBeaconPage::updateBeaconIcon(const QIcon& icon)
     const int icon_size = ui->beaconIconLabel->width();
 
     ui->beaconIconLabel->setPixmap(icon.pixmap(icon_size, icon_size));
+}
+
+void ResearcherWizardBeaconPage::onVerificationMethodToggled()
+{
+    m_v3_selected = ui->v3RadioButton->isChecked();
+    m_v3_key_generated = false;
+
+    if (m_v3_selected) {
+        ui->sendBeaconButton->setText(tr("&Generate Beacon Key"));
+    } else {
+        ui->sendBeaconButton->setText(tr("&Advertise Beacon"));
+    }
+
+    emit completeChanged();
 }

--- a/src/qt/researcher/researcherwizardbeaconpage.h
+++ b/src/qt/researcher/researcherwizardbeaconpage.h
@@ -35,12 +35,15 @@ private:
     Ui::ResearcherWizardBeaconPage *ui;
     ResearcherModel *m_researcher_model;
     WalletModel *m_wallet_model;
+    bool m_v3_selected;
+    bool m_v3_key_generated;
 
 private slots:
     void refresh();
     void advertiseBeacon();
     void updateBeaconStatus(const QString& status);
     void updateBeaconIcon(const QIcon& icon);
+    void onVerificationMethodToggled();
 };
 
 #endif // GRIDCOIN_QT_RESEARCHER_RESEARCHERWIZARDBEACONPAGE_H

--- a/src/qt/researcher/researcherwizardownershipproofpage.cpp
+++ b/src/qt/researcher/researcherwizardownershipproofpage.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2014-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/forms/ui_researcherwizardownershipproofpage.h"
+#include "qt/researcher/researchermodel.h"
+#include "qt/researcher/researcherwizard.h"
+#include "qt/researcher/researcherwizardownershipproofpage.h"
+#include "qt/walletmodel.h"
+
+#include <QClipboard>
+
+// -----------------------------------------------------------------------------
+// Class: ResearcherWizardOwnershipProofPage
+// -----------------------------------------------------------------------------
+
+ResearcherWizardOwnershipProofPage::ResearcherWizardOwnershipProofPage(QWidget *parent)
+    : QWizardPage(parent)
+    , ui(new Ui::ResearcherWizardOwnershipProofPage)
+    , m_researcher_model(nullptr)
+    , m_wallet_model(nullptr)
+    , m_beacon_sent(false)
+{
+    ui->setupUi(this);
+}
+
+ResearcherWizardOwnershipProofPage::~ResearcherWizardOwnershipProofPage()
+{
+    delete ui;
+}
+
+void ResearcherWizardOwnershipProofPage::setModel(
+    ResearcherModel* researcher_model,
+    WalletModel* wallet_model)
+{
+    this->m_researcher_model = researcher_model;
+    this->m_wallet_model = wallet_model;
+
+    if (!m_researcher_model || !m_wallet_model) {
+        return;
+    }
+
+    connect(ui->copyPubKeyButton, &QPushButton::clicked,
+            this, &ResearcherWizardOwnershipProofPage::copyPubKeyToClipboard);
+    connect(ui->sendBeaconButton, &QPushButton::clicked,
+            this, &ResearcherWizardOwnershipProofPage::submitOwnershipProof);
+}
+
+void ResearcherWizardOwnershipProofPage::initializePage()
+{
+    if (!m_researcher_model) {
+        return;
+    }
+
+    m_beacon_sent = false;
+
+    // Populate beacon public key.
+    ui->pubkeyLabel->setText(m_researcher_model->cachedBeaconPubKeyHex());
+
+    // Build the list of v3-capable projects with clickable URLs.
+    const auto projects = m_researcher_model->buildV3ProjectList();
+
+    QString project_html;
+    for (const auto& [name, url] : projects) {
+        project_html += QString("<a href=\"%1\">%2</a><br/>")
+            .arg(url.toHtmlEscaped(), name.toHtmlEscaped());
+    }
+
+    if (project_html.isEmpty()) {
+        project_html = tr("No projects currently support this method.");
+    }
+
+    ui->projectListLabel->setText(project_html);
+
+    // Clear any previous state.
+    ui->ownershipProofXmlEdit->clear();
+    ui->statusLabel->clear();
+    ui->statusIconLabel->clear();
+
+    emit completeChanged();
+}
+
+bool ResearcherWizardOwnershipProofPage::isComplete() const
+{
+    if (m_beacon_sent) {
+        return true;
+    }
+
+    if (!m_researcher_model) {
+        return false;
+    }
+
+    return m_researcher_model->hasActiveBeacon()
+        || m_researcher_model->hasPendingBeacon();
+}
+
+int ResearcherWizardOwnershipProofPage::nextId() const
+{
+    return ResearcherWizard::PageSummary;
+}
+
+void ResearcherWizardOwnershipProofPage::copyPubKeyToClipboard()
+{
+    QApplication::clipboard()->setText(ui->pubkeyLabel->text());
+}
+
+void ResearcherWizardOwnershipProofPage::submitOwnershipProof()
+{
+    if (!m_researcher_model || !m_wallet_model) {
+        return;
+    }
+
+    const QString xml = ui->ownershipProofXmlEdit->toPlainText().trimmed();
+
+    if (xml.isEmpty()) {
+        ui->statusLabel->setText(tr("Please paste the ownership proof XML from the project website."));
+        return;
+    }
+
+    const WalletModel::UnlockContext unlock_context(m_wallet_model->requestUnlock());
+
+    if (!unlock_context.isValid()) {
+        return;
+    }
+
+    BeaconStatus status = m_researcher_model->advertiseBeaconV3(xml);
+
+    if (status == BeaconStatus::ACTIVE) {
+        status = BeaconStatus::PENDING;
+    }
+
+    ui->statusLabel->setText(ResearcherModel::mapBeaconStatus(status));
+    updateStatusIcon(m_researcher_model->mapBeaconStatusIcon(status));
+
+    if (status == BeaconStatus::PENDING) {
+        m_beacon_sent = true;
+    }
+
+    emit completeChanged();
+}
+
+void ResearcherWizardOwnershipProofPage::updateStatusIcon(const QIcon& icon)
+{
+    const int icon_size = ui->statusIconLabel->width();
+
+    ui->statusIconLabel->setPixmap(icon.pixmap(icon_size, icon_size));
+}

--- a/src/qt/researcher/researcherwizardownershipproofpage.h
+++ b/src/qt/researcher/researcherwizardownershipproofpage.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2014-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_RESEARCHER_RESEARCHERWIZARDOWNERSHIPPROOFPAGE_H
+#define GRIDCOIN_QT_RESEARCHER_RESEARCHERWIZARDOWNERSHIPPROOFPAGE_H
+
+#include <QWizardPage>
+
+class QIcon;
+class ResearcherModel;
+class WalletModel;
+
+namespace Ui {
+class ResearcherWizardOwnershipProofPage;
+}
+
+class ResearcherWizardOwnershipProofPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    explicit ResearcherWizardOwnershipProofPage(QWidget *parent = nullptr);
+    ~ResearcherWizardOwnershipProofPage();
+
+    void setModel(ResearcherModel *researcher_model, WalletModel *wallet_model);
+
+    void initializePage() override;
+    bool isComplete() const override;
+    int nextId() const override;
+
+private:
+    Ui::ResearcherWizardOwnershipProofPage *ui;
+    ResearcherModel *m_researcher_model;
+    WalletModel *m_wallet_model;
+    bool m_beacon_sent;
+
+private slots:
+    void copyPubKeyToClipboard();
+    void submitOwnershipProof();
+    void updateStatusIcon(const QIcon& icon);
+};
+
+#endif // GRIDCOIN_QT_RESEARCHER_RESEARCHERWIZARDOWNERSHIPPROOFPAGE_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1557,9 +1557,9 @@ UniValue advertisebeaconv3(const UniValue& params, bool fHelp)
     // Parse the XML block from the BOINC project.
     const std::string xml = params[0].get_str();
 
-    const std::string master_url = ExtractXML(xml, "<master_url>", "</master_url>");
-    const std::string msg = ExtractXML(xml, "<msg>", "</msg>");
-    const std::string sig_b64 = ExtractXML(xml, "<signature>", "</signature>");
+    const std::string master_url = TrimString(ExtractXML(xml, "<master_url>", "</master_url>"));
+    const std::string msg = TrimString(ExtractXML(xml, "<msg>", "</msg>"));
+    const std::string sig_b64 = TrimString(ExtractXML(xml, "<signature>", "</signature>"));
 
     if (master_url.empty() || msg.empty() || sig_b64.empty()) {
         throw JSONRPCError(


### PR DESCRIPTION
## Summary

- Adds a v2/v3 verification method choice (radio buttons) to the beacon wizard page
- When v3 is selected, user generates a beacon key, then navigates to a new ownership proof page where they paste the signed XML from a supporting BOINC project website
- New `ResearcherWizardOwnershipProofPage` with beacon pubkey display + copy, clickable project links, XML paste area, send button, and status feedback
- V3 option is automatically disabled with explanation when block v14 is not active or no whitelisted projects support ownership proof
- Existing v2 flow is completely unchanged

## End-to-end v3 beacon workflow (testnet)

Screenshots from isolated 3-node testnet. Some screenshots redacted (email, browser bookmarks/account, wallet balances).

**1. Mode selection** — choose Solo researcher mode

<img width="1600" height="1248" alt="01_mode_selection" src="https://github.com/user-attachments/assets/d69cddf4-e0be-4372-a3a4-535ba80cb415" />

**2. BOINC email** — enter email to locate BOINC projects

<img width="1600" height="1248" alt="02_email_entry_redacted" src="https://github.com/user-attachments/assets/1cc95bff-e707-4f75-bfd5-1608c95cc189" />

**3. Projects** — whitelisted projects detected

<img width="1600" height="1248" alt="03_projects" src="https://github.com/user-attachments/assets/692ba40c-56ff-4817-8656-c7eab225c187" />

**4. Beacon page — v2/v3 choice** — radio buttons for classic (v2) vs ownership proof (v3) verification

<img width="1600" height="1248" alt="04_beacon_v2v3_choice" src="https://github.com/user-attachments/assets/b9c95cc4-5e16-422e-85b6-fc6c44cc32c5" />

**5. Beacon key generated** — after clicking "Generate Beacon Key" with v3 selected

<img width="1600" height="1248" alt="05_beacon_key_generated" src="https://github.com/user-attachments/assets/8f981558-8a70-4d3e-b7a9-bd7573cd8e4c" />

**6. Ownership proof page** — shows beacon pubkey (with copy button), lists v3-capable projects with clickable URLs, and provides XML paste area

<img width="1600" height="1248" alt="06_ownership_proof_page" src="https://github.com/user-attachments/assets/1d65abe8-fd5d-422f-881a-a282107361a6" />

**7. BOINC project — generate proof** — paste beacon pubkey into project's ownership proof page (minecraft@home shown)

<img width="3794" height="2025" alt="07_boinc_generate_proof_redacted" src="https://github.com/user-attachments/assets/9a4505ca-511b-4cc3-9ae5-55dc94ff03fb" />

**8. BOINC project — proof results** — project returns signed XML ownership proof

<img width="3794" height="2025" alt="08_boinc_proof_results_redacted" src="https://github.com/user-attachments/assets/b79a4cd8-5a93-4b7d-876e-a0e60f31d768" />

**9. XML pasted** — paste ownership proof XML back into wizard

<img width="1600" height="1248" alt="09_xml_pasted" src="https://github.com/user-attachments/assets/56c994bf-e2c1-4754-896d-30617d4c179a" />

**10. Beacon sent** — beacon transaction submitted successfully

<img width="1724" height="1494" alt="10_beacon_sent" src="https://github.com/user-attachments/assets/ffa83799-4fc7-472e-b020-e78a468e648c" />

**11. Summary** — wizard complete, beacon in pending status awaiting next superblock

<img width="1724" height="1494" alt="11_summary" src="https://github.com/user-attachments/assets/148f452c-78b3-467b-9a6d-7303be645c7c" />

## New files
- `src/qt/researcher/researcherwizardownershipproofpage.h/.cpp` — ownership proof wizard page
- `src/qt/forms/researcherwizardownershipproofpage.ui` — UI layout

## Modified files
- `src/gridcoin/scraper/scraper.h/.cpp` — `GetProjectsWithOwnershipProofSupport()` accessor
- `src/qt/researcher/researchermodel.h/.cpp` — v3 methods (key gen, XML parsing, project list, beacon send)
- `src/qt/researcher/researcherwizardbeaconpage.h/.cpp` — v2/v3 radio choice and routing
- `src/qt/forms/researcherwizardbeaconpage.ui` — radio buttons + unavailability label
- `src/qt/researcher/researcherwizard.h/.cpp` — `PageOwnershipProof` enum + wiring
- `src/qt/forms/researcherwizard.ui` — register new page widget
- `src/qt/CMakeLists.txt` — add new source file

## Test plan
- [x] Build all targets (`gridcoinresearchd`, `gridcoinresearch`, `test_gridcoin`)
- [x] Open wizard before v14 activation: v3 radio disabled with "requires block version 14" message
- [x] Open wizard after v14 activation with v3-capable projects: v3 radio enabled
- [x] Select v2: existing flow works unchanged (advertise beacon → auth page → summary)
- [x] Select v3: button changes to "Generate Beacon Key", generates key, navigates to ownership proof page
- [x] Ownership proof page: pubkey displayed, project list with clickable URLs, paste XML, send beacon
- [x] Verify beacon appears as pending, activates at next superblock
- [x] Verify beacon renewal flow still works via v2 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)