### PR TITLE
net: fix lock-order inversions in ThreadSocketHandler2 cleanup

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -809,8 +809,14 @@ void ThreadSocketHandler2(void* parg)
                     vNodesDisconnected.push_back(pnode);
                 }
             }
+        }
 
-            // Delete disconnected nodes
+        // Delete disconnected nodes
+        // Moved outside cs_vNodes scope: this section only touches the
+        // function-local vNodesDisconnected list and per-node locks.
+        // Keeping it inside cs_vNodes created a lock-order conflict with
+        // ThreadMessageHandler (cs_vRecvMsg -> cs_main -> cs_vNodes).
+        {
             list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
             for (auto const& pnode : vNodesDisconnectedCopy)
             {
@@ -819,11 +825,11 @@ void ThreadSocketHandler2(void* parg)
                 {
                     bool fDelete = false;
                     {
-                        TRY_LOCK(pnode->cs_vSend, lockSend);
-                        if (lockSend)
+                        TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
+                        if (lockRecv)
                         {
-                            TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
-                            if (lockRecv)
+                            TRY_LOCK(pnode->cs_vSend, lockSend);
+                            if (lockSend)
                             {
                                 TRY_LOCK(pnode->cs_inventory, lockInv);
                                 if (lockInv)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -432,11 +432,6 @@ void CNode::CloseSocketDisconnect()
         LogPrint(BCLog::LogFlags::NET, "disconnecting node %s", addrName);
         closesocket(hSocket);
         hSocket = INVALID_SOCKET;
-
-        // in case this fails, we'll empty the recv buffer when the CNode is deleted
-        TRY_LOCK(cs_vRecvMsg, lockRecv);
-        if (lockRecv)
-            vRecvMsg.clear();
     }
 }
 
@@ -828,6 +823,7 @@ void ThreadSocketHandler2(void* parg)
                         TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
                         if (lockRecv)
                         {
+                            pnode->vRecvMsg.clear();
                             TRY_LOCK(pnode->cs_vSend, lockSend);
                             if (lockSend)
                             {
@@ -1010,6 +1006,7 @@ void ThreadSocketHandler2(void* parg)
                         if (!pnode->fDisconnect)
                             LogPrintf("socket recv flood control disconnect (%u bytes)", pnode->GetTotalRecvSize());
                         pnode->CloseSocketDisconnect();
+                        pnode->vRecvMsg.clear();
                     }
                     else {
                         // typical socket buffer is 8K-64K
@@ -1018,7 +1015,10 @@ void ThreadSocketHandler2(void* parg)
                         if (nBytes > 0)
                         {
                             if (!pnode->ReceiveMsgBytes(pchBuf, nBytes))
+                            {
                                 pnode->CloseSocketDisconnect();
+                                pnode->vRecvMsg.clear();
+                            }
                             pnode->nLastRecv = GetAdjustedTime();
                             pnode->RecordBytesRecv(nBytes);
                         }
@@ -1030,6 +1030,7 @@ void ThreadSocketHandler2(void* parg)
                               LogPrint(BCLog::LogFlags::NET, "socket closed");
                             }
                             pnode->CloseSocketDisconnect();
+                            pnode->vRecvMsg.clear();
                         }
                         else if (nBytes < 0)
                         {
@@ -1042,6 +1043,7 @@ void ThreadSocketHandler2(void* parg)
                                    LogPrint(BCLog::LogFlags::NET, "socket recv error %d", nErr);
                                 }
                                 pnode->CloseSocketDisconnect();
+                                pnode->vRecvMsg.clear();
                             }
                         }
                     }
@@ -1800,7 +1802,10 @@ void ThreadMessageHandler2(void* parg)
                 TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
                 if (lockRecv)
                     if (!ProcessMessages(pnode))
+                    {
                         pnode->CloseSocketDisconnect();
+                        pnode->vRecvMsg.clear();
+                    }
             }
 
             if (fShutdown)


### PR DESCRIPTION
When complied with `DEBUG_LOCKORDER=true`; following potential deadlock:
```
2026-03-16T20:21:10Z POTENTIAL DEADLOCK DETECTED

2026-03-16T20:21:10Z Conflict: 'pnode->cs_vSend' and 'pnode->cs_vRecvMsg' acquired in inconsistent orders.

2026-03-16T20:21:10Z   Current:    'pnode->cs_vSend' -> 'pnode->cs_vRecvMsg'

2026-03-16T20:21:10Z   Historical: 'pnode->cs_vRecvMsg' -> 'pnode->cs_vSend'

2026-03-16T20:21:10Z

2026-03-16T20:21:10Z Historical lock stack (where the reverse order was first seen):

2026-03-16T20:21:10Z   #1 'pnode->cs_vRecvMsg' in /var/tmp/Gridcoin-Research/src/net.cpp:1794 (TRY) (in thread 'grc-msghand')  <--

2026-03-16T20:21:10Z   #2 'cs_vSend' in /var/tmp/Gridcoin-Research/src/net.h:500 (in thread 'grc-msghand')  <--

2026-03-16T20:21:10Z

2026-03-16T20:21:10Z Current lock stack (triggering this warning):

2026-03-16T20:21:10Z   #1 'cs_vNodes' in /var/tmp/Gridcoin-Research/src/net.cpp:789 (in thread 'grc-net')

2026-03-16T20:21:10Z   #2 'pnode->cs_vSend' in /var/tmp/Gridcoin-Research/src/net.cpp:822 (TRY) (in thread 'grc-net')  <--

2026-03-16T20:21:10Z   #3 'pnode->cs_vRecvMsg' in /var/tmp/Gridcoin-Research/src/net.cpp:825 (TRY) (in thread 'grc-net')  <--

2026-03-16T20:21:10Z

2026-03-16T20:21:10Z potential deadlock detected: pnode->cs_vRecvMsg -> pnode->cs_vSend -> pnode->cs_vRecvMsg
```

Move the "delete disconnected nodes" block outside the LOCK(cs_vNodes) scope — it only touches the function-local vNodesDisconnected list and per-node locks, so cs_vNodes is unnecessary.  This eliminates the cs_vNodes → cs_vRecvMsg ordering that conflicts with ThreadMessageHandler's cs_vRecvMsg → cs_main → cs_vNodes chain.

Within the delete block, swap the TRY_LOCK order so cs_vRecvMsg is acquired before cs_vSend, matching the established order in ThreadMessageHandler (cs_vRecvMsg held at net.cpp:1794, then cs_vSend acquired via PushMessage).

Fixes two POTENTIAL DEADLOCK DETECTED warnings from DEBUG_LOCKORDER:
  1. cs_vSend / cs_vRecvMsg (grc-net vs grc-msghand)
  2. cs_vNodes / cs_vRecvMsg (grc-net vs grc-msghand)
  
- [x] CI passed
- [ ] Warning message does not reoccur. 