### PR TITLE
scraper: fix lock ordering inconsistency in RecvManifest

### DIFF
--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -696,7 +696,8 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
         // Hold cs_mapParts together with cs_manifest in canonical order. UnserializeCheck() calls
         // addPart() which acquires both locks via LOCK2. Without cs_mapParts held here, the recursive
         // re-lock of cs_manifest inside addPart() establishes the reverse ordering cs_manifest ->
-        // cs_mapParts, conflicting with the canonical cs_mapParts -> cs_manifest at line 740.
+        // cs_mapParts, conflicting with the canonical cs_mapParts -> cs_manifest lock ordering
+        // established by the LOCK2(cs_mapParts, manifest->cs_manifest) below.
         LOCK2(cs_mapParts, manifest->cs_manifest);
 
         // The phash in the manifest points to the actual hash which is the index to the element in the map.

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -693,7 +693,11 @@ bool CScraperManifest::RecvManifest(CNode* pfrom, CDataStream& vRecv)
     const auto it = mapManifest.emplace(hash, manifest);
 
     {
-        LOCK(manifest->cs_manifest);
+        // Hold cs_mapParts together with cs_manifest in canonical order. UnserializeCheck() calls
+        // addPart() which acquires both locks via LOCK2. Without cs_mapParts held here, the recursive
+        // re-lock of cs_manifest inside addPart() establishes the reverse ordering cs_manifest ->
+        // cs_mapParts, conflicting with the canonical cs_mapParts -> cs_manifest at line 740.
+        LOCK2(cs_mapParts, manifest->cs_manifest);
 
         // The phash in the manifest points to the actual hash which is the index to the element in the map.
         manifest->phash = &it.first->first;


### PR DESCRIPTION
## Summary

Fixes the 373 lock ordering violations (98% of all DEBUG_LOCKORDER warnings) reported in #2870.

The scoped block in `RecvManifest` held only `cs_manifest` while calling `UnserializeCheck()`, which invokes `addPart()`. Since `addPart()` does `LOCK2(cs_mapParts, cs_manifest)` and `cs_manifest` is already held (recursive mutex), only `cs_mapParts` is freshly acquired — establishing the ordering `cs_manifest -> cs_mapParts`. Later, `LOCK2(cs_mapParts, cs_manifest)` at line 740 establishes the reverse canonical ordering `cs_mapParts -> cs_manifest`.

Both orderings occurred with both locks held simultaneously. While deadlock-safe due to single-threaded execution on `grc-msghand`, the lock checker correctly flagged the inconsistency.

**Fix:** Widen the scoped block from `LOCK(manifest->cs_manifest)` to `LOCK2(cs_mapParts, manifest->cs_manifest)`, maintaining the canonical ordering `cs_mapManifest -> cs_mapParts -> cs_manifest` throughout. The `addPart()` internal `LOCK2` becomes a recursive no-op. The deliberate gap between the scoped block and the later `LOCK2` (for `cs_ConvergedScraperStatsCache`) is preserved.

**Regression risk:** Minimal — only widens `cs_mapParts` scope to also cover `UnserializeCheck`. No lock orderings are changed, removed, or reordered. The canonical ordering chain is maintained throughout.

Addresses pattern 1 of #2870.

## Test plan

- [x] Build with `-DENABLE_DEBUG_LOCKORDER=ON -DCMAKE_BUILD_TYPE=Debug`
- [x] Run on testnet, verify the 373 `cs_mapParts` vs `cs_manifest` warnings are eliminated
- [x] Verify the remaining 7 warnings (patterns 2-3, TRY_LOCK mitigated) are unchanged
- [x] Verify scraper convergence still works correctly on testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)