### PR TITLE
qt: fix tab indentation in sendcoinsentry, walletmodel

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -144,7 +144,7 @@ SendCoinsRecipient SendCoinsEntry::getValue()
     rv.address = ui->payTo->text();
     rv.label = ui->addAsLabel->text();
     rv.amount = ui->payAmount->value();
-	rv.Message = ui->messageText->text();
+    rv.Message = ui->messageText->text();
     return rv;
 }
 
@@ -163,7 +163,7 @@ void SendCoinsEntry::setValue(const SendCoinsRecipient &value)
     ui->payTo->setText(value.address);
     ui->addAsLabel->setText(value.label);
     ui->payAmount->setValue(value.amount);
-	ui->messageText->setText(value.Message);
+    ui->messageText->setText(value.Message);
 }
 
 bool SendCoinsEntry::isClear()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -248,7 +248,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
 
         CReserveKey keyChange(wallet);
         int64_t nFeeRequired = 0;
-		bool fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
+        bool fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
 
         if(!fCreated)
         {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -29,7 +29,7 @@ public:
     QString address;
     QString label;
     qint64 amount;
-	QString Message;
+    QString Message;
 };
 
 /** Interface to Bitcoin wallet from Qt view code. */


### PR DESCRIPTION
## Summary

- Replace tab characters with 4-space indentation in 3 files to pass lint-whitespace checks

Trivial fix — tabs were introduced in earlier commits on `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)