### PR TITLE
consensus: fix misleading ERROR log for voluntary sidestake to mandatory address

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -897,6 +897,21 @@ private:
                         // what is required by the mandatory sidestake. Note that the test uses the GRC::Allocation class, which
                         // extends the Fraction class, and provides comparison operators. This is now a precise calculation as it
                         // is integer arithmetic.
+                        //
+                        // IMPORTANT: An output to a mandatory sidestake address that does NOT meet the >= threshold is not
+                        // necessarily an error. This happens legitimately when a staker configures a voluntary sidestake to
+                        // the same address as an active mandatory sidestake. The miner produces two outputs to that address:
+                        //   - A voluntary output (e.g. 5% of total_owed) which is smaller than required.
+                        //   - A mandatory output (e.g. 10% of total_owed) which meets the >= threshold.
+                        //
+                        // Because this loop scans all non-MRC outputs, the voluntary output is encountered first (or second,
+                        // depending on the vout layout after stake splitting reorders outputs). It matches the mandatory
+                        // sidestake destination but fails the amount check. This is expected — the actual mandatory output
+                        // elsewhere in the vout array will satisfy the threshold and increment validated_mandatory_sidestakes.
+                        //
+                        // Therefore, a per-output amount mismatch is logged at VERBOSE level only. The definitive validation
+                        // is the final count check below (validated_mandatory_sidestakes vs expected), which correctly handles
+                        // the coincidence case because the mandatory output's amount will pass the >= check.
                         if (!mandatory_sidestake.empty()) {
                             CAmount actual_output = coinstake.vout[i].nValue;
 
@@ -904,18 +919,17 @@ private:
                                                        * total_owed_to_staker).ToCAmount();
 
                             if (actual_output >= required_output) {
-
                                 ++validated_mandatory_sidestakes;
                             } else {
-                                error_out = "Mandatory sidestake failed validation";
-
-                                error("%s: vout[%u] is mandatory sidestake destination %s, but failed validation: "
-                                      "actual_output = %" PRId64 ", required_output = %" PRId64,
-                                          __func__,
-                                          i,
-                                          EncodeDestination(output_destination),
-                                          actual_output,
-                                          required_output);
+                                LogPrint(BCLog::LogFlags::VERBOSE,
+                                         "INFO: %s: vout[%u] destination %s matches mandatory sidestake but "
+                                         "amount is below threshold (actual = %" PRId64 ", required = %" PRId64 "). "
+                                         "This is expected when a voluntary sidestake shares the same address.",
+                                         __func__,
+                                         i,
+                                         EncodeDestination(output_destination),
+                                         actual_output,
+                                         required_output);
                             }
                         }
 


### PR DESCRIPTION
## Summary

- Fix misleading `ERROR: CheckReward: vout[N] is mandatory sidestake destination ...` log that fires when a voluntary sidestake shares the same address as a mandatory sidestake
- The voluntary output is legitimately smaller than the mandatory threshold, but the per-output check logged it as an ERROR even though the actual mandatory output passes the check and overall validation succeeds
- Downgrade to VERBOSE with an explanatory message; add detailed comments documenting the coincidence scenario

## Background

Discovered during isolated testnet testing of PR #2885 (BlockRewardRules). A staker with a 5% voluntary sidestake and a 10% mandatory sidestake to the same address produces two outputs. The validator iterates all outputs and checks each against the mandatory threshold. The voluntary output (5%) fails the `>=` check against the 10% requirement, triggering a false ERROR. The mandatory output (10%) subsequently passes, and the final count check succeeds.

This is a **log-only change** — validation logic is completely unchanged. Zero regression risk.

## Test plan

- [x] Verified build compiles
- [x] Confirmed the scenario reproduces on isolated testnet with coincident voluntary/mandatory sidestakes
- [x] Verified blocks pass validation correctly (no fork, all 3 nodes agree on chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)