### PR TITLE
gui: add sync overlay and out-of-sync action guards

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(gridcoinqt STATIC
     researcher/researcherwizardsummarypage.cpp
     rpcconsole.cpp
     sendcoinsdialog.cpp
+    syncoverlay.cpp
     sendcoinsentry.cpp
     sidestaketablemodel.cpp
     signverifymessagedialog.cpp

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -45,6 +45,7 @@
 #include "upgradeqt.h"
 #include "voting/votingmodel.h"
 #include "voting/polltablemodel.h"
+#include "syncoverlay.h"
 #include "updatedialog.h"
 
 #ifdef Q_OS_MAC
@@ -110,6 +111,8 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
         , trayIcon(nullptr)
         , notificator(nullptr)
         , rpcConsole(nullptr)
+        , m_sync_overlay(nullptr)
+        , m_in_sync(false)
         , nWeight(0)
 {
     QSettings settings;
@@ -215,6 +218,11 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
     centralWidget->addWidget(votingPage);
 
     setCentralWidget(centralWidget);
+
+    // Create sync overlay — sits on top of the central widget and blocks
+    // interaction until the wallet is in sync (or the user dismisses it).
+    m_sync_overlay = new SyncOverlay(centralWidget);
+    m_sync_overlay->setVisible(true);
 
     // Create status bar
     statusBar();
@@ -1078,13 +1086,14 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     // Note: It is a really good question why the GUI uses a different standard than the core for determining whether
     // the client is in sync.
     // TODO: Review this and decide whether to converge the sync standards.
-    bool in_sync = false;
 
     // return if we have no connection to the network
     if (!clientModel || clientModel->getNumConnections() == 0)
     {
         labelBlocksIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_sync_stalled_" + sSheet));
         labelBlocksIcon->setToolTip(tr("Sync: no connections."));
+        m_in_sync = false;
+        m_sync_overlay->setSyncState(true, 0, 0);
         return;
     }
 
@@ -1123,7 +1132,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         labelBlocksIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_sync_done_" + sSheet));
 
         overviewPage->showOutOfSyncWarning(false);
-        in_sync = true;
+        m_in_sync = true;
         statusbarAlertsLabel->setText(clientModel->getStatusBarWarnings());
     }
     else
@@ -1132,8 +1141,10 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
         tooltip = tr("Catching up...") + QString("<br>") + tooltip;
 
         overviewPage->showOutOfSyncWarning(true);
-        in_sync = false;
+        m_in_sync = false;
     }
+
+    m_sync_overlay->setSyncState(!m_in_sync, count, nTotalBlocks);
 
     if(!text.isEmpty())
     {
@@ -1145,7 +1156,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     tooltip = QString("<nobr>") + tooltip + QString("</nobr>");
 
     labelBlocksIcon->setToolTip(tooltip);
-    overviewPage->setHeight(count, nTotalBlocks, in_sync);
+    overviewPage->setHeight(count, nTotalBlocks, m_in_sync);
 }
 
 void BitcoinGUI::setDifficulty(double difficulty)
@@ -1471,6 +1482,18 @@ void BitcoinGUI::peersClicked()
         rpcConsole->showPeersTab();
 }
 
+void BitcoinGUI::recheckCurrentTabAction()
+{
+    QWidget* current = centralWidget->currentWidget();
+
+    if (current == overviewPage)        overviewAction->setChecked(true);
+    else if (current == sendCoinsPage)  sendCoinsAction->setChecked(true);
+    else if (current == receiveCoinsPage) receiveCoinsAction->setChecked(true);
+    else if (current == transactionView) historyAction->setChecked(true);
+    else if (current == addressBookPage) addressBookAction->setChecked(true);
+    else if (current == votingPage)     votingAction->setChecked(true);
+}
+
 void BitcoinGUI::gotoOverviewPage()
 {
     overviewAction->setChecked(true);
@@ -1519,6 +1542,22 @@ void BitcoinGUI::gotoReceiveCoinsPage()
 
 void BitcoinGUI::gotoSendCoinsPage()
 {
+    if (!m_in_sync) {
+        QMessageBox::StandardButton reply = QMessageBox::warning(this,
+            tr("Wallet Not In Sync"),
+            tr("The wallet is not yet in sync with the network. Your balance "
+               "may be inaccurate, and transactions created while out of sync "
+               "may not confirm properly.\n\n"
+               "Are you sure you want to proceed?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+
+        if (reply != QMessageBox::Yes) {
+            recheckCurrentTabAction();
+            return;
+        }
+    }
+
     sendCoinsAction->setChecked(true);
     centralWidget->setCurrentWidget(sendCoinsPage);
 
@@ -1528,6 +1567,15 @@ void BitcoinGUI::gotoSendCoinsPage()
 
 void BitcoinGUI::gotoVotingPage()
 {
+    if (!m_in_sync) {
+        QMessageBox::warning(this,
+            tr("Wallet Not In Sync"),
+            tr("The wallet must be in sync to access the voting system. "
+               "Please wait for synchronization to complete."));
+        recheckCurrentTabAction();
+        return;
+    }
+
     votingAction->setChecked(true);
     centralWidget->setCurrentWidget(votingPage);
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -32,6 +32,7 @@ class Notificator;
 class RPCConsole;
 class DiagnosticsDialog;
 class ClickLabel;
+class SyncOverlay;
 class UpdateDialog;
 
 QT_BEGIN_NAMESPACE
@@ -113,6 +114,9 @@ private:
     SignVerifyMessageDialog *signVerifyMessageDialog;
     std::unique_ptr<UpdateDialog> updateMessageDialog;
 
+    SyncOverlay *m_sync_overlay;
+    bool m_in_sync;
+
     QLabel *statusbarAlertsLabel;
     QLabel *labelEncryptionIcon;
     QLabel *labelStakingIcon;
@@ -191,6 +195,8 @@ private:
     void createTrayIconMenu();
     /** Set Icons */
     void setIcons();
+    /** Re-check the toolbar action that matches the currently displayed page. */
+    void recheckCurrentTabAction();
 
 
 public slots:

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -23,6 +23,7 @@
 #include "qt/researcher/researchermodel.h"
 #include "qt/researcher/researcherwizard.h"
 
+#include <QApplication>
 #include <QIcon>
 #include <QMessageBox>
 #include <QTimer>
@@ -202,6 +203,15 @@ QIcon ResearcherModel::mapBeaconStatusIcon(const BeaconStatus status) const
 void ResearcherModel::showWizard(WalletModel* wallet_model)
 {
     if (m_wizard_open) {
+        return;
+    }
+
+    if (outOfSync()) {
+        QMessageBox::warning(QApplication::activeWindow(),
+            QObject::tr("Wallet Not In Sync"),
+            QObject::tr("The wallet must be in sync to manage beacons. Please wait "
+               "for synchronization to complete before using the researcher "
+               "and beacon configuration wizard."));
         return;
     }
 

--- a/src/qt/syncoverlay.cpp
+++ b/src/qt/syncoverlay.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/syncoverlay.h"
+#include "qt/decoration.h"
+
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+SyncOverlay::SyncOverlay(QWidget* parent)
+    : QWidget(parent)
+    , m_dismissed(false)
+    , m_out_of_sync(true)
+{
+    // Fill the entire parent widget area and sit on top of everything.
+    setAttribute(Qt::WA_TranslucentBackground, false);
+
+    if (parent) {
+        parent->installEventFilter(this);
+        resize(parent->size());
+    }
+
+    // --- Central panel ---
+
+    QWidget* panel = new QWidget(this);
+    panel->setObjectName("syncOverlayPanel");
+    panel->setStyleSheet(
+        "#syncOverlayPanel {"
+        "  background-color: palette(window);"
+        "  border: 1px solid palette(mid);"
+        "  border-radius: 8px;"
+        "}"
+    );
+    panel->setFixedWidth(480);
+
+    // Icon
+    m_icon_label = new QLabel(panel);
+    m_icon_label->setPixmap(GRC::ScaleIcon(this, ":/icons/no_result", 48));
+    m_icon_label->setAlignment(Qt::AlignCenter);
+
+    // Title
+    m_title_label = new QLabel(panel);
+    m_title_label->setText(tr("Wallet is syncing"));
+    m_title_label->setAlignment(Qt::AlignCenter);
+    QFont title_font = m_title_label->font();
+    title_font.setPointSize(title_font.pointSize() + 4);
+    title_font.setBold(true);
+    m_title_label->setFont(title_font);
+
+    // Detail
+    m_detail_label = new QLabel(panel);
+    m_detail_label->setText(
+        tr("The displayed information may be out of date. Your wallet "
+           "automatically synchronizes with the Gridcoin network after a "
+           "connection is established, but this process has not completed yet."
+           "\n\n"
+           "Operations such as beacon management, voting, and sending "
+           "transactions should not be performed until synchronization "
+           "is complete.")
+    );
+    m_detail_label->setAlignment(Qt::AlignCenter);
+    m_detail_label->setWordWrap(true);
+
+    // Hide button
+    m_hide_button = new QPushButton(tr("Hide"), panel);
+    m_hide_button->setFixedWidth(120);
+    connect(m_hide_button, &QPushButton::clicked, this, &SyncOverlay::dismiss);
+
+    // Panel layout
+    QVBoxLayout* panel_layout = new QVBoxLayout(panel);
+    panel_layout->setContentsMargins(32, 24, 32, 24);
+    panel_layout->setSpacing(12);
+    panel_layout->addWidget(m_icon_label);
+    panel_layout->addWidget(m_title_label);
+    panel_layout->addWidget(m_detail_label);
+
+    QHBoxLayout* button_layout = new QHBoxLayout();
+    button_layout->addStretch();
+    button_layout->addWidget(m_hide_button);
+    button_layout->addStretch();
+    panel_layout->addSpacing(8);
+    panel_layout->addLayout(button_layout);
+
+    // Overlay layout — center the panel
+    QVBoxLayout* outer_v = new QVBoxLayout(this);
+    outer_v->setContentsMargins(0, 0, 0, 0);
+
+    QHBoxLayout* outer_h = new QHBoxLayout();
+    outer_h->addStretch();
+    outer_h->addWidget(panel);
+    outer_h->addStretch();
+
+    outer_v->addStretch();
+    outer_v->addLayout(outer_h);
+    outer_v->addStretch();
+}
+
+bool SyncOverlay::eventFilter(QObject* watched, QEvent* event)
+{
+    if (watched == parent() && event->type() == QEvent::Resize) {
+        resize(parentWidget()->size());
+        raise();
+    }
+
+    return QWidget::eventFilter(watched, event);
+}
+
+void SyncOverlay::setSyncState(bool out_of_sync, int blocks, int total_blocks)
+{
+    m_out_of_sync = out_of_sync;
+
+    if (!out_of_sync) {
+        // In sync — hide unconditionally and reset dismissed state so the
+        // overlay will reappear if the wallet falls out of sync again later.
+        m_dismissed = false;
+        QWidget::hide();
+        return;
+    }
+
+    if (m_dismissed) {
+        return;
+    }
+
+    // Update progress detail. Only show block count and percentage when the
+    // peer median is meaningful (blocks < total_blocks). Otherwise fall back
+    // to the generic message — showing "100%" while out of sync would mislead.
+    if (total_blocks > 0 && blocks < total_blocks) {
+        int pct = static_cast<int>(100.0 * blocks / total_blocks);
+        m_detail_label->setText(
+            tr("The wallet is currently synchronizing with the Gridcoin "
+               "network. Progress: %1 of %2 blocks (%3%)."
+               "\n\n"
+               "Operations such as beacon management, voting, and sending "
+               "transactions should not be performed until synchronization "
+               "is complete.")
+            .arg(blocks)
+            .arg(total_blocks)
+            .arg(pct)
+        );
+    } else {
+        m_detail_label->setText(
+            tr("The displayed information may be out of date. Your wallet "
+               "automatically synchronizes with the Gridcoin network after a "
+               "connection is established, but this process has not completed yet."
+               "\n\n"
+               "Operations such as beacon management, voting, and sending "
+               "transactions should not be performed until synchronization "
+               "is complete.")
+        );
+    }
+
+    raise();
+    show();
+}
+
+bool SyncOverlay::isActive() const
+{
+    return m_out_of_sync && !m_dismissed;
+}
+
+void SyncOverlay::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+
+    QPainter painter(this);
+    painter.fillRect(rect(), QColor(0, 0, 0, 160));
+}
+
+void SyncOverlay::dismiss()
+{
+    m_dismissed = true;
+    QWidget::hide();
+}

--- a/src/qt/syncoverlay.h
+++ b/src/qt/syncoverlay.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SYNCOVERLAY_H
+#define BITCOIN_QT_SYNCOVERLAY_H
+
+#include <QWidget>
+
+class QLabel;
+class QPushButton;
+
+//!
+//! \brief A semi-transparent overlay that covers the main window's central
+//! widget while the wallet is not in sync.
+//!
+//! This prevents users from interacting with features that require an
+//! up-to-date chain state (beacon management, voting, etc.) before the
+//! wallet has finished synchronizing.
+//!
+//! The overlay can be dismissed for the current sync cycle by clicking the
+//! "Hide" button, after which the user can browse the wallet freely (with
+//! per-action guards still in place for dangerous operations). If the wallet
+//! later reaches in-sync and then falls out of sync again, the overlay will
+//! reappear.
+//!
+class SyncOverlay : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SyncOverlay(QWidget* parent);
+
+    //! Update the overlay visibility based on the current sync state.
+    //! When \p out_of_sync is true and the overlay has not been dismissed,
+    //! it is raised to the front and shown. When false, it is hidden.
+    void setSyncState(bool out_of_sync, int blocks, int total_blocks);
+
+    //! Returns true if the overlay is logically active (wallet is out of
+    //! sync and the user has not dismissed the overlay).
+    bool isActive() const;
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+    void paintEvent(QPaintEvent* event) override;
+
+private slots:
+    void dismiss();
+
+private:
+    QLabel* m_icon_label;
+    QLabel* m_title_label;
+    QLabel* m_detail_label;
+    QPushButton* m_hide_button;
+    bool m_dismissed;
+    bool m_out_of_sync;
+};
+
+#endif // BITCOIN_QT_SYNCOVERLAY_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1399,6 +1399,10 @@ UniValue advertisebeacon(const UniValue& params, bool fHelp)
                 "\n"
                 "Advertise a beacon (Requires wallet to be fully unlocked)\n");
 
+    if (OutOfSyncByAge()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to advertise a beacon.");
+    }
+
     EnsureWalletIsUnlocked();
 
     const bool force = params.size() >= 1 ? params[0].get_bool() : false;
@@ -1538,6 +1542,10 @@ UniValue advertisebeaconv3(const UniValue& params, bool fHelp)
                 "  wallet with your original beacon keys but not necessary otherwise.\n"
                 "\n"
                 "Requires wallet to be fully unlocked.\n");
+
+    if (OutOfSyncByAge()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to advertise a beacon.");
+    }
 
     EnsureWalletIsUnlocked();
 
@@ -1679,6 +1687,10 @@ UniValue revokebeacon(const UniValue& params, bool fHelp)
                 "[cpid] CPID associated with the beacon to revoke. If omitted, uses the current CPID.\n"
                 "\n"
                 "Revoke a beacon (Requires wallet to be fully unlocked)\n");
+
+    if (OutOfSyncByAge()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to revoke a beacon.");
+    }
 
     EnsureWalletIsUnlocked();
 

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -653,6 +653,10 @@ UniValue vote(const UniValue& params, bool fHelp)
             "This RPC function is deprecated and may be removed in the future. "
             "Use \"votebyid\" instead.");
 
+    if (OutOfSyncByAge()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to vote.");
+    }
+
     EnsureWalletIsUnlocked();
 
     const std::string title = boost::to_lower_copy(params[0].get_str());
@@ -691,6 +695,10 @@ UniValue votebyid(const UniValue& params, bool fHelp)
             "<choice_ids...> --> Numeric IDs of the choices to vote for.\n"
             "\n"
             "Cast a vote for a poll.\n");
+
+    if (OutOfSyncByAge()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to vote.");
+    }
 
     EnsureWalletIsUnlocked();
 


### PR DESCRIPTION
## Summary
- Add a `SyncOverlay` widget that covers the main window while the wallet is catching up, preventing users from attempting operations that require an up-to-date chain state
- The overlay shows sync progress (block count and percentage) and can be permanently dismissed for the session via a "Hide" button
- Even after dismissing the overlay, per-action guards remain in place:
  - **Beacon wizard**: blocked with a warning dialog (guard in `ResearcherModel::showWizard()` covers all entry points — menu, tray, overview gear icon)
  - **Voting page**: blocked with a warning dialog
  - **Send coins**: warned with a Yes/No confirmation (allows proceeding)
- When a guarded navigation is declined, the toolbar highlight is restored to match the currently displayed page
- **RPC sync guards**: `advertisebeacon`, `advertisebeaconv3`, `revokebeacon`, `vote`, and `votebyid` now reject with an error when the wallet is out of sync (`beaconauth` is excluded since it only generates a local key pair; `addpoll` already had a guard)
- The no-connections early return in `setNumBlocks()` now correctly sets `m_in_sync = false` and updates the overlay, preventing the guards from being bypassed when the wallet loses all connections after having been in sync

This addresses a common support issue where users attempt to set up beacons, vote, or send transactions before their wallet has finished synchronizing. The approach here is similar to current Bitcoin Core.

## Test plan
- [x] Start wallet out of sync — verify overlay appears covering the main window
- [x] Verify sync progress updates in the overlay as blocks are processed
- [x] Resize the main window while the overlay is active — verify the overlay follows and covers the full area
- [x] Click "Hide" — verify overlay is dismissed and does not reappear during the session
- [x] While out of sync, click beacon icon (gear) on overview — verify warning dialog
- [x] While out of sync, click Researcher menu item — verify warning dialog
- [x] While out of sync, click Voting tab — verify warning dialog and toolbar highlight restored
- [x] While out of sync, click Send tab — verify Yes/No warning; "No" restores highlight, "Yes" proceeds
- [x] While out of sync, run `advertisebeacon` via RPC console — verify error
- [x] While out of sync, run `votebyid` via RPC console — verify error
- [x] Once in sync, verify overlay auto-hides and all actions work normally
- [x] Verify overlay reappears if wallet falls out of sync again after having been in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)