### PR TITLE
rpc: add listsidestakes RPC for combined sidestake view

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3126,39 +3126,77 @@ UniValue listprotocolentries(const UniValue& params, bool fHelp)
     return res;
 }
 
+UniValue listsidestakes(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "listsidestakes [type]\n"
+            "\n"
+            "Displays all active sidestakes (mandatory and local/voluntary).\n"
+            "\n"
+            "Arguments:\n"
+            "  type    (string, optional) Filter by type: \"mandatory\", \"local\", or \"all\" (default: \"all\")\n");
+
+    std::string type_filter = "all";
+    if (params.size() == 1) {
+        type_filter = params[0].get_str();
+        if (type_filter != "all" && type_filter != "mandatory" && type_filter != "local") {
+            throw runtime_error("Invalid type filter. Must be \"all\", \"mandatory\", or \"local\".");
+        }
+    }
+
+    GRC::SideStake::FilterFlag filter = GRC::SideStake::FilterFlag::ALL;
+    if (type_filter == "mandatory") {
+        filter = GRC::SideStake::FilterFlag::MANDATORY;
+    } else if (type_filter == "local") {
+        filter = GRC::SideStake::FilterFlag::LOCAL;
+    }
+
+    UniValue res(UniValue::VOBJ);
+    UniValue entries(UniValue::VARR);
+
+    for (const auto& sidestake : GRC::GetSideStakeRegistry().ActiveSideStakeEntries(filter, false)) {
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("address", EncodeDestination(sidestake->GetDestination()));
+        entry.pushKV("allocation_pct", sidestake->GetAllocation().ToPercent());
+        entry.pushKV("type", sidestake->IsMandatory() ? "mandatory" : "local");
+        entry.pushKV("description", sidestake->GetDescription());
+        entry.pushKV("status", sidestake->StatusToString());
+
+        if (sidestake->IsMandatory()) {
+            entry.pushKV("tx_hash", sidestake->GetHash().ToString());
+            if (sidestake->GetPreviousHash().IsNull()) {
+                entry.pushKV("previous_tx_hash", "null");
+            } else {
+                entry.pushKV("previous_tx_hash", sidestake->GetPreviousHash().ToString());
+            }
+            entry.pushKV("timestamp", sidestake->GetTimeStamp());
+            entry.pushKV("time", DateTimeStrFormat(sidestake->GetTimeStamp()));
+        }
+
+        entries.push_back(entry);
+    }
+
+    res.pushKV("sidestake_entries", entries);
+
+    return res;
+}
+
 UniValue listmandatorysidestakes(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "listprotocolentries\n"
+            "listmandatorysidestakes\n"
             "\n"
-            "Displays the mandatory sidestakes on the network.\n");
+            "Displays the mandatory sidestakes on the network.\n"
+            "\n"
+            "This is equivalent to listsidestakes \"mandatory\".\n");
 
-    UniValue res(UniValue::VOBJ);
-    UniValue scraper_entries(UniValue::VARR);
+    UniValue filter_params(UniValue::VARR);
+    filter_params.push_back("mandatory");
 
-    for (const auto& sidestake : GRC::GetSideStakeRegistry().ActiveSideStakeEntries(GRC::SideStake::FilterFlag::MANDATORY, false)) {
-        UniValue entry(UniValue::VOBJ);
-
-        entry.pushKV("mandatory_sidestake_entry_address", EncodeDestination(sidestake->GetDestination()));
-        entry.pushKV("mandatory_sidestake_entry_allocation", sidestake->GetAllocation().ToPercent());
-        entry.pushKV("mandatory_sidestake_entry_tx_hash", sidestake->GetHash().ToString());
-        if (sidestake->GetPreviousHash().IsNull()) {
-            entry.pushKV("previous_mandatory_sidestake_entry_tx_hash", "null");
-        } else {
-            entry.pushKV("previous_mandatory_sidestake_entry_tx_hash", sidestake->GetPreviousHash().ToString());
-        }
-
-        entry.pushKV("mandatory_sidestake_entry_timestamp", sidestake->GetTimeStamp());
-        entry.pushKV("mandatory_sidestake_entry_time", DateTimeStrFormat(sidestake->GetTimeStamp()));
-        entry.pushKV("mandatory_sidestake_entry_status", sidestake->StatusToString());
-
-        scraper_entries.push_back(entry);
-    }
-
-    res.pushKV("current_mandatory_sidestake_entries", scraper_entries);
-
-    return res;
+    return listsidestakes(filter_params, false);
 }
 
 UniValue network(const UniValue& params, bool fHelp)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -395,6 +395,7 @@ static const CRPCCommand vRPCCommands[] =
     { "listprotocolentries",     &listprotocolentries,     cat_developer     },
     { "listresearcheraccounts",  &listresearcheraccounts,  cat_developer     },
     { "listscrapers",            &listscrapers,            cat_developer     },
+    { "listsidestakes",          &listsidestakes,           cat_developer     },
     { "listmandatorysidestakes", &listmandatorysidestakes, cat_developer     },
     { "listsettings",            &listsettings,            cat_developer     },
     { "logging",                 &logging,                 cat_developer     },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -205,6 +205,7 @@ extern UniValue getautogreylist(const UniValue& params, bool fHelp);
 extern UniValue listprotocolentries(const UniValue& params, bool fHelp);
 extern UniValue listresearcheraccounts(const UniValue& params, bool fHelp);
 extern UniValue listscrapers(const UniValue& params, bool fHelp);
+extern UniValue listsidestakes(const UniValue& params, bool fHelp);
 extern UniValue listmandatorysidestakes(const UniValue& params, bool fHelp);
 extern UniValue listsettings(const UniValue& params, bool fHelp);
 extern UniValue logging(const UniValue& params, bool fHelp);


### PR DESCRIPTION
## Summary
- Add `listsidestakes` RPC that returns all active sidestakes (mandatory and local/voluntary) with an optional type filter argument (`"all"`, `"mandatory"`, `"local"`)
- This mirrors the combined sidestake table available in the GUI but was previously missing from the RPC surface
- Refactor `listmandatorysidestakes` to delegate to `listsidestakes` with the mandatory filter, eliminating duplicated logic and standardizing field names

## Test plan
- [x] `listsidestakes` returns combined mandatory + local entries
- [x] `listsidestakes "mandatory"` returns only mandatory entries
- [x] `listmandatorysidestakes` delegates correctly, output matches `listsidestakes "mandatory"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)