### PR TITLE
build: add changed build folders to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ src/test-suite.log
 src/test/test_gridcoin.log
 src/test/test_gridcoin.trs
 
+build
+build_macos
+build_win64
+build_linux_depends
+
 src/build.h
 src/obj/build.h
 src/qt/forms/*.h
@@ -62,7 +67,6 @@ qrc_*.cpp
 *.pro.user.*
 #mac specific
 .DS_Store
-build
 background.tiff
 background.tiff.png
 background.tiff@2x.png


### PR DESCRIPTION
build_targets.sh introduces various different build folders (e.g. build_macos). These were missed from the .gitignore.
Small commit to add them, also moves build from the macOS specific section
