### PR TITLE
build, ci, cd: fix macOS DMG packaging and release artifact naming

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -332,6 +332,65 @@ jobs:
       - name: Package (DMG)
         run: cmake --build build --target deploy
 
+      - name: Verify DMG Package
+        run: |
+          set -e
+          DMG_FILE=$(find build -maxdepth 1 -name "gridcoin-*.dmg" | head -1)
+          if [ -z "$DMG_FILE" ]; then
+            echo "ERROR: No DMG file found in build/"
+            exit 1
+          fi
+          echo "Verifying: $DMG_FILE"
+
+          # Mount the DMG read-only
+          MOUNT_POINT="/Volumes/GridcoinVerify"
+          hdiutil attach "$DMG_FILE" -readonly -mountpoint "$MOUNT_POINT"
+
+          # Verify app bundle structure
+          APP="$MOUNT_POINT/Gridcoin.app"
+          for dir in Contents/MacOS Contents/Frameworks Contents/PlugIns Contents/Resources; do
+            if [ ! -d "$APP/$dir" ]; then
+              echo "FAIL: Missing $dir"
+              hdiutil detach "$MOUNT_POINT"
+              exit 1
+            fi
+          done
+          echo "PASS: App bundle structure intact"
+
+          # Verify main executable
+          BINARY="$APP/Contents/MacOS/gridcoinresearch"
+          if [ ! -x "$BINARY" ]; then
+            echo "FAIL: Main binary not found or not executable"
+            hdiutil detach "$MOUNT_POINT"
+            exit 1
+          fi
+          echo "PASS: Main binary exists and is executable"
+
+          # List deployed frameworks for diagnostics
+          echo "Deployed frameworks:"
+          ls "$APP/Contents/Frameworks/"
+
+          # Verify ad-hoc code signature
+          if codesign --verify --deep "$APP" 2>&1; then
+            echo "PASS: Code signature valid"
+          else
+            echo "WARNING: Code signature verification failed (ad-hoc signing may not verify on CI)"
+          fi
+
+          # Verify binary is a valid Mach-O executable (no runtime execution
+          # since the GUI binary pops up dialogs that hang in headless CI)
+          if file "$BINARY" | grep -q "Mach-O"; then
+            echo "PASS: Binary is valid Mach-O executable"
+          else
+            echo "FAIL: Binary is not a valid Mach-O executable"
+            hdiutil detach "$MOUNT_POINT"
+            exit 1
+          fi
+
+          # Cleanup
+          hdiutil detach "$MOUNT_POINT"
+          echo "DMG verification: ALL CHECKS PASSED"
+
       - name: Upload Artifacts
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -296,6 +296,11 @@ jobs:
             echo "Concurrency: Limit set externally to $CMAKE_BUILD_PARALLEL_LEVEL."
           fi
 
+      - name: Set up Python venv for DMG packaging
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/venv"
+          "${RUNNER_TEMP}/venv/bin/pip" install ds_store mac_alias
+
       - name: Configure CMake
         run: |
           export CC_LAUNCHER='-DCMAKE_C_COMPILER_LAUNCHER=ccache'
@@ -314,6 +319,7 @@ jobs:
             -DUSE_QT6=ON \
             -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT" \
+            -DPython3_EXECUTABLE="${RUNNER_TEMP}/venv/bin/python3" \
             $CC_LAUNCHER \
             $CXX_LAUNCHER
 
@@ -324,14 +330,14 @@ jobs:
         run: ctest --test-dir build --output-on-failure
 
       - name: Package (DMG)
-        run: cpack -G DragNDrop --config build/CPackConfig.cmake -B release_packages
+        run: cmake --build build --target deploy
 
       - name: Upload Artifacts
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
           name: gridcoin-macos-dmg
-          path: release_packages/*.dmg
+          path: build/Gridcoin.dmg
           retention-days: 5
 
   # ----------------------------------------------------------------------

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -264,8 +264,8 @@ jobs:
   # ----------------------------------------------------------------------
   # JOB 2: macOS Native
   # ----------------------------------------------------------------------
-  macos-native:
-    name: macOS Native (Homebrew Qt6)
+  macos-native-arm64:
+    name: macOS ARM64 (Homebrew Qt6)
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -279,8 +279,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /Users/runner/Library/Caches/ccache
-          key: ccache-macos-${{ github.sha }}
-          restore-keys: ccache-macos-
+          key: ccache-macos-arm64-${{ github.sha }}
+          restore-keys: ccache-macos-arm64-
 
       # Setup Concurrency for macOS too
       - name: Setup Concurrency
@@ -395,7 +395,143 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
-          name: gridcoin-macos-dmg
+          name: gridcoin-macos-arm64-dmg
+          path: build/gridcoin-*.dmg
+          retention-days: 5
+
+  macos-native-intel:
+    name: macOS Intel (Homebrew Qt6)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install x86_64 Homebrew and Dependencies
+        run: |
+          # Install a separate x86_64 Homebrew at /usr/local (Intel prefix).
+          # The ARM64 runner has Rosetta 2, so x86_64 binaries run transparently.
+          arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
+          arch -x86_64 /usr/local/bin/brew update
+          arch -x86_64 /usr/local/bin/brew install qt boost openssl libevent miniupnpc qrencode libzip ccache cmake
+
+      - name: Configure Ccache
+        uses: actions/cache@v4
+        with:
+          path: /Users/runner/Library/Caches/ccache
+          key: ccache-macos-intel-${{ github.sha }}
+          restore-keys: ccache-macos-intel-
+
+      - name: Setup Concurrency
+        run: |
+          if [ -z "$CMAKE_BUILD_PARALLEL_LEVEL" ]; then
+            CORES=$(sysctl -n hw.logicalcpu)
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
+            echo "CTEST_PARALLEL_LEVEL=$CORES" >> $GITHUB_ENV
+            echo "Concurrency: Auto-detected $CORES cores."
+          else
+            echo "Concurrency: Limit set externally to $CMAKE_BUILD_PARALLEL_LEVEL."
+          fi
+
+      - name: Set up Python venv for DMG packaging
+        run: |
+          arch -x86_64 /usr/local/bin/python3 -m venv "${RUNNER_TEMP}/venv"
+          "${RUNNER_TEMP}/venv/bin/pip" install ds_store mac_alias
+
+      - name: Configure CMake
+        run: |
+          export CC_LAUNCHER='-DCMAKE_C_COMPILER_LAUNCHER=ccache'
+          export CXX_LAUNCHER='-DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+          QT6_PATH=$(arch -x86_64 /usr/local/bin/brew --prefix qt)
+          OPENSSL_ROOT=$(arch -x86_64 /usr/local/bin/brew --prefix openssl)
+
+          arch -x86_64 /usr/local/bin/cmake -B build \
+            -DCMAKE_PREFIX_PATH="$QT6_PATH" \
+            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+            -DENABLE_GUI=ON \
+            -DENABLE_QRENCODE=ON \
+            -DENABLE_UPNP=ON \
+            -DDEFAULT_UPNP=ON \
+            -DENABLE_TESTS=ON \
+            -DENABLE_DOCS=OFF \
+            -DUSE_QT6=ON \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT" \
+            -DPython3_EXECUTABLE="${RUNNER_TEMP}/venv/bin/python3" \
+            $CC_LAUNCHER \
+            $CXX_LAUNCHER
+
+      - name: Build
+        run: arch -x86_64 /usr/local/bin/cmake --build build
+
+      - name: Test
+        run: arch -x86_64 /usr/local/bin/ctest --test-dir build --output-on-failure
+
+      - name: Package (DMG)
+        run: arch -x86_64 /usr/local/bin/cmake --build build --target deploy
+
+      - name: Verify DMG Package
+        run: |
+          set -e
+          DMG_FILE=$(find build -maxdepth 1 -name "gridcoin-*.dmg" | head -1)
+          if [ -z "$DMG_FILE" ]; then
+            echo "ERROR: No DMG file found in build/"
+            exit 1
+          fi
+          echo "Verifying: $DMG_FILE"
+
+          # Mount the DMG read-only
+          MOUNT_POINT="/Volumes/GridcoinVerify"
+          hdiutil attach "$DMG_FILE" -readonly -mountpoint "$MOUNT_POINT"
+
+          # Verify app bundle structure
+          APP="$MOUNT_POINT/Gridcoin.app"
+          for dir in Contents/MacOS Contents/Frameworks Contents/PlugIns Contents/Resources; do
+            if [ ! -d "$APP/$dir" ]; then
+              echo "FAIL: Missing $dir"
+              hdiutil detach "$MOUNT_POINT"
+              exit 1
+            fi
+          done
+          echo "PASS: App bundle structure intact"
+
+          # Verify main executable
+          BINARY="$APP/Contents/MacOS/gridcoinresearch"
+          if [ ! -x "$BINARY" ]; then
+            echo "FAIL: Main binary not found or not executable"
+            hdiutil detach "$MOUNT_POINT"
+            exit 1
+          fi
+          echo "PASS: Main binary exists and is executable"
+
+          # List deployed frameworks for diagnostics
+          echo "Deployed frameworks:"
+          ls "$APP/Contents/Frameworks/"
+
+          # Verify ad-hoc code signature
+          if codesign --verify --deep "$APP" 2>&1; then
+            echo "PASS: Code signature valid"
+          else
+            echo "WARNING: Code signature verification failed (ad-hoc signing may not verify on CI)"
+          fi
+
+          # Verify binary is a valid Mach-O executable (no runtime execution
+          # since the GUI binary pops up dialogs that hang in headless CI)
+          if file "$BINARY" | grep -q "Mach-O"; then
+            echo "PASS: Binary is valid Mach-O executable"
+          else
+            echo "FAIL: Binary is not a valid Mach-O executable"
+            hdiutil detach "$MOUNT_POINT"
+            exit 1
+          fi
+
+          # Cleanup
+          hdiutil detach "$MOUNT_POINT"
+          echo "DMG verification: ALL CHECKS PASSED"
+
+      - name: Upload Artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gridcoin-macos-intel-dmg
           path: build/gridcoin-*.dmg
           retention-days: 5
 
@@ -700,7 +836,7 @@ jobs:
   # ----------------------------------------------------------------------
   deploy:
     name: Create Release
-    needs: [depends-builds, macos-native, flatpak-build]
+    needs: [depends-builds, macos-native-arm64, macos-native-intel, flatpak-build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:

--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -337,7 +337,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gridcoin-macos-dmg
-          path: build/Gridcoin.dmg
+          path: build/gridcoin-*.dmg
           retention-days: 5
 
   # ----------------------------------------------------------------------
@@ -396,7 +396,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
-          name: gridcoin-x86_64-linux-gnu
+          name: docker-gridcoin-x86_64-linux-gnu
           path: dist/
           retention-days: 5
 
@@ -491,7 +491,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
-          name: gridcoin-aarch64-linux-gnu
+          name: docker-gridcoin-aarch64-linux-gnu
           path: dist/
           retention-days: 5
 
@@ -569,13 +569,13 @@ jobs:
       - name: Download x86_64 Build Artifact
         uses: actions/download-artifact@v4
         with:
-          name: gridcoin-x86_64-linux-gnu
+          name: docker-gridcoin-x86_64-linux-gnu
           path: artifacts/amd64
 
       - name: Download ARM64 Build Artifact
         uses: actions/download-artifact@v4
         with:
-          name: gridcoin-aarch64-linux-gnu
+          name: docker-gridcoin-aarch64-linux-gnu
           path: artifacts/arm64
 
       - name: Stage Binaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,17 @@ option(ENABLE_X86_SHANI "Build code that uses x86 SHA-NI intrinsics" ${HAS_X86_S
 option(ENABLE_ARM_SHANI "Build code that uses ARM SHA-NI intrinsics" ${HAS_ARM_SHANI})
 option(USE_ASM          "Enable assembly routines" ON)
 
+# Scrypt assembly uses GNU assembler syntax incompatible with Apple's
+# LLVM assembler, so default to OFF on Apple and ON elsewhere.
+if(NOT DEFINED USE_ASM_SCRYPT)
+    if(APPLE)
+        set(USE_ASM_SCRYPT OFF)
+    else()
+        set(USE_ASM_SCRYPT ${USE_ASM})
+    endif()
+endif()
+option(USE_ASM_SCRYPT   "Enable scrypt assembly routines (requires GNU assembler)" ${USE_ASM_SCRYPT})
+
 # Optional functionality
 option(ENABLE_PIE       "Build position-independent executables" OFF)
 option(ENABLE_DEBUG_LOCKORDER "Enable run-time lock-order checking (DEBUG_LOCKORDER)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,9 +438,16 @@ else()
 endif()
 
 if(CMAKE_C_COMPILER_TARGET)
-    # Naming: gridcoinresearch-5.x.x-x86_64-pc-linux-gnu.tar.gz
+    # Cross/depends builds: e.g. x86_64-pc-linux-gnu, x86_64-w64-mingw32
     set(CPACK_SYSTEM_NAME "${CMAKE_C_COMPILER_TARGET}")
+elseif(CMAKE_SYSTEM_PROCESSOR)
+    # Native builds: e.g. x86_64, aarch64
+    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_PROCESSOR}")
 endif()
+
+# CPack constructs CPACK_PACKAGE_VERSION from MAJOR.MINOR.PATCH, excluding
+# TWEAK. Override it to use the full quad version (e.g. 5.4.9.10).
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
 
 set(CPACK_NSIS_PACKAGE_NAME ${PROJECT_NAME})
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "gridcoinresearch-${PROJECT_VERSION}")

--- a/build_targets.sh
+++ b/build_targets.sh
@@ -196,6 +196,12 @@ if [[ ! "$TARGET" =~ ^(native|depends|win64|macos|all)$ ]]; then
     exit 1
 fi
 
+# Catch common mistake: using Linux-only targets on macOS
+if [[ "$(uname -s)" == "Darwin" ]] && [[ "$TARGET" =~ ^(native|depends|win64)$ ]]; then
+    echo "Error: TARGET='$TARGET' is a Linux-only target. Use TARGET=macos for native macOS builds."
+    exit 1
+fi
+
 # Prepare specific CMake arguments for Native/macOS
 NATIVE_CMAKE_ARGS=""
 

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -507,16 +507,21 @@ if not os.path.exists(app_bundle):
 
 # ------------------------------------------------
 
+# When -dmg is given with an explicit basename, use it for the output file;
+# otherwise fall back to appname.  The volume name always uses appname so that
+# the mounted disk appears as e.g. "Gridcoin" regardless of the .dmg filename.
+dmg_basename = config.dmg if (config.dmg is not None and config.dmg != "") else appname
+
 if os.path.exists("dist"):
     print("+ Removing existing dist folder +")
     shutil.rmtree("dist")
 
-if os.path.exists(appname + ".dmg"):
+if os.path.exists(dmg_basename + ".dmg"):
     print("+ Removing existing DMG +")
-    os.unlink(appname + ".dmg")
+    os.unlink(dmg_basename + ".dmg")
 
-if os.path.exists(appname + ".temp.dmg"):
-    os.unlink(appname + ".temp.dmg")
+if os.path.exists(dmg_basename + ".temp.dmg"):
+    os.unlink(dmg_basename + ".temp.dmg")
 
 # ------------------------------------------------
 
@@ -667,7 +672,7 @@ if config.dmg is not None:
     if verbose:
         print("Creating temp image for modification...")
 
-    tempname: str = appname + ".temp.dmg"
+    tempname: str = dmg_basename + ".temp.dmg"
 
     run(["hdiutil", "create", tempname, "-srcfolder", "dist", "-format", "UDRW", "-size", str(size), "-volname", appname], check=True, universal_newlines=True)
 
@@ -696,7 +701,7 @@ if config.dmg is not None:
 
     run(["hdiutil", "detach", f"/Volumes/{appname}"], universal_newlines=True)
 
-    run(["hdiutil", "convert", tempname, "-format", "UDZO", "-o", appname, "-imagekey", "zlib-level=9"], check=True, universal_newlines=True)
+    run(["hdiutil", "convert", tempname, "-format", "UDZO", "-o", dmg_basename, "-imagekey", "zlib-level=9"], check=True, universal_newlines=True)
 
     os.unlink(tempname)
 

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -18,8 +18,12 @@
 
 import sys, re, os, platform, shutil, stat, subprocess, os.path
 from argparse import ArgumentParser
-from ds_store import DSStore
-from mac_alias import Alias
+try:
+    from ds_store import DSStore
+    from mac_alias import Alias
+    HAS_DS_STORE = True
+except ImportError:
+    HAS_DS_STORE = False
 from pathlib import Path
 from subprocess import PIPE, run
 from typing import List, Optional
@@ -92,7 +96,9 @@ class FrameworkInfo(object):
         if m is None:
             raise RuntimeError(f"Line could not be parsed: {line}")
 
-        path = m.group(1)
+        # Normalize the path to collapse any '..' traversals that may arise
+        # from @rpath or @loader_path expansion in different directory layouts.
+        path = os.path.normpath(m.group(1))
 
         info = cls()
         info.sourceFilePath = path
@@ -115,13 +121,15 @@ class FrameworkInfo(object):
             info.destinationDirectory = cls.bundleFrameworkDirectory
         else:
             parts = path.split("/")
-            i = 0
-            # Search for the .framework directory
-            for part in parts:
+            # Search for the LAST .framework directory. When relative rpaths
+            # are expanded, the path may traverse through a sibling framework
+            # directory before reaching the actual dependency. Using the last
+            # match ensures we identify the correct dependency framework.
+            i = -1
+            for j, part in enumerate(parts):
                 if part.endswith(".framework"):
-                    break
-                i += 1
-            if i == len(parts):
+                    i = j
+            if i == -1:
                 raise RuntimeError(f"Could not find .framework or .dylib in line: {line}")
 
             info.frameworkName = parts[i]
@@ -169,9 +177,16 @@ class DeploymentInfo(object):
             self.qtPath = os.getenv("QTDIR", None)
 
         if self.qtPath is not None:
-            pluginPath = os.path.join(self.qtPath, "plugins")
-            if os.path.exists(pluginPath):
-                self.pluginPath = pluginPath
+            # Try common plugin directory layouts:
+            #   Classic Qt:   ${prefix}/plugins
+            #   Homebrew Qt6: ${prefix}/share/qt/plugins
+            for candidate in [
+                os.path.join(self.qtPath, "plugins"),
+                os.path.join(self.qtPath, "share", "qt", "plugins"),
+            ]:
+                if os.path.exists(candidate):
+                    self.pluginPath = candidate
+                    break
 
     def usesFramework(self, name: str) -> bool:
         for framework in self.deployedFrameworks:
@@ -182,6 +197,57 @@ class DeploymentInfo(object):
                 if framework.startswith(f"lib{name}."):
                     return True
         return False
+
+def getRpaths(binaryPath: str, verbose: int) -> List[str]:
+    """Extract LC_RPATH search paths from a Mach-O binary using otool."""
+    output = run(["otool", "-l", binaryPath], stdout=PIPE, stderr=PIPE, text=True)
+    if output.returncode != 0:
+        return []
+    rpaths = []
+    lines = output.stdout.split("\n")
+    for i, line in enumerate(lines):
+        if "cmd LC_RPATH" in line:
+            for j in range(i + 1, min(i + 4, len(lines))):
+                if "path " in lines[j]:
+                    rp = lines[j].strip().split("path ")[1].split(" (offset")[0].strip()
+                    rpaths.append(rp)
+                    break
+    if verbose and rpaths:
+        print(f"  rpaths for {binaryPath}: {rpaths}")
+    return rpaths
+
+def expandRpathTokens(rpath: str, binaryPath: str) -> str:
+    """Expand @loader_path and @executable_path tokens in an rpath entry."""
+    rpath = rpath.replace("@loader_path", os.path.dirname(binaryPath))
+    rpath = rpath.replace("@executable_path", os.path.dirname(binaryPath))
+    return rpath
+
+def resolveRpath(line: str, rpaths: List[str], binaryPath: str) -> Optional[str]:
+    """Try to resolve an @rpath reference using extracted rpaths.
+
+    Returns the line with @rpath replaced by the matching rpath,
+    or None if no rpath resolves to an existing path.
+    Expands @loader_path/@executable_path tokens within rpath entries.
+    """
+    for rp in rpaths:
+        rp = expandRpathTokens(rp, binaryPath)
+        candidate = line.replace("@rpath", rp)
+        stripped = candidate.strip()
+        m = FrameworkInfo.reOLine.match(stripped)
+        if m:
+            # Normalize the path to collapse '..' traversals. Without this,
+            # relative rpaths expanded in a bundle context can produce paths
+            # that pass through a sibling .framework directory (e.g.
+            # .../QtGui.framework/Versions/A/../../QtCore.framework/...).
+            # The old first-match .framework check would then find the wrong
+            # framework and accept a bogus candidate.
+            path = os.path.normpath(m.group(1))
+            if os.path.exists(path):
+                # Reconstruct the line with the normalized path so downstream
+                # parsing sees a clean path without '..' components.
+                version_info = stripped[len(m.group(1)):]
+                return f"  {path}{version_info}"
+    return None
 
 def getFrameworks(binaryPath: str, verbose: int) -> List[FrameworkInfo]:
     objdump = os.getenv("OBJDUMP", "objdump")
@@ -198,11 +264,32 @@ def getFrameworks(binaryPath: str, verbose: int) -> List[FrameworkInfo]:
     if ".framework" in binaryPath or binaryPath.endswith(".dylib"):
         lines.pop(0) # Frameworks and dylibs list themselves as a dependency.
 
+    # Extract rpaths for resolving @rpath references
+    rpaths = getRpaths(binaryPath, verbose)
+
     libraries = []
     for line in lines:
+        # Extract the raw install name before any token resolution.
+        # install_name_tool -change must match the exact string in the binary.
+        raw_match = FrameworkInfo.reOLine.match(line.strip())
+        raw_installname = raw_match.group(1) if raw_match else None
+
         line = line.replace("@loader_path", os.path.dirname(binaryPath))
+        if "@rpath/" in line:
+            resolved = resolveRpath(line, rpaths, binaryPath)
+            if resolved is not None:
+                line = resolved
+            else:
+                if verbose:
+                    print(f"  Skipping unresolvable @rpath reference: {line.strip()}")
+                continue
         info = FrameworkInfo.fromLibraryLine(line.strip())
         if info is not None:
+            # Restore the original install name so that install_name_tool -change
+            # can match the actual reference in the binary (e.g. @rpath/... or
+            # @loader_path/...) rather than the resolved absolute path.
+            if raw_installname and raw_installname != info.installName:
+                info.installName = raw_installname
             if verbose:
                 print("Found framework:")
                 print(info)
@@ -319,8 +406,14 @@ def deployFrameworks(frameworks: List[FrameworkInfo], bundlePath: str, binaryPat
 
         # install_name_tool it a new id.
         changeIdentification(framework.deployedInstallName, deployedBinaryPath, verbose)
-        # Check for framework dependencies
-        dependencies = getFrameworks(deployedBinaryPath, verbose)
+        # Check for framework dependencies.
+        # Scan the ORIGINAL binary so that @loader_path / @rpath tokens
+        # resolve relative to the Qt prefix (where sibling frameworks
+        # exist) rather than the bundle (where they may not yet be copied).
+        originalPath = framework.sourceFilePath
+        if originalPath.startswith("Qt"):
+            originalPath = f"/Library/Frameworks/{originalPath}"
+        dependencies = getFrameworks(originalPath, verbose)
 
         for dependency in dependencies:
             changeInstallName(dependency.installName, dependency.deployedInstallName, deployedBinaryPath, verbose)
@@ -396,6 +489,7 @@ ap.add_argument("-verbose", nargs="?", const=True, help="Output additional debug
 ap.add_argument("-no-plugins", dest="plugins", action="store_false", default=True, help="skip plugin deployment")
 ap.add_argument("-no-strip", dest="strip", action="store_false", default=True, help="don't run 'strip' on the binaries")
 ap.add_argument("-dmg", nargs="?", const="", metavar="basename", help="create a .dmg disk image")
+ap.add_argument("-plugin-dir", nargs=1, metavar="path", default=None, help="Path to Qt's plugins directory (e.g. from qtpaths --query QT_INSTALL_PLUGINS)")
 ap.add_argument("-translations-dir", nargs=1, metavar="path", default=None, help="Path to Qt's translations. Base translations will automatically be added to the bundle's resources.")
 
 config = ap.parse_args()
@@ -452,16 +546,27 @@ except RuntimeError as e:
     sys.stderr.write(f"Error: {str(e)}\n")
     sys.exit(1)
 
+# Override plugin path if explicitly provided via -plugin-dir
+if config.plugin_dir is not None:
+    explicit_plugin_dir = config.plugin_dir[0]
+    if os.path.isdir(explicit_plugin_dir):
+        deploymentInfo.pluginPath = explicit_plugin_dir
+    else:
+        sys.stderr.write(f"Warning: -plugin-dir path does not exist: {explicit_plugin_dir}\n")
+
 # ------------------------------------------------
 
 if config.plugins:
     print("+ Deploying plugins +")
 
-    try:
-        deployPlugins(applicationBundle, deploymentInfo, config.strip, verbose)
-    except RuntimeError as e:
-        sys.stderr.write(f"Error: {str(e)}\n")
-        sys.exit(1)
+    if deploymentInfo.pluginPath is None:
+        sys.stderr.write("Warning: Qt plugin path not found, skipping plugin deployment!\n")
+    else:
+        try:
+            deployPlugins(applicationBundle, deploymentInfo, config.strip, verbose)
+        except RuntimeError as e:
+            sys.stderr.write(f"Error: {str(e)}\n")
+            sys.exit(1)
 
 # ------------------------------------------------
 
@@ -470,18 +575,18 @@ if config.translations_dir:
         sys.stderr.write(f"Error: Could not find translation dir \"{config.translations_dir[0]}\"\n")
         sys.exit(1)
 
-print("+ Adding Qt translations +")
+    print("+ Adding Qt translations +")
 
-translations = Path(config.translations_dir[0])
+    translations = Path(config.translations_dir[0])
 
-regex = re.compile('qt_[a-z]*(.qm|_[A-Z]*.qm)')
+    regex = re.compile('qt_[a-z]*(.qm|_[A-Z]*.qm)')
 
-lang_files = [x for x in translations.iterdir() if regex.match(x.name)]
+    lang_files = [x for x in translations.iterdir() if regex.match(x.name)]
 
-for file in lang_files:
-    if verbose:
-        print(file.as_posix(), "->", os.path.join(applicationBundle.resourcesPath, file.name))
-    shutil.copy2(file.as_posix(), os.path.join(applicationBundle.resourcesPath, file.name))
+    for file in lang_files:
+        if verbose:
+            print(file.as_posix(), "->", os.path.join(applicationBundle.resourcesPath, file.name))
+        shutil.copy2(file.as_posix(), os.path.join(applicationBundle.resourcesPath, file.name))
 
 # ------------------------------------------------
 
@@ -497,47 +602,50 @@ with open(os.path.join(applicationBundle.resourcesPath, "qt.conf"), "wb") as f:
 
 # ------------------------------------------------
 
-print("+ Generating .DS_Store +")
+if HAS_DS_STORE:
+    print("+ Generating .DS_Store +")
 
-output_file = os.path.join("dist", ".DS_Store")
+    output_file = os.path.join("dist", ".DS_Store")
 
-ds = DSStore.open(output_file, 'w+')
+    ds = DSStore.open(output_file, 'w+')
 
-ds['.']['bwsp'] = {
-    'WindowBounds': '{{300, 280}, {500, 343}}',
-    'PreviewPaneVisibility': False,
-}
+    ds['.']['bwsp'] = {
+        'WindowBounds': '{{300, 280}, {500, 343}}',
+        'PreviewPaneVisibility': False,
+    }
 
-icvp = {
-    'gridOffsetX': 0.0,
-    'textSize': 12.0,
-    'viewOptionsVersion': 1,
-    'backgroundImageAlias': b'\x00\x00\x00\x00\x02\x1e\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd1\x94\\\xb0H+\x00\x05\x00\x00\x00\x98\x0fbackground.tiff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x99\xd19\xb0\xf8\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x00\x00\r\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b.background\x00\x00\x10\x00\x08\x00\x00\xd1\x94\\\xb0\x00\x00\x00\x11\x00\x08\x00\x00\xd19\xb0\xf8\x00\x00\x00\x01\x00\x04\x00\x00\x00\x98\x00\x0e\x00 \x00\x0f\x00b\x00a\x00c\x00k\x00g\x00r\x00o\x00u\x00n\x00d\x00.\x00t\x00i\x00f\x00f\x00\x0f\x00\x02\x00\x00\x00\x12\x00\x1c/.background/background.tiff\x00\x14\x01\x06\x00\x00\x00\x00\x01\x06\x00\x02\x00\x00\x0cMacintosh HD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xce\x97\xab\xc3H+\x00\x00\x01\x88[\x88\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02u\xab\x8d\xd1\x94\\\xb0devrddsk\xff\xff\xff\xff\x00\x00\t \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07bitcoin\x00\x00\x10\x00\x08\x00\x00\xce\x97\xab\xc3\x00\x00\x00\x11\x00\x08\x00\x00\xd1\x94\\\xb0\x00\x00\x00\x01\x00\x14\x01\x88[\x88\x00\x16\xa9\t\x00\x08\xfaR\x00\x08\xfaQ\x00\x02d\x8e\x00\x0e\x00\x02\x00\x00\x00\x0f\x00\x1a\x00\x0c\x00M\x00a\x00c\x00i\x00n\x00t\x00o\x00s\x00h\x00 \x00H\x00D\x00\x13\x00\x01/\x00\x00\x15\x00\x02\x00\x14\xff\xff\x00\x00\xff\xff\x00\x00',
-    'backgroundColorBlue': 1.0,
-    'iconSize': 96.0,
-    'backgroundColorGreen': 1.0,
-    'arrangeBy': 'none',
-    'showIconPreview': True,
-    'gridSpacing': 100.0,
-    'gridOffsetY': 0.0,
-    'showItemInfo': False,
-    'labelOnBottom': True,
-    'backgroundType': 2,
-    'backgroundColorRed': 1.0
-}
-alias = Alias().from_bytes(icvp['backgroundImageAlias'])
-alias.volume.name = appname
-alias.volume.posix_path = '/Volumes/' + appname
-icvp['backgroundImageAlias'] = alias.to_bytes()
-ds['.']['icvp'] = icvp
+    icvp = {
+        'gridOffsetX': 0.0,
+        'textSize': 12.0,
+        'viewOptionsVersion': 1,
+        'backgroundImageAlias': b'\x00\x00\x00\x00\x02\x1e\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd1\x94\\\xb0H+\x00\x05\x00\x00\x00\x98\x0fbackground.tiff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x99\xd19\xb0\xf8\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\x00\x00\r\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b.background\x00\x00\x10\x00\x08\x00\x00\xd1\x94\\\xb0\x00\x00\x00\x11\x00\x08\x00\x00\xd19\xb0\xf8\x00\x00\x00\x01\x00\x04\x00\x00\x00\x98\x00\x0e\x00 \x00\x0f\x00b\x00a\x00c\x00k\x00g\x00r\x00o\x00u\x00n\x00d\x00.\x00t\x00i\x00f\x00f\x00\x0f\x00\x02\x00\x00\x00\x12\x00\x1c/.background/background.tiff\x00\x14\x01\x06\x00\x00\x00\x00\x01\x06\x00\x02\x00\x00\x0cMacintosh HD\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xce\x97\xab\xc3H+\x00\x00\x01\x88[\x88\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02u\xab\x8d\xd1\x94\\\xb0devrddsk\xff\xff\xff\xff\x00\x00\t \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07bitcoin\x00\x00\x10\x00\x08\x00\x00\xce\x97\xab\xc3\x00\x00\x00\x11\x00\x08\x00\x00\xd1\x94\\\xb0\x00\x00\x00\x01\x00\x14\x01\x88[\x88\x00\x16\xa9\t\x00\x08\xfaR\x00\x08\xfaQ\x00\x02d\x8e\x00\x0e\x00\x02\x00\x00\x00\x0f\x00\x1a\x00\x0c\x00M\x00a\x00c\x00i\x00n\x00t\x00o\x00s\x00h\x00 \x00H\x00D\x00\x13\x00\x01/\x00\x00\x15\x00\x02\x00\x14\xff\xff\x00\x00\xff\xff\x00\x00',
+        'backgroundColorBlue': 1.0,
+        'iconSize': 96.0,
+        'backgroundColorGreen': 1.0,
+        'arrangeBy': 'none',
+        'showIconPreview': True,
+        'gridSpacing': 100.0,
+        'gridOffsetY': 0.0,
+        'showItemInfo': False,
+        'labelOnBottom': True,
+        'backgroundType': 2,
+        'backgroundColorRed': 1.0
+    }
+    alias = Alias().from_bytes(icvp['backgroundImageAlias'])
+    alias.volume.name = appname
+    alias.volume.posix_path = '/Volumes/' + appname
+    icvp['backgroundImageAlias'] = alias.to_bytes()
+    ds['.']['icvp'] = icvp
 
-ds['.']['vSrn'] = ('long', 1)
+    ds['.']['vSrn'] = ('long', 1)
 
-ds['Applications']['Iloc'] = (370, 156)
-ds['Gridcoin.app']['Iloc'] = (128, 156)
+    ds['Applications']['Iloc'] = (370, 156)
+    ds['Gridcoin.app']['Iloc'] = (128, 156)
 
-ds.flush()
-ds.close()
+    ds.flush()
+    ds.close()
+else:
+    print("+ Skipping .DS_Store generation (ds_store/mac_alias packages not installed) +")
 
 # ------------------------------------------------
 
@@ -572,11 +680,15 @@ if config.dmg is not None:
 
     print("+ Applying fancy settings +")
 
-    bg_path = os.path.join(disk_root, ".background", os.path.basename('background.tiff'))
-    os.mkdir(os.path.dirname(bg_path))
-    if verbose:
-        print('background.tiff', "->", bg_path)
-    shutil.copy2('background.tiff', bg_path)
+    bg_file = 'background.tiff'
+    if os.path.exists(bg_file):
+        bg_path = os.path.join(disk_root, ".background", os.path.basename(bg_file))
+        os.mkdir(os.path.dirname(bg_path))
+        if verbose:
+            print(bg_file, "->", bg_path)
+        shutil.copy2(bg_file, bg_path)
+    else:
+        print("  (Skipping background image: background.tiff not found)")
 
     os.symlink("/Applications", os.path.join(disk_root, "Applications"))
 

--- a/doc/cmake-options.md
+++ b/doc/cmake-options.md
@@ -30,6 +30,19 @@ These options toggle specific functionality within the Gridcoin client.
 
 ---
 
+## CPU & Assembly
+
+| Option | Default | Description |
+| :--- | :--- | :--- |
+| `USE_ASM` | `ON` | Enable assembly routines (SHA-256 SSE4, secp256k1). |
+| `USE_ASM_SCRYPT` | `USE_ASM` (non-Apple), `OFF` (Apple) | Enable scrypt x86/x86_64 assembly. Requires a GNU-compatible assembler; Apple's LLVM assembler is not compatible, so this defaults to `OFF` on macOS. The C++ fallback in `scrypt.cpp` is used when disabled. |
+| `ENABLE_SSE41` | Auto-detected | Build SHA-256 code that uses SSE4.1 intrinsics. |
+| `ENABLE_AVX2` | Auto-detected | Build SHA-256 code that uses AVX2 intrinsics. |
+| `ENABLE_X86_SHANI` | Auto-detected | Build SHA-256 code that uses x86 SHA-NI intrinsics. |
+| `ENABLE_ARM_SHANI` | Auto-detected | Build SHA-256 code that uses ARM SHA-NI intrinsics. |
+
+---
+
 ## Advanced / Cross-Compilation
 
 These options are primarily used by the `depends` system or advanced users.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -517,7 +517,8 @@ Suppression files for known issues in dependencies are located in
 
 Notes:
 - `-DUSE_ASM=OFF` is recommended when using ASan, as the hand-written assembly
-  in SHA-256 can produce false positives.
+  can produce false positives. This also disables `USE_ASM_SCRYPT` (scrypt
+  assembly). See `doc/cmake-options.md` for details on these flags.
 - If you are compiling with GCC you will typically need to install corresponding
   "san" libraries, e.g. `libasan` for ASan, `libtsan` for TSan, and `libubsan`
   for UBSan.

--- a/share/qt/Info.plist.cmake.in
+++ b/share/qt/Info.plist.cmake.in
@@ -7,7 +7,7 @@
 
   <key>LSArchitecturePriority</key>
   <array>
-    <string>x86_64</string>
+    <string>@CMAKE_SYSTEM_PROCESSOR@</string>
   </array>
 
   <key>CFBundleIconFile</key>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,8 +203,6 @@ add_library(gridcoin_util STATIC
     rpc/voting.cpp
     scheduler.cpp
     script.cpp
-    scrypt-x86.S
-    scrypt-x86_64.S
     scrypt.cpp
     support/cleanse.cpp
     support/lockedpool.cpp
@@ -230,6 +228,10 @@ add_library(gridcoin_util STATIC
     wallet/walletdb.cpp
     wallet/walletutil.cpp
 )
+
+if(USE_ASM_SCRYPT)
+    target_sources(gridcoin_util PRIVATE scrypt-x86.S scrypt-x86_64.S)
+endif()
 
 target_include_directories(gridcoin_util PUBLIC
     ${CMAKE_SOURCE_DIR}/src

--- a/src/config/gridcoin-config.h.cmake.in
+++ b/src/config/gridcoin-config.h.cmake.in
@@ -35,6 +35,7 @@
 #endif
 
 #cmakedefine USE_ASM
+#cmakedefine USE_ASM_SCRYPT
 
 #cmakedefine USE_DBUS
 #cmakedefine USE_QRCODE

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -344,8 +344,8 @@ endif()
 #
 if(APPLE)
     # Use Python3_EXECUTABLE if explicitly set (e.g. -DPython3_EXECUTABLE=...),
-    # otherwise fall back to "python3" resolved via PATH at build time.
-    # This ensures the deploy target works with a venv activated at build time.
+    # otherwise resolve via find_program at configure time, with a final
+    # fallback to the literal "python3" string resolved via PATH at build time.
     if(NOT Python3_EXECUTABLE)
         find_program(Python3_EXECUTABLE NAMES python3)
     endif()

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -336,6 +336,90 @@ else()
     )
 endif()
 
+# macOS Deploy Target
+# ===================
+#
+# Creates a self-contained, ad-hoc signed DMG using macdeployqtplus.
+# Usage: cmake --build build --target deploy
+#
+if(APPLE)
+    # Use Python3_EXECUTABLE if explicitly set (e.g. -DPython3_EXECUTABLE=...),
+    # otherwise fall back to "python3" resolved via PATH at build time.
+    # This ensures the deploy target works with a venv activated at build time.
+    if(NOT Python3_EXECUTABLE)
+        find_program(Python3_EXECUTABLE NAMES python3)
+    endif()
+    if(NOT Python3_EXECUTABLE)
+        set(Python3_EXECUTABLE "python3")
+    endif()
+
+    # Locate Qt translations directory and QTDIR for plugin discovery.
+    # Try qtpaths first (the canonical Qt tool), then fall back to
+    # deriving paths from the Qt6::Core imported target location.
+    find_program(QTPATHS_EXECUTABLE NAMES qtpaths6 qtpaths)
+
+    if(QTPATHS_EXECUTABLE)
+        execute_process(
+            COMMAND "${QTPATHS_EXECUTABLE}" --query QT_INSTALL_TRANSLATIONS
+            OUTPUT_VARIABLE _qt_translations_dir
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND "${QTPATHS_EXECUTABLE}" --query QT_INSTALL_PREFIX
+            OUTPUT_VARIABLE _qt_prefix_dir
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND "${QTPATHS_EXECUTABLE}" --query QT_INSTALL_PLUGINS
+            OUTPUT_VARIABLE _qt_plugins_dir
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
+
+    # Fallback: derive from Qt6::Core target location
+    if(NOT _qt_translations_dir OR NOT _qt_prefix_dir)
+        get_target_property(_qt_core_loc ${QT}::Core LOCATION)
+        # e.g. /opt/homebrew/lib/QtCore.framework/Versions/A/QtCore
+        #   -> /opt/homebrew
+        get_filename_component(_qt_lib_dir "${_qt_core_loc}" DIRECTORY)
+        # Walk up from lib/ (or framework internals) to the prefix
+        string(REGEX REPLACE "/lib(/.*)?$" "" _qt_prefix_dir_fallback "${_qt_lib_dir}")
+        if(NOT _qt_prefix_dir)
+            set(_qt_prefix_dir "${_qt_prefix_dir_fallback}")
+        endif()
+        if(NOT _qt_translations_dir)
+            set(_qt_translations_dir "${_qt_prefix_dir}/translations")
+        endif()
+    endif()
+
+    set(_deploy_script "${CMAKE_SOURCE_DIR}/contrib/macdeploy/macdeployqtplus")
+    set(_app_bundle "$<TARGET_BUNDLE_DIR:gridcoinresearch>")
+
+    # Build the macdeployqtplus command
+    set(_deploy_cmd
+        ${Python3_EXECUTABLE} "${_deploy_script}"
+        "${_app_bundle}" Gridcoin
+        -dmg
+    )
+
+    # Only pass -plugin-dir if the directory actually exists
+    if(_qt_plugins_dir AND EXISTS "${_qt_plugins_dir}")
+        list(APPEND _deploy_cmd -plugin-dir "${_qt_plugins_dir}")
+    endif()
+
+    # Only pass -translations-dir if the directory actually exists
+    if(_qt_translations_dir AND EXISTS "${_qt_translations_dir}")
+        list(APPEND _deploy_cmd -translations-dir "${_qt_translations_dir}")
+    endif()
+
+    add_custom_target(deploy
+        COMMAND ${CMAKE_COMMAND} -E env "QTDIR=${_qt_prefix_dir}" ${_deploy_cmd}
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        COMMENT "Deploying Gridcoin.app into DMG via macdeployqtplus"
+        DEPENDS gridcoinresearch
+    )
+endif()
+
 # Tests
 # =====
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -394,12 +394,14 @@ if(APPLE)
 
     set(_deploy_script "${CMAKE_SOURCE_DIR}/contrib/macdeploy/macdeployqtplus")
     set(_app_bundle "$<TARGET_BUNDLE_DIR:gridcoinresearch>")
+    set(_dmg_name "gridcoin-${PROJECT_VERSION}-macos-${CMAKE_SYSTEM_PROCESSOR}")
 
-    # Build the macdeployqtplus command
+    # Build the macdeployqtplus command.
+    # appname ("Gridcoin") is the volume name; -dmg <basename> sets the output filename.
     set(_deploy_cmd
         ${Python3_EXECUTABLE} "${_deploy_script}"
         "${_app_bundle}" Gridcoin
-        -dmg
+        -dmg "${_dmg_name}"
     )
 
     # Only pass -plugin-dir if the directory actually exists
@@ -415,7 +417,7 @@ if(APPLE)
     add_custom_target(deploy
         COMMAND ${CMAKE_COMMAND} -E env "QTDIR=${_qt_prefix_dir}" ${_deploy_cmd}
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-        COMMENT "Deploying Gridcoin.app into DMG via macdeployqtplus"
+        COMMENT "Deploying ${_dmg_name}.dmg via macdeployqtplus"
         DEPENDS gridcoinresearch
     )
 endif()

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -1,5 +1,6 @@
 #include "macdockiconhandler.h"
 
+#include <QCoreApplication>
 #include <QImageWriter>
 #include <QMenu>
 #include <QTemporaryFile>
@@ -7,8 +8,6 @@
 
 #undef slots
 #include <Cocoa/Cocoa.h>
-
-extern bool fRequestShutdown;
 
 @interface DockIconClickEventHandler : NSObject
 {
@@ -57,10 +56,19 @@ MacDockShutdownHandler::MacDockShutdownHandler() {
 }
 
 int MacDockShutdownHandler::handleShutdown(id self, SEL _cmd, ...) {
-    // Proper shutdown is possible, if MacOS does not decide to
-    // instantly send us to the shadow realm.
-    fRequestShutdown = true;
-    return false;
+    // Exit the Qt event loop directly so app.exec() returns and the
+    // normal Shutdown() sequence in bitcoin.cpp proceeds. We cannot use
+    // StartShutdown() -> uiInterface.QueueShutdown() -> qApp->quit()
+    // because Qt's quit() on macOS calls [NSApp terminate:] which
+    // re-triggers applicationShouldTerminate: creating an infinite loop.
+    // QCoreApplication::exit() just posts a QEvent::Quit without going
+    // through the Cocoa terminate cycle.
+    static bool shutdownInitiated = false;
+    if (!shutdownInitiated) {
+        shutdownInitiated = true;
+        QCoreApplication::exit(0);
+    }
+    return NSTerminateCancel;
 }
 
 MacDockIconHandler::MacDockIconHandler() : QObject()

--- a/src/scrypt-x86.S
+++ b/src/scrypt-x86.S
@@ -30,7 +30,7 @@
 	.section .note.GNU-stack,"",%progbits
 #endif
 
-#if defined(USE_ASM) && defined(__i386__)
+#if defined(USE_ASM_SCRYPT) && defined(__i386__)
 	
 .macro scrypt_shuffle src, so, dest, do
 	movl	\so+60(\src), %eax

--- a/src/scrypt-x86_64.S
+++ b/src/scrypt-x86_64.S
@@ -30,7 +30,7 @@
 	.section .note.GNU-stack,"",%progbits
 #endif
 
-#if defined(USE_ASM) && defined(__x86_64__)
+#if defined(USE_ASM_SCRYPT) && defined(__x86_64__)
 	.text
 	.p2align 6
 	.globl scrypt_best_throughput

--- a/src/scrypt.cpp
+++ b/src/scrypt.cpp
@@ -40,7 +40,7 @@
 
 #define SCRYPT_BUFFER_SIZE (131072 + 63)
 
-#if defined (USE_ASM) && ( defined (__x86_64__) || defined (__i386__) )
+#if defined(USE_ASM_SCRYPT) && (defined(__x86_64__) || defined(__i386__))
 extern "C" void scrypt_core(unsigned int *X, unsigned int *V, int N);
 #else
 // Generic scrypt_core implementation


### PR DESCRIPTION
## Summary

Fixes macOS DMG packaging (closes #2795, closes #2807) and corrects release artifact naming across all platforms.

### Commit 1: macOS DMG packaging

The macOS DMG produced by CI was non-functional: the `.app` bundle linked to Homebrew Qt framework paths, so it crashed on any machine without the exact same Homebrew Qt installed. Additionally, no ad-hoc code signing was performed.

Replaces `cpack -G DragNDrop` with the existing `contrib/macdeploy/macdeployqtplus` script via a new CMake `deploy` target. The script handles the complete deployment pipeline:

- Copies and bundles Qt frameworks and plugins into the `.app`
- Rewrites dynamic library paths with `install_name_tool`
- Creates `qt.conf` for plugin discovery
- Performs ad-hoc code signing
- Produces a DMG with optional `.DS_Store` layout

Also fixes several bugs in `macdeployqtplus` uncovered during testing:

- **Transitive framework dependencies**: scan the original binary (not the deployed bundle copy) so `@loader_path`/`@rpath` tokens resolve to the Qt prefix where sibling frameworks exist. Fixes missing QtDBus, QtOpenGL, etc.
- **Install name preservation**: capture raw install names from `objdump` output before `@rpath`/`@loader_path` token resolution so `install_name_tool -change` can match the actual references in the binary.
- **Path normalization**: normalize candidate paths with `os.path.normpath()` in `resolveRpath()` to collapse `..` traversals from relative rpath expansion, and check actual file existence instead of just `.framework` directory existence.
- **Framework path parsing**: search for the LAST `.framework` in path in `fromLibraryLine()` as safety net for paths that traverse through sibling framework directories.
- **Homebrew Qt6 plugin layout**: add `-plugin-dir` argument and query `QT_INSTALL_PLUGINS` via `qtpaths` in CMake. Also try `${prefix}/share/qt/plugins` as fallback in `detectQtPath()` since Homebrew Qt6 doesn't use the classic `${prefix}/plugins` layout.
- **Miscellaneous**: conditional `ds_store`/`mac_alias` imports, translations indentation, `.DS_Store` guard, `background.tiff` guard.

**Changes:**
- `contrib/macdeploy/macdeployqtplus`: Fix framework deployment, plugin discovery, install name handling
- `src/qt/CMakeLists.txt`: Add macOS `deploy` custom target with `-plugin-dir` from `qtpaths`
- `.github/workflows/cmake_production.yml`: Use deploy target, install pip packages
- `share/qt/Info.plist.cmake.in`: Fix hardcoded `x86_64` architecture

### Commit 2: Release artifact naming

Four packaging naming issues:

1. **Quad version**: CPack constructs `CPACK_PACKAGE_VERSION` from `MAJOR.MINOR.PATCH`, silently dropping `TWEAK`. Override with `PROJECT_VERSION` so all packages use the full quad version (e.g. `5.4.9.10` not `5.4.9`).

2. **Linux tarball arch suffix**: `CPACK_SYSTEM_NAME` was only set from `CMAKE_C_COMPILER_TARGET` (cross/depends builds). Added `CMAKE_SYSTEM_PROCESSOR` fallback for native builds.

3. **macOS DMG filename**: `macdeployqtplus` uses `-dmg <basename>` for output filename while keeping `appname` as the volume name.

4. **Stray Docker binaries**: Renamed to `docker-gridcoin-*` so bare binaries no longer leak into GitHub releases.

### Commit 3: CI DMG verification

Adds a post-deploy verification step to the macOS CI workflow that mounts the DMG and checks:
- App bundle directory structure (MacOS, Frameworks, PlugIns, Resources)
- Main binary exists, is executable, and is valid Mach-O
- Lists deployed frameworks for diagnostic visibility
- Code signature validation (warning-only for ad-hoc)

This caught the missing PlugIns directory during development of this PR.

**Expected artifact names after this PR:**

| Platform | Filename |
|----------|----------|
| Windows installer | `gridcoin-5.4.9.10-win64-setup.exe` |
| Linux static tarball | `gridcoinresearch-5.4.9.10-x86_64-pc-linux-gnu.tar.gz` |
| macOS DMG | `gridcoin-5.4.9.10-macos-arm64.dmg` |
| Flatpak | `gridcoin-5.4.9.10-x86_64.flatpak` |

## Test plan

- [x] macOS: DMG mounts, bundle structure verified (CI verification step)
- [x] macOS: Frameworks deployed including transitive deps (QtDBus etc.)
- [x] macOS: Qt plugins deployed (platforms, styles, imageformats)
- [x] macOS: Code signature passes `codesign --verify --deep`
- [x] macOS: DMG filename includes version and arch
- [x] Windows: Installer filename uses quad version
- [x] Linux: Tarball filename includes arch suffix
- [x] Tag build: No stray bare binaries in release assets
- [x] macOS: User testing on machine without Homebrew Qt

🤖 Generated with [Claude Code](https://claude.com/claude-code)