### PR TITLE
build: add Flatpak support with CI/CD artifact

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -490,6 +490,63 @@ jobs:
           retention-days: 5
 
   # ----------------------------------------------------------------------
+  # JOB 2d: Flatpak Build
+  # ----------------------------------------------------------------------
+  flatpak-build:
+    name: Flatpak Build (x86_64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Flatpak and flatpak-builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add Flathub Remote
+        run: |
+          sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Install KDE 6.9 SDK and Runtime
+        run: |
+          sudo flatpak install -y --noninteractive flathub org.kde.Platform//6.9 org.kde.Sdk//6.9
+
+      - name: Cache flatpak-builder
+        uses: actions/cache@v4
+        with:
+          path: .flatpak-builder
+          key: flatpak-builder-${{ hashFiles('contrib/flatpak/us.gridcoin.GridcoinResearch.yml') }}
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --force-clean \
+            --repo=flatpak-repo \
+            flatpak-build \
+            contrib/flatpak/us.gridcoin.GridcoinResearch.yml
+
+      - name: Create Flatpak Bundle
+        run: |
+          VERSION=$(sed -n 's/^[[:space:]]*VERSION \([0-9.]*\)$/\1/p' CMakeLists.txt)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract project version from CMakeLists.txt"
+            exit 1
+          fi
+          flatpak build-bundle \
+            flatpak-repo \
+            "gridcoin-${VERSION}-x86_64.flatpak" \
+            us.gridcoin.GridcoinResearch
+          echo "FLATPAK_BUNDLE=gridcoin-${VERSION}-x86_64.flatpak" >> $GITHUB_ENV
+
+      - name: Upload Artifact
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gridcoin-flatpak-x86_64
+          path: ${{ env.FLATPAK_BUNDLE }}
+          retention-days: 5
+
+  # ----------------------------------------------------------------------
   # JOB 3: Publish Docker Images
   # ----------------------------------------------------------------------
   docker-publish:
@@ -578,7 +635,7 @@ jobs:
   # ----------------------------------------------------------------------
   deploy:
     name: Create Release
-    needs: [depends-builds, macos-native]
+    needs: [depends-builds, macos-native, flatpak-build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,9 @@ doc/doxygen/
 src/test/data/*.bin.h
 src/test/data/*.json.h
 src/test/data/*.txt.h
+
+# Flatpak build artifacts
+flatpak-build/
+flatpak-repo/
+.flatpak-builder/
+*.flatpak

--- a/contrib/flatpak/build-flatpak.sh
+++ b/contrib/flatpak/build-flatpak.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+#
+# Build a Gridcoin Flatpak bundle locally.
+#
+# Prerequisites:
+#   flatpak install flathub org.kde.Platform//6.9 org.kde.Sdk//6.9
+#   sudo apt install flatpak-builder   # or equivalent
+#
+# Usage:
+#   contrib/flatpak/build-flatpak.sh
+#
+# Outputs:
+#   gridcoin-<VERSION>-x86_64.flatpak in the repo root
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+MANIFEST="${SCRIPT_DIR}/us.gridcoin.GridcoinResearch.yml"
+APP_ID="us.gridcoin.GridcoinResearch"
+BUILD_DIR="${REPO_ROOT}/flatpak-build"
+REPO_DIR="${REPO_ROOT}/flatpak-repo"
+
+# Extract version from CMakeLists.txt
+VERSION=$(sed -n 's/^[[:space:]]*VERSION \([0-9.]*\)$/\1/p' "${REPO_ROOT}/CMakeLists.txt")
+if [ -z "$VERSION" ]; then
+    echo "Error: Could not extract version from CMakeLists.txt"
+    exit 1
+fi
+
+ARCH=$(flatpak --default-arch)
+BUNDLE_NAME="gridcoin-${VERSION}-${ARCH}.flatpak"
+
+echo "=== Gridcoin Flatpak Builder ==="
+echo "Version:  ${VERSION}"
+echo "Arch:     ${ARCH}"
+echo "Manifest: ${MANIFEST}"
+echo ""
+
+# Build
+echo "Building Flatpak..."
+flatpak-builder \
+    --force-clean \
+    --repo="${REPO_DIR}" \
+    "${BUILD_DIR}" \
+    "${MANIFEST}"
+
+# Bundle
+echo "Creating bundle: ${BUNDLE_NAME}"
+flatpak build-bundle \
+    "${REPO_DIR}" \
+    "${REPO_ROOT}/${BUNDLE_NAME}" \
+    "${APP_ID}"
+
+echo ""
+echo "Done! Bundle: ${REPO_ROOT}/${BUNDLE_NAME}"
+echo ""
+echo "To install locally:"
+echo "  flatpak install ${REPO_ROOT}/${BUNDLE_NAME}"
+echo ""
+echo "To run:"
+echo "  flatpak run ${APP_ID}"

--- a/contrib/flatpak/us.gridcoin.GridcoinResearch.metainfo.xml.in
+++ b/contrib/flatpak/us.gridcoin.GridcoinResearch.metainfo.xml.in
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>us.gridcoin.GridcoinResearch</id>
+
+  <name>Gridcoin Research</name>
+  <summary>Cryptocurrency rewarding BOINC computation</summary>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+
+  <description>
+    <p>
+      Gridcoin is a proof-of-stake cryptocurrency that rewards users for
+      contributing computational power to scientific research through BOINC
+      (Berkeley Open Infrastructure for Network Computing).
+    </p>
+    <p>
+      Gridcoin Research is the full-featured desktop wallet with a graphical
+      interface for sending and receiving Gridcoin, managing BOINC researcher
+      identities, staking, and participating in network governance through
+      on-chain voting.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">us.gridcoin.GridcoinResearch.desktop</launchable>
+
+  <url type="homepage">https://gridcoin.us</url>
+  <url type="bugtracker">https://github.com/gridcoin-community/Gridcoin-Research/issues</url>
+  <url type="help">https://wiki.gridcoin.us</url>
+  <url type="vcs-browser">https://github.com/gridcoin-community/Gridcoin-Research</url>
+
+  <categories>
+    <category>Office</category>
+    <category>Finance</category>
+    <category>Network</category>
+  </categories>
+
+  <provides>
+    <binary>gridcoinresearch</binary>
+  </provides>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#7c50ea</color>
+    <color type="primary" scheme_preference="dark">#5a2dba</color>
+  </branding>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="@PROJECT_VERSION@" date="@GIT_COMMIT_DATE@" />
+  </releases>
+</component>

--- a/contrib/flatpak/us.gridcoin.GridcoinResearch.yml
+++ b/contrib/flatpak/us.gridcoin.GridcoinResearch.yml
@@ -1,0 +1,117 @@
+app-id: us.gridcoin.GridcoinResearch
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+command: gridcoinresearch
+
+rename-desktop-file: gridcoinresearch.desktop
+rename-icon: gridcoinresearch
+
+finish-args:
+  # X11 + Wayland
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  # GPU acceleration
+  - --device=dri
+  # Network access (P2P, RPC)
+  - --share=network
+  # System tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # Desktop notifications
+  - --talk-name=org.freedesktop.Notifications
+  # BOINC data access (Flatpak BOINC)
+  - --filesystem=~/.var/app/edu.berkeley.BOINC:ro
+  # BOINC data access (native packages)
+  - --filesystem=/var/lib/boinc-client:ro
+  - --filesystem=/var/lib/boinc:ro
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /lib64/pkgconfig
+  - /lib64/cmake
+  - /share/man
+  - /lib/systemd
+  - '*.la'
+  - '*.a'
+
+modules:
+  # ------------------------------------------------------------------
+  # Boost 1.86.0 (filesystem, iostreams, thread, serialization, etc.)
+  # ------------------------------------------------------------------
+  - name: boost
+    buildsystem: simple
+    build-commands:
+      - ./bootstrap.sh --prefix=/app --with-libraries=filesystem,iostreams,thread,serialization,date_time,system,chrono
+      - ./b2 install --libdir=/app/lib variant=release link=shared threading=multi runtime-link=shared -j $FLATPAK_BUILDER_N_JOBS
+    sources:
+      - type: archive
+        url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2
+        sha256: 1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
+
+  # ------------------------------------------------------------------
+  # libzip 1.11.2
+  # ------------------------------------------------------------------
+  - name: libzip
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DBUILD_TOOLS=OFF
+      - -DBUILD_REGRESS=OFF
+      - -DBUILD_EXAMPLES=OFF
+      - -DBUILD_DOC=OFF
+    sources:
+      - type: archive
+        url: https://libzip.org/download/libzip-1.11.2.tar.xz
+        sha256: 5d471308cef4c4752bbcf973d9cd37ba4cb53739116c30349d4764ba1410dfc1
+
+  # ------------------------------------------------------------------
+  # miniupnpc 2.2.8
+  # ------------------------------------------------------------------
+  - name: miniupnpc
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DUPNPC_BUILD_TESTS=OFF
+      - -DUPNPC_BUILD_SAMPLE=OFF
+    sources:
+      - type: archive
+        url: https://miniupnp.tuxfamily.org/files/miniupnpc-2.2.8.tar.gz
+        sha256: 05b929679091b9921b6b6c1f25e39e4c8d1f4d46c8feb55a412aa697aee03a93
+
+  # ------------------------------------------------------------------
+  # libqrencode 4.1.1
+  # ------------------------------------------------------------------
+  - name: libqrencode
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DWITH_TOOLS=OFF
+      - -DWITH_TESTS=OFF
+      - -DBUILD_SHARED_LIBS=ON
+    sources:
+      - type: archive
+        url: https://github.com/fukuchi/libqrencode/archive/refs/tags/v4.1.1.tar.gz
+        sha256: 5385bc1b8c2f20f3b91d258bf8ccc8cf62023935df2d2676b5b67049f31a049c
+
+  # ------------------------------------------------------------------
+  # Gridcoin Research
+  # ------------------------------------------------------------------
+  - name: gridcoin
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DENABLE_GUI=ON
+      - -DUSE_QT6=ON
+      - -DUSE_DBUS=ON
+      - -DENABLE_TESTS=OFF
+      - -DENABLE_UPNP=ON
+      - -DDEFAULT_UPNP=ON
+      - -DENABLE_QRENCODE=ON
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: dir
+        path: ../..

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -309,6 +309,25 @@ if(UNIX AND NOT APPLE)
     install(FILES "${CMAKE_SOURCE_DIR}/doc/gridcoinresearch.1" COMPONENT gui
         DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
     )
+    execute_process(
+        COMMAND git log -1 --format=%cs
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_VARIABLE GIT_COMMIT_DATE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE GIT_COMMIT_DATE_RESULT
+        ERROR_QUIET
+    )
+    if(NOT GIT_COMMIT_DATE_RESULT EQUAL 0 OR GIT_COMMIT_DATE STREQUAL "")
+        string(TIMESTAMP GIT_COMMIT_DATE "%Y-%m-%d")
+    endif()
+    configure_file(
+        "${CMAKE_SOURCE_DIR}/contrib/flatpak/us.gridcoin.GridcoinResearch.metainfo.xml.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/us.gridcoin.GridcoinResearch.metainfo.xml"
+        @ONLY
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/us.gridcoin.GridcoinResearch.metainfo.xml" COMPONENT gui
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/metainfo"
+    )
 else()
     install(TARGETS gridcoinresearch COMPONENT gui
         RUNTIME DESTINATION bin


### PR DESCRIPTION
## Summary

- Add Flatpak manifest targeting KDE Qt6 6.9 runtime with bundled Boost, libzip, miniupnpc, and libqrencode
- Add AppStream metainfo XML for Flathub compatibility
- Add local build convenience script (`contrib/flatpak/build-flatpak.sh`)
- Add `flatpak-build` CI job to `cmake_production.yml` that produces a `.flatpak` bundle as a release artifact
- Install metainfo.xml via CMake for native package managers (AppStream data)

Supersedes stale PR #2724 (autotools-based, KDE 5.15 runtime). The existing `XDG_STATE_HOME` data directory support (commit 2f0b627d5) ensures the wallet uses the correct Flatpak-sandboxed path.

## Key design decisions

- **KDE 6.9 runtime** — current stable, required for Flathub submission
- **`CMAKE_INSTALL_LIBDIR=lib`** on all modules — the KDE SDK defaults to `lib64` on x86_64, causing runtime linker failures
- **`builddir: true`** on the gridcoin module — our CMake stale-autotools cleanup assumes out-of-source builds
- **DBus enabled** (`-DUSE_DBUS=ON`) — for desktop notifications via the KDE runtime
- **BOINC data access** — sandbox grants read-only access to both Flatpak BOINC (`~/.var/app/edu.berkeley.BOINC`) and native BOINC (`/var/lib/boinc-client`, `/var/lib/boinc`) data directories

## Test plan

- [x] CI `flatpak-build` job passes (builds, bundles, uploads artifact)
- [x] Lint checks pass (`LC_ALL=C` in shell script)
- [x] Downloaded `.flatpak` artifact installs locally via `flatpak install --user`
- [x] `flatpak run us.gridcoin.GridcoinResearch` launches the wallet GUI
- [x] Wallet data directory is sandboxed at `~/.var/app/us.gridcoin.GridcoinResearch/.local/state/GridcoinResearch/`
- [x] Version string in bundle filename is correct (5.4.9.10, not cmake_minimum_required)
- [x] Verify on clean system without prior Flatpak setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)