### PR TITLE
refactor: add CValidationState and remove embedded DoS scoring (#2877)

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_VALIDATION_H
+#define BITCOIN_CONSENSUS_VALIDATION_H
+
+#include <string>
+
+/** Capture information about block/transaction validation. */
+class CValidationState
+{
+private:
+    enum mode_state {
+        MODE_VALID,   //!< everything ok
+        MODE_INVALID, //!< network rule violation (DoS value may be set)
+        MODE_ERROR,   //!< run-time error
+    } mode;
+    int nDoS;
+    std::string strRejectReason;
+
+public:
+    CValidationState() : mode(MODE_VALID), nDoS(0) {}
+
+    bool DoS(int level, bool ret = false,
+             const std::string& strRejectReasonIn = "")
+    {
+        nDoS += level;
+        mode = MODE_INVALID;
+        strRejectReason = strRejectReasonIn;
+        return ret;
+    }
+
+    bool Invalid(bool ret = false,
+                 const std::string& strRejectReasonIn = "")
+    {
+        return DoS(0, ret, strRejectReasonIn);
+    }
+
+    bool Error(const std::string& strRejectReasonIn = "")
+    {
+        mode = MODE_ERROR;
+        strRejectReason = strRejectReasonIn;
+        return false;
+    }
+
+    bool IsValid() const
+    {
+        return mode == MODE_VALID;
+    }
+
+    bool IsInvalid() const
+    {
+        return mode == MODE_INVALID;
+    }
+
+    bool IsInvalid(int& nDoSOut) const
+    {
+        if (IsInvalid()) {
+            nDoSOut = nDoS;
+            return true;
+        }
+        return false;
+    }
+
+    bool IsError() const
+    {
+        return mode == MODE_ERROR;
+    }
+
+    int GetDoS() const { return nDoS; }
+
+    std::string GetRejectReason() const { return strRejectReason; }
+};
+
+#endif // BITCOIN_CONSENSUS_VALIDATION_H

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -480,7 +480,8 @@ bool CTxDB::LoadBlockIndex()
             }
         }
 
