### PR TITLE
build, qt: fix DebugMessageHandler linkage and DEP_LIB path resolution

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -232,6 +232,8 @@ target_link_libraries(gridcoinresearch PRIVATE
 
 # Linux Static Math Lib Workaround
 if(UNIX AND NOT APPLE AND DEFINED DEP_LIB)
+    # Ensure DEP_LIB is absolute so the link command works from any directory.
+    get_filename_component(DEP_LIB "${DEP_LIB}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
     # 1. The "Imposter" Math Target
     # We must link against the system's SHARED libm to avoid static linking issues.
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -226,7 +226,7 @@ static std::string Translate(const char* psz)
 }
 
 /* qDebug() message handler --> debug.log */
-void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
+static void DebugMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &msg)
 {
     Q_UNUSED(context);
     if (type == QtDebugMsg) {


### PR DESCRIPTION
## Summary
- Make `DebugMessageHandler` in `bitcoin.cpp` `static` to prevent multiple-definition linker error when Qt's `libqmldbg_messages.a` is pulled in (which defines the same symbol name)
- Resolve `DEP_LIB` to an absolute path via `get_filename_component` so the static link fixup in `CMAKE_CXX_LINK_EXECUTABLE` works correctly when the build directory differs from the source root

## Test plan
- [x] Verified fix resolves link error when building with Qt6 + qtdeclarative (QML) depends
- [x] Verified `DEP_LIB` resolution works with both relative and absolute paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)