### PR TITLE
beacon: fix stale GUI researcher status after beacon revocation

### DIFF
--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -8,6 +8,8 @@
 #include "main.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/contract/contract.h"
+#include "gridcoin/researcher.h"
+#include "node/ui_interface.h"
 #include "util.h"
 #include "wallet/wallet.h"
 
@@ -584,6 +586,13 @@ void BeaconRegistry::Delete(const ContractContext& ctx)
 
     // Insert the deleted beacon entry in the storage db.
     m_beacon_db.insert(deleted_beacon.m_hash, height, deleted_beacon);
+
+    // A beacon revocation changes the researcher's eligibility status,
+    // so mark the context dirty to refresh the cached status.
+    Researcher::MarkDirty();
+
+    // Notify the GUI if present that beacons have changed.
+    uiInterface.BeaconChanged();
 }
 
 void BeaconRegistry::Revert(const ContractContext& ctx)


### PR DESCRIPTION
## Summary
- After revoking a beacon, the GUI continued showing "Eligible for Research Rewards" despite the "Action Needed" badge updating correctly
- Root cause: `BeaconRegistry::Delete()` removes the beacon from `m_beacons` but did not call `Researcher::MarkDirty()` or `uiInterface.BeaconChanged()` to refresh the cached researcher status
- Same class of bug as #2852 (which fixed the activation path), but for the revocation path
- Adds `Researcher::MarkDirty()` and `uiInterface.BeaconChanged()` calls at the end of `BeaconRegistry::Delete()`

## Test plan
- [x] Tested on isolated 3-node testnet: revoke beacon via debug console, verify GUI status updates immediately to reflect revoked state

🤖 Generated with [Claude Code](https://claude.com/claude-code)