### PR TITLE
rpc: make revokebeacon CPID parameter optional

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1461,20 +1461,24 @@ UniValue advertisebeacon(const UniValue& params, bool fHelp)
 
 UniValue revokebeacon(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() > 1)
         throw runtime_error(
-                "revokebeacon <cpid>\n"
+                "revokebeacon [cpid]\n"
                 "\n"
-                "<cpid> CPID associated with the beacon to revoke.\n"
+                "[cpid] CPID associated with the beacon to revoke. If omitted, uses the current CPID.\n"
                 "\n"
                 "Revoke a beacon (Requires wallet to be fully unlocked)\n");
 
     EnsureWalletIsUnlocked();
 
-    const GRC::CpidOption cpid = GRC::MiningId::Parse(params[0].get_str()).TryCpid();
+    const GRC::CpidOption cpid = params.size() == 1
+        ? GRC::MiningId::Parse(params[0].get_str()).TryCpid()
+        : GRC::Researcher::Get()->Id().TryCpid();
 
     if (!cpid) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid CPID.");
+        throw JSONRPCError(
+            params.size() == 1 ? RPC_INVALID_PARAMETER : RPC_INVALID_REQUEST,
+            params.size() == 1 ? "Invalid CPID." : "No CPID configured for this wallet.");
     }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);


### PR DESCRIPTION
## Summary
- Make the CPID parameter optional in \`revokebeacon\`, defaulting to the current wallet's CPID
- The explicit CPID parameter is retained for the edge case of revoking a beacon on an old CPID after a CPID split or change
- Since you can only revoke a beacon for which you hold the private key, requiring the CPID is redundant in the common case

## Test plan
- [x] \`revokebeacon\` with no args revokes the current CPID's beacon
- [x] \`revokebeacon <cpid>\` still works as before
- [x] \`revokebeacon\` with no CPID configured returns appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)