### PR TITLE
consensus: set testnet v14 activation height and remove temporary arg overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ HunterGate(
 # =====================
 
 project("Gridcoin"
-    VERSION 5.4.9.10
+    VERSION 5.4.9.11
     DESCRIPTION "POS-based cryptocurrency that rewards BOINC computation"
     HOMEPAGE_URL "https://gridcoin.us"
     LANGUAGES C CXX

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -192,7 +192,7 @@ public:
         consensus.BlockV11Height = 1301500;
         consensus.BlockV12Height = 1871830;
         consensus.BlockV13Height = 2870000;
-        consensus.BlockV14Height = std::numeric_limits<int>::max();
+        consensus.BlockV14Height = 3126500;
         consensus.PollV3Height = 1944820;
         consensus.ProjectV2Height = 1944820;
         consensus.AutoGreylistAuditHeight = 3111000;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -11,14 +11,9 @@
 #include "consensus/params.h"
 #include "protocol.h"
 
-// system.h and extern reference to cs_main included only for temporary V13 fork point overrides for testing.
-#include "util/system.h"
-
 #include <memory>
 #include <stdexcept>
 #include <vector>
-
-extern CCriticalSection cs_main;
 
 typedef std::map<int, uint256> MapCheckpoints;
 typedef std::map<int, std::vector<unsigned char>> MapMasterKeys;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -156,9 +156,7 @@ inline bool IsV12Enabled(int nHeight)
 
 inline bool IsV13Enabled(int nHeight)
 {
-    // The argument driven override temporarily here to facilitate testing.
-
-    return nHeight >= gArgs.GetArg("-blockv13height", Params().GetConsensus().BlockV13Height);
+    return nHeight >= Params().GetConsensus().BlockV13Height;
 }
 
 inline bool IsPollV3Enabled(int nHeight)
@@ -173,29 +171,22 @@ inline bool IsProjectV2Enabled(int nHeight)
 
 inline bool IsAutoGreylistAuditEnabled(int nHeight)
 {
-    // The argument driven override temporarily here to facilitate testing.
-    return nHeight >= gArgs.GetArg("-autogreylistauditheight", Params().GetConsensus().AutoGreylistAuditHeight);
+    return nHeight >= Params().GetConsensus().AutoGreylistAuditHeight;
 }
 
 inline bool IsSuperblockV3Enabled(int nHeight)
 {
-    // The argument driven override temporarily here to facilitate testing.
-
-    return nHeight >= gArgs.GetArg("-superblockv3height", Params().GetConsensus().SuperblockV3Height);
+    return nHeight >= Params().GetConsensus().SuperblockV3Height;
 }
 
 inline bool IsV14Enabled(int nHeight)
 {
-    // The argument driven override temporarily here to facilitate testing.
-
-    return nHeight >= gArgs.GetArg("-blockv14height", Params().GetConsensus().BlockV14Height);
+    return nHeight >= Params().GetConsensus().BlockV14Height;
 }
 
 inline bool IsProjectV4Enabled(int nHeight)
 {
-    // The argument driven override temporarily here to facilitate testing.
-
-    return nHeight >= gArgs.GetArg("-projectv4height", Params().GetConsensus().ProjectV4Height);
+    return nHeight >= Params().GetConsensus().ProjectV4Height;
 }
 
 inline int GetSuperblockAgeSpacing(int nHeight)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -627,18 +627,6 @@ void SetupServerArgs()
     hidden_args.emplace_back("-daemonwait");
 #endif
 
-    // Temporary hidden option for block v13 height override to facilitate testing.
-    hidden_args.emplace_back("-blockv13height");
-
-    // Temporary hidden option for project v4 height override to facilitate testing.
-    hidden_args.emplace_back("-projectv4height");
-
-    // Temporary hidden option for superblock v3 height override to facilitate testing.
-    hidden_args.emplace_back("-superblockv3height");
-
-    // Temporary hidden option for block v14 height override to facilitate testing.
-    hidden_args.emplace_back("-blockv14height");
-
     // Additional hidden options
     hidden_args.emplace_back("-devbuild");
     hidden_args.emplace_back("-scrapersleep");
@@ -1044,8 +1032,9 @@ bool AppInit2(ThreadHandlerPtr threads)
         return InitError(_("Initialization sanity check failed. Gridcoin is shutting down."));
 
     LogPrintf("Block version 11 hard fork configured for block %d", Params().GetConsensus().BlockV11Height);
-    LogPrintf("Block version 12 hard fork configured for block %d",
-              gArgs.GetArg("-blockv12height", Params().GetConsensus().BlockV12Height));
+    LogPrintf("Block version 12 hard fork configured for block %d", Params().GetConsensus().BlockV12Height);
+    LogPrintf("Block version 13 hard fork configured for block %d", Params().GetConsensus().BlockV13Height);
+    LogPrintf("Block version 14 hard fork configured for block %d", Params().GetConsensus().BlockV14Height);
 
     fs::path datadir = GetDataDir();
     fs::path walletFileName = gArgs.GetArg("-wallet", "wallet.dat");

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1462,7 +1462,7 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
     // Head: nullopt -> sb_from_baseline==1: TC=1000 -> sb_from_baseline==2: TC=500
     // Expected: ZCD = 0 (benefit-of-doubt suppresses false ZCD at sb==1)
 
-    gArgs.ForceSetArg("-autogreylistauditheight", "0");
+    const_cast<Consensus::Params&>(Params().GetConsensus()).AutoGreylistAuditHeight = 0;
 
     auto_greylist->Reset();
 
@@ -1482,7 +1482,7 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
     // ---- Scenario A': Same data, benefit-of-doubt OFF ----
     // Expected: ZCD = 1 (TC=1000 >= nullopt bookmark at sb==1 -> false ZCD counted)
 
-    gArgs.ForceSetArg("-autogreylistauditheight", ToString(std::numeric_limits<int>::max()));
+    const_cast<Consensus::Params&>(Params().GetConsensus()).AutoGreylistAuditHeight = std::numeric_limits<int>::max();
 
     auto_greylist->Reset();
 
@@ -1501,7 +1501,7 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
     // Head: TC=2000 -> sb_from_baseline==1: nullopt -> sb_from_baseline==2: TC=1000 -> sb_from_baseline==3: TC=500
     // Expected: ZCD = 1 (nullopt at sb==1 correctly counted; benefit-of-doubt does NOT apply because head has data)
 
-    gArgs.ForceSetArg("-autogreylistauditheight", "0");
+    const_cast<Consensus::Params&>(Params().GetConsensus()).AutoGreylistAuditHeight = 0;
 
     auto_greylist->Reset();
 
@@ -1521,7 +1521,7 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
     // ---- Cleanup ----
 
     // Restore default (disabled) state.
-    gArgs.ForceSetArg("-autogreylistauditheight", ToString(std::numeric_limits<int>::max()));
+    const_cast<Consensus::Params&>(Params().GetConsensus()).AutoGreylistAuditHeight = std::numeric_limits<int>::max();
 
     for (auto& iter : *unit_test_blocks) {
         delete iter.second.first;


### PR DESCRIPTION
## Summary

- Set testnet `BlockV14Height` to `3126500` (~2 week grace period from current testnet height 3114224)
- Remove all temporary argument-driven consensus height overrides (`-blockv13height`, `-blockv14height`, `-superblockv3height`, `-projectv4height`, `-autogreylistauditheight`) used during isolated testnet development testing
- Fix stale `-blockv12height` arg reference in debug log and add v13/v14 fork height log lines for consistency

## Test plan

- [x] Verify build succeeds (all targets)
- [x] Verify testnet node starts and logs correct v11-v14 fork heights
- [x] Verify removed args are no longer accepted as hidden options

🤖 Generated with [Claude Code](https://claude.com/claude-code)