-        if (nCheckLevel>0 && !CheckBlock(block, pindex->nHeight, true, true, (nCheckLevel>6), true))
+        CValidationState check_state;
+        if (nCheckLevel>0 && !CheckBlock(block, check_state, pindex->nHeight, true, true, (nCheckLevel>6), true))
         {
             LogPrintf("LoadBlockIndex() : *** found bad block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             pindexFork = pindex->pprev;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -537,7 +537,7 @@ bool CTxDB::LoadBlockIndex()
                                         LogPrintf("LoadBlockIndex(): *** cannot read spending transaction of %s:%i from disk", hashTx.ToString(), nOutput);
                                         pindexFork = pindex->pprev;
                                     }
-                                    else if (!CheckTransaction(txSpend))
+                                    else if (CValidationState spend_state; !CheckTransaction(txSpend, spend_state))
                                     {
                                         LogPrintf("LoadBlockIndex(): *** spending transaction of %s:%i is invalid", hashTx.ToString(), nOutput);
                                         pindexFork = pindex->pprev;

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -439,6 +439,7 @@ bool GRC::CalculateLegacyV3HashProof(
     CTxDB& txdb,
     const CBlock& block,
     const double por_nonce,
+    CValidationState& state,
     uint256& out_hash_proof)
 {
     const CTransaction& coinstake = block.vtx[1];
@@ -448,7 +449,7 @@ bool GRC::CalculateLegacyV3HashProof(
     CBlockHeader input_block;
 
     if (!ReadStakedInput(txdb, prevout.hash, input_block, input_tx, nullptr)) {
-        return coinstake.DoS(1, error("Read staked input failed."));
+        return state.DoS(1, error("Read staked input failed."));
     }
 
     CHashWriter out(SER_GETHASH, 0);
@@ -583,6 +584,7 @@ bool GRC::CheckProofOfStakeV8(
     CBlockIndex* pindexPrev, //previous block in chain index
     CBlock& Block, //block to check
     bool generated_by_me,
+    CValidationState& state,
     uint256& hashProofOfStake) //proof hash out-parameter
 {
     //Block Transaction 0 is coin:base
@@ -603,21 +605,21 @@ bool GRC::CheckProofOfStakeV8(
     CTransaction txPrev;
 
     if (!ReadStakedInput(txdb, prevout.hash, header, txPrev, pindexPrev))
-        return tx.DoS(10, error("%s: read staked input failed", __func__));
+        return state.DoS(10, error("%s: read staked input failed", __func__));
 
     if (!VerifySignature(txPrev, tx, SCRIPT_VERIFY_P2SH, 0, 0))
-        return tx.DoS(100, error("%s: VerifySignature failed on coinstake %s", __func__, tx.GetHash().ToString()));
+        return state.DoS(100, error("%s: VerifySignature failed on coinstake %s", __func__, tx.GetHash().ToString()));
 
     // Check times
     if (tx.nTime < txPrev.nTime)
-        return tx.DoS(100, error("%s: nTime violation", __func__));
+        return state.DoS(100, error("%s: nTime violation", __func__));
 
     if (header.nTime + nStakeMinAge > tx.nTime)
-        return tx.DoS(100, error("%s: min age violation", __func__));
+        return state.DoS(100, error("%s: min age violation", __func__));
 
     if (Block.nVersion >= 12) {
         if (tx.nTime != MaskStakeTime(tx.nTime)) {
-            return tx.DoS(100, error("%s: mask violation", __func__));
+            return state.DoS(100, error("%s: mask violation", __func__));
         }
     }
 
@@ -650,7 +652,7 @@ bool GRC::CheckProofOfStakeV8(
 
     // Now check if proof-of-stake hash meets target protocol
     if (bnHashProof > bnTarget) {
-        return tx.DoS(100, error("%s: invalid proof (proof: %s, target: %s)", __func__, bnHashProof.GetHex(), bnTarget.GetHex()));
+        return state.DoS(100, error("%s: invalid proof (proof: %s, target: %s)", __func__, bnHashProof.GetHex(), bnTarget.GetHex()));
     }
 
     return true;

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -91,6 +91,7 @@ bool CalculateLegacyV3HashProof(
     CTxDB& txdb,
     const CBlock& block,
     const double por_nonce,
+    CValidationState& state,
     uint256& out_hash_proof);
 
 //Block version 8+ Staking
@@ -99,6 +100,7 @@ bool CheckProofOfStakeV8(
     CBlockIndex* pindexPrev, //previous block in chain index
     CBlock& Block, //block to check
     bool generated_by_me,
+    CValidationState& state,
     uint256& hashProofOfStake); //proof hash out-parameter
 
 bool FindStakeModifierRev(uint64_t& StakeModifier, CBlockIndex* pindexPrev, int &nHeight);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -366,7 +366,7 @@ int CMerkleTx::SetMerkleBranch(const CBlock* pblock) EXCLUSIVE_LOCKS_REQUIRED(cs
 }
 
 
-bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& state, bool* pfMissingInputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     if (pfMissingInputs)
@@ -374,19 +374,19 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
 
     // Mandatory switch to binary contracts (tx version 2):
     if (tx.nVersion < 2) {
-        return tx.DoS(100, error("AcceptToMemoryPool : legacy transaction"));
+        return state.DoS(100, error("AcceptToMemoryPool : legacy transaction"));
     }
 
-    if (!CheckTransaction(tx))
+    if (!CheckTransaction(tx, state))
         return error("AcceptToMemoryPool : CheckTransaction failed");
 
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
-        return tx.DoS(100, error("AcceptToMemoryPool : coinbase as individual tx"));
+        return state.DoS(100, error("AcceptToMemoryPool : coinbase as individual tx"));
 
     // ppcoin: coinstake is also only valid in a block, not as a loose transaction
     if (tx.IsCoinStake())
-        return tx.DoS(100, error("AcceptToMemoryPool : coinstake as individual tx"));
+        return state.DoS(100, error("AcceptToMemoryPool : coinstake as individual tx"));
 
     // Rather not work on nonstandard transactions
     if (!IsStandardTx(tx))
@@ -396,7 +396,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
 
     int DoS = 0;
     if (!tx.GetContracts().empty() && !GRC::ValidateContracts(tx, DoS)) {
-        return tx.DoS(DoS, error("%s: invalid contract in tx %s, assigning DoS misbehavior of %i",
+        return state.DoS(DoS, error("%s: invalid contract in tx %s, assigning DoS misbehavior of %i",
                                  __func__,
                                  tx.GetHash().ToString(),
                                  DoS));
@@ -452,7 +452,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
                         // Reject and put a stiff DoS...
                         if (!found && cpid == other_cpid) {
                             found = true;
-                            tx.DoS(25, error("%s: MRC contract in tx %s has the same CPID as an existing transaction "
+                            state.DoS(25, error("%s: MRC contract in tx %s has the same CPID as an existing transaction "
                                              "in the memory pool, %s.",
                                              __func__,
                                              tx.GetHash().ToString(),
@@ -512,7 +512,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
         MapPrevTx mapInputs;
         map<uint256, CTxIndex> mapUnused;
         bool fInvalid = false;
-        if (!FetchInputs(tx, txdb, mapUnused, false, false, mapInputs, fInvalid))
+        if (!FetchInputs(tx, state, txdb, mapUnused, false, false, mapInputs, fInvalid))
         {
             if (fInvalid)
                 return error("AcceptToMemoryPool : FetchInputs found invalid tx %s", hash.ToString().substr(0,10).c_str());
@@ -540,7 +540,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
                          nFees, txMinFee, nSize);
 
         // Validate any contracts published in the transaction:
-        if (!tx.GetContracts().empty() && !CheckContracts(tx, mapInputs, pindexBest->nHeight)) {
+        if (!tx.GetContracts().empty() && !CheckContracts(tx, state, mapInputs, pindexBest->nHeight)) {
             return false;
         }
 
@@ -554,7 +554,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool* pfMissingInput
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!ConnectInputs(tx, txdb, mapInputs, mapUnused, CDiskTxPos(1,1,1), pindexBest, false, false))
+        if (!ConnectInputs(tx, state, txdb, mapInputs, mapUnused, CDiskTxPos(1,1,1), pindexBest, false, false))
         {
             LogPrint(BCLog::LogFlags::MEMPOOL, "WARNING: %s: Unable to Connect Inputs %s.",
                      __func__,
@@ -699,7 +699,8 @@ int CMerkleTx::GetBlocksToMaturity() const
 
 bool CMerkleTx::AcceptToMemoryPool() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    return ::AcceptToMemoryPool(mempool, *this, nullptr);
+    CValidationState state;
+    return ::AcceptToMemoryPool(mempool, *this, state, nullptr);
 }
 
 
@@ -1032,8 +1033,10 @@ bool DisconnectBlocksBatch(CTxDB& txdb, list<CTransaction>& vResurrect, unsigned
     if (cnt_dis > 0)
     {
         // Resurrect memory transactions that were in the disconnected branch
-        for( CTransaction& tx : vResurrect)
-            AcceptToMemoryPool(mempool, tx, nullptr);
+        for( CTransaction& tx : vResurrect) {
+            CValidationState resurrect_state;
+            AcceptToMemoryPool(mempool, tx, resurrect_state, nullptr);
+        }
 
         if (!txdb.TxnCommit())
             return error("DisconnectBlocksBatch: TxnCommit failed"); /*fatal*/
@@ -1185,7 +1188,8 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                 assert(pindex->GetBlockHash()==block.GetHash(true));
                 assert(pindex->pprev == pindexBest);
 
-                if (!ConnectBlock(block, txdb, pindex, false)) {
+                CValidationState connect_state;
+                if (!ConnectBlock(block, connect_state, txdb, pindex, false)) {
                     txdb.TxnAbort();
                     error("%s: ConnectBlock %s failed, Previous block %s",
                           __func__,
@@ -1467,7 +1471,7 @@ bool AskForOutstandingBlocks(uint256 hashStart)
     return true;
 }
 
-bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -1494,7 +1498,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
     }
 
     // Preliminary checks
-    if (!CheckBlock(*pblock, pindexBest->nHeight + 1))
+    if (!CheckBlock(*pblock, state, pindexBest->nHeight + 1))
         return error("ProcessBlock() : CheckBlock FAILED");
 
     // If don't already have its previous block, shunt it off to holding area until we get it
@@ -1550,7 +1554,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
     }
 
     // Store to disk
-    if (!AcceptBlock(*pblock, generated_by_me))
+    if (!AcceptBlock(*pblock, state, generated_by_me))
         return error("ProcessBlock() : AcceptBlock FAILED");
 
     // Recursively process any orphan blocks that depended on this one
@@ -1564,7 +1568,8 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
              ++mi)
         {
             CBlock* pblockOrphan = mi->second;
-            if (AcceptBlock(*pblockOrphan, generated_by_me))
+            CValidationState orphan_state;
+            if (AcceptBlock(*pblockOrphan, orphan_state, generated_by_me))
                 vWorkQueue.push_back(pblockOrphan->GetHash(true));
             mapOrphanBlocks.erase(pblockOrphan->GetHash(true));
             g_seen_stakes.ForgetOrphan(pblockOrphan->vtx[1]);
@@ -1748,7 +1753,7 @@ bool LoadBlockIndex(bool fAllowNew)
         uint256 merkle_root = uint256S("0x5109d5782a26e6a5a5eb76c7867f3e8ddae2bff026632c36afec5dc32ed8ce9f");
         assert(block.hashMerkleRoot == merkle_root);
         assert(block.GetHash(true) == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet));
-        assert(CheckBlock(block, 1));
+        { CValidationState genesis_state; assert(CheckBlock(block, genesis_state, 1)); }
 
         // Start new block file
         unsigned int nFile;
@@ -1907,7 +1912,8 @@ bool LoadExternalBlockFile(FILE* fileIn, size_t file_size, unsigned int percent_
                 {
                     CBlock block;
                     blkdat >> block;
-                    if (ProcessBlock(nullptr, &block, false)) {
+                    CValidationState load_state;
+                    if (ProcessBlock(nullptr, &block, false, load_state)) {
                         ++nLoaded;
 
                         if (display_progress) {
@@ -2567,8 +2573,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LOCK(cs_main);
 
+        CValidationState state;
         bool fMissingInputs = false;
-        if (AcceptToMemoryPool(mempool, tx, &fMissingInputs))
+        if (AcceptToMemoryPool(mempool, tx, state, &fMissingInputs))
         {
             RelayTransaction(tx, inv.hash);
             mapAlreadyAskedFor.erase(inv);
@@ -2585,9 +2592,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 {
                     const uint256& orphanTxHash = *mi;
                     CTransaction& orphanTx = mapOrphanTransactions[orphanTxHash];
+                    CValidationState orphan_state;
                     bool fMissingInputs2 = false;
 
-                    if (AcceptToMemoryPool(mempool, orphanTx, &fMissingInputs2))
+                    if (AcceptToMemoryPool(mempool, orphanTx, orphan_state, &fMissingInputs2))
                     {
                         LogPrintf("   accepted orphan tx %s", orphanTxHash.ToString().substr(0,10));
                         RelayTransaction(orphanTx, orphanTxHash);
@@ -2617,7 +2625,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             if (nEvicted > 0)
                 LogPrintf("mapOrphan overflow, removed %u tx", nEvicted);
         }
-        if (tx.nDoS) pfrom->Misbehaving(tx.nDoS);
+        int nDoS = 0;
+        if (state.IsInvalid(nDoS) && nDoS > 0)
+            pfrom->Misbehaving(nDoS);
     }
 
 
@@ -2638,14 +2648,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LOCK(cs_main);
 
-        if (ProcessBlock(pfrom, &block, false))
+        CValidationState state;
+        if (ProcessBlock(pfrom, &block, false, state))
         {
             mapAlreadyAskedFor.erase(inv);
             pfrom->nTrust++;
         }
-        if (block.nDoS)
+        int nDoS = 0;
+        if (state.IsInvalid(nDoS) && nDoS > 0)
         {
-                pfrom->Misbehaving(block.nDoS);
+                pfrom->Misbehaving(nDoS);
                 pfrom->nTrust--;
         }
 

--- a/src/main.h
+++ b/src/main.h
@@ -115,7 +115,7 @@ void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = nullptr, bool fUpdate = false, bool fConnect = true);
 void UpdatedTransaction(const uint256& hashTx);
-bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me);
+bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state);
 bool CheckDiskSpace(uint64_t nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);
@@ -139,7 +139,7 @@ bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx,
-                        bool* pfMissingInputs);
+                        CValidationState& state, bool* pfMissingInputs);
 bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew);
 
 
@@ -344,10 +344,6 @@ public:
     // memory only
     mutable bool fChecked;
 
-    // Denial-of-service detection:
-    mutable int nDoS;
-    bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
-
     CBlock()
     {
         SetNull();
@@ -383,7 +379,6 @@ public:
         vtx.clear();
         vchBlockSig.clear();
         fChecked = false;
-        nDoS = 0;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -527,7 +527,8 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
             map<uint256, CTxIndex> mapTestPoolTmp(mapTestPool);
             MapPrevTx mapInputs;
             bool fInvalid;
-            if (!FetchInputs(tx, txdb, mapTestPoolTmp, false, true, mapInputs, fInvalid))
+            CValidationState miner_state;
+            if (!FetchInputs(tx, miner_state, txdb, mapTestPoolTmp, false, true, mapInputs, fInvalid))
             {
                 LogPrint(BCLog::LogFlags::NOISY, "Unable to fetch inputs for tx %s ", tx.GetHash().GetHex());
                 continue;
@@ -553,7 +554,7 @@ bool CreateRestOfTheBlock(CBlock &block, CBlockIndex* pindexPrev,
                 continue;
             }
 
-            if (!ConnectInputs(tx, txdb, mapInputs, mapTestPoolTmp, CDiskTxPos(1,1,1), pindexPrev, false, true))
+            if (!ConnectInputs(tx, miner_state, txdb, mapInputs, mapTestPoolTmp, CDiskTxPos(1,1,1), pindexPrev, false, true))
             {
                 LogPrint(BCLog::LogFlags::NOISY, "Unable to connect inputs for tx %s ",tx.GetHash().GetHex());
                 continue;
@@ -1504,7 +1505,8 @@ void StakeMiner(CWallet *pwallet)
         }
 
         // * delegate to ProcessBlock
-        if (!ProcessBlock(nullptr, &StakeBlock, true)) {
+        CValidationState stake_state;
+        if (!ProcessBlock(nullptr, &StakeBlock, true, stake_state)) {
             error("%s: Block vehemently rejected", __func__);
             continue;
         }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -244,9 +244,6 @@ public:
     std::vector<CTxOut> vout;
     unsigned int nLockTime;
 
-    // Denial-of-service detection:
-    mutable int nDoS;
-    bool DoS(int nDoSIn, bool fIn) const { nDoS += nDoSIn; return fIn; }
     std::string hashBoinc;
     std::vector<GRC::Contract> vContracts;
 
@@ -280,7 +277,6 @@ public:
         vin.clear();
         vout.clear();
         nLockTime = 0;
-        nDoS = 0;  // Denial-of-service prevention
         hashBoinc = "";
         vContracts.clear();
     }

--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -239,8 +239,11 @@ UniValue claimhtlc(const UniValue& params, bool fHelp)
     }
 
     // Broadcast
-    if (!AcceptToMemoryPool(mempool, txSpend, nullptr))
-        throw JSONRPCError(RPC_TRANSACTION_ERROR, "Transaction rejected by mempool");
+    {
+        CValidationState state;
+        if (!AcceptToMemoryPool(mempool, txSpend, state, nullptr))
+            throw JSONRPCError(RPC_TRANSACTION_ERROR, "Transaction rejected by mempool");
+    }
 
     uint256 txHash = txSpend.GetHash();
     SyncWithWallets(txSpend, nullptr, true);
@@ -375,8 +378,11 @@ UniValue refundhtlc(const UniValue& params, bool fHelp)
     }
 
     // Broadcast
-    if (!AcceptToMemoryPool(mempool, txSpend, nullptr))
-        throw JSONRPCError(RPC_TRANSACTION_ERROR, "Transaction rejected by mempool");
+    {
+        CValidationState state;
+        if (!AcceptToMemoryPool(mempool, txSpend, state, nullptr))
+            throw JSONRPCError(RPC_TRANSACTION_ERROR, "Transaction rejected by mempool");
+    }
 
     uint256 txHash = txSpend.GetHash();
     SyncWithWallets(txSpend, nullptr, true);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1706,7 +1706,8 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
 
         // FetchInputs aborts on failure, so we go one at a time.
         tempTx.vin.push_back(mergedTx.vin[i]);
-        FetchInputs(tempTx, txdb, unused, false, false, mapPrevTx, fInvalid);
+        CValidationState fetch_state;
+        FetchInputs(tempTx, fetch_state, txdb, unused, false, false, mapPrevTx, fInvalid);
 
         // Copy results into mapPrevOut:
         for (auto const& txin : tempTx.vin)
@@ -1884,7 +1885,8 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
     else
     {
         // push to local node
-        if (!AcceptToMemoryPool(mempool, tx, nullptr))
+        CValidationState state;
+        if (!AcceptToMemoryPool(mempool, tx, state, nullptr))
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX rejected");
 
         SyncWithWallets(tx, nullptr, true);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -152,7 +152,8 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             stream >> btx;
             CTransaction tx = ConvertFromMutableBitcoinTransaction(btx);
 
-            BOOST_CHECK_MESSAGE(CheckTransaction(tx), strTest);
+            CValidationState valid_state;
+            BOOST_CHECK_MESSAGE(CheckTransaction(tx, valid_state), strTest);
 
             for (unsigned int i = 0; i < tx.vin.size(); i++)
             {
@@ -225,7 +226,8 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             stream >> btx;
             CTransaction tx = ConvertFromMutableBitcoinTransaction(btx);
 
-            fValid = CheckTransaction(tx);
+            CValidationState invalid_state;
+            fValid = CheckTransaction(tx, invalid_state);
 
             for (unsigned int i = 0; i < tx.vin.size() && fValid; i++)
             {
@@ -277,11 +279,13 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
     CMutableBitcoinTransaction btx;
     stream >> btx;
     CTransaction tx = ConvertFromMutableBitcoinTransaction(btx);
-    BOOST_CHECK_MESSAGE(CheckTransaction(tx), "Simple deserialized transaction should be valid.");
+    CValidationState deser_state;
+    BOOST_CHECK_MESSAGE(CheckTransaction(tx, deser_state), "Simple deserialized transaction should be valid.");
 
     // Check that duplicate txins fail
     tx.vin.push_back(tx.vin[0]);
-    BOOST_CHECK_MESSAGE(!CheckTransaction(tx), "Transaction with duplicate txins should be invalid.");
+    CValidationState dup_state;
+    BOOST_CHECK_MESSAGE(!CheckTransaction(tx, dup_state), "Transaction with duplicate txins should be invalid.");
 }
 
 //

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -94,16 +94,16 @@ bool ReadTxFromDisk(CTransaction& tx, COutPoint prevout)
     return ReadTxFromDisk(tx, txdb, prevout, txindex);
 }
 
-bool CheckTransaction(const CTransaction& tx)
+bool CheckTransaction(const CTransaction& tx, CValidationState& state)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
-        return tx.DoS(10, error("CheckTransaction() : vin empty"));
+        return state.DoS(10, error("CheckTransaction() : vin empty"));
     if (tx.vout.empty())
-        return tx.DoS(10, error("CheckTransaction() : vout empty"));
+        return state.DoS(10, error("CheckTransaction() : vout empty"));
     // Size limits - don't count coinbase superblocks--we check this at the block level:
     if (GetSerializeSize(tx, (SER_NETWORK & SER_SKIPSUPERBLOCK), PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
-        return tx.DoS(100, error("CheckTransaction() : size limits failed"));
+        return state.DoS(100, error("CheckTransaction() : size limits failed"));
 
     // Check for negative or overflow output values (see CVE-2010-5139)
     CAmount nValueOut = 0;
@@ -111,14 +111,14 @@ bool CheckTransaction(const CTransaction& tx)
     {
         const CTxOut& txout = tx.vout[i];
         if (txout.IsEmpty() && !tx.IsCoinBase() && !tx.IsCoinStake())
-            return tx.DoS(100, error("CheckTransaction() : txout empty for user transaction"));
+            return state.DoS(100, error("CheckTransaction() : txout empty for user transaction"));
         if (txout.nValue < 0)
-            return tx.DoS(100, error("CheckTransaction() : txout.nValue negative"));
+            return state.DoS(100, error("CheckTransaction() : txout.nValue negative"));
         if (txout.nValue > MAX_MONEY)
-            return tx.DoS(100, error("CheckTransaction() : txout.nValue too high"));
+            return state.DoS(100, error("CheckTransaction() : txout.nValue too high"));
         nValueOut += txout.nValue;
         if (!MoneyRange(nValueOut))
-            return tx.DoS(100, error("CheckTransaction() : txout total out of range"));
+            return state.DoS(100, error("CheckTransaction() : txout total out of range"));
     }
     // Check for duplicate inputs
     std::set<COutPoint> vInOutPoints;
@@ -132,19 +132,19 @@ bool CheckTransaction(const CTransaction& tx)
     if (tx.IsCoinBase())
     {
         if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
-            return tx.DoS(100, error("CheckTransaction() : coinbase script size is invalid"));
+            return state.DoS(100, error("CheckTransaction() : coinbase script size is invalid"));
     }
     else
     {
         for (auto const& txin : tx.vin)
             if (txin.prevout.IsNull())
-                return tx.DoS(10, error("CheckTransaction() : prevout is null"));
+                return state.DoS(10, error("CheckTransaction() : prevout is null"));
     }
 
     return true;
 }
 
-bool CheckContracts(const CTransaction& tx, const MapPrevTx& inputs, int block_height)
+bool CheckContracts(const CTransaction& tx, CValidationState& state, const MapPrevTx& inputs, int block_height)
 {
     if (tx.nVersion <= 1) {
         return true;
@@ -153,28 +153,28 @@ bool CheckContracts(const CTransaction& tx, const MapPrevTx& inputs, int block_h
     // Although v2 transactions support multiple contracts, we just allow one
     // for now to mitigate spam:
     if (tx.GetContracts().size() > 1) {
-        return tx.DoS(100, error("%s: only one contract allowed in tx", __func__));
+        return state.DoS(100, error("%s: only one contract allowed in tx", __func__));
     }
 
     if ((tx.IsCoinBase() || tx.IsCoinStake())) {
-        return tx.DoS(100, error("%s: contract in non-standard tx", __func__));
+        return state.DoS(100, error("%s: contract in non-standard tx", __func__));
     }
 
     CAmount required_burn_fee = 0;
 
     for (const auto& contract : tx.GetContracts()) {
         if (contract.m_version <= 1) {
-            return tx.DoS(100, error("%s: legacy contract", __func__));
+            return state.DoS(100, error("%s: legacy contract", __func__));
         }
 
         if (!contract.WellFormed()) {
-            return tx.DoS(100, error("%s: malformed contract", __func__));
+            return state.DoS(100, error("%s: malformed contract", __func__));
         }
 
         // Reject any transactions with administrative contracts sent from a
         // wallet that does not hold the master key:
         if (contract.RequiresMasterKey() && !HasMasterKeyInput(tx, inputs, block_height)) {
-            return tx.DoS(100, error("%s: contract requires master key", __func__));
+            return state.DoS(100, error("%s: contract requires master key", __func__));
         }
 
         required_burn_fee += contract.RequiredBurnAmount();
@@ -189,7 +189,7 @@ bool CheckContracts(const CTransaction& tx, const MapPrevTx& inputs, int block_h
     }
 
     if (supplied_burn_fee < required_burn_fee) {
-        return tx.DoS(100, error(
+        return state.DoS(100, error(
             "%s: insufficient burn output. Required: %s, supplied: %s",
             __func__,
             FormatMoney(required_burn_fee),
@@ -281,7 +281,7 @@ bool DisconnectInputs(CTransaction& tx, CTxDB& txdb)
 }
 
 
-bool FetchInputs(CTransaction& tx, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool,
+bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool,
                  bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid)
 {
     // FetchInputs can return false either because we just haven't seen some inputs
@@ -348,14 +348,14 @@ bool FetchInputs(CTransaction& tx, CTxDB& txdb, const std::map<uint256, CTxIndex
             // Revisit this if/when transaction replacement is implemented and allows
             // adding inputs:
             fInvalid = true;
-            return tx.DoS(100, error("FetchInputs() : %s prevout.n out of range %d %" PRIszu " %" PRIszu " prev tx %s\n%s", tx.GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
+            return state.DoS(100, error("FetchInputs() : %s prevout.n out of range %d %" PRIszu " %" PRIszu " prev tx %s\n%s", tx.GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
         }
     }
 
     return true;
 }
 
-bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
+bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
     const CBlockIndex* pindexBlock, bool fBlock, bool fMiner)
 {
     // Take over previous transactions' spent pointers
@@ -374,7 +374,7 @@ bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uin
             CTransaction& txPrev = inputs[prevout.hash].second;
 
             if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.vSpent.size())
-                return tx.DoS(100, error("ConnectInputs() : %s prevout.n out of range %d %" PRIszu " %" PRIszu " prev tx %s\n%s", tx.GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
+                return state.DoS(100, error("ConnectInputs() : %s prevout.n out of range %d %" PRIszu " %" PRIszu " prev tx %s\n%s", tx.GetHash().ToString().substr(0,10).c_str(), prevout.n, txPrev.vout.size(), txindex.vSpent.size(), prevout.hash.ToString().substr(0,10).c_str(), txPrev.ToString().c_str()));
 
             // If prev is coinbase or coinstake, check that it's matured
             if (txPrev.IsCoinBase() || txPrev.IsCoinStake())
@@ -384,12 +384,12 @@ bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uin
 
             // ppcoin: check transaction timestamp
             if (txPrev.nTime > tx.nTime)
-                return tx.DoS(100, error("ConnectInputs() : transaction timestamp earlier than input transaction"));
+                return state.DoS(100, error("ConnectInputs() : transaction timestamp earlier than input transaction"));
 
             // Check for negative or overflow input values
             nValueIn += txPrev.vout[prevout.n].nValue;
             if (!MoneyRange(txPrev.vout[prevout.n].nValue) || !MoneyRange(nValueIn))
-                return tx.DoS(100, error("ConnectInputs() : txin values out of range"));
+                return state.DoS(100, error("ConnectInputs() : txin values out of range"));
 
         }
         // The first loop above does all the inexpensive checks.
@@ -437,7 +437,7 @@ bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uin
                 // Verify signature
                 if (!VerifySignature(txPrev, tx, GetBlockScriptFlags(*pindexBlock), i, 0))
                 {
-                    return tx.DoS(100,error("ConnectInputs() : %s VerifySignature failed", tx.GetHash().ToString().substr(0,10).c_str()));
+                    return state.DoS(100,error("ConnectInputs() : %s VerifySignature failed", tx.GetHash().ToString().substr(0,10).c_str()));
                 }
             }
 
@@ -456,21 +456,21 @@ bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uin
             if (nValueIn < tx.GetValueOut())
             {
                 LogPrintf("ConnectInputs(): VALUE IN < VALUEOUT ");
-                return tx.DoS(100, error("ConnectInputs() : %s value in < value out", tx.GetHash().ToString().substr(0,10).c_str()));
+                return state.DoS(100, error("ConnectInputs() : %s value in < value out", tx.GetHash().ToString().substr(0,10).c_str()));
             }
 
             // Tally transaction fees
             CAmount nTxFee = nValueIn - tx.GetValueOut();
             if (nTxFee < 0)
-                return tx.DoS(100, error("ConnectInputs() : %s nTxFee < 0", tx.GetHash().ToString().substr(0,10).c_str()));
+                return state.DoS(100, error("ConnectInputs() : %s nTxFee < 0", tx.GetHash().ToString().substr(0,10).c_str()));
 
             // enforce transaction fees for every block
             if (nTxFee < GetMinFee(tx))
-                return fBlock? tx.DoS(100, error("ConnectInputs() : %s not paying required fee=%s, paid=%s", tx.GetHash().ToString().substr(0,10).c_str(), FormatMoney(GetMinFee(tx)).c_str(), FormatMoney(nTxFee).c_str())) : false;
+                return fBlock? state.DoS(100, error("ConnectInputs() : %s not paying required fee=%s, paid=%s", tx.GetHash().ToString().substr(0,10).c_str(), FormatMoney(GetMinFee(tx)).c_str(), FormatMoney(nTxFee).c_str())) : false;
 
             nFees += nTxFee;
             if (!MoneyRange(nFees))
-                return tx.DoS(100, error("ConnectInputs() : nFees out of range"));
+                return state.DoS(100, error("ConnectInputs() : nFees out of range"));
         }
     }
 
@@ -740,12 +740,14 @@ class ClaimValidator
 public:
     ClaimValidator(
         const CBlock& block,
+        CValidationState& state,
         const CBlockIndex* const pindex,
         const CAmount stake_value_in,
         const CAmount total_claimed,
         const CAmount fees,
         const CAmount coin_age)
         : m_block(block)
+        , m_state(state)
         , m_pindex(pindex)
         , m_claim(block.GetClaim())
         , m_stake_value_in(stake_value_in)
@@ -764,6 +766,7 @@ public:
 
 private:
     const CBlock& m_block;
+    CValidationState& m_state;
     const CBlockIndex* const m_pindex;
     const GRC::Claim& m_claim;
     const int64_t m_stake_value_in;
@@ -1080,7 +1083,7 @@ private:
             return true;
         }
 
-        return m_block.DoS(10, error(
+        return m_state.DoS(10, error(
                                    "ConnectBlock[%s]: non-cruncher claim %s, expected %s, fees %: %s",
                                    __func__,
                                    FormatMoney(m_total_claimed),
@@ -1131,7 +1134,7 @@ private:
         const CAmount max_reward = 12750 * COIN;
 
         return m_claim.m_research_subsidy <= max_reward
-            || m_block.DoS(1, error(
+            || m_state.DoS(1, error(
                 "ConnectBlock[%s]: research claim %s exceeds max %s. CPID %s",
                 __func__,
                 FormatMoney(m_claim.m_research_subsidy),
@@ -1154,7 +1157,7 @@ private:
         }
 
         return m_claim.TotalSubsidy() + drift_allowed >= reward_claimed
-            || m_block.DoS(20, error(
+            || m_state.DoS(20, error(
                 "ConnectBlock[%s]: reward claim %s exceeds allowed %s. CPID %s",
                 __func__,
                 FormatMoney(reward_claimed),
@@ -1168,7 +1171,7 @@ private:
         const double mag = GRC::Quorum::GetMagnitude(m_claim.m_mining_id).Floating();
 
         return m_claim.m_magnitude <= (mag * 1.25)
-            || m_block.DoS(20, error(
+            || m_state.DoS(20, error(
                 "ConnectBlock[%s]: magnitude claim %f exceeds superblock %f. CPID %s",
                 __func__,
                 m_claim.m_magnitude,
@@ -1227,7 +1230,7 @@ private:
             return true;
         }
 
-        return m_block.DoS(20, error(
+        return m_state.DoS(20, error(
             "ConnectBlock[%s]: signature verification failed. CPID %s, LBH %s",
             __func__,
             m_claim.m_mining_id.ToString(),
@@ -1314,7 +1317,7 @@ private:
             return true;
         }
 
-        return m_block.DoS(10, error(
+        return m_state.DoS(10, error(
                                    "ConnectBlock[%s]: researcher claim %s compared to expected %s for CPID %s. "
                                    "Expected research %s, stake %s, fees %s. "
                                    "Claimed research %s, stake %s: %s",
@@ -1349,7 +1352,7 @@ private:
         // If the number of MRCs in the claim's mrc tx map exceeds the output limit, then validation fails. This would be
         // a problem introduced by the staking node and should get the same DoS as other claim validation errors above.
         if (mrc_claimed_outputs > mrc_output_limit) {
-            return m_block.DoS(10, error(
+            return m_state.DoS(10, error(
                                    "ConnectBlock[%s]: MRC claimed outputs, %u, exceeds max of %u excluding foundation "
                                    "sidestake.",
                                    __func__,
@@ -1382,7 +1385,7 @@ private:
                                     // If an MRC fails validation no point in continuing. Return false immediately with an
                                     // appropriate DoS.
                                     if (!ValidateMRC(m_pindex->pprev, mrc)) {
-                                        return m_block.DoS(10, error(
+                                        return m_state.DoS(10, error(
                                                                "ConnectBlock[%s]: An MRC in the claim failed to validate.",
                                                                __func__));
                                     }
@@ -1427,7 +1430,7 @@ private:
                                     // If this doesn't match we have a problem with the correlation between the coinstake
                                     // and the claim in the MRC area.
                                     if (coinstake_mrc_reward != mrc_reward) {
-                                        return m_block.DoS(10, error(
+                                        return m_state.DoS(10, error(
                                                                "ConnectBlock[%s]: The rewards in an MRC, %s, do not "
                                                                "correspond to the value of the corresponding output "
                                                                "on the coinstake, %s.",
@@ -1480,7 +1483,7 @@ private:
         // mrc_tx_map, because the hashes in the mrc_tx_map (the values) are also unique. The greater than condition is
         // checked first above.
         if (mrc_outputs < mrc_claimed_outputs) {
-            return m_block.DoS(10, error(
+            return m_state.DoS(10, error(
                                    "ConnectBlock[%s]: The number of validated claims in MRC transactions, %u, "
                                    "is less than the number of MRCs in the stake claim, %u.",
                                    __func__,
@@ -1500,6 +1503,7 @@ private:
 
 bool TryLoadSuperblock(
     CBlock& block,
+    CValidationState& state,
     const CBlockIndex* const pindex,
     const GRC::Claim& claim)
 {
@@ -1512,7 +1516,7 @@ bool TryLoadSuperblock(
     if ((!fColdBoot || block.nVersion >= 11)
         && !GRC::Quorum::ValidateSuperblockClaim(claim, superblock, pindex))
     {
-        return block.DoS(25, error("ConnectBlock: Rejected invalid superblock."));
+        return state.DoS(25, error("ConnectBlock: Rejected invalid superblock."));
     }
 
     // Block versions 11+ calculate research rewards from snapshots of
@@ -1545,6 +1549,7 @@ bool TryLoadSuperblock(
 
 bool GridcoinConnectBlock(
     CBlock& block,
+    CValidationState& state,
     CBlockIndex* const pindex,
     CTxDB& txdb,
     const int64_t stake_value_in,
@@ -1559,12 +1564,12 @@ bool GridcoinConnectBlock(
             return false;
         }
 
-        if (!ClaimValidator(block, pindex, stake_value_in, total_claimed, fees, out_coin_age).Check()) {
+        if (!ClaimValidator(block, state, pindex, stake_value_in, total_claimed, fees, out_coin_age).Check()) {
             return false;
         }
 
         if (claim.ContainsSuperblock()) {
-            if (!TryLoadSuperblock(block, pindex, claim)) {
+            if (!TryLoadSuperblock(block, state, pindex, claim)) {
                 return false;
             }
 
@@ -1648,10 +1653,10 @@ unsigned int GetBlockScriptFlags(const CBlockIndex& block_index)
     return flags;
 }
 
-bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
+bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
 {
     // Check it again in case a previous version let a bad block in, but skip BlockSig checking
-    if (!CheckBlock(block, pindex->nHeight, !fJustCheck, !fJustCheck, false, false))
+    if (!CheckBlock(block, state, pindex->nHeight, !fJustCheck, !fJustCheck, false, false))
     {
         return error("%s: CheckBlock failed", __func__);
     }
@@ -1680,7 +1685,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
     if (block.nVersion >= 8 && pindex->nStakeModifier == 0)
     {
         uint256 tmp_hashProof;
-        if (!GRC::CheckProofOfStakeV8(txdb, pindex->pprev, block, /*generated_by_me*/ false, tmp_hashProof))
+        if (!GRC::CheckProofOfStakeV8(txdb, pindex->pprev, block, /*generated_by_me*/ false, state, tmp_hashProof))
             return error("%s: check proof-of-stake failed", __func__);
     }
 
@@ -1709,7 +1714,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
 
         nSigOps += GetLegacySigOpCount(tx);
         if (nSigOps > MAX_BLOCK_SIGOPS)
-            return block.DoS(100, error("%s: too many sigops", __func__));
+            return state.DoS(100, error("%s: too many sigops", __func__));
 
         CDiskTxPos posThisTx(pindex->nFile, pindex->nBlockPos, nTxPos);
         if (!fJustCheck)
@@ -1723,7 +1728,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
         else
         {
             bool fInvalid;
-            if (!FetchInputs(tx, txdb, mapQueuedChanges, true, false, mapInputs, fInvalid))
+            if (!FetchInputs(tx, state, txdb, mapQueuedChanges, true, false, mapInputs, fInvalid))
                 return false;
 
             // Add in sigops done by pay-to-script-hash inputs;
@@ -1731,7 +1736,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
             // an incredibly-expensive-to-validate block.
             nSigOps += GetP2SHSigOpCount(tx, mapInputs);
             if (nSigOps > MAX_BLOCK_SIGOPS)
-                return block.DoS(100, error("%s: too many sigops", __func__));
+                return state.DoS(100, error("%s: too many sigops", __func__));
 
             CAmount nTxValueIn = GetValueIn(tx, mapInputs);
             CAmount nTxValueOut = tx.GetValueOut();
@@ -1770,7 +1775,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
                 if (pindex->nVersion >= 10)
                 {
                     if (tx.vout.size() > GetCoinstakeOutputLimit(pindex->nVersion))
-                        return block.DoS(100, error("%s: too many coinstake outputs", __func__));
+                        return state.DoS(100, error("%s: too many coinstake outputs", __func__));
                 }
                 else if (bIsDPOR && pindex->nHeight > nGrandfather && pindex->nVersion < 10)
                 {
@@ -1781,7 +1786,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
                     {
                         if (CoinToDouble(tx.vout[i].nValue) > 0)
                         {
-                            return block.DoS(50, error("%s: coinstake output %u forbidden", __func__, i));
+                            return state.DoS(50, error("%s: coinstake output %u forbidden", __func__, i));
                         }
                     }
                 }
@@ -1789,20 +1794,20 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
 
             // Validate any contracts published in the transaction:
             if (!tx.GetContracts().empty()) {
-                if (!CheckContracts(tx, mapInputs, pindex->nHeight)) {
+                if (!CheckContracts(tx, state, mapInputs, pindex->nHeight)) {
                     return false;
                 }
 
                 int DoS = 0;
                 if (block.nVersion >= 11 && !GRC::BlockValidateContracts(pindex, tx, DoS)) {
-                    return tx.DoS(DoS, error("%s: invalid contract in tx %s, assigning DoS misbehavior of %i",
+                    return state.DoS(DoS, error("%s: invalid contract in tx %s, assigning DoS misbehavior of %i",
                                              __func__,
                                              tx.GetHash().ToString(),
                                              DoS));
                 }
             }
 
-            if (!ConnectInputs(tx, txdb, mapInputs, mapQueuedChanges, posThisTx, pindex, true, false))
+            if (!ConnectInputs(tx, state, txdb, mapInputs, mapQueuedChanges, posThisTx, pindex, true, false))
                 return false;
         }
 
@@ -1810,7 +1815,7 @@ bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustChe
     }
 
     if (IsResearchAgeEnabled(pindex->nHeight)
-        && !GridcoinConnectBlock(block, pindex, txdb, stake_value_in, nStakeReward, nFees))
+        && !GridcoinConnectBlock(block, state, pindex, txdb, stake_value_in, nStakeReward, nFees))
     {
         return false;
     }
@@ -1919,7 +1924,7 @@ bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, 
     return true;
 }
 
-bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig, bool fLoadingIndex)
+bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig, bool fLoadingIndex)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
@@ -1941,53 +1946,53 @@ bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMer
         || ::GetSerializeSize(block, (SER_NETWORK & SER_SKIPSUPERBLOCK), PROTOCOL_VERSION) > MAX_BLOCK_SIZE
         || ::GetSerializeSize(block.GetSuperblock(), SER_NETWORK, PROTOCOL_VERSION) > GRC::Superblock::MAX_SIZE)
     {
-        return block.DoS(100, error("%s: size limits failed", __func__));
+        return state.DoS(100, error("%s: size limits failed", __func__));
     }
 
     // Check proof of work matches claimed amount
     if (fCheckPOW && block.IsProofOfWork() && !CheckProofOfWork(block.GetHash(true), block.nBits, Params().GetConsensus()))
-        return block.DoS(50, error("%s: proof of work failed", __func__));
+        return state.DoS(50, error("%s: proof of work failed", __func__));
 
     //Reject blocks with diff that has grown to an extraordinary level (should never happen)
     double blockdiff = GRC::GetBlockDifficulty(block.nBits);
     if (height1 > nGrandfather && blockdiff > 10000000000000000)
     {
-       return block.DoS(1, error("%s: Block Bits larger than 10000000000000000.", __func__));
+       return state.DoS(1, error("%s: Block Bits larger than 10000000000000000.", __func__));
     }
 
     // First transaction must be coinbase, the rest must not be
     if (block.vtx.empty() || !block.vtx[0].IsCoinBase())
-        return block.DoS(100, error("%s: first tx is not coinbase", __func__));
+        return state.DoS(100, error("%s: first tx is not coinbase", __func__));
     for (unsigned int i = 1; i < block.vtx.size(); i++)
         if (block.vtx[i].IsCoinBase())
-            return block.DoS(100, error("%s: more than one coinbase", __func__));
+            return state.DoS(100, error("%s: more than one coinbase", __func__));
 
     // Version 11+ blocks store the Gridcoin claim context as a contract in the
     // coinbase transaction instead of the hashBoinc field.
     //
     if (block.nVersion >= 11) {
         if (block.vtx[0].vContracts.empty()) {
-            return block.DoS(100, error("%s: missing claim contract", __func__));
+            return state.DoS(100, error("%s: missing claim contract", __func__));
         }
 
         if (block.vtx[0].vContracts.size() > 1) {
-            return block.DoS(100, error("%s: too many coinbase contracts", __func__));
+            return state.DoS(100, error("%s: too many coinbase contracts", __func__));
         }
 
         if (block.vtx[0].vContracts[0].m_type != GRC::ContractType::CLAIM) {
-            return block.DoS(100, error("%s: unexpected coinbase contract", __func__));
+            return state.DoS(100, error("%s: unexpected coinbase contract", __func__));
         }
 
         if (!block.vtx[0].vContracts[0].WellFormed()) {
-            return block.DoS(100, error("%s: malformed claim contract", __func__));
+            return state.DoS(100, error("%s: malformed claim contract", __func__));
         }
 
         if (block.vtx[0].vContracts[0].m_version <= 1 || block.GetClaim().m_version <= 1) {
-            return block.DoS(100, error("%s: legacy claim", __func__));
+            return state.DoS(100, error("%s: legacy claim", __func__));
         }
 
         if (!fTestNet && block.GetClaim().m_version == 2) {
-            return block.DoS(100, error("%s: testnet-only claim", __func__));
+            return state.DoS(100, error("%s: testnet-only claim", __func__));
         }
     }
 
@@ -1998,22 +2003,22 @@ bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMer
         if (height1 > nGrandfather)
         {
             if (fCheckSig && !CheckBlockSignature(block))
-                return block.DoS(100, error("%s: bad proof-of-stake block signature", __func__));
+                return state.DoS(100, error("%s: bad proof-of-stake block signature", __func__));
         }
 
         // Coinbase output should be empty if proof-of-stake block
         if (block.vtx[0].vout.size() != 1 || !block.vtx[0].vout[0].IsEmpty())
-            return block.DoS(100, error("%s: coinbase output not empty for proof-of-stake block", __func__));
+            return state.DoS(100, error("%s: coinbase output not empty for proof-of-stake block", __func__));
 
         // Second transaction must be coinstake, the rest must not be
         if (block.vtx.empty() || !block.vtx[1].IsCoinStake())
-            return block.DoS(100, error("%s: second tx is not coinstake", __func__));
+            return state.DoS(100, error("%s: second tx is not coinstake", __func__));
 
         for (unsigned int i = 2; i < block.vtx.size(); i++)
         {
             if (block.vtx[i].IsCoinStake())
             {
-                return block.DoS(100, error("%s: more than one coinstake (at %d)", __func__, i));
+                return state.DoS(100, error("%s: more than one coinstake (at %d)", __func__, i));
             }
         }
     }
@@ -2021,12 +2026,12 @@ bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMer
     // Check transactions
     for (auto const& tx : block.vtx)
     {
-        if (!CheckTransaction(tx))
-            return block.DoS(tx.nDoS, error("%s: CheckTransaction failed", __func__));
+        if (!CheckTransaction(tx, state))
+            return error("%s: CheckTransaction failed", __func__);
 
         // ppcoin: check transaction timestamp
         if (block.GetBlockTime() < (int64_t)tx.nTime)
-            return block.DoS(50, error("%s: block timestamp earlier than transaction timestamp", __func__));
+            return state.DoS(50, error("%s: block timestamp earlier than transaction timestamp", __func__));
     }
 
     // Check for duplicate txids. This is caught by ConnectInputs(),
@@ -2037,7 +2042,7 @@ bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMer
         uniqueTx.insert(tx.GetHash());
     }
     if (uniqueTx.size() != block.vtx.size())
-        return block.DoS(100, error("%s: duplicate transaction", __func__));
+        return state.DoS(100, error("%s: duplicate transaction", __func__));
 
     unsigned int nSigOps = 0;
     for (auto const& tx : block.vtx)
@@ -2045,20 +2050,20 @@ bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMer
         nSigOps += GetLegacySigOpCount(tx);
     }
     if (nSigOps > MAX_BLOCK_SIGOPS)
-        return block.DoS(100, error("%s: out-of-bounds SigOpCount", __func__));
+        return state.DoS(100, error("%s: out-of-bounds SigOpCount", __func__));
 
     // Check merkle root
     if (fCheckMerkleRoot) {
         bool mutated;
         uint256 hashMerkleRoot = BlockMerkleRoot(block, &mutated);
         if (block.hashMerkleRoot != hashMerkleRoot)
-            return block.DoS(100, error("%s: hashMerkleRoot mismatch", __func__));
+            return state.DoS(100, error("%s: hashMerkleRoot mismatch", __func__));
 
         // Check for merkle tree malleability (CVE-2012-2459): repeating sequences
         // of transactions in a block without affecting the merkle root of a block,
         // while still invalidating it.
         if (mutated)
-            return block.DoS(100, error("%s: duplicate transaction", __func__));
+            return state.DoS(100, error("%s: duplicate transaction", __func__));
     }
 
     if (fCheckPOW && fCheckMerkleRoot && fCheckSig)
@@ -2067,12 +2072,12 @@ bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW, bool fCheckMer
     return true;
 }
 
-bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
     if (block.nVersion > CBlock::CURRENT_VERSION)
-        return block.DoS(100, error("%s: reject unknown block version %d", __func__, block.nVersion));
+        return state.DoS(100, error("%s: reject unknown block version %d", __func__, block.nVersion));
 
     // Check for duplicate
     uint256 hash = block.GetHash(true);
@@ -2082,7 +2087,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
     // Get prev block index
     BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
     if (mi == mapBlockIndex.end())
-        return block.DoS(10, error("%s: prev block not found", __func__));
+        return state.DoS(10, error("%s: prev block not found", __func__));
     CBlockIndex* pindexPrev = mi->second;
     const int nHeight = pindexPrev->nHeight + 1;
     const int checkpoint_height = Params().Checkpoints().GetHeight();
@@ -2091,7 +2096,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
     // use a cheaper condition than IsInitialBlockDownload() to skip the checks
     // during initial sync:
     if (nBestHeight > checkpoint_height && nHeight <= checkpoint_height) {
-        return block.DoS(25, error("%s: rejected height below checkpoint", __func__));
+        return state.DoS(25, error("%s: rejected height below checkpoint", __func__));
     }
 
     // The block height at which point we start rejecting v7 blocks and
@@ -2105,7 +2110,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
             || (IsV13Enabled(nHeight) && block.nVersion < 13)
             || (IsV14Enabled(nHeight) && block.nVersion < 14)
             ) {
-        return block.DoS(20, error("%s: reject too old nVersion = %d", __func__, block.nVersion));
+        return state.DoS(20, error("%s: reject too old nVersion = %d", __func__, block.nVersion));
     } else if ((!IsProtocolV2(nHeight) && block.nVersion >= 7)
                || (!IsV8Enabled(nHeight) && block.nVersion >= 8)
                || (!IsV9Enabled(nHeight) && block.nVersion >= 9)
@@ -2115,39 +2120,39 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
                || (!IsV13Enabled(nHeight) && block.nVersion >= 13)
                || (!IsV14Enabled(nHeight) && block.nVersion >= 14)
                ) {
-        return block.DoS(100, error("%s: reject too new nVersion = %d", __func__, block.nVersion));
+        return state.DoS(100, error("%s: reject too new nVersion = %d", __func__, block.nVersion));
     }
 
     if (block.IsProofOfWork() && nHeight > LAST_POW_BLOCK)
-        return block.DoS(100, error("%s: reject proof-of-work at height %d", __func__, nHeight));
+        return state.DoS(100, error("%s: reject proof-of-work at height %d", __func__, nHeight));
 
     if (nHeight > nGrandfather)
     {
         // Check coinbase timestamp
         if (block.GetBlockTime() > FutureDrift((int64_t)block.vtx[0].nTime, nHeight))
         {
-            return block.DoS(80, error("%s: coinbase timestamp is too early", __func__));
+            return state.DoS(80, error("%s: coinbase timestamp is too early", __func__));
         }
         // Check timestamp against prev
         if (block.nVersion < 12 && (block.GetBlockTime() <= pindexPrev->GetPastTimeLimit() || FutureDrift(block.GetBlockTime(), nHeight) < pindexPrev->GetBlockTime()))
-            return block.DoS(60, error("%s: block's timestamp is too early", __func__));
+            return state.DoS(60, error("%s: block's timestamp is too early", __func__));
         // Check proof-of-work or proof-of-stake
         if (block.nBits != GRC::GetNextTargetRequired(pindexPrev))
-            return block.DoS(100, error("%s: incorrect target", __func__));
+            return state.DoS(100, error("%s: incorrect target", __func__));
     }
 
     if (block.nVersion >= 12) {
         // Check timestamp
         if (pindexPrev->GetBlockTime() - block.GetBlockTime() > 128) {
-            return block.DoS(50, error("%s: block timestamp too early", __func__));
+            return state.DoS(50, error("%s: block timestamp too early", __func__));
         }
 
         if (block.GetBlockTime() - GetAdjustedTime() > 128) {
-            return block.DoS(25, error("%s: block timestamp too far in future", __func__));
+            return state.DoS(25, error("%s: block timestamp too far in future", __func__));
         }
 
         if (block.vtx[1].nTime != block.GetBlockTime()) {
-            return block.DoS(50, error("%s: block coinstake time mismatch", __func__));
+            return state.DoS(50, error("%s: block coinstake time mismatch", __func__));
         }
     }
 
@@ -2158,24 +2163,24 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
         if (block.nVersion >= 11 && tx.nVersion < 2) {
             // Disallow tx version 1 after the mandatory block to prohibit the
             // use of legacy string contracts:
-            return block.DoS(100, error("%s: legacy transaction", __func__));
+            return state.DoS(100, error("%s: legacy transaction", __func__));
         }
 
         // Check that all transactions are finalized
         if (!IsFinalTx(tx, nHeight, block.GetBlockTime()))
-            return block.DoS(10, error("%s: contains a non-final transaction", __func__));
+            return state.DoS(10, error("%s: contains a non-final transaction", __func__));
 
         // BIP68: Check sequence locks for v14+ blocks (skip coinbase and coinstake)
         if (IsV14Enabled(nHeight) && !tx.IsCoinBase() && !tx.IsCoinStake()) {
             if (!CheckSequenceLocks(tx, 0, pindexPrev)) {
-                return block.DoS(10, error("%s: contains a transaction with unsatisfied sequence locks", __func__));
+                return state.DoS(10, error("%s: contains a transaction with unsatisfied sequence locks", __func__));
             }
         }
     }
 
     // Check that the block chain matches the known block chain up to a checkpoint
     if (!Checkpoints::CheckHardened(nHeight, hash))
-        return block.DoS(100, error("%s: rejected by hardened checkpoint lock-in at %d", __func__, nHeight));
+        return state.DoS(100, error("%s: rejected by hardened checkpoint lock-in at %d", __func__, nHeight));
 
     uint256 hashProof;
 
@@ -2185,12 +2190,12 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
         //no grandfather exceptions
         //if (IsProofOfStake())
         CTxDB txdb("r");
-        if(!GRC::CheckProofOfStakeV8(txdb, pindexPrev, block, generated_by_me, hashProof))
+        if(!GRC::CheckProofOfStakeV8(txdb, pindexPrev, block, generated_by_me, state, hashProof))
         {
-            return block.DoS(block.vtx[1].nDoS, error("%s: invalid proof-of-stake for block %s, prev %s",
-                                                      __func__,
-                                                      hash.ToString(),
-                                                      pindexPrev->GetBlockHash().ToString()));
+            return error("%s: invalid proof-of-stake for block %s, prev %s",
+                         __func__,
+                         hash.ToString(),
+                         pindexPrev->GetBlockHash().ToString());
         }
 
         if (g_seen_stakes.ContainsProof(hashProof)
@@ -2214,7 +2219,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
         // testnet: nGrandfather (196551) to version 8 (311999)
         //
         CTxDB txdb("r");
-        if (!GRC::CalculateLegacyV3HashProof(txdb, block, block.nNonce, hashProof)) {
+        if (!GRC::CalculateLegacyV3HashProof(txdb, block, block.nNonce, state, hashProof)) {
             return error("%s: Failed to carry v7 proof hash.", __func__);
         }
     }
@@ -2232,7 +2237,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
         CScript expect = CScript() << nHeight;
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
                 !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin()))
-            return block.DoS(100, error("%s: block height mismatch in coinbase", __func__));
+            return state.DoS(100, error("%s: block height mismatch in coinbase", __func__));
     }
 
     // Write block to history file

--- a/src/validation.h
+++ b/src/validation.h
@@ -7,6 +7,7 @@
 #define BITCOIN_VALIDATION_H
 
 #include "amount.h"
+#include "consensus/validation.h"
 #include "index/disktxpos.h"
 #include "primitives/transaction.h"
 
@@ -28,7 +29,7 @@ bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout, CTxIndex& 
 bool ReadTxFromDisk(CTransaction& tx, CTxDB& txdb, COutPoint prevout);
 bool ReadTxFromDisk(CTransaction& tx, COutPoint prevout);
 
-bool CheckTransaction(const CTransaction& tx);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state);
 
 //! \brief Check the validity of any contracts contained in the transaction.
 //!
@@ -40,7 +41,7 @@ bool CheckTransaction(const CTransaction& tx);
 //!
 //! \return \c true if all of the contracts in the transaction validate.
 //!
-bool CheckContracts(const CTransaction& tx, const MapPrevTx& inputs, int block_height);
+bool CheckContracts(const CTransaction& tx, CValidationState& state, const MapPrevTx& inputs, int block_height);
 
 //! \brief Determine whether a transaction contains an input spent by the
 //! master key holder.
@@ -79,7 +80,7 @@ bool DisconnectInputs(CTransaction& tx, CTxDB& txdb);
     @param[out] fInvalid	returns true if tx is invalid
     @return	Returns true if all inputs are in txdb or mapTestPool
 */
-bool FetchInputs(CTransaction& tx, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool, bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
+bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool, bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
 
 /** Sanity check previous transactions, then, if all checks succeed,
     mark them as spent by tx.
@@ -92,7 +93,7 @@ bool FetchInputs(CTransaction& tx, CTxDB& txdb, const std::map<uint256, CTxIndex
     @param[in] fMiner	true if called from CreateNewBlock
     @return Returns true if all checks succeed
     */
-bool ConnectInputs(CTransaction& tx, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner);
+bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner);
 
 bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge); // ppcoin: get transaction coin age
 
@@ -101,10 +102,10 @@ int GetDepthInMainChain(const CTxIndex& txi);
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params);
 
 bool DisconnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex);
-bool ConnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck=false);
+bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck=false);
 bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, const uint256& hashProof);
-bool CheckBlock(const CBlock& block, int height1, bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true, bool fLoadingIndex=false);
-bool AcceptBlock(CBlock& block, bool generated_by_me);
+bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true, bool fLoadingIndex=false);
+bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me);
 bool CheckBlockSignature(const CBlock& block);
 
 // Returns the script flags which should be checked for a given block

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1369,7 +1369,8 @@ bool CWalletTx::RevalidateTransaction(CTxDB& txdb)
     MapPrevTx mapInputs;
     map<uint256, CTxIndex> mapUnused;
     bool fInvalid = false;
-    if (!FetchInputs(tx, txdb, mapUnused, false, false, mapInputs, fInvalid))
+    CValidationState wallet_state;
+    if (!FetchInputs(tx, wallet_state, txdb, mapUnused, false, false, mapInputs, fInvalid))
     {
         if (fInvalid) {
             return error("%s: FetchInputs found invalid tx %s", __func__, tx.GetHash().ToString());
@@ -1380,7 +1381,7 @@ bool CWalletTx::RevalidateTransaction(CTxDB& txdb)
     // Validate any contracts published in the transaction:
 
     if (!tx.GetContracts().empty()) {
-        if (!CheckContracts(tx, mapInputs, pindexBest->nHeight)) {
+        if (!CheckContracts(tx, wallet_state, mapInputs, pindexBest->nHeight)) {
             return error("%s: CheckContracts found invalid contract in tx %s", __func__, tx.GetHash().ToString());
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1362,7 +1362,8 @@ bool CWalletTx::RevalidateTransaction(CTxDB& txdb)
     CTransaction tx = (CTransaction) *this;
 
     // Redo basic transaction check
-    if (!CheckTransaction(tx)) return false;
+    CValidationState check_state;
+    if (!CheckTransaction(tx, check_state)) return false;
 
     // Do a subset of the AcceptToMemoryPool transaction checks. Here we are going to check and see if the inputs exist
     // and also do the vanilla contract and GRC specific contract checks.

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -235,7 +235,8 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssKey >> hash;
             CWalletTx& wtx = pwallet->mapWallet[hash];
             ssValue >> wtx;
-            if (CheckTransaction(wtx) && (wtx.GetHash() == hash))
+            CValidationState wtx_state;
+            if (CheckTransaction(wtx, wtx_state) && (wtx.GetHash() == hash))
                 wtx.BindWallet(pwallet);
             else
             {


### PR DESCRIPTION
## Summary

- Introduces `CValidationState` class (`consensus/validation.h`) following Bitcoin Core's pattern for separating validation results from transaction/block types
- Removes `nDoS` field and `DoS()` method from `CTransaction` and `CBlock` — DoS scoring now lives in `CValidationState`
- Threads `CValidationState` through `CheckTransaction`, `CheckBlock`, `AcceptBlock`, `AcceptToMemoryPool`, and staking validation
- Keeps unified `CValidationState` (not split into `TxValidationState`/`BlockValidationState`) — the split requires separate reject code enums and can be a follow-up

Part of #2877 PSGT refactoring series (Phase D). Depends on #2878 (Phase C: script/ split) only for the final rebase — cherry-picked onto `development` so it can be reviewed independently.

**4 commits:**
1. `refactor: add CValidationState class in consensus/validation.h` — new header with validation state class
2. `refactor: remove nDoS/DoS() from CTransaction and CBlock, update callers` — remove embedded DoS scoring from transaction/block types
3. `refactor: thread CValidationState through validation and staking` — plumb CValidationState through CheckTransaction, CheckBlock, AcceptBlock, etc.
4. `refactor: fix remaining CheckTransaction callers missing CValidationState` — catch remaining callers

**15 files changed** across consensus, validation, staking, RPC, wallet, and tests.

## Test plan

- [ ] Full build compiles without errors
- [ ] `test_gridcoin` passes (especially `transaction_tests`)
- [ ] Verify DoS scoring still functions correctly via CValidationState in P2P message handling
- [ ] Verify staking validation threads CValidationState properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)