### PR TITLE
build: define DEBUG macro for CMake Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,11 @@ else()
     add_compile_options(-UNDEBUG)
 endif()
 
+# Define DEBUG for Debug builds to match the old Autotools --enable-debug behavior.
+# Code in init.cpp and span.h uses #ifdef DEBUG to select debug-specific paths.
+# Uses a generator expression so it works with multi-config generators too.
+add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)
+
 
 # Load CMake modules
 # ==================


### PR DESCRIPTION
## Summary

The old Autotools build system defined `-DDEBUG` when `--enable-debug` was used. The CMake migration did not replicate this, so `#ifdef DEBUG` checks were never active in CMake builds. This caused:

- **`src/init.cpp:826`**: Debug builds report themselves as "release build" in the log output
- **`src/span.h:13`**: `ASSERT_IF_DEBUG` macros are no-ops even in Debug builds

Adds `add_compile_definitions(DEBUG)` when `CMAKE_BUILD_TYPE` is `Debug`, matching the previous Autotools behavior. The definition is only active for Debug builds — RelWithDebInfo and Release are unaffected.

## Test plan

- [x] Configure with `-DCMAKE_BUILD_TYPE=Debug`, verify `DEBUG` appears in the preprocessor macros summary
- [x] Configure with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`, verify `DEBUG` does NOT appear
- [x] Run a Debug build and confirm log says "debug build" instead of "release build"

🤖 Generated with [Claude Code](https://claude.com/claude-code)