### PR TITLE
voting, doc: fix false-positive lockorder warning and document LOCK2 semantics

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -546,6 +546,31 @@ as each waits for the other to release its lock) are a problem. Compile with
 `-DENABLE_DEBUG_LOCKORDER=ON` to get lock order inconsistencies reported in the
 `debug.log` file.
 
+### Lock macros
+
+- **`LOCK(cs)`** — Acquires a single lock.
+- **`LOCK2(cs1, cs2)`** — Acquires two locks **sequentially in argument order**
+  (cs1 first, then cs2). Bitcoin Core later reimplemented `LOCK2` using
+  `std::lock()` to provide deadlock avoidance regardless of argument order.
+  This codebase does not use that approach — `LOCK2` is simply two sequential
+  lock acquisitions. This means **argument order matters**: callers must list
+  locks in the canonical order to prevent deadlocks. For example, always write
+  `LOCK2(cs_main, cs_wallet)`, never `LOCK2(cs_wallet, cs_main)`.
+- **`TRY_LOCK(cs, name)`** — Non-blocking lock attempt.
+
+### Canonical lock ordering
+
+When multiple locks must be held simultaneously, acquire them in the following
+order to prevent deadlocks:
+
+1. `cs_main` (blockchain state)
+2. `cs_wallet` (wallet operations)
+3. Subsystem-specific locks (e.g. `cs_poll_registry`, `cs_ScraperGlobals`)
+
+This ordering applies regardless of whether you use `LOCK2` or separate `LOCK`
+statements. The `DEBUG_LOCKORDER` build flag will detect violations at runtime
+and report them in `debug.log`.
+
 ### Reading DEBUG_LOCKORDER output
 
 When a lock ordering violation is detected, the output looks like this:

--- a/src/gridcoin/voting/poll.cpp
+++ b/src/gridcoin/voting/poll.cpp
@@ -215,7 +215,7 @@ int64_t Poll::Expiration() const
     return m_timestamp + (m_duration_days * 86400);
 }
 
-Fraction Poll::ResolveMagnitudeWeightFactor(CBlockIndex *index) const
+Fraction Poll::ResolveMagnitudeWeightFactor(const CBlockIndex* index) const
 {
     if (index == nullptr) {
         return Fraction();

--- a/src/gridcoin/voting/poll.h
+++ b/src/gridcoin/voting/poll.h
@@ -516,7 +516,7 @@ public:
     //!
     //! \return Fraction Magnitude factor expressed as a Fraction.
     //!
-    Fraction ResolveMagnitudeWeightFactor(CBlockIndex* index) const;
+    Fraction ResolveMagnitudeWeightFactor(const CBlockIndex* index) const;
 
     //!
     //! \brief Get the set of possible answers to the poll.

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -1110,7 +1110,7 @@ void PollRegistry::AddPoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(
         auto result_pair = m_polls_by_txid.emplace(ctx.m_tx.GetHash(), &poll_ref);
         poll_ref.m_txid = result_pair.first->first;
 
-        poll_ref.m_magnitude_weight_factor = payload->m_poll.ResolveMagnitudeWeightFactor(poll_ref.GetStartingBlockIndexPtr());
+        poll_ref.m_magnitude_weight_factor = payload->m_poll.ResolveMagnitudeWeightFactor(ctx.m_pindex);
 
         poll_ref.Notify(PollReference::PollNotificationType::POLL_ADD);
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -243,6 +243,13 @@ template<typename MutexArg>
 using DebugLock = UniqueLock<typename std::remove_reference<typename std::remove_pointer<MutexArg>::type>::type>;
 
 #define LOCK(cs) DebugLock<decltype(cs)> PASTE2(criticalblock, __COUNTER__)(cs, #cs, __FILE__, __LINE__)
+
+// LOCK2 acquires two locks sequentially in ARGUMENT ORDER (cs1 first, then cs2).
+// Bitcoin Core later reimplemented LOCK2 using std::lock() to provide deadlock
+// avoidance regardless of argument order. This codebase does not use that approach;
+// LOCK2 simply constructs two DebugLock objects in sequence. Callers must ensure a
+// consistent ordering convention (e.g. cs_main before cs_wallet) across all call
+// sites to avoid deadlocks.
 #define LOCK2(cs1, cs2)                                               \
     DebugLock<decltype(cs1)> criticalblock1(cs1, #cs1, __FILE__, __LINE__); \
     DebugLock<decltype(cs2)> criticalblock2(cs2, #cs2, __FILE__, __LINE__);


### PR DESCRIPTION
## Summary

Fixes #2866.

- **Fix false-positive lockorder warning**: `AddPoll()` called `GetStartingBlockIndexPtr()` → `GetTransaction()` which re-entered `LOCK(cs_main)` while `cs_poll_registry` was held. The lockorder checker recorded the re-entrant acquisition as cs_poll_registry → cs_main and flagged a conflict with the canonical ordering. Fix: use `ctx.m_pindex` (already available from `ContractContext`) instead of the redundant `GetTransaction()` lookup.
- **const-correctness**: `ResolveMagnitudeWeightFactor` now takes `const CBlockIndex*` since it only reads `nHeight`.
- **Document LOCK2 semantics**: Add comment in `sync.h` and new sections in `developer-notes.md` explaining that `LOCK2` acquires in argument order (not by address like Bitcoin Core's newer implementation) and documenting canonical lock ordering.

## Test plan

- [x] Build with `-DENABLE_DEBUG_LOCKORDER=ON` and verify the cs_poll_registry / cs_main warning no longer appears
- [x] Verify polls are correctly added during sync (magnitude weight factor resolved correctly)
- [x] Linux CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)