### PR TITLE
fix: use hash comparison in CTransaction::operator==

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -323,11 +323,7 @@ public:
 
     friend bool operator==(const CTransaction& a, const CTransaction& b)
     {
-        return (a.nVersion  == b.nVersion &&
-                a.nTime     == b.nTime &&
-                a.vin       == b.vin &&
-                a.vout      == b.vout &&
-                a.nLockTime == b.nLockTime);
+        return a.GetHash() == b.GetHash();
     }
 
     friend bool operator!=(const CTransaction& a, const CTransaction& b)


### PR DESCRIPTION
## Summary

- `CTransaction::operator==` compared only 5 of 7 serialized fields, omitting `hashBoinc` (v1) and `vContracts` (v2+). Two transactions differing only in contract content compared as equal despite having different hashes.
- Replace field-by-field comparison with `GetHash()` comparison, which covers all serialized data and matches the Bitcoin Core pattern (v0.15+).
- Single call site (`CMerkleTx::SetMerkleBranch`) is not performance-sensitive, so the hash computation cost is negligible.

Flagged by @jamescowens in #2889 review. Tracked as #2896.

## Test plan

- [x] CI build and existing test suite pass
- [x] `transaction_tests` suite covers basic transaction operations — no new test needed for a one-line hash-equality change

🤖 Generated with [Claude Code](https://claude.com/claude-code)