### PR TITLE
rpc: add fundrawtransaction # 2877 (A)

### DIFF
--- a/src/gridcoin/consensus/mutable_transaction.h
+++ b/src/gridcoin/consensus/mutable_transaction.h
@@ -7,6 +7,7 @@
 
 #include "primitives/transaction.h"
 
+#include <string>
 #include <vector>
 
 //! Scaffolding for CMutableTransaction — a mutable transaction builder type.
@@ -39,6 +40,8 @@ struct CMutableTransaction
     std::vector<CTxIn> vin;
     std::vector<CTxOut> vout;
     unsigned int nLockTime;
+    std::string hashBoinc;
+    std::vector<GRC::Contract> vContracts;
 
     CMutableTransaction()
         : nVersion(CTransaction::CURRENT_VERSION)
@@ -46,6 +49,8 @@ struct CMutableTransaction
         , vin()
         , vout()
         , nLockTime(0)
+        , hashBoinc()
+        , vContracts()
     {
     }
 
@@ -56,6 +61,8 @@ struct CMutableTransaction
         , vin(tx.vin)
         , vout(tx.vout)
         , nLockTime(tx.nLockTime)
+        , hashBoinc(tx.hashBoinc)
+        , vContracts(tx.vContracts)
     {
     }
 };
@@ -74,6 +81,8 @@ inline CTransaction MakeTransaction(const CMutableTransaction& mtx)
     tx.vin = mtx.vin;
     tx.vout = mtx.vout;
     tx.nLockTime = mtx.nLockTime;
+    tx.hashBoinc = mtx.hashBoinc;
+    tx.vContracts = mtx.vContracts;
     return tx;
 }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1590,8 +1590,10 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
                 "fundrawtransaction \"hexstring\" ( options )\n"
                 "\nAdd inputs to a transaction until it has enough in value to meet its out value.\n"
                 "This will not modify existing inputs, and will add one change output to the outputs.\n"
-                "Note that inputs which were signed may need to be resigned after completion since in/outputs have been added.\n"
                 "The inputs added will not be signed, use signrawtransaction for that.\n"
+                "\nNote: The transaction must have no existing inputs. Unlike Bitcoin Core's\n"
+                "fundrawtransaction, this command does not yet support adding funds to a\n"
+                "transaction that already has inputs.\n"
                 "\nArguments:\n"
                 "1. \"hexstring\"           (string, required) The hex string of the raw transaction\n"
                 "2. options               (object, optional)\n"
@@ -1624,9 +1626,11 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
     if (tx.vout.size() == 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "TX must have at least one output");
 
+    // Unlike Bitcoin Core, we don't yet support funding transactions that
+    // already have inputs, since computing their value requires UTXO lookups.
     if (tx.vin.size() > 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER,
-            "fundrawtransaction does not support transactions with existing inputs. "
+            "fundrawtransaction does not yet support transactions with existing inputs. "
             "Use createrawtransaction with outputs only.");
 
     // Parse options

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1583,6 +1583,120 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
     return HexStr(ss);
 }
 
