### PR TITLE
wallet, qt: add subtract fee from amount option to send dialog

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -27,13 +27,15 @@
 
 using namespace std;
 
-CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl, QList<qint64>* payAmounts)
+CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl, QList<qint64>* payAmounts,
+                                     bool fSubtractFeeFromAmount)
                : QDialog(parent)
                , m_inputSelectionLimit(GetMaxInputsForConsolidationTxn())
                , ui(new Ui::CoinControlDialog)
                , coinControl(coinControl)
                , payAmounts(payAmounts)
                , model(nullptr)
+               , m_fSubtractFeeFromAmount(fSubtractFeeFromAmount)
 {
     assert(coinControl != nullptr && payAmounts != nullptr);
 
@@ -158,7 +160,7 @@ void CoinControlDialog::setModel(WalletModel *model)
     {
         updateView();
         //updateLabelLocked();
-        CoinControlDialog::updateLabels(model, coinControl, payAmounts, this);
+        CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, m_fSubtractFeeFromAmount);
     }
 }
 
@@ -226,7 +228,7 @@ void CoinControlDialog::buttonSelectAllClicked()
        ui->selectAllPushButton->setText(tr("Select None"));
     }
 
-    CoinControlDialog::updateLabels(model, coinControl, payAmounts, this);
+    CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, m_fSubtractFeeFromAmount);
     showHideConsolidationReadyToSend();
 }
 
@@ -353,7 +355,7 @@ bool CoinControlDialog::filterInputsByValue(const bool& less, const CAmount& inp
     // Re-enable update signals.
     ui->treeWidget->setEnabled(true);
 
-    CoinControlDialog::updateLabels(model, coinControl, payAmounts, this);
+    CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, m_fSubtractFeeFromAmount);
 
     // If the number of inputs selected was limited, then true is returned.
     return culled_inputs;
@@ -596,7 +598,7 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         // selection changed -> update labels
         if (ui->treeWidget->isEnabled()) // do not update on every click for (un)select all
         {
-            CoinControlDialog::updateLabels(model, coinControl, payAmounts, this);
+            CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, m_fSubtractFeeFromAmount);
         }
     }
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -619,7 +619,8 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
 void CoinControlDialog::updateLabels(WalletModel *model,
                                      CCoinControl *coinControl,
                                      QList<qint64>* payAmounts,
-                                     QDialog* dialog)
+                                     QDialog* dialog,
+                                     bool fSubtractFeeFromAmount)
 {
     if (!model) return;
 
@@ -695,7 +696,11 @@ void CoinControlDialog::updateLabels(WalletModel *model,
 
         if (nPayAmount > 0)
         {
-            nChange = nAmount - nPayFee - nPayAmount;
+            // When subtracting fee from amount, the fee is absorbed by the
+            // recipients rather than coming from the change output.
+            nChange = fSubtractFeeFromAmount
+                ? nAmount - nPayAmount
+                : nAmount - nPayFee - nPayAmount;
 
             // if sub-cent change is required, the fee must be raised to at least CTransaction::nMinTxFee
             if (nPayFee < CENT && nChange > 0 && nChange < CENT)

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -26,7 +26,8 @@ class CoinControlDialog : public QDialog
 public:
     explicit CoinControlDialog(QWidget* parent = nullptr,
                                CCoinControl* coinControl = nullptr,
-                               QList<qint64>* payAmounts = nullptr);
+                               QList<qint64>* payAmounts = nullptr,
+                               bool fSubtractFeeFromAmount = false);
     ~CoinControlDialog();
 
     void setModel(WalletModel *model);
@@ -61,6 +62,7 @@ private:
     std::pair<QString, QString> m_consolidationAddress;
     Qt::CheckState m_ToState = Qt::Checked;
     bool m_FilterMode = true;
+    bool m_fSubtractFeeFromAmount = false;
 
     QString strPad(QString, int, QString);
     void sortView(int, Qt::SortOrder);

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -32,7 +32,8 @@ public:
     void setModel(WalletModel *model);
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, CCoinControl*, QList<qint64>*, QDialog*);
+    static void updateLabels(WalletModel*, CCoinControl*, QList<qint64>*, QDialog*,
+                             bool fSubtractFeeFromAmount = false);
 
     // This is based on what will guarantee a successful transaction.
     const size_t m_inputSelectionLimit;

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -130,6 +130,16 @@
    <item row="6" column="1">
     <widget class="BitcoinAmountField" name="payAmount"/>
    </item>
+   <item row="7" column="1">
+    <widget class="QCheckBox" name="subtractFee">
+     <property name="toolTip">
+      <string>The transaction fee will be deducted from the amount sent</string>
+     </property>
+     <property name="text">
+      <string>Subtract fee from amount</string>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0">
     <widget class="QLabel" name="labelTextLabel">
      <property name="text">

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -212,6 +212,13 @@ void SendCoinsDialog::on_sendButton_clicked()
             arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, sendstatus.fee)),
             QMessageBox::Ok, QMessageBox::Ok);
         break;
