### PR TITLE
build: add ENABLE_DEBUG_LOCKORDER CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ option(USE_ASM          "Enable assembly routines" ON)
 
 # Optional functionality
 option(ENABLE_PIE       "Build position-independent executables" OFF)
+option(ENABLE_DEBUG_LOCKORDER "Enable run-time lock-order checking (DEBUG_LOCKORDER)" OFF)
 option(ENABLE_QRENCODE  "Enable generation of QR Codes for receiving payments" OFF)
 option(ENABLE_UPNP      "Enable UPnP port mapping support" OFF)
 option(DEFAULT_UPNP     "Turn UPnP on startup" OFF)

--- a/build_targets.sh
+++ b/build_targets.sh
@@ -39,6 +39,8 @@ print_help() {
     echo "                      Default: number of cpu threads reported by OS"
     echo "  QT_PATH=<path>      Override path to Qt root (e.g. /usr/local/Qt/6.6.0/macos)."
     echo "                      Bypasses Homebrew detection if set."
+    echo "  DEBUG_LOCKORDER=<bool> Enable run-time lock-order checking. Options: true, false."
+    echo "                      Default: false"
     echo "  EXTRA_CMAKE_ARGS    Pass additional arguments to CMake (e.g. '-DBoost_USE_STATIC_LIBS=ON')"
     echo "  CC=<path>           Override C compiler."
     echo "  CXX=<path>          Override C++ compiler."
@@ -115,6 +117,7 @@ USE_QT6="true"
 CC_OVERRIDE=""
 CXX_OVERRIDE=""
 MANUAL_QT_PATH=""
+DEBUG_LOCKORDER="false"
 EXTRA_ARGS=""
 
 for arg in "$@"; do
@@ -157,6 +160,10 @@ for arg in "$@"; do
             ;;
         QT_PATH=*)
             MANUAL_QT_PATH="${arg#*=}"
+            shift
+            ;;
+        DEBUG_LOCKORDER=*)
+            DEBUG_LOCKORDER="${arg#*=}"
             shift
             ;;
         EXTRA_CMAKE_ARGS=*)
@@ -225,6 +232,13 @@ else
     DOCS_CMAKE_FLAG="-DENABLE_DOCS=OFF"
 fi
 
+# Lock-order checking logic
+if [ "$DEBUG_LOCKORDER" = "true" ]; then
+    LOCKORDER_CMAKE_FLAG="-DENABLE_DEBUG_LOCKORDER=ON"
+else
+    LOCKORDER_CMAKE_FLAG="-DENABLE_DEBUG_LOCKORDER=OFF"
+fi
+
 # Determine Concurrency
 if [ -n "$PARALLEL" ]; then
     CORES="$PARALLEL"
@@ -250,6 +264,7 @@ echo "Skip Deps:    $SKIP_DEPS"
 echo "Use Ccache:   $USE_CCACHE"
 echo "With GUI:     $WITH_GUI"
 echo "With Docs:    $WITH_DOCS"
+echo "Lock Order:   $DEBUG_LOCKORDER"
 echo "Qt6:          $USE_QT6"
 if [ -n "$MANUAL_QT_PATH" ]; then echo "Manual Qt:    $MANUAL_QT_PATH"; fi
 if [ -n "$EXTRA_ARGS" ]; then     echo "Extra Args:   $EXTRA_ARGS"; fi
@@ -307,6 +322,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "native" ]] && [[ "$(uname -s)" == "Lin
         cmake -B build \
             $GUI_CMAKE_FLAG \
             $DOCS_CMAKE_FLAG \
+            $LOCKORDER_CMAKE_FLAG \
             -DENABLE_QRENCODE=ON \
             -DUSE_DBUS=ON \
             -DENABLE_UPNP=ON \
@@ -393,6 +409,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "depends" ]] && [[ "$(uname -s)" == "Li
             --toolchain depends/x86_64-pc-linux-gnu/toolchain.cmake \
             $GUI_CMAKE_FLAG \
             $DOCS_CMAKE_FLAG \
+            $LOCKORDER_CMAKE_FLAG \
             -DUSE_QT6=ON \
             -DSTATIC_LIBS=ON \
             -DENABLE_UPNP=ON \
@@ -483,6 +500,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "win64" ]] && [[ "$(uname -s)" == "Linu
             --toolchain depends/x86_64-w64-mingw32/toolchain.cmake \
             $GUI_CMAKE_FLAG \
             $DOCS_CMAKE_FLAG \
+            $LOCKORDER_CMAKE_FLAG \
             -DUSE_QT6=ON \
             -DENABLE_UPNP=ON \
             -DDEFAULT_UPNP=ON \
@@ -577,6 +595,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "macos" ]] && [[ "$(uname -s)" == "Darw
             -DCMAKE_PREFIX_PATH="$PREFIX_PATHS" \
             $GUI_CMAKE_FLAG \
             $DOCS_CMAKE_FLAG \
+            $LOCKORDER_CMAKE_FLAG \
             -DENABLE_QRENCODE=ON \
             -DENABLE_UPNP=ON \
             -DDEFAULT_UPNP=ON \

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -12,6 +12,7 @@ This document details the CMake configuration options available for Gridcoin. Th
 | `ENABLE_DOCS` | `OFF` | Generates Doxygen documentation. |
 | `STATIC_LIBS` | `OFF` | Forces the build system to look for static libraries (`.a`) instead of shared libraries (`.so`). Required for `depends` builds. |
 | `ENABLE_PIE` | `OFF` | Enables Position Independent Executables (PIE) for hardening. Recommended for Linux production builds. |
+| `ENABLE_DEBUG_LOCKORDER` | `OFF` | Enables run-time lock-order checking (`DEBUG_LOCKORDER`). Detects potential deadlocks by tracking lock acquisition order and logging inconsistencies to `debug.log`. Recommended with `Debug` build type. |
 
 ---
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,6 +284,10 @@ if(ENABLE_UPNP)
     target_link_libraries(gridcoin_util PUBLIC ${LIBMINIUPNPC})
 endif()
 
+if(ENABLE_DEBUG_LOCKORDER)
+    target_compile_definitions(gridcoin_util PUBLIC DEBUG_LOCKORDER)
+endif()
+
 # Daemon
 # ======
 


### PR DESCRIPTION
## Summary

- Adds `ENABLE_DEBUG_LOCKORDER` CMake option (default `OFF`) that sets the `DEBUG_LOCKORDER` compile definition on `gridcoin_util` with `PUBLIC` visibility, propagating to all dependent targets
- Adds corresponding `DEBUG_LOCKORDER=<bool>` parameter to `build_targets.sh` across all four platform targets (native, depends, win64, macos)
- Documents the option in `doc/cmake-options.md`

This provides an explicit opt-in for run-time lock-order checking, independent of build type. A known benign lock-order issue in message handling makes automatic enablement in Debug builds counterproductive for line-by-line debugging — developers can now enable it when specifically hunting for lock-order problems.

Prompted by Copilot review of PR #2186, which noted that `DEBUG_LOCKORDER` was not actually wired up in CMake despite doc claims.

## Test plan

- [x] `cmake -B build -DENABLE_DEBUG_LOCKORDER=ON` succeeds; `-DDEBUG_LOCKORDER` appears in compile flags
- [x] `cmake -B build -DENABLE_DEBUG_LOCKORDER=OFF` (or omitted) succeeds; no `DEBUG_LOCKORDER` in compile flags
- [x] Full build + test suite passes with option ON (`build_targets.sh TARGET=native DEBUG_LOCKORDER=true BUILD_TYPE=Debug` — 100% tests passed)
- [x] `build_targets.sh TARGET=native DEBUG_LOCKORDER=true` passes flag correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)