+UniValue fundrawtransaction(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw runtime_error(
+                "fundrawtransaction \"hexstring\" ( options )\n"
+                "\nAdd inputs to a transaction until it has enough in value to meet its out value.\n"
+                "This will not modify existing inputs, and will add one change output to the outputs.\n"
+                "Note that inputs which were signed may need to be resigned after completion since in/outputs have been added.\n"
+                "The inputs added will not be signed, use signrawtransaction for that.\n"
+                "\nArguments:\n"
+                "1. \"hexstring\"           (string, required) The hex string of the raw transaction\n"
+                "2. options               (object, optional)\n"
+                "   {\n"
+                "     \"changeAddress\"     (string, optional) The address to receive the change\n"
+                "     \"changePosition\"    (numeric, optional) The index of the change output\n"
+                "     \"includeWatching\"   (boolean, optional, default false) Also select inputs which are watch only\n"
+                "   }\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"hex\":       \"value\", (string) The resulting raw transaction (hex-encoded string)\n"
+                "  \"fee\":       n,       (numeric) Fee in GRC the resulting transaction pays\n"
+                "  \"changepos\": n        (numeric) The position of the added change output, or -1\n"
+                "}\n"
+                + HelpRequiringPassphrase());
+
+    RPCTypeCheck(params, { UniValue::VSTR });
+
+    // parse hex string from parameter
+    vector<unsigned char> txData(ParseHex(params[0].get_str()));
+    CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction tx;
+    try {
+        ssData >> tx;
+    }
+    catch (std::exception& e) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    }
+
+    if (tx.vout.size() == 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "TX must have at least one output");
+
+    if (tx.vin.size() > 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+            "fundrawtransaction does not support transactions with existing inputs. "
+            "Use createrawtransaction with outputs only.");
+
+    // Parse options
+    CCoinControl coinControl;
+    int changePosition = -1;
+    bool includeWatching = false;
+
+    if (params.size() > 1 && !params[1].isNull())
+    {
+        RPCTypeCheck({ params[1] }, { UniValue::VOBJ });
+        UniValue options = params[1].get_obj();
+
+        UniValue changeAddressValue = find_value(options, "changeAddress");
+        if (!changeAddressValue.isNull())
+        {
+            CTxDestination dest = DecodeDestination(changeAddressValue.get_str());
+            if (!IsValidDestination(dest))
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "changeAddress must be a valid Gridcoin address");
+            coinControl.destChange = dest;
+        }
+
+        UniValue changePosValue = find_value(options, "changePosition");
+        if (!changePosValue.isNull())
+        {
+            changePosition = changePosValue.get_int();
+            if (changePosition < 0)
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "changePosition must be >= 0");
+        }
+
+        UniValue includeWatchingValue = find_value(options, "includeWatching");
+        if (!includeWatchingValue.isNull())
+        {
+            if (!includeWatchingValue.isBool())
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "includeWatching must be a boolean");
+            includeWatching = includeWatchingValue.get_bool();
+        }
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    EnsureWalletIsUnlocked();
+
+    int64_t nFeeOut = 0;
+    int nChangePosOut = -1;
+    string strFailReason;
+
+    if (!pwalletMain->FundTransaction(tx, nFeeOut, nChangePosOut, strFailReason, includeWatching))
+        throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
+
+    // If user requested a specific change position, move change output there
+    if (changePosition >= 0 && nChangePosOut >= 0 && changePosition != nChangePosOut)
+    {
+        if (changePosition >= (int)tx.vout.size())
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "changePosition out of bounds");
+
+        CTxOut changeOut = tx.vout[nChangePosOut];
+        tx.vout.erase(tx.vout.begin() + nChangePosOut);
+        tx.vout.insert(tx.vout.begin() + changePosition, changeOut);
+        nChangePosOut = changePosition;
+    }
+
+    UniValue result(UniValue::VOBJ);
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << tx;
+    result.pushKV("hex", HexStr(ssTx));
+    result.pushKV("fee", ValueFromAmount(nFeeOut));
+    result.pushKV("changepos", nChangePosOut);
+
+    return result;
+}
+
 UniValue decoderawtransaction(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1669,6 +1669,8 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
         }
     }
 
+    coinControl.fAllowWatchOnly = includeWatching;
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
     EnsureWalletIsUnlocked();
 
@@ -1676,7 +1678,7 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
     int nChangePosOut = -1;
     string strFailReason;
 
-    if (!pwalletMain->FundTransaction(tx, nFeeOut, nChangePosOut, strFailReason, includeWatching))
+    if (!pwalletMain->FundTransaction(tx, nFeeOut, nChangePosOut, strFailReason, &coinControl))
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
 
     // If user requested a specific change position, move change output there

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -8,6 +8,7 @@
 #include "main.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/claim.h"
+#include "gridcoin/consensus/mutable_transaction.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/mrc.h"
 #include "gridcoin/project.h"
@@ -1681,15 +1682,19 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
     if (!pwalletMain->FundTransaction(tx, nFeeOut, nChangePosOut, strFailReason, &coinControl))
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
 
-    // If user requested a specific change position, move change output there
+    // If user requested a specific change position, move change output there.
+    // The erase/insert dance lifts to a mutable copy so it stays compilable
+    // once CTransaction's vout becomes const (see #2901, F3).
     if (changePosition >= 0 && nChangePosOut >= 0 && changePosition != nChangePosOut)
     {
         if (changePosition >= (int)tx.vout.size())
             throw JSONRPCError(RPC_INVALID_PARAMETER, "changePosition out of bounds");
 
-        CTxOut changeOut = tx.vout[nChangePosOut];
-        tx.vout.erase(tx.vout.begin() + nChangePosOut);
-        tx.vout.insert(tx.vout.begin() + changePosition, changeOut);
+        CMutableTransaction mtx(tx);
+        CTxOut changeOut = mtx.vout[nChangePosOut];
+        mtx.vout.erase(mtx.vout.begin() + nChangePosOut);
+        mtx.vout.insert(mtx.vout.begin() + changePosition, changeOut);
+        tx = MakeTransaction(mtx);
         nChangePosOut = changePosition;
     }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -300,6 +300,7 @@ static const CRPCCommand vRPCCommands[] =
     { "decoderawtransaction",    &decoderawtransaction,    cat_wallet        },
     { "decodescript",            &decodescript,            cat_wallet        },
     { "dumpprivkey",             &dumpprivkey,             cat_wallet        },
+    { "fundrawtransaction",      &fundrawtransaction,      cat_wallet        },
     { "dumpwallet",              &dumpwallet,              cat_wallet        },
     { "encryptwallet",           &encryptwallet,           cat_wallet        },
     { "getaccount",              &getaccount,              cat_wallet        },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -114,6 +114,7 @@ extern UniValue consolidatemsunspent(const UniValue& params, bool fHelp);
 extern UniValue decoderawtransaction(const UniValue& params, bool fHelp);
 extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp);
+extern UniValue fundrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue dumpwallet(const UniValue& params, bool fHelp);
 extern UniValue encryptwallet(const UniValue& params, bool fHelp);
 extern UniValue getaccount(const UniValue& params, bool fHelp);

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -6,15 +6,17 @@ class CCoinControl
 {
 public:
     CTxDestination destChange;
+    bool fAllowWatchOnly;
 
     CCoinControl()
     {
         SetNull();
     }
-        
+
     void SetNull()
     {
         destChange = CNoDestination();
+        fAllowWatchOnly = false;
         setSelected.clear();
     }
     

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -21,6 +21,7 @@
 #include "main.h"
 #include "util.h"
 #include <util/string.h>
+#include "gridcoin/consensus/mutable_transaction.h"
 #include "gridcoin/mrc.h"
 #include "gridcoin/staking/kernel.h"
 #include "gridcoin/support/block_finder.h"
@@ -1993,11 +1994,13 @@ bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePo
         vecSend.push_back(std::make_pair(txOut.scriptPubKey, txOut.nValue));
     }
 
-    CWalletTx wtx;
+    // Construct CWalletTx from the input transaction so its CTransaction
+    // base (notably nTime, hashBoinc, vContracts) is carried into
+    // CreateTransaction without post-construction mutation. Direct
+    // assignment to wtx.nTime stops compiling once CTransaction's fields
+    // become const (see #2901, F3).
+    CWalletTx wtx(this, tx);
     CReserveKey reservekey(this);
-
-    // Copy nTime from the input transaction
-    wtx.nTime = tx.nTime;
 
     if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet, nChangePosInOut, coinControl))
     {
@@ -2009,15 +2012,20 @@ bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePo
     // another transaction before the caller broadcasts this one.
     reservekey.KeepKey();
 
-    // Copy inputs and outputs back to the raw transaction
-    tx.vin = wtx.vin;
-    tx.vout = wtx.vout;
+    // Lift tx into a mutable copy, install the funded inputs/outputs, strip
+    // signatures, then copy back. Direct mutation of tx.vin / tx.vout stops
+    // compiling once CTransaction's vectors become const (see #2901, F3).
+    CMutableTransaction mtx(tx);
+    mtx.vin = wtx.vin;
+    mtx.vout = wtx.vout;
 
     // Strip signatures — caller gets an unsigned funded transaction.
-    for (auto& txin : tx.vin)
+    for (auto& txin : mtx.vin)
     {
         txin.scriptSig = CScript();
     }
+
+    tx = MakeTransaction(mtx);
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1973,6 +1973,74 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
     return true;
 }
 
+bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePosInOut,
+                              std::string& strFailReason, bool includeWatching)
+{
+    std::vector<std::pair<CScript, int64_t>> vecSend;
+
+    // Collect existing outputs
+    for (const auto& txOut : tx.vout)
+    {
+        vecSend.push_back(std::make_pair(txOut.scriptPubKey, txOut.nValue));
+    }
+
+    CWalletTx wtx;
+    CReserveKey reservekey(this);
+
+    // Copy nTime from the input transaction
+    wtx.nTime = tx.nTime;
+
+    if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet))
+    {
+        strFailReason = "Insufficient funds or unable to create transaction";
+        return false;
+    }
+
+    // Identify which output is the change output. CreateTransaction inserts
+    // change at a random position if nChange > 0. The change output is the
+    // one in wtx.vout that was NOT in vecSend. We use a marking approach:
+    // mark each vecSend entry as matched against the wtx outputs.
+    nChangePosInOut = -1;
+    if (wtx.vout.size() > vecSend.size())
+    {
+        // Build a list of unmatched original outputs (by script+amount)
+        std::vector<bool> matched(vecSend.size(), false);
+
+        for (unsigned int i = 0; i < wtx.vout.size(); i++)
+        {
+            bool isOriginal = false;
+            for (unsigned int j = 0; j < vecSend.size(); j++)
+            {
+                if (!matched[j]
+                    && wtx.vout[i].scriptPubKey == vecSend[j].first
+                    && wtx.vout[i].nValue == vecSend[j].second)
+                {
+                    matched[j] = true;
+                    isOriginal = true;
+                    break;
+                }
+            }
+            if (!isOriginal)
+            {
+                nChangePosInOut = i;
+                break;
+            }
+        }
+    }
+
+    // Copy inputs and outputs back to the raw transaction
+    tx.vin = wtx.vin;
+    tx.vout = wtx.vout;
+
+    // Strip signatures — caller gets an unsigned funded transaction.
+    for (auto& txin : tx.vin)
+    {
+        txin.scriptSig = CScript();
+    }
+
+    return true;
+}
+
 bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, set<pair<const CWalletTx*,unsigned int>>& setCoins_in,
                                 CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl,
                                 bool change_back_to_input_address)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1990,42 +1990,10 @@ bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePo
     // Copy nTime from the input transaction
     wtx.nTime = tx.nTime;
 
-    if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet))
+    if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet, nChangePosInOut))
     {
         strFailReason = "Insufficient funds or unable to create transaction";
         return false;
-    }
-
-    // Identify which output is the change output. CreateTransaction inserts
-    // change at a random position if nChange > 0. The change output is the
-    // one in wtx.vout that was NOT in vecSend. We use a marking approach:
-    // mark each vecSend entry as matched against the wtx outputs.
-    nChangePosInOut = -1;
-    if (wtx.vout.size() > vecSend.size())
-    {
-        // Build a list of unmatched original outputs (by script+amount)
-        std::vector<bool> matched(vecSend.size(), false);
-
-        for (unsigned int i = 0; i < wtx.vout.size(); i++)
-        {
-            bool isOriginal = false;
-            for (unsigned int j = 0; j < vecSend.size(); j++)
-            {
-                if (!matched[j]
-                    && wtx.vout[i].scriptPubKey == vecSend[j].first
-                    && wtx.vout[i].nValue == vecSend[j].second)
-                {
-                    matched[j] = true;
-                    isOriginal = true;
-                    break;
-                }
-            }
-            if (!isOriginal)
-            {
-                nChangePosInOut = i;
-                break;
-            }
-        }
     }
 
     // Copy inputs and outputs back to the raw transaction
@@ -2042,8 +2010,8 @@ bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePo
 }
 
 bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, set<pair<const CWalletTx*,unsigned int>>& setCoins_in,
-                                CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl,
-                                bool change_back_to_input_address)
+                                CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, int& nChangePosRet,
+                                const CCoinControl* coinControl, bool change_back_to_input_address)
 {
 
     int64_t nValueOut = 0;
@@ -2243,12 +2211,14 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
                     }
 
                     // Insert change output at random position in the transaction:
-                    vector<CTxOut>::iterator position = wtxNew.vout.begin() + GetRand<int>(wtxNew.vout.size());
-                    wtxNew.vout.insert(position, CTxOut(nChange, scriptChange));
+                    int nChangeInsertPos = GetRand<int>(wtxNew.vout.size());
+                    wtxNew.vout.insert(wtxNew.vout.begin() + nChangeInsertPos, CTxOut(nChange, scriptChange));
+                    nChangePosRet = nChangeInsertPos;
                 }
                 else
                 {
                     reservekey.ReturnKey();
+                    nChangePosRet = -1;
                 }
 
                 if (setCoins_in.size())
@@ -2331,12 +2301,26 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
 }
 
 bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
-    int64_t& nFeeRet, const CCoinControl* coinControl, bool change_back_to_input_address)
+    int64_t& nFeeRet, int& nChangePosRet, const CCoinControl* coinControl, bool change_back_to_input_address)
 {
     // Initialize setCoins empty to let CreateTransaction choose via SelectCoins...
     set<pair<const CWalletTx*,unsigned int>> setCoins;
 
-    return CreateTransaction(vecSend, setCoins, wtxNew, reservekey, nFeeRet, coinControl, change_back_to_input_address);
+    return CreateTransaction(vecSend, setCoins, wtxNew, reservekey, nFeeRet, nChangePosRet, coinControl, change_back_to_input_address);
+}
+
+bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
+    int64_t& nFeeRet, const CCoinControl* coinControl, bool change_back_to_input_address)
+{
+    int nChangePosRet = -1;
+    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, nChangePosRet, coinControl, change_back_to_input_address);
+}
+
+bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, set<pair<const CWalletTx*,unsigned int>>& setCoins,
+    CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl, bool change_back_to_input_address)
+{
+    int nChangePosRet = -1;
+    return CreateTransaction(vecSend, setCoins, wtxNew, reservekey, nFeeRet, nChangePosRet, coinControl, change_back_to_input_address);
 }
 
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1501,7 +1501,16 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++)
 			{
-                if ((!(pcoin->IsSpent(i)) && (IsMine(pcoin->vout[i]) != ISMINE_NO) && pcoin->vout[i].nValue >= nMinimumInputValue &&
+                isminetype mine = IsMine(pcoin->vout[i]);
+                // Preserve historical behavior when no coinControl is supplied
+                // (include anything we have any interest in). When coinControl
+                // is supplied, restrict to spendable unless the caller opts in
+                // to watch-only via fAllowWatchOnly.
+                bool mine_ok = coinControl
+                    ? ((mine & ISMINE_SPENDABLE)
+                        || ((mine & ISMINE_WATCH_ONLY) && coinControl->fAllowWatchOnly))
+                    : (mine != ISMINE_NO);
+                if ((!(pcoin->IsSpent(i)) && mine_ok && pcoin->vout[i].nValue >= nMinimumInputValue &&
                      (!coinControl || !coinControl->HasSelected() || coinControl->IsSelected(it->first, i))) ||
                     (fIncludeStakedCoins && pcoin->IsCoinStake() && pcoin->GetBlocksToMaturity() > 0 && pcoin->GetDepthInMainChain() > 0)) {
                     vCoins.push_back(COutput(pcoin, i, nDepth));
@@ -1974,7 +1983,7 @@ bool CWallet::SelectCoinsForStaking(unsigned int nSpendTime, std::vector<pair<co
 }
 
 bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePosInOut,
-                              std::string& strFailReason, bool includeWatching)
+                              std::string& strFailReason, const CCoinControl* coinControl)
 {
     std::vector<std::pair<CScript, int64_t>> vecSend;
 
@@ -1990,11 +1999,15 @@ bool CWallet::FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePo
     // Copy nTime from the input transaction
     wtx.nTime = tx.nTime;
 
-    if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet, nChangePosInOut))
+    if (!CreateTransaction(vecSend, wtx, reservekey, nFeeRet, nChangePosInOut, coinControl))
     {
         strFailReason = "Insufficient funds or unable to create transaction";
         return false;
     }
+
+    // Keep the change key so it isn't returned to the pool and reused by
+    // another transaction before the caller broadcasts this one.
+    reservekey.KeepKey();
 
     // Copy inputs and outputs back to the raw transaction
     tx.vin = wtx.vin;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -265,6 +265,8 @@ public:
     int64_t GetImmatureBalance() const;
     int64_t GetStake() const;
     int64_t GetNewMint() const;
+    bool FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePosInOut,
+                         std::string& strFailReason, bool includeWatching);
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
                            int64_t& nFeeRet, const CCoinControl* coinControl = nullptr, bool change_back_to_input_address = false);
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, std::set<std::pair<const CWalletTx*,unsigned int>>& setCoins,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -268,7 +268,13 @@ public:
     bool FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePosInOut,
                          std::string& strFailReason, bool includeWatching);
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
+                           int64_t& nFeeRet, int& nChangePosRet, const CCoinControl* coinControl = nullptr,
+                           bool change_back_to_input_address = false);
+    bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
                            int64_t& nFeeRet, const CCoinControl* coinControl = nullptr, bool change_back_to_input_address = false);
+    bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, std::set<std::pair<const CWalletTx*,unsigned int>>& setCoins,
+                           CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, int& nChangePosRet,
+                           const CCoinControl* coinControl = nullptr, bool change_back_to_input_address = false);
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, std::set<std::pair<const CWalletTx*,unsigned int>>& setCoins,
                            CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl = nullptr,
                            bool change_back_to_input_address = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -266,7 +266,7 @@ public:
     int64_t GetStake() const;
     int64_t GetNewMint() const;
     bool FundTransaction(CTransaction& tx, int64_t& nFeeRet, int& nChangePosInOut,
-                         std::string& strFailReason, bool includeWatching);
+                         std::string& strFailReason, const CCoinControl* coinControl);
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t>>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey,
                            int64_t& nFeeRet, int& nChangePosRet, const CCoinControl* coinControl = nullptr,
                            bool change_back_to_input_address = false);


### PR DESCRIPTION
### PR A: `rpc: add fundrawtransaction`
Target: `development` on `gridcoin-community/Gridcoin-Research`
Branch: `Issue-2877-A` on `PrestackI/Gridcoin-Research`

#### Summary
- Add `fundrawtransaction` RPC command that selects wallet UTXOs to fund a raw transaction
- Add `FundTransaction` method to `CWallet` with `CreateTransaction` overloads that return the change output index directly (avoiding fragile script+amount matching)
- Document that existing inputs are not yet supported (divergence from Bitcoin Core)

#### Test plan
- [x] CI passes
- [x] `fundrawtransaction` help text shows correctly
- [x] Manual test: `createrawtransaction` with outputs only → `fundrawtransaction` → verify funded tx has inputs and change
