### PR TITLE
qt, init: fix Unicode data directory path handling on Windows

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -62,7 +62,7 @@ void init_blockindex(leveldb::Options& options, bool fRemoveOld = false) {
 
     fs::create_directory(directory);
     LogPrintf("Opening LevelDB in %s", directory.string());
-    leveldb::Status status = leveldb::DB::Open(options, directory.string(), &txdb);
+    leveldb::Status status = leveldb::DB::Open(options, fsbridge::Utf8PathString(directory), &txdb);
     if (!status.ok()) {
         throw runtime_error(strprintf("init_blockindex(): error opening database environment %s", status.ToString()));
     }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -62,6 +62,10 @@ void init_blockindex(leveldb::Options& options, bool fRemoveOld = false) {
 
     fs::create_directory(directory);
     LogPrintf("Opening LevelDB in %s", directory.string());
+    // LevelDB's Windows port internally converts paths from UTF-8 to UTF-16 via
+    // MultiByteToWideChar(CP_UTF8). But fs::path::string() produces code page bytes, not UTF-8.
+    // Utf8PathString provides proper UTF-8 encoding when the path contains non-codepage characters.
+    // For codepage-safe paths, it returns path.string() unchanged. See #2736.
     leveldb::Status status = leveldb::DB::Open(options, fsbridge::Utf8PathString(directory), &txdb);
     if (!status.ok()) {
         throw runtime_error(strprintf("init_blockindex(): error opening database environment %s", status.ToString()));

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -121,13 +121,38 @@ bool PathHasNonCodepageChars(const fs::path& path)
 #ifdef WIN32
     std::wstring wide = path.wstring();
     BOOL used_default = FALSE;
+    // First call: determine the buffer size needed for the code page conversion.
     int needed = WideCharToMultiByte(CP_ACP, 0, wide.c_str(), (int)wide.size(), nullptr, 0, nullptr, nullptr);
     if (needed <= 0) return true;
+    // Second call: perform the actual conversion. WideCharToMultiByte sets used_default to TRUE if any
+    // character in the wide string could not be represented in the system code page and was replaced
+    // with a default substitution character.
     std::string narrow(needed, '\0');
     WideCharToMultiByte(CP_ACP, 0, wide.c_str(), (int)wide.size(), narrow.data(), needed, nullptr, &used_default);
     return used_default != FALSE;
 #else
     return false;
+#endif
+}
+
+std::string LongPathString(const fs::path& path)
+{
+#ifdef WIN32
+    std::wstring wpath = path.wstring();
+    wchar_t long_path[MAX_PATH];
+    DWORD result = GetLongPathNameW(wpath.c_str(), long_path, MAX_PATH);
+    if (result > 0 && result < MAX_PATH) {
+        // Return as UTF-8 so Qt (QString::fromStdString) and log output display correctly.
+        int needed = WideCharToMultiByte(CP_UTF8, 0, long_path, (int)result, nullptr, 0, nullptr, nullptr);
+        if (needed > 0) {
+            std::string utf8(needed, '\0');
+            WideCharToMultiByte(CP_UTF8, 0, long_path, (int)result, utf8.data(), needed, nullptr, nullptr);
+            return utf8;
+        }
+    }
+    return path.string();
+#else
+    return path.string();
 #endif
 }
 

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -116,6 +116,58 @@ bool FileLock::TryLock()
 }
 #endif
 
+bool PathHasNonCodepageChars(const fs::path& path)
+{
+#ifdef WIN32
+    std::wstring wide = path.wstring();
+    BOOL used_default = FALSE;
+    int needed = WideCharToMultiByte(CP_ACP, 0, wide.c_str(), (int)wide.size(), nullptr, 0, nullptr, nullptr);
+    if (needed <= 0) return true;
+    std::string narrow(needed, '\0');
+    WideCharToMultiByte(CP_ACP, 0, wide.c_str(), (int)wide.size(), narrow.data(), needed, nullptr, &used_default);
+    return used_default != FALSE;
+#else
+    return false;
+#endif
+}
+
+std::string ShortPathString(const fs::path& path)
+{
+#ifdef WIN32
+    if (!PathHasNonCodepageChars(path)) {
+        return path.string();
+    }
+    std::wstring wpath = path.wstring();
+    wchar_t short_path[MAX_PATH];
+    DWORD result = GetShortPathNameW(wpath.c_str(), short_path, MAX_PATH);
+    if (result > 0 && result < MAX_PATH) {
+        // Short path names are ASCII-safe, so narrow conversion is lossless.
+        return std::string(short_path, short_path + result);
+    }
+    // 8.3 name generation is disabled on this volume.
+    return "";
+#else
+    return path.string();
+#endif
+}
+
+std::string Utf8PathString(const fs::path& path)
+{
+#ifdef WIN32
+    if (!PathHasNonCodepageChars(path)) {
+        return path.string();
+    }
+    std::wstring wide = path.wstring();
+    int needed = WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), (int)wide.size(), nullptr, 0, nullptr, nullptr);
+    if (needed <= 0) return path.string();
+    std::string utf8(needed, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), (int)wide.size(), utf8.data(), needed, nullptr, nullptr);
+    return utf8;
+#else
+    return path.string();
+#endif
+}
+
 std::string get_filesystem_error_message(const fs::filesystem_error& e)
 {
 #ifndef WIN32

--- a/src/fs.h
+++ b/src/fs.h
@@ -54,6 +54,35 @@ namespace fsbridge {
 
     std::string get_filesystem_error_message(const fs::filesystem_error& e);
 
+    /** Check if a path contains characters not representable in the system code page.
+     *
+     * On Windows, fs::path::string() converts to the system code page, which silently
+     * corrupts characters outside that code page. This function detects such paths so
+     * callers can engage appropriate workarounds.
+     *
+     * Always returns false on non-Windows platforms (UTF-8 is the native encoding).
+     */
+    bool PathHasNonCodepageChars(const fs::path& path);
+
+    /** Return a narrow string for BDB, which only accepts const char* paths.
+     *
+     * If the path is representable in the system code page, returns path.string() unchanged.
+     * Otherwise, converts to the Windows short (8.3) form via GetShortPathNameW(), which is
+     * ASCII-safe. Returns an empty string if conversion is needed but 8.3 names are unavailable.
+     *
+     * On non-Windows platforms, simply returns path.string().
+     */
+    std::string ShortPathString(const fs::path& path);
+
+    /** Return a narrow string for LevelDB, which internally converts from UTF-8 to UTF-16.
+     *
+     * If the path is representable in the system code page, returns path.string() unchanged.
+     * Otherwise, converts to UTF-8 encoding via WideCharToMultiByte(CP_UTF8).
+     *
+     * On non-Windows platforms, simply returns path.string() (already UTF-8).
+     */
+    std::string Utf8PathString(const fs::path& path);
+
     // GNU libstdc++ specific workaround for opening UTF-8 paths on Windows.
     //
     // On Windows, it is only possible to reliably access multibyte file paths through

--- a/src/fs.h
+++ b/src/fs.h
@@ -64,20 +64,41 @@ namespace fsbridge {
      */
     bool PathHasNonCodepageChars(const fs::path& path);
 
-    /** Return a narrow string for BDB, which only accepts const char* paths.
+    /** Return a narrow string safe for BDB's DbEnv::open() and gArgs storage.
+     *
+     * BDB only accepts narrow (const char*) paths, and gArgs stores narrow strings. On Windows,
+     * fs::path::string() converts to the system code page, which corrupts characters outside that
+     * code page. This function converts to the Windows short (8.3) form via GetShortPathNameW()
+     * only when the path contains non-codepage characters. 8.3 names are ASCII-safe and work as
+     * valid aliases for the original Unicode path.
      *
      * If the path is representable in the system code page, returns path.string() unchanged.
-     * Otherwise, converts to the Windows short (8.3) form via GetShortPathNameW(), which is
-     * ASCII-safe. Returns an empty string if conversion is needed but 8.3 names are unavailable.
+     * Returns an empty string if conversion is needed but 8.3 names are unavailable on the volume.
      *
      * On non-Windows platforms, simply returns path.string().
      */
     std::string ShortPathString(const fs::path& path);
 
-    /** Return a narrow string for LevelDB, which internally converts from UTF-8 to UTF-16.
+    /** Return a UTF-8 display string, converting from Windows 8.3 short form if needed.
      *
-     * If the path is representable in the system code page, returns path.string() unchanged.
-     * Otherwise, converts to UTF-8 encoding via WideCharToMultiByte(CP_UTF8).
+     * On Windows, converts from 8.3 short form back to the original long (Unicode) path via
+     * GetLongPathNameW(), then encodes as UTF-8. Qt interprets UTF-8 correctly via
+     * QString::fromStdString(), and log output preserves the original characters.
+     * Use this for error messages, log output, and any user-facing display.
+     *
+     * On non-Windows platforms, simply returns path.string().
+     */
+    std::string LongPathString(const fs::path& path);
+
+    /** Return a UTF-8 narrow string safe for LevelDB's leveldb::DB::Open().
+     *
+     * LevelDB's Windows port (env_windows.cc) internally converts paths from UTF-8 to UTF-16
+     * via MultiByteToWideChar(CP_UTF8). But fs::path::string() produces system code page bytes,
+     * not UTF-8, which causes LevelDB's conversion to produce garbled wide strings. This function
+     * provides proper UTF-8 encoding only when the path contains non-codepage characters.
+     *
+     * If the path is representable in the system code page, returns path.string() unchanged
+     * (code page and UTF-8 are identical for ASCII characters).
      *
      * On non-Windows platforms, simply returns path.string() (already UTF-8).
      */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1050,29 +1050,35 @@ bool AppInit2(ThreadHandlerPtr threads)
     fs::path datadir = GetDataDir();
     fs::path walletFileName = gArgs.GetArg("-wallet", "wallet.dat");
 
-    LogPrintf("INFO %s: DataDir = %s.", __func__, datadir.string());
+    LogPrintf("INFO %s: DataDir = %s.", __func__, fsbridge::LongPathString(datadir));
 
     // WalletFileName must be a plain filename without a directory
     if (walletFileName != walletFileName.filename())
-        return InitError(strprintf(_("Wallet %s resides outside data directory %s."), walletFileName.string(), datadir.string()));
+        return InitError(strprintf(_("Wallet %s resides outside data directory %s."), walletFileName.string(), fsbridge::LongPathString(datadir)));
 
     // Make sure only a single Bitcoin process is using the data directory.
     if (!DirIsWritable(datadir)) {
-        return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), datadir.string()));
+        return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), fsbridge::LongPathString(datadir)));
     }
     if (!LockDirectory(datadir, ".lock", false)) {
-        return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), datadir.string(), PACKAGE_NAME));
+        return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), fsbridge::LongPathString(datadir), PACKAGE_NAME));
     }
 
     // Check early whether the data directory path can be used by legacy database libraries (BDB, LevelDB)
     // that only accept narrow (const char*) paths. On Windows, paths with characters outside the system
     // code page require conversion to 8.3 short names for BDB compatibility.
