### PR TITLE
qt: fix macOS quit hang with QCoreApplication::exit

### DIFF
--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -1,5 +1,6 @@
 #include "macdockiconhandler.h"
 
+#include <QCoreApplication>
 #include <QImageWriter>
 #include <QMenu>
 #include <QTemporaryFile>
@@ -7,8 +8,6 @@
 
 #undef slots
 #include <Cocoa/Cocoa.h>
-
-extern bool fRequestShutdown;
 
 @interface DockIconClickEventHandler : NSObject
 {
@@ -57,10 +56,19 @@ MacDockShutdownHandler::MacDockShutdownHandler() {
 }
 
 int MacDockShutdownHandler::handleShutdown(id self, SEL _cmd, ...) {
-    // Proper shutdown is possible, if MacOS does not decide to
-    // instantly send us to the shadow realm.
-    fRequestShutdown = true;
-    return false;
+    // Exit the Qt event loop directly so app.exec() returns and the
+    // normal Shutdown() sequence in bitcoin.cpp proceeds. We cannot use
+    // StartShutdown() -> uiInterface.QueueShutdown() -> qApp->quit()
+    // because Qt's quit() on macOS calls [NSApp terminate:] which
+    // re-triggers applicationShouldTerminate: creating an infinite loop.
+    // QCoreApplication::exit() just posts a QEvent::Quit without going
+    // through the Cocoa terminate cycle.
+    static bool shutdownInitiated = false;
+    if (!shutdownInitiated) {
+        shutdownInitiated = true;
+        QCoreApplication::exit(0);
+    }
+    return NSTerminateCancel;
 }
 
 MacDockIconHandler::MacDockIconHandler() : QObject()


### PR DESCRIPTION
## Summary

- Fix the macOS wallet not responding to Cmd+Q / dock Quit, requiring force-quit
- Root cause: `MacDockShutdownHandler::handleShutdown()` set `fRequestShutdown` directly, but nothing in the Qt event loop checked this flag — `app.exec()` never returned
- Fix: call `QCoreApplication::exit(0)` directly, which posts a `QEvent::Quit` to the event queue without going through the Cocoa terminate cycle, allowing `app.exec()` to return cleanly and proceed with normal `Shutdown()`

## Details

The Cocoa `applicationShouldTerminate:` handler was intercepted by `MacDockShutdownHandler`, which returned `false` (equivalent to `NSTerminateCancel`, telling macOS "I'll handle shutdown myself") and set `fRequestShutdown = true`. However, `bitcoin.cpp` calls `app.setQuitOnLastWindowClosed(false)` and the main event loop (`app.exec()`) never checks `fRequestShutdown`.

The naive fix of routing through `StartShutdown()` → `uiInterface.QueueShutdown()` → `qApp->quit()` does not work because Qt's `quit()` on macOS internally calls `[NSApp terminate:]`, which triggers `applicationShouldTerminate:` again — creating an infinite loop that fills debug.log.

`QCoreApplication::exit(0)` is the correct API: it posts a `QEvent::Quit` directly to the Qt event queue without invoking the Cocoa terminate cycle. A static re-entry guard prevents multiple calls, and `NSTerminateCancel` is returned to prevent Cocoa from force-terminating the app before cleanup completes.

This is a pre-existing issue that manifests on modern macOS versions.

## Test plan

- [x] Verify Cmd+Q / dock Quit cleanly exits the wallet on macOS
- [x] Verify Linux/Windows shutdown behavior is unaffected (code is macOS-only `.mm` file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)