### PR TITLE
rpc: fix params index bug in addkey project auto_greylist_override

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2420,7 +2420,7 @@ UniValue addkey(const UniValue& params, bool fHelp)
                     if (params.size() == 7) {
                         if (ToLower(params[6].get_str()) == "man_greylist") {
                             status = GRC::ProjectEntryStatus::MAN_GREYLISTED;
-                        } else if (ToLower(params[5].get_str()) == "auto_greylist_override") {
+                        } else if (ToLower(params[6].get_str()) == "auto_greylist_override") {
                             status = GRC::ProjectEntryStatus::AUTO_GREYLIST_OVERRIDE;
                         } else {
                             throw JSONRPCError(RPC_INVALID_PARAMETER, "project status specifier, if provided, "


### PR DESCRIPTION
## Summary
- In the v4 project `addkey` path (7 params, `project_v4_enabled`), the `auto_greylist_override` status check compared `params[5]` instead of `params[6]`
- The `man_greylist` check on the line above correctly used `params[6]`, but the `auto_greylist_override` check was a copy-paste error reading `params[5]` (the `requires_ext_adapter` boolean), so it never matched
- The non-v4 path (6 params) was correct
- One-character fix: `params[5]` → `params[6]` on the `auto_greylist_override` comparison

## Test plan
- [x] Tested on isolated testnet: `addkey add project minecraft@home <url> false false auto_greylist_override` now succeeds (previously returned error code -8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)