### PR TITLE
gui: add "Add Existing" button to receive tab address book

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -61,11 +61,13 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
         ui->explanationLabel->setVisible(false);
         ui->deleteButton->setVisible(true);
         ui->signMessageButton->setVisible(false);
+        ui->addExistingButton->setVisible(false);
         break;
     case ReceivingTab:
         ui->deleteButton->setVisible(false);
         ui->verifyMessageButton->setVisible(false);
         ui->signMessageButton->setVisible(true);
+        ui->addExistingButton->setVisible(true);
         break;
     }
 
@@ -232,6 +234,18 @@ void AddressBookPage::on_newAddressButton_clicked()
             tab == SendingTab ?
             EditAddressDialog::NewSendingAddress :
             EditAddressDialog::NewReceivingAddress, this);
+    dlg.setModel(model);
+    if(dlg.exec())
+    {
+        newAddressToSelect = dlg.getAddress();
+    }
+}
+
+void AddressBookPage::on_addExistingButton_clicked()
+{
+    if(!model)
+        return;
+    EditAddressDialog dlg(EditAddressDialog::AddExistingReceivingAddress, this);
     dlg.setModel(model);
     if(dlg.exec())
     {

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -71,6 +71,7 @@ private:
 private slots:
     void on_deleteButton_clicked();
     void on_newAddressButton_clicked();
+    void on_addExistingButton_clicked();
     /** Copy address of currently selected address entry to clipboard */
     void on_copyToClipboardButton_clicked();
     void on_signMessageButton_clicked();

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -11,6 +11,7 @@
 
 const QString AddressTableModel::Send = "S";
 const QString AddressTableModel::Receive = "R";
+const QString AddressTableModel::ReceiveExisting = "RE";
 
 struct AddressTableEntry
 {
@@ -367,6 +368,26 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
         }
         strAddress = EncodeDestination(newKey.GetID());
     }
+    else if(type == ReceiveExisting)
+    {
+        if(!walletModel->validateAddress(address))
+        {
+            editStatus = INVALID_ADDRESS;
+            return QString();
+        }
+        LOCK(wallet->cs_wallet);
+        CTxDestination dest = DecodeDestination(strAddress);
+        if(IsMine(*wallet, dest) == ISMINE_NO)
+        {
+            editStatus = NOT_MINE;
+            return QString();
+        }
+        if(wallet->mapAddressBook.count(dest))
+        {
+            editStatus = DUPLICATE_ADDRESS;
+            return QString();
+        }
+    }
     else
     {
         return QString();
@@ -395,6 +416,22 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
         wallet->DelAddressBookName(DecodeDestination(rec->address.toStdString()));
     }
     return true;
+}
+
+QStringList AddressTableModel::unbookedReceiveAddresses() const
+{
+    QStringList result;
+    {
+        LOCK(wallet->cs_wallet);
+        std::map<CTxDestination, int64_t> balances = wallet->GetAddressBalances();
+        for (const auto& [dest, balance] : balances) {
+            if (balance > 0 && wallet->mapAddressBook.count(dest) == 0) {
+                result.append(QString::fromStdString(EncodeDestination(dest)));
+            }
+        }
+    }
+    result.sort();
+    return result;
 }
 
 /* Look up label for address in address book, if not found return empty string.

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -38,11 +38,13 @@ public:
         INVALID_ADDRESS,        /**< Unparseable address */
         DUPLICATE_ADDRESS,      /**< Address already in address book */
         WALLET_UNLOCK_FAILURE,  /**< Wallet could not be unlocked to create new receiving address */
-        KEY_GENERATION_FAILURE  /**< Generating a new public key for a receiving address failed */
+        KEY_GENERATION_FAILURE, /**< Generating a new public key for a receiving address failed */
+        NOT_MINE                /**< Address is not owned by this wallet */
     };
 
-    static const QString Send;      /**< Specifies send address */
-    static const QString Receive;   /**< Specifies receive address */
+    static const QString Send;              /**< Specifies send address */
+    static const QString Receive;           /**< Specifies receive address */
+    static const QString ReceiveExisting;   /**< Specifies existing receive address */
 
     /** @name Methods overridden from QAbstractTableModel
         @{*/
@@ -60,6 +62,10 @@ public:
        Returns the added address on success, and an empty string otherwise.
      */
     QString addRow(const QString &type, const QString &label, const QString &address);
+
+    /* Return list of owned addresses not yet in the address book.
+     */
+    QStringList unbookedReceiveAddresses() const;
 
     /* Look up label for address in address book, if not found return empty string.
      */

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -4,12 +4,14 @@
 #include "guiutil.h"
 #include "qt/decoration.h"
 
+#include <QComboBox>
 #include <QDataWidgetMapper>
 #include <QMessageBox>
 
 EditAddressDialog::EditAddressDialog(Mode mode, QWidget* parent)
                : QDialog(parent)
                , ui(new Ui::EditAddressDialog)
+               , addressCombo(nullptr)
                , mapper(nullptr)
                , mode(mode)
                , model(nullptr)
@@ -36,6 +38,14 @@ EditAddressDialog::EditAddressDialog(Mode mode, QWidget* parent)
     case EditSendingAddress:
         setWindowTitle(tr("Edit sending address"));
         break;
+    case AddExistingReceivingAddress:
+        setWindowTitle(tr("Add existing receiving address"));
+        // Replace the address line edit with a combo box of unbooked addresses
+        addressCombo = new QComboBox(this);
+        addressCombo->setFont(GUIUtil::bitcoinAddressFont());
+        ui->formLayout->replaceWidget(ui->addressEdit, addressCombo);
+        ui->addressEdit->hide();
+        break;
     }
 
     mapper = new QDataWidgetMapper(this);
@@ -56,6 +66,11 @@ void EditAddressDialog::setModel(AddressTableModel *model)
     mapper->setModel(model);
     mapper->addMapping(ui->labelEdit, AddressTableModel::Label);
     mapper->addMapping(ui->addressEdit, AddressTableModel::Address);
+
+    if(mode == AddExistingReceivingAddress && addressCombo)
+    {
+        addressCombo->addItems(model->unbookedReceiveAddresses());
+    }
 }
 
 void EditAddressDialog::loadRow(int row)
@@ -76,6 +91,12 @@ bool EditAddressDialog::saveCurrentRow()
                 mode == NewSendingAddress ? AddressTableModel::Send : AddressTableModel::Receive,
                 ui->labelEdit->text(),
                 ui->addressEdit->text());
+        break;
+    case AddExistingReceivingAddress:
+        address = model->addRow(
+                AddressTableModel::ReceiveExisting,
+                ui->labelEdit->text(),
+                addressCombo ? addressCombo->currentText() : QString());
         break;
     case EditReceivingAddress:
     case EditSendingAddress:
@@ -105,12 +126,12 @@ void EditAddressDialog::accept()
             break;
         case AddressTableModel::INVALID_ADDRESS:
             QMessageBox::warning(this, windowTitle(),
-                tr("The entered address \"%1\" is not a valid Gridcoin address.").arg(ui->addressEdit->text()),
+                tr("The entered address \"%1\" is not a valid Gridcoin address.").arg(getDisplayAddress()),
                 QMessageBox::Ok, QMessageBox::Ok);
             break;
         case AddressTableModel::DUPLICATE_ADDRESS:
             QMessageBox::warning(this, windowTitle(),
-                tr("The entered address \"%1\" is already in the address book.").arg(ui->addressEdit->text()),
+                tr("The entered address \"%1\" is already in the address book.").arg(getDisplayAddress()),
                 QMessageBox::Ok, QMessageBox::Ok);
             break;
         case AddressTableModel::WALLET_UNLOCK_FAILURE:
@@ -123,11 +144,22 @@ void EditAddressDialog::accept()
                 tr("New key generation failed."),
                 QMessageBox::Ok, QMessageBox::Ok);
             break;
-
+        case AddressTableModel::NOT_MINE:
+            QMessageBox::warning(this, windowTitle(),
+                tr("The entered address \"%1\" is not owned by this wallet.").arg(getDisplayAddress()),
+                QMessageBox::Ok, QMessageBox::Ok);
+            break;
         }
         return;
     }
     QDialog::accept();
+}
+
+QString EditAddressDialog::getDisplayAddress() const
+{
+    if(addressCombo)
+        return addressCombo->currentText();
+    return ui->addressEdit->text();
 }
 
 QString EditAddressDialog::getAddress() const

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 
 QT_BEGIN_NAMESPACE
+class QComboBox;
 class QDataWidgetMapper;
 QT_END_NAMESPACE
 
@@ -23,7 +24,8 @@ public:
         NewReceivingAddress,
         NewSendingAddress,
         EditReceivingAddress,
-        EditSendingAddress
+        EditSendingAddress,
+        AddExistingReceivingAddress
     };
 
     explicit EditAddressDialog(Mode mode, QWidget* parent = nullptr);
@@ -40,8 +42,10 @@ public slots:
 
 private:
     bool saveCurrentRow();
+    QString getDisplayAddress() const;
 
     Ui::EditAddressDialog *ui;
+    QComboBox *addressCombo;
     QDataWidgetMapper *mapper;
     Mode mode;
     AddressTableModel *model;

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -136,6 +136,20 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="addExistingButton">
+        <property name="toolTip">
+         <string>Add an existing address owned by this wallet to the address book</string>
+        </property>
+        <property name="text">
+         <string>Add &amp;Existing</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="copyToClipboardButton">
         <property name="toolTip">
          <string>Copy the currently selected address to the system clipboard</string>


### PR DESCRIPTION
## Summary
- Add "Add Existing" button to the receive tab of the address book, allowing users to add wallet-owned addresses that aren't yet in the address book
- The dialog presents a pick list of owned addresses with non-zero balances that are missing from the address book
- Previously, the only way to add a receive address was to generate a new one, leaving keypool-derived or RPC-created addresses invisible in the receive tab despite receiving payments

## Background
Addresses created via RPC (`getnewaddress`) or from the keypool can receive coins (e.g. sidestake payments) but never appear in the GUI's receive table or send address book chooser, because they were never added to `mapAddressBook`. The wallet owns the keys and can spend the funds, but the GUI doesn't know about them. The receive tab's "New" button only generates fresh addresses — there was no way to register an existing owned address.

Closes #2888.

## Test plan
- [x] "Add Existing" button visible on Receive tab, hidden on Send tab
- [x] Dialog shows combo box of owned addresses with non-zero balance not in address book
- [x] Selecting an address and entering a label adds it to the receive table
- [x] Address appears in receive table after adding
- [x] Duplicate address rejected with warning
- [x] Empty pick list when all funded addresses are already in the book

🤖 Generated with [Claude Code](https://claude.com/claude-code)