+    case WalletModel::FeeExceedsSubtractedAmount:
+        QMessageBox::warning(this, tr("Send Coins"),
+            tr("The transaction fee (%1) exceeds the amount being sent to a recipient "
+               "with 'Subtract fee from amount' enabled. Please enter a larger amount.")
+            .arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, sendstatus.fee)),
+            QMessageBox::Ok, QMessageBox::Ok);
+        break;
     case WalletModel::DuplicateAddress:
         QMessageBox::warning(this, tr("Send Coins"),
             tr("Duplicate address found, can only send to each address once per send operation."),

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -462,7 +462,7 @@ void SendCoinsDialog::coinControlFeatureChanged(bool checked)
 // Coin Control: button inputs -> show actual coin control dialog
 void SendCoinsDialog::coinControlButtonClicked()
 {
-    CoinControlDialog dlg(this, coinControl, payAmounts);
+    CoinControlDialog dlg(this, coinControl, payAmounts, hasSubtractFeeRecipient());
     dlg.setModel(model);
 
     connect(&dlg, &CoinControlDialog::selectedConsolidationRecipientSignal,
@@ -480,7 +480,7 @@ void SendCoinsDialog::coinControlResetButtonClicked()
 
 void SendCoinsDialog::coinControlConsolidateWizardButtonClicked()
 {
-    CoinControlDialog dlg(this, coinControl, payAmounts);
+    CoinControlDialog dlg(this, coinControl, payAmounts, hasSubtractFeeRecipient());
     dlg.setModel(model);
 
     connect(&dlg, &CoinControlDialog::selectedConsolidationRecipientSignal,
@@ -575,6 +575,16 @@ void SendCoinsDialog::coinControlChangeEdited(const QString & text)
     }
 }
 
+bool SendCoinsDialog::hasSubtractFeeRecipient() const
+{
+    for (int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
+        if (entry && entry->getValue().fSubtractFeeFromAmount) return true;
+    }
+    return false;
+}
+
 // Coin Control: update labels
 void SendCoinsDialog::coinControlUpdateLabels()
 {
@@ -585,22 +595,16 @@ void SendCoinsDialog::coinControlUpdateLabels()
 
     // set pay amounts
     payAmounts->clear();
-    bool fAnySubtractFeeFromAmount = false;
     for (int i = 0; i < ui->entries->count(); ++i)
     {
         SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
-        if (entry)
-        {
-            SendCoinsRecipient val = entry->getValue();
-            payAmounts->append(val.amount);
-            if (val.fSubtractFeeFromAmount) fAnySubtractFeeFromAmount = true;
-        }
+        if (entry) payAmounts->append(entry->getValue().amount);
     }
 
     if (coinControl->HasSelected())
     {
         // actual coin control calculation
-        CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, fAnySubtractFeeFromAmount);
+        CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, hasSubtractFeeRecipient());
 
         // show coin control stats
         ui->coinControlAutomaticallySelectedLabel->hide();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -152,7 +152,12 @@ void SendCoinsDialog::on_sendButton_clicked()
     // Format confirmation message
     QStringList formatted;
     for (const SendCoinsRecipient& rcp : recipients) {
-        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount),
+        QString amountStr = BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, rcp.amount);
+        if (rcp.fSubtractFeeFromAmount)
+        {
+            amountStr += " " + tr("(minus fee)");
+        }
+        formatted.append(tr("<b>%1</b> to %2 (%3)").arg(amountStr,
               rcp.label.toHtmlEscaped(), rcp.address));
     }
 
@@ -580,16 +585,22 @@ void SendCoinsDialog::coinControlUpdateLabels()
 
     // set pay amounts
     payAmounts->clear();
+    bool fAnySubtractFeeFromAmount = false;
     for (int i = 0; i < ui->entries->count(); ++i)
     {
         SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
-        if (entry) payAmounts->append(entry->getValue().amount);
+        if (entry)
+        {
+            SendCoinsRecipient val = entry->getValue();
+            payAmounts->append(val.amount);
+            if (val.fSubtractFeeFromAmount) fAnySubtractFeeFromAmount = true;
+        }
     }
 
     if (coinControl->HasSelected())
     {
         // actual coin control calculation
-        CoinControlDialog::updateLabels(model, coinControl, payAmounts, this);
+        CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, fAnySubtractFeeFromAmount);
 
         // show coin control stats
         ui->coinControlAutomaticallySelectedLabel->hide();

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -48,6 +48,8 @@ private:
     WalletModel *model;
     bool fNewRecipientAllowed;
 
+    bool hasSubtractFeeRecipient() const;
+
 private slots:
     void on_sendButton_clicked();
     void removeEntry(SendCoinsEntry* entry);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -8,6 +8,7 @@
 #include "addresstablemodel.h"
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QClipboard>
 
 SendCoinsEntry::SendCoinsEntry(QWidget* parent)
@@ -73,6 +74,7 @@ void SendCoinsEntry::setModel(WalletModel *model)
         updateIcons();
     }
     connect(ui->payAmount, &BitcoinAmountField::textChanged, this, &SendCoinsEntry::payAmountChanged);