+    //
+    // Known limitation: if -datadir is passed on the command line with non-codepage characters, the path
+    // is already garbled by the time we see it — Windows main(argc, argv) delivers narrow strings in the
+    // system code page. The same applies to datadir= in gridcoin.conf saved as UTF-8. Fixing this would
+    // require switching to GetCommandLineW()/wmain at the argument parsing level. The Qt directory chooser
+    // path (which stays in UTF-16 via QString) is not affected.
     if (fsbridge::PathHasNonCodepageChars(datadir)) {
         if (fsbridge::ShortPathString(datadir).empty()) {
             return InitError(strprintf(_("The data directory path '%s' contains characters that cannot be "
                 "represented in the system code page, and Windows 8.3 short filename generation is not available "
                 "on this volume. Please choose a data directory path using only characters supported by your "
-                "system locale, or enable 8.3 filename generation."), datadir.string()));
+                "system locale, or enable 8.3 filename generation."), fsbridge::LongPathString(datadir)));
         }
     }
 
@@ -1115,7 +1121,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
          string msg = strprintf(_("Error initializing database environment %s!"
                                  " To recover, BACKUP THAT DIRECTORY, then remove"
-                                 " everything from it except for wallet.dat."), datadir.string());
+                                 " everything from it except for wallet.dat."), fsbridge::LongPathString(datadir));
         return InitError(msg);
     }
 
@@ -1135,7 +1141,7 @@ bool AppInit2(ThreadHandlerPtr threads)
             string msg = strprintf(_("Warning: wallet.dat corrupt, data salvaged!"
                                      " Original wallet.dat saved as wallet.{timestamp}.bak in %s; if"
                                      " your balance or transactions are incorrect you should"
-                                     " restore from a backup."), datadir.string());
+                                     " restore from a backup."), fsbridge::LongPathString(datadir));
             InitWarning(msg);
         }
         if (r == CDBEnv::RECOVER_FAIL)
@@ -1264,7 +1270,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         string msg = strprintf(_("Error initializing database environment %s!"
                                  " To recover, BACKUP THAT DIRECTORY, then remove"
-                                 " everything from it except for wallet.dat."), datadir.string());
+                                 " everything from it except for wallet.dat."), fsbridge::LongPathString(datadir));
         return InitError(msg);
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1064,6 +1064,18 @@ bool AppInit2(ThreadHandlerPtr threads)
         return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), datadir.string(), PACKAGE_NAME));
     }
 
+    // Check early whether the data directory path can be used by legacy database libraries (BDB, LevelDB)
+    // that only accept narrow (const char*) paths. On Windows, paths with characters outside the system
+    // code page require conversion to 8.3 short names for BDB compatibility.
+    if (fsbridge::PathHasNonCodepageChars(datadir)) {
+        if (fsbridge::ShortPathString(datadir).empty()) {
+            return InitError(strprintf(_("The data directory path '%s' contains characters that cannot be "
+                "represented in the system code page, and Windows 8.3 short filename generation is not available "
+                "on this volume. Please choose a data directory path using only characters supported by your "
+                "system locale, or enable 8.3 filename generation."), datadir.string()));
+        }
+    }
+
     #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
         LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
     #elif defined OPENSSL_VERSION

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -441,11 +441,12 @@ int main(int argc, char *argv[])
     // Determine availability of data directory and parse gridcoinresearch.conf
     // Do not call GetDataDir(true) before this step finishes
     if (!CheckDataDirOption()) {
-        ThreadSafeMessageBox(strprintf("Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "")),
+        std::string datadir_display = fsbridge::LongPathString(fs::path(gArgs.GetArg("-datadir", "")));
+        ThreadSafeMessageBox(strprintf("Specified data directory \"%s\" does not exist.\n", datadir_display),
                              "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             QObject::tr("Error: Specified data directory \"%1\" does not exist.")
-                              .arg(QString::fromStdString(gArgs.GetArg("-datadir", ""))));
+                              .arg(QString::fromStdString(datadir_display)));
         return EXIT_FAILURE;
     }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1007,18 +1007,19 @@ void BitcoinGUI::openConfigClicked()
 {
     boost::filesystem::path pathConfig = GetConfigFile();
     /* Open gridcoinresearch.conf with the associated application */
-    bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathConfig.string())));
+    QString qPathConfig = GUIUtil::boostPathToQString(pathConfig);
+    bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(qPathConfig));
 
 #ifdef Q_OS_WIN
     // Workaround for Windows specific behaviour
     if(!res) {
-        res = QProcess::startDetached("C:\\Windows\\system32\\notepad.exe", QStringList{QString::fromStdString(pathConfig.string())});
+        res = QProcess::startDetached("C:\\Windows\\system32\\notepad.exe", QStringList{qPathConfig});
     }
 #endif
 #ifdef Q_OS_MAC
     // Workaround for macOS-specific behaviour; see https://github.com/bitcoin/bitcoin/issues/15409
     if (!res) {
-        res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", QString::fromStdString(pathConfig.string())});
+        res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", qPathConfig});
     }
 #endif
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -299,12 +299,20 @@ QList<QModelIndex> getEntryData(QAbstractItemView *view, int column)
 
 fs::path qstringToBoostPath(const QString &path)
 {
+#ifdef WIN32
+    return fs::path(path.toStdWString());
+#else
     return fs::path(path.toStdString());
+#endif
 }
 
 QString boostPathToQString(const fs::path &path)
 {
+#ifdef WIN32
+    return QString::fromStdWString(path.wstring());
+#else
     return QString::fromStdString(path.string());
+#endif
 }
 
 QString getDefaultDataDirectory()
@@ -388,7 +396,7 @@ void openDebugLogfile()
 
     /* Open debug.log with the associated application */
     if (fs::exists(pathDebug))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathDebug.string())));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
 }
 
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -299,6 +299,10 @@ QList<QModelIndex> getEntryData(QAbstractItemView *view, int column)
 
 fs::path qstringToBoostPath(const QString &path)
 {
+    // On Windows, QString is UTF-16 and toStdString() produces UTF-8, but boost::filesystem::path
+    // interprets narrow strings as the system code page (e.g. CP-1252), not UTF-8. Using
+    // toStdWString() stays in UTF-16, which is the native Windows path encoding and is accepted
+    // directly by boost::filesystem::path. See #2736.
 #ifdef WIN32
     return fs::path(path.toStdWString());
 #else
@@ -308,6 +312,9 @@ fs::path qstringToBoostPath(const QString &path)
 
 QString boostPathToQString(const fs::path &path)
 {
+    // On Windows, path.string() converts to the system code page, but QString::fromStdString()
+    // expects UTF-8 — encoding mismatch corrupts non-ASCII characters. Using wstring() stays in
+    // UTF-16 which QString::fromStdWString() handles natively. See #2736.
 #ifdef WIN32
     return QString::fromStdWString(path.wstring());
 #else

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -242,7 +242,10 @@ bool Intro::showIfNeeded(bool& did_show_intro)
     if (dataDir != GUIUtil::getDefaultDataDirectory() || originally_not_default_datadir) {
         // This must be a ForceSetArg, because the optionsModel has already loaded the datadir argument if it exists in
         // the Qt settings file prior to this.
-        gArgs.ForceSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
+        // Use ShortPathString to get an 8.3 short path on Windows when the path contains characters
+        // outside the system code page. gArgs is a narrow-string store and fs::path::string() would
+        // corrupt non-codepage characters via code page narrowing.
+        gArgs.ForceSetArg("-datadir", fsbridge::ShortPathString(GUIUtil::qstringToBoostPath(dataDir)));
     }
 
     return true;

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -176,9 +176,13 @@ bool Intro::showIfNeeded(bool& did_show_intro)
     // If the stored path does not exist (e.g. moved, deleted, or corrupted by a Unicode encoding issue),
     // fall through to the directory chooser dialog so the user can reselect.
     std::string datadir_arg = gArgs.GetArg("-datadir", "");
+    // Use the non-throwing fs::exists() overload. A path corrupted by the Unicode encoding bug
+    // (see #2736) may be ill-formed and cause boost::filesystem::filesystem_error. Treating
+    // errors as "does not exist" lets us fall through to the directory chooser safely.
+    boost::system::error_code ec;
     if (!datadir_arg.empty()
             && !gArgs.GetBoolArg("-choosedatadir", DEFAULT_CHOOSE_DATADIR)
-            && fs::exists(datadir_arg)) {
+            && fs::exists(datadir_arg, ec)) {
         return true;
     }
     /* 1) Default data directory for operating system */

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -167,11 +167,18 @@ void Intro::setDataDirectory(const QString &dataDir)
 bool Intro::showIfNeeded(bool& did_show_intro)
 {
     QSettings settings;
-    // If data directory provided on command line AND -choosedatadir is not specified, no need to look at settings or
-    // show a picking dialog. The -choosedatadir test is required because showIfNeeded is called after the initialization
-    // of the optionsModel, which will populate the datadir from the GUI settings if present. Without it, you would then
-    // not be able to get the chooser dialog to come up again once a datadir is stored in the GUI settings config file.
-    if (!gArgs.GetArg("-datadir", "").empty() && !gArgs.GetBoolArg("-choosedatadir", DEFAULT_CHOOSE_DATADIR)) {
+    // If data directory provided on command line AND -choosedatadir is not specified AND the directory exists,
+    // no need to look at settings or show a picking dialog. The -choosedatadir test is required because
+    // showIfNeeded is called after the initialization of the optionsModel, which will populate the datadir
+    // from the GUI settings if present. Without it, you would then not be able to get the chooser dialog to
+    // come up again once a datadir is stored in the GUI settings config file.
+    //
+    // If the stored path does not exist (e.g. moved, deleted, or corrupted by a Unicode encoding issue),
+    // fall through to the directory chooser dialog so the user can reselect.
+    std::string datadir_arg = gArgs.GetArg("-datadir", "");
+    if (!datadir_arg.empty()
+            && !gArgs.GetBoolArg("-choosedatadir", DEFAULT_CHOOSE_DATADIR)
+            && fs::exists(datadir_arg)) {
         return true;
     }
     /* 1) Default data directory for operating system */

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -150,7 +150,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case DisableUpdateCheck:
             return QVariant(gArgs.GetBoolArg("-disableupdatecheck", false));
         case DataDir:
-            return settings.value("dataDir", QString::fromStdString(gArgs.GetArg("-datadir", GetDataDir().string())));
+            return settings.value("dataDir", GUIUtil::boostPathToQString(GetDataDir()));
         case EnableStaking:
             // This comes from the core and is a read-write setting (see below).
             return QVariant(gArgs.GetBoolArg("-staking", true));

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -77,7 +77,13 @@ void OptionsModel::Init()
         gArgs.SoftSetBoolArg("-disableupdatecheck", settings.value("fDisableUpdateCheck").toBool());
     }
     if (settings.contains("dataDir") && dataDir != GUIUtil::getDefaultDataDirectory()) {
-        gArgs.SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(settings.value("dataDir").toString()).string());
+        // Use ShortPathString to get an 8.3 short path on Windows when the path contains characters
+        // outside the system code page. gArgs is a narrow-string store, and fs::path::string() would
+        // corrupt non-codepage characters via code page narrowing.
+        std::string datadir_narrow = fsbridge::ShortPathString(GUIUtil::qstringToBoostPath(settings.value("dataDir").toString()));
+        if (!datadir_narrow.empty()) {
+            gArgs.SoftSetArg("-datadir", datadir_narrow);
+        }
     }
 
     m_sidestake_model = new SideStakeTableModel(this);

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -419,7 +419,7 @@ QString ResearcherModel::formatStatus() const
 
 QString ResearcherModel::formatBoincPath() const
 {
-    return QString::fromStdString(GetBoincDataDir().string());
+    return GUIUtil::boostPathToQString(GetBoincDataDir());
 }
 
 BeaconStatus ResearcherModel::getBeaconStatus() const

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -66,6 +66,10 @@ bool CDBEnv::Open(fs::path pathEnv_)
 
     pathEnv = pathEnv_;
     fs::path pathDataDir = pathEnv;
+    // BDB's DbEnv::open() only accepts narrow (const char*) paths. On Windows, fs::path::string()
+    // converts via the system code page, which corrupts characters outside that code page (e.g. Chinese
+    // on a Western locale). ShortPathString converts to 8.3 short names when needed, which are ASCII-safe.
+    // For codepage-safe paths, it returns path.string() unchanged. See #2736.
     strPath = fsbridge::ShortPathString(pathDataDir);
     fs::path pathLogDir = pathDataDir / "database";
     fs::create_directory(pathLogDir);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -66,7 +66,7 @@ bool CDBEnv::Open(fs::path pathEnv_)
 
     pathEnv = pathEnv_;
     fs::path pathDataDir = pathEnv;
-    strPath = pathDataDir.string();
+    strPath = fsbridge::ShortPathString(pathDataDir);
     fs::path pathLogDir = pathDataDir / "database";
     fs::create_directory(pathLogDir);
     fs::path pathErrorFile = pathDataDir / "db.log";
@@ -77,7 +77,7 @@ bool CDBEnv::Open(fs::path pathEnv_)
         nEnvFlags |= DB_PRIVATE;
 
     int nDbCache = std::clamp<int>(gArgs.GetArg("-dbcache", nDefaultDbCache), nMinDbCache, nMaxDbCache);
-    dbenv.set_lg_dir(pathLogDir.string().c_str());
+    dbenv.set_lg_dir(fsbridge::ShortPathString(pathLogDir).c_str());
     dbenv.set_cachesize(nDbCache / 1024, (nDbCache % 1024)*1048576, 1);
     dbenv.set_lg_bsize(1048576);
     dbenv.set_lg_max(10485760);


### PR DESCRIPTION
## Summary

Fixes #2736. Fixes #2650.

On Windows, Unicode data directory paths (e.g. containing Chinese, Japanese, or other non-ASCII characters) were silently corrupted at multiple layers, causing wallet initialization failures. This PR addresses four distinct encoding corruption points:

### Commit 1: Qt encoding fix (`4cc51f86a`)
- `qstringToBoostPath()`: `QString::toStdString()` produces UTF-8, but `boost::filesystem::path` interprets narrow strings as the system code page on Windows. Fixed to use `toStdWString()` (UTF-16) on Windows.
- `boostPathToQString()`: `path.string()` narrows to system code page, but `QString::fromStdString()` expects UTF-8. Fixed to use `path.wstring()` with `QString::fromStdWString()` on Windows.
- Consolidated scattered inline `QString::fromStdString(path.string())` calls in `bitcoingui.cpp`, `optionsmodel.cpp`, and `researchermodel.cpp` to use `boostPathToQString()`.

### Commit 2: Non-throwing `fs::exists()` (`db706e9e1`)
- In `intro.cpp`, the stored datadir path (potentially corrupted by the encoding bug in prior versions) could cause `boost::filesystem::filesystem_error` when passed to `fs::exists()`. Changed to the `boost::system::error_code` overload so ill-formed paths safely fall through to the directory chooser.

### Commit 3: BDB/LevelDB path handling (`cb4df5e91`)
Added three new `fsbridge` helpers in `fs.h`/`fs.cpp` with distinct strategies for each library:

- **`PathHasNonCodepageChars()`** — Detects paths with characters outside the system code page using `WideCharToMultiByte(CP_ACP)` with the `lpUsedDefaultChar` flag. Workarounds are only engaged when this returns true.
- **`ShortPathString()`** — For BDB, which only accepts `const char*` paths with no Unicode API. Converts to Windows 8.3 short names via `GetShortPathNameW()` when needed. Returns empty string if 8.3 generation is disabled on the volume.
- **`Utf8PathString()`** — For LevelDB, whose Windows port (`env_windows.cc`) internally converts from UTF-8 to UTF-16 via `MultiByteToWideChar(CP_UTF8)`. Provides proper UTF-8 encoding when `path.string()` would produce code page bytes.

Added early validation in `init.cpp` that checks for non-codepage paths and exits with a clear error message if 8.3 short names are unavailable.

### Commit 4: gArgs path corruption + display helpers (`df9b1e476`)
- **`OptionsModel::Init()`** and **`Intro::showIfNeeded()`** both inserted garbled paths into `gArgs` (a narrow-string store) via `path.string()`. Fixed to use `ShortPathString()` at both insertion points.
- **`LongPathString()`** — New display helper that converts 8.3 short paths back to the original Unicode long form via `GetLongPathNameW()`, returning UTF-8. Used in all error messages in `init.cpp` and `bitcoin.cpp` so users see the real path, not the 8.3 alias.
- Documented the known limitation that `-datadir=` on the command line and `datadir=` in `gridcoin.conf` with non-codepage characters are garbled at the `main(argc, argv)` level before our code runs. Fixing this would require `GetCommandLineW()`/`wmain` at the argument parsing level.

## Design principles

- **No unnecessary workarounds**: `PathHasNonCodepageChars()` gates all conversions — paths representable in the system code page use `path.string()` unchanged.
- **Library-appropriate strategies**: BDB gets 8.3 (ASCII-safe alias), LevelDB gets UTF-8 (matches its internal conversion).
- **BDB treated as invariant interface**: Fixes are at the call boundary, not inside BDB, preserving `SYSTEM_BDB` CMake option compatibility.
- **Transparent display**: `LongPathString()` ensures error messages and log output show the real Unicode path.

## Test plan

Tested on Windows 11 VM with mixed English/Chinese data directory paths:
- [x] Directory chooser appears when stored datadir doesn't exist
- [x] Wallet starts and syncs with non-codepage datadir path
- [x] BDB wallet database initializes correctly
- [x] LevelDB txindex opens correctly
- [x] Error messages display the real Unicode path (not 8.3)
- [x] Normal ASCII/codepage paths are completely unaffected
- [x] Linux testnet nodes unaffected (rebased `testnet_v13_checkpoint_removed`)
- [x] All three build targets pass: native Linux, Linux static (depends), Windows cross-compile