+    connect(ui->subtractFee, &QCheckBox::toggled, this, &SendCoinsEntry::payAmountChanged);
 
     clear();
 }
@@ -99,6 +101,7 @@ void SendCoinsEntry::clear()
     ui->payAmount->clear();
     ui->payTo->setFocus();
     ui->messageText->clear();
+    ui->subtractFee->setChecked(false);
     // update the display unit, to not use the default ("BTC")
     updateDisplayUnit();
 }
@@ -144,7 +147,8 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     rv.address = ui->payTo->text();
     rv.label = ui->addAsLabel->text();
     rv.amount = ui->payAmount->value();
-	rv.Message = ui->messageText->text();
+    rv.Message = ui->messageText->text();
+    rv.fSubtractFeeFromAmount = ui->subtractFee->isChecked();
     return rv;
 }
 
@@ -155,7 +159,9 @@ QWidget *SendCoinsEntry::setupTabChain(QWidget *prev)
     QWidget::setTabOrder(ui->addressBookButton, ui->pasteButton);
     QWidget::setTabOrder(ui->pasteButton, ui->deleteButton);
     QWidget::setTabOrder(ui->deleteButton, ui->addAsLabel);
-    return ui->payAmount->setupTabChain(ui->addAsLabel);
+    QWidget *w = ui->payAmount->setupTabChain(ui->addAsLabel);
+    QWidget::setTabOrder(w, ui->subtractFee);
+    return ui->subtractFee;
 }
 
 void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
@@ -163,7 +169,8 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
     ui->payTo->setText(value.address);
     ui->addAsLabel->setText(value.label);
     ui->payAmount->setValue(value.amount);
-	ui->messageText->setText(value.Message);
+    ui->messageText->setText(value.Message);
+    ui->subtractFee->setChecked(value.fSubtractFeeFromAmount);
 }
 
 bool SendCoinsEntry::isClear()

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -291,8 +291,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 }
 
                 int64_t nValue = txout.nValue;
-                /* Add fee to first output */
-                if (nTxFee > 0)
+                /* Add fee to first output, unless subtract-fee-from-amount
+                 * was used — in that case the fee is already reflected in
+                 * the output values and should not be added again. */
+                if (nTxFee > 0 && !mapValue.count("subtractFeeFromAmount"))
                 {
                     nValue += nTxFee;
                     nTxFee = 0;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -238,6 +238,11 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
 
     CWalletTx wtx;
 
+    if (fAnySubtractFeeFromAmount)
+    {
+        wtx.mapValue["subtractFeeFromAmount"] = "1";
+    }
+
     if (!recipients[0].Message.isEmpty())
     {
         wtx.vContracts.emplace_back(GRC::MakeContract<GRC::TxMessage>(

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -216,12 +216,22 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
     for (auto const& out : vCoins)
         nBalance += out.tx->vout[out.i].nValue;
 
+    bool fAnySubtractFeeFromAmount = false;
+    for (const SendCoinsRecipient& rcp : recipients)
+    {
+        if (rcp.fSubtractFeeFromAmount)
+        {
+            fAnySubtractFeeFromAmount = true;
+            break;
+        }
+    }
+
     if(total > nBalance)
     {
         return AmountExceedsBalance;
     }
 
-    if((total + nTransactionFee) > nBalance)
+    if(!fAnySubtractFeeFromAmount && (total + nTransactionFee) > nBalance)
     {
         return SendCoinsReturn(AmountWithFeeExceedsBalance, nTransactionFee);
     }
@@ -248,11 +258,43 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
 
         CReserveKey keyChange(wallet);
         int64_t nFeeRequired = 0;
-		bool fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
+        bool fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
+
+        // If any recipient has "subtract fee from amount" enabled, rebuild the
+        // outputs with the fee deducted and create the transaction again.
+        if (fCreated && fAnySubtractFeeFromAmount)
+        {
+            int nSubtractRecipients = 0;
+            for (const SendCoinsRecipient& rcp : recipients)
+            {
+                if (rcp.fSubtractFeeFromAmount) ++nSubtractRecipients;
+            }
+
+            vecSend.clear();
+            for (const SendCoinsRecipient& rcp : recipients)
+            {
+                CScript scriptPubKey;
+                scriptPubKey.SetDestination(DecodeDestination(rcp.address.toStdString()));
+                int64_t nAmount = rcp.amount;
+
+                if (rcp.fSubtractFeeFromAmount)
+                {
+                    nAmount -= nFeeRequired / nSubtractRecipients;
+                    if (nAmount <= 0)
+                    {
+                        return SendCoinsReturn(AmountWithFeeExceedsBalance, nFeeRequired);
+                    }
+                }
+
+                vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
+            }
+
+            fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
+        }
 
         if(!fCreated)
         {
-            if((total + nFeeRequired) > nBalance) // FIXME: could cause collisions in the future
+            if((total + nFeeRequired) > nBalance)
             {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance, nFeeRequired);
             }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -290,7 +290,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                     }
                     if (nAmount <= 0)
                     {
-                        return SendCoinsReturn(AmountWithFeeExceedsBalance, nFeeRequired);
+                        return SendCoinsReturn(FeeExceedsSubtractedAmount, nFeeRequired);
                     }
                 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -271,6 +271,8 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
             }
 
             vecSend.clear();
+            int64_t nFeeRemainder = nFeeRequired % nSubtractRecipients;
+            bool fFirst = true;
             for (const SendCoinsRecipient& rcp : recipients)
             {
                 CScript scriptPubKey;
@@ -280,6 +282,12 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                 if (rcp.fSubtractFeeFromAmount)
                 {
                     nAmount -= nFeeRequired / nSubtractRecipients;
+                    // First opted-in recipient absorbs the truncation remainder
+                    if (fFirst)
+                    {
+                        nAmount -= nFeeRemainder;
+                        fFirst = false;
+                    }
                     if (nAmount <= 0)
                     {
                         return SendCoinsReturn(AmountWithFeeExceedsBalance, nFeeRequired);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -262,7 +262,17 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
 
         // If any recipient has "subtract fee from amount" enabled, rebuild the
         // outputs with the fee deducted and create the transaction again.
-        if (fCreated && fAnySubtractFeeFromAmount)
+        // This runs even if the first pass failed (e.g. sending entire balance),
+        // since nFeeRequired is initialized to nTransactionFee and provides a
+        // reasonable starting estimate.
+        //
+        // The outer loop handles fee refinement: CreateTransaction may discover
+        // that the actual fee (based on transaction size) exceeds the initial
+        // estimate. When that happens, it updates nFeeRequired and fails because
+        // SelectCoins can't cover the higher total. We detect the fee increase,
+        // rebuild outputs with the new fee, and retry. This converges quickly
+        // since fees are monotonically non-decreasing and bounded by tx size.
+        if (fAnySubtractFeeFromAmount)
         {
             int nSubtractRecipients = 0;
             for (const SendCoinsRecipient& rcp : recipients)
@@ -270,34 +280,45 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                 if (rcp.fSubtractFeeFromAmount) ++nSubtractRecipients;
             }
 
-            vecSend.clear();
-            int64_t nFeeRemainder = nFeeRequired % nSubtractRecipients;
-            bool fFirst = true;
-            for (const SendCoinsRecipient& rcp : recipients)
+            // Retry limit prevents infinite loops in pathological cases
+            for (int nAttempt = 0; nAttempt < 10; ++nAttempt)
             {
-                CScript scriptPubKey;
-                scriptPubKey.SetDestination(DecodeDestination(rcp.address.toStdString()));
-                int64_t nAmount = rcp.amount;
-
-                if (rcp.fSubtractFeeFromAmount)
+                vecSend.clear();
+                int64_t nFeeRemainder = nFeeRequired % nSubtractRecipients;
+                bool fFirst = true;
+                for (const SendCoinsRecipient& rcp : recipients)
                 {
-                    nAmount -= nFeeRequired / nSubtractRecipients;
-                    // First opted-in recipient absorbs the truncation remainder
-                    if (fFirst)
+                    CScript scriptPubKey;
+                    scriptPubKey.SetDestination(DecodeDestination(rcp.address.toStdString()));
+                    int64_t nAmount = rcp.amount;
+
+                    if (rcp.fSubtractFeeFromAmount)
                     {
-                        nAmount -= nFeeRemainder;
-                        fFirst = false;
+                        nAmount -= nFeeRequired / nSubtractRecipients;
+                        // First opted-in recipient absorbs the truncation remainder
+                        if (fFirst)
+                        {
+                            nAmount -= nFeeRemainder;
+                            fFirst = false;
+                        }
+                        if (nAmount <= 0)
+                        {
+                            return SendCoinsReturn(FeeExceedsSubtractedAmount, nFeeRequired);
+                        }
                     }
-                    if (nAmount <= 0)
-                    {
-                        return SendCoinsReturn(FeeExceedsSubtractedAmount, nFeeRequired);
-                    }
+
+                    vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
                 }
 
-                vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
-            }
+                int64_t nFeePrev = nFeeRequired;
+                fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
 
-            fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
+                if (fCreated || nFeeRequired <= nFeePrev)
+                    break;
+
+                // Fee increased (tx was larger than estimated) — retry with
+                // the updated fee subtracted from recipient amounts.
+            }
         }
 
         if(!fCreated)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -302,7 +302,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
 
         if(!fCreated)
         {
-            if((total + nFeeRequired) > nBalance)
+            if(!fAnySubtractFeeFromAmount && (total + nFeeRequired) > nBalance)
             {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance, nFeeRequired);
             }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -49,6 +49,7 @@ public:
         InvalidAddress,
         AmountExceedsBalance,
         AmountWithFeeExceedsBalance,
+        FeeExceedsSubtractedAmount,
         DuplicateAddress,
         TransactionCreationFailed, // Error returned when wallet is still locked
         TransactionCommitFailed,

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -28,8 +28,9 @@ class SendCoinsRecipient
 public:
     QString address;
     QString label;
-    qint64 amount;
-	QString Message;
+    qint64 amount = 0;
+    QString Message;
+    bool fSubtractFeeFromAmount = false;
 };
 
 /** Interface to Bitcoin wallet from Qt view code. */


### PR DESCRIPTION
## Summary

Adds a "Subtract fee from amount" checkbox to the Send Coins dialog, allowing the transaction fee to be deducted from the recipient's amount rather than added on top. This enables:

- Emptying a wallet completely
- Sending exact invoice totals where the fee is absorbed by the send amount

This takes over the work from #2831 (by @keshavdadhichb), reworked to fix several issues found during review.

## Changes

- **UI**: "Subtract fee from amount" checkbox on each send entry, with "(minus fee)" shown in the confirmation dialog
- **Logic**: Two-pass `CreateTransaction` approach — first pass estimates the fee, second pass rebuilds outputs with the fee shared equally among opted-in recipients
- **Fee refinement**: Retry loop handles large transactions where the initial fee estimate is too low — rebuilds outputs with the updated fee until convergence
- **Transaction display**: Stores `subtractFeeFromAmount` flag in `CWalletTx::mapValue` so `decomposeTransaction` skips fee attribution for subtract-fee transactions (prevents double-counting)
- **Coin control fix**: `updateLabels()` now accounts for subtract-fee when computing change, preventing false "insufficient funds" warnings when selected coins exactly cover the send amount (the bug reported in #2831 review)
- **Cleanup**: Initialized `fSubtractFeeFromAmount` field (was uninitialized POD bool), fixed tab indentation in walletmodel.h/sendcoinsentry.cpp, simplified the fee deduction logic

## Test plan

- [x] Send with subtract-fee unchecked — behavior unchanged
- [x] Send with subtract-fee checked — recipient receives amount minus fee, wallet debited exactly the entered amount
- [x] Send entire available balance with subtract-fee — succeeds (no "insufficient funds")
- [x] Coin control with subtract-fee — no false "insufficient funds" warning when selected coins equal send amount
- [x] Multiple recipients, some with subtract-fee checked — fee shared only among opted-in recipients
- [x] Send amount smaller than fee with subtract-fee — returns appropriate error

Supersedes #2831. Closes #2825.