### PR TITLE
refactor, net: orphan block manager and network hardening

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,6 +181,7 @@ add_library(gridcoin_util STATIC
     netaddress.cpp
     netbase.cpp
     node/blockstorage.cpp
+    node/orphan_blocks.cpp
     node/ui_interface.cpp
     noui.cpp
     pbkdf2.cpp

--- a/src/gridcoin/superblock.h
+++ b/src/gridcoin/superblock.h
@@ -509,7 +509,13 @@ public:
             m_magnitudes.clear();
 
             const uint64_t size = ReadCompactSize(stream);
-            m_magnitudes.reserve(size);
+
+            // Cap reserve to the maximum plausible entry count within the
+            // superblock size limit to prevent memory amplification from a
+            // malicious size field. Minimum serialized entry size is
+            // sizeof(Cpid) + 1 byte for the magnitude.
+            constexpr uint64_t max_entries = Superblock::MAX_SIZE / (sizeof(Cpid) + 1);
+            m_magnitudes.reserve(std::min(size, max_entries));
 
             for (size_t i = 0; i < size; i++) {
                 Cpid cpid;
@@ -1164,7 +1170,14 @@ public:
             stream >> m_converged_by_project;
 
             const uint64_t project_count = ReadCompactSize(stream);
-            m_projects.reserve(project_count);
+
+            // Cap reserve to prevent memory amplification from a malicious
+            // size field. The minimum serialized project entry is ~5 bytes
+            // (empty name + 3 single-byte VARINTs) so this bounds the
+            // reserve to a plausible entry count within the superblock size
+            // limit.
+            constexpr uint64_t max_projects = Superblock::MAX_SIZE / 5;
+            m_projects.reserve(std::min(project_count, max_projects));
 
             for (uint64_t i = 0; i < project_count; i++) {
                 ProjectPair project_pair;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include "gridcoin/tally.h"
 #include "gridcoin/tx_message.h"
 #include "node/blockstorage.h"
+#include "node/orphan_blocks.h"
 #include "policy/fees.h"
 #include "policy/policy.h"
 #include "random.h"
@@ -97,8 +98,7 @@ CMedianFilter<int> cPeerBlockCounts(5, 0); // Amount of blocks that other nodes 
 
 
 
-map<uint256, CBlock*> mapOrphanBlocks;
-multimap<uint256, CBlock*> mapOrphanBlocksByPrev;
+// Orphan block storage managed by g_orphan_blocks (node/orphan_blocks.h)
 
 map<uint256, CTransaction> mapOrphanTransactions;
 map<uint256, set<uint256> > mapOrphanTransactionsByPrev;
@@ -762,15 +762,6 @@ bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock)
 //
 // CBlock and CBlockIndex
 //
-static const CBlock* GetOrphanRoot(const CBlock* pblock)
-{
-    // Work back to the first block in the orphan chain
-    while (mapOrphanBlocks.count(pblock->hashPrevBlock))
-        pblock = mapOrphanBlocks[pblock->hashPrevBlock];
-    return pblock;
-}
-
-
 // Return maximum amount of blocks that other nodes claim to have
 int GetNumBlocksOfPeers()
 {
@@ -1475,7 +1466,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
     uint256 hash = pblock->GetHash(true);
     if (mapBlockIndex.count(hash))
         return error("ProcessBlock() : already have block %d %s", mapBlockIndex[hash]->nHeight, hash.ToString().c_str());
-    if (mapOrphanBlocks.count(hash))
+    if (g_orphan_blocks.Contains(hash))
         return error("ProcessBlock() : already have block (orphan) %s", hash.ToString().c_str());
 
     if (pblock->hashPrevBlock != hashBestChain)
@@ -1510,7 +1501,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
 
         if (pblock->IsProofOfStake()) {
             if (g_seen_stakes.ContainsOrphan(pblock->vtx[1])
-                && !mapOrphanBlocksByPrev.count(hash))
+                && !g_orphan_blocks.HasChildrenOf(hash))
             {
                 return error(
                     "%s: ignored duplicate proof-of-stake for orphan %s",
@@ -1521,29 +1512,32 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
             }
         }
 
-        CBlock* pblock2 = new CBlock(*pblock);
-        mapOrphanBlocks.insert(make_pair(hash, pblock2));
-        mapOrphanBlocksByPrev.insert(make_pair(pblock->hashPrevBlock, pblock2));
+        if (!g_orphan_blocks.Add(hash, *pblock, GetTime())) {
+            return true;
+        }
 
         // Ask this guy to fill in what we're missing
-        const CBlock* const pblock_root = GetOrphanRoot(pblock2);
-        pfrom->PushGetBlocks(pindexBest, pblock_root->GetHash(true));
-        // ppcoin: getblocks may not obtain the ancestor block rejected
-        // earlier by duplicate-stake check so we ask for it again directly
-        if (!IsInitialBlockDownload())
-        {
-            const CInv ancestor_request(MSG_BLOCK, pblock_root->hashPrevBlock);
+        const CBlock* pblock_root = g_orphan_blocks.GetRootBlock(hash);
 
-            // Ensure that this request is not deferred. CNode::AskFor() bumps
-            // the earliest time for a message by two minutes for each call. A
-            // node with many connections can miss a parent block because this
-            // method can delay the queued request so far into the future that
-            // it never sends the request to download that block. We reset the
-            // request time first to guarantee that the node does not postpone
-            // the message:
-            //
-            mapAlreadyAskedFor[ancestor_request] = 0;
-            pfrom->AskFor(ancestor_request);
+        if (pblock_root) {
+            pfrom->PushGetBlocks(pindexBest, pblock_root->GetHash(true));
+            // ppcoin: getblocks may not obtain the ancestor block rejected
+            // earlier by duplicate-stake check so we ask for it again directly
+            if (!IsInitialBlockDownload())
+            {
+                const CInv ancestor_request(MSG_BLOCK, pblock_root->hashPrevBlock);
+
+                // Ensure that this request is not deferred. CNode::AskFor() bumps
+                // the earliest time for a message by two minutes for each call. A
+                // node with many connections can miss a parent block because this
+                // method can delay the queued request so far into the future that
+                // it never sends the request to download that block. We reset the
+                // request time first to guarantee that the node does not postpone
+                // the message:
+                //
+                mapAlreadyAskedFor[ancestor_request] = 0;
+                pfrom->AskFor(ancestor_request);
+            }
         }
 
         return true;
@@ -1553,25 +1547,11 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me) EXCLUSIVE_
     if (!AcceptBlock(*pblock, generated_by_me))
         return error("ProcessBlock() : AcceptBlock FAILED");
 
-    // Recursively process any orphan blocks that depended on this one
-    vector<uint256> vWorkQueue;
-    vWorkQueue.push_back(hash);
-    for (unsigned int i = 0; i < vWorkQueue.size(); i++)
-    {
-        uint256 hashPrev = vWorkQueue[i];
-        for (multimap<uint256, CBlock*>::iterator mi = mapOrphanBlocksByPrev.lower_bound(hashPrev);
-             mi != mapOrphanBlocksByPrev.upper_bound(hashPrev);
-             ++mi)
-        {
-            CBlock* pblockOrphan = mi->second;
-            if (AcceptBlock(*pblockOrphan, generated_by_me))
-                vWorkQueue.push_back(pblockOrphan->GetHash(true));
-            mapOrphanBlocks.erase(pblockOrphan->GetHash(true));
-            g_seen_stakes.ForgetOrphan(pblockOrphan->vtx[1]);
-            delete pblockOrphan;
-        }
-        mapOrphanBlocksByPrev.erase(hashPrev);
-    }
+    // Recursively process any orphan blocks that depended on this one.
+    // ProcessQueue handles BFS traversal and SeenStakes cleanup internally.
+    g_orphan_blocks.ProcessQueue(hash, [&](CBlock& orphan) -> bool {
+        return AcceptBlock(orphan, generated_by_me);
+    });
 
     return true;
 }
@@ -2002,7 +1982,7 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
 
     case MSG_BLOCK:
         return mapBlockIndex.count(inv.hash) ||
-               mapOrphanBlocks.count(inv.hash);
+               g_orphan_blocks.Contains(inv.hash);
     }
     // Don't know what it is, just say we already got one
     return true;
@@ -2330,8 +2310,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
                 if (!fAlreadyHave)
                     pfrom->AskFor(inv);
-                else if (inv.type == MSG_BLOCK && mapOrphanBlocks.count(inv.hash)) {
-                    pfrom->PushGetBlocks(pindexBest, GetOrphanRoot(mapOrphanBlocks[inv.hash])->GetHash(true));
+                else if (inv.type == MSG_BLOCK && g_orphan_blocks.Contains(inv.hash)) {
+                    const CBlock* pblock_root = g_orphan_blocks.GetRootBlock(inv.hash);
+                    if (pblock_root) {
+                        pfrom->PushGetBlocks(pindexBest, pblock_root->GetHash(true));
+                    }
                 } else if (nInv == nLastBlock) {
                     // In case we are on a very long side-chain, it is possible that we already have
                     // the last block in an inv bundle sent in response to getblocks. Try to detect

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2058,6 +2058,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (!vRecv.empty()) {
             vRecv >> pfrom->strSubVer;
 
+            if (pfrom->strSubVer.size() > 256) {
+                pfrom->strSubVer.resize(256);
+            }
+
             // This handles the special disconnect for clients between the mandatory 5.4.0.0 and the 5.4.5.0 since
             // 5.4.6.0 effectively became a mandatory due to the contract version error in TxMessage. The protocol version
             // was not incremented since 5.4.6.0 was originally a leisure and so this is the only reasonable way to distinguish

--- a/src/main.h
+++ b/src/main.h
@@ -87,8 +87,7 @@ extern std::atomic<bool> g_reorg_in_progress;
 extern const std::string strMessageMagic;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;
-extern std::map<uint256, CBlock*> mapOrphanBlocks;
-extern std::multimap<uint256, CBlock*> mapOrphanBlocksByPrev;
+// Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
 // Settings
 extern int64_t nTransactionFee;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -536,6 +536,11 @@ bool CNode::Misbehaving(int howmuch)
 
 int CNode::GetMisbehavior() const
 {
+    return GetMisbehaviorAddr(addr);
+}
+
+int CNode::GetMisbehaviorAddr(const CAddress& addr)
+{
     int nMisbehavior = 0;
 
     LOCK(cs_mapMisbehavior);
@@ -561,6 +566,32 @@ int CNode::GetMisbehavior() const
     }
 
     return nMisbehavior;
+}
+
+bool CNode::MisbehavingAddr(const CAddress& addr, int howmuch)
+{
+    if (addr.IsLocal())
+    {
+        LogPrintf("Warning: Local address %s misbehaving (delta: %d)!", addr.ToString(), howmuch);
+        return false;
+    }
+
+    LOCK(cs_mapMisbehavior);
+
+    int nMisbehavior = GetMisbehaviorAddr(addr) + howmuch;
+
+    mapMisbehavior[addr] = std::make_pair(nMisbehavior, GetAdjustedTime());
+
+    if (nMisbehavior >= gArgs.GetArg("-banscore", 100))
+    {
+        LogPrint(BCLog::LogFlags::NET, "MisbehavingAddr: %s (%d -> %d) BANNING", addr.ToString(), nMisbehavior - howmuch, nMisbehavior);
+
+        g_banman->Ban(addr, BanReasonNodeMisbehaving);
+        return true;
+    }
+
+    LogPrint(BCLog::LogFlags::NET, "MisbehavingAddr: %s (%d -> %d)", addr.ToString(), nMisbehavior - howmuch, nMisbehavior);
+    return false;
 }
 
 void CNode::copyStats(CNodeStats &stats)
@@ -933,11 +964,17 @@ void ThreadSocketHandler2(void* parg)
                 if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))
                     LogPrintf("Warning: Unknown socket family");
 
+            std::set<CNetAddr> setActiveInbound;
             {
                 LOCK(cs_vNodes);
                 for (auto const& pnode : vNodes)
+                {
                     if (pnode->fInbound)
+                    {
                         nInbound++;
+                        setActiveInbound.insert(pnode->addr);
+                    }
+                }
             }
 
             if (hSocket == INVALID_SOCKET)
@@ -961,6 +998,37 @@ void ThreadSocketHandler2(void* parg)
             }
             else
             {
+                // Rate-limit inbound connections: at most one connection per
+                // 5 seconds from the same IP. Rapid reconnection scores
+                // misbehavior points (10 per violation) which accumulate
+                // toward a ban at the default banscore threshold.
+                {
+                    static std::map<CNetAddr, int64_t> mapInboundLastConnect;
+                    int64_t nNow = GetAdjustedTime();
+                    auto it = mapInboundLastConnect.find(addr);
+
+                    if (it != mapInboundLastConnect.end() && nNow - it->second < 5)
+                    {
+                        CNode::MisbehavingAddr(addr, 10);
+                        closesocket(hSocket);
+                        mapInboundLastConnect[addr] = nNow;
+                        continue;
+                    }
+
+                    mapInboundLastConnect[addr] = nNow;
+
+                    // Prune entries for IPs that have no active inbound
+                    // CNode and whose last connection attempt is older
+                    // than the rate-limit window.
+                    for (auto mit = mapInboundLastConnect.begin(); mit != mapInboundLastConnect.end(); )
+                    {
+                        if (nNow - mit->second >= 5 && !setActiveInbound.count(mit->first))
+                            mit = mapInboundLastConnect.erase(mit);
+                        else
+                            ++mit;
+                    }
+                }
+
                 LogPrint(BCLog::LogFlags::NET, "accepted connection %s", addr.ToString());
                 CNode* pnode = new CNode(hSocket, addr, "", true);
                 pnode->AddRef();

--- a/src/net.h
+++ b/src/net.h
@@ -556,7 +556,32 @@ public:
     // static void ClearBanned(); // needed for unit testing
     // static bool IsBanned(CNetAddr ip);
     bool Misbehaving(int howmuch); // 1 == a little, 100 == a lot
+
+    //!
+    //! \brief Score misbehavior against an address without requiring a CNode
+    //! instance. Operates on the same static mapMisbehavior used by the
+    //! instance method, so scores are shared — misbehavior accumulated here
+    //! is visible to any CNode with the same address.
+    //!
+    //! \param addr    The address to score against.
+    //! \param howmuch Misbehavior points to add.
+    //!
+    //! \return \c true if the accumulated score triggered a ban.
+    //!
+    static bool MisbehavingAddr(const CAddress& addr, int howmuch);
+
     int GetMisbehavior() const;
+
+    //!
+    //! \brief Get the current misbehavior score for an address without
+    //! requiring a CNode instance. Applies the same time-based decay as
+    //! the instance method.
+    //!
+    //! \param addr The address to query.
+    //!
+    //! \return The decayed misbehavior score.
+    //!
+    static int GetMisbehaviorAddr(const CAddress& addr);
     void copyStats(CNodeStats &stats);
 
     static void CopyNodeStats(std::vector<CNodeStats>& vstats);

--- a/src/net.h
+++ b/src/net.h
@@ -395,7 +395,7 @@ public:
         // Known checking here is only to save space from duplicates.
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
-        if (addr.IsValid() && !setAddrKnown.count(addr))
+        if (addr.IsValid() && !setAddrKnown.count(addr) && vAddrToSend.size() < 10000)
             vAddrToSend.push_back(addr);
     }
 
@@ -412,7 +412,7 @@ public:
     {
         {
             LOCK(cs_inventory);
-            if (!setInventoryKnown.count(inv))
+            if (!setInventoryKnown.count(inv) && vInventoryToSend.size() < 10000)
                 vInventoryToSend.push_back(inv);
         }
     }
@@ -421,6 +421,8 @@ public:
     {
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
+        if (mapAskFor.size() > 50000) return;
+
         int64_t& nRequestTime = mapAlreadyAskedFor[inv];
         LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
 

--- a/src/node/orphan_blocks.cpp
+++ b/src/node/orphan_blocks.cpp
@@ -145,6 +145,12 @@ size_t OrphanBlockManager::Size() const
 
 void OrphanBlockManager::Clear()
 {
+    for (auto& [hash, entry] : m_orphans) {
+        if (entry.block->IsProofOfStake()) {
+            g_seen_stakes.ForgetOrphan(entry.block->vtx[1]);
+        }
+    }
+
     m_orphans.clear();
     m_by_prev.clear();
 }

--- a/src/node/orphan_blocks.cpp
+++ b/src/node/orphan_blocks.cpp
@@ -1,0 +1,210 @@
+// Copyright (c) 2024-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "node/orphan_blocks.h"
+
+#include "main.h"
+#include "random.h"
+#include "gridcoin/staking/spam.h"
+#include "util.h"
+
+extern GRC::SeenStakes g_seen_stakes;
+
+OrphanBlockManager g_orphan_blocks;
+
+bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t now)
+{
+    // Reject duplicates.
+    if (m_orphans.count(hash)) {
+        return false;
+    }
+
+    // Expire stale orphans first, then evict randomly if still full.
+    EraseExpired(now);
+
+    while (m_orphans.size() >= MAX_ORPHAN_BLOCKS) {
+        EvictRandom();
+    }
+
+    OrphanEntry entry;
+    entry.block = std::make_unique<CBlock>(block);
+    entry.time_received = now;
+
+    const uint256 prev_hash = block.hashPrevBlock;
+
+    m_orphans.emplace(hash, std::move(entry));
+    m_by_prev.emplace(prev_hash, hash);
+
+    return true;
+}
+
+size_t OrphanBlockManager::ProcessQueue(
+    const uint256& accepted_hash,
+    std::function<bool(CBlock&)> accept_fn)
+{
+    std::vector<uint256> work_queue;
+    work_queue.push_back(accepted_hash);
+
+    size_t accepted_count = 0;
+
+    for (size_t i = 0; i < work_queue.size(); ++i) {
+        const uint256 parent_hash = work_queue[i];
+
+        // Collect all orphan hashes that depend on this parent. We must
+        // collect first because EraseInternal modifies m_by_prev.
+        std::vector<uint256> children;
+        auto range = m_by_prev.equal_range(parent_hash);
+        for (auto it = range.first; it != range.second; ++it) {
+            children.push_back(it->second);
+        }
+
+        for (const uint256& orphan_hash : children) {
+            auto it = m_orphans.find(orphan_hash);
+            if (it == m_orphans.end()) {
+                continue;
+            }
+
+            CBlock& orphan_block = *it->second.block;
+
+            if (accept_fn(orphan_block)) {
+                work_queue.push_back(orphan_hash);
+                ++accepted_count;
+            }
+
+            // Clean up SeenStakes tracking for the orphan's coinstake before
+            // erasing. The block must be a PoS block to have orphan stake
+            // tracking (PoW blocks and empty vtx won't have a coinstake).
+            if (orphan_block.IsProofOfStake()) {
+                g_seen_stakes.ForgetOrphan(orphan_block.vtx[1]);
+            }
+
+            EraseInternal(orphan_hash);
+        }
+    }
+
+    return accepted_count;
+}
+
+const CBlock* OrphanBlockManager::GetRootBlock(const uint256& hash) const
+{
+    return FindRootBlock(hash);
+}
+
+bool OrphanBlockManager::Contains(const uint256& hash) const
+{
+    return m_orphans.count(hash) > 0;
+}
+
+bool OrphanBlockManager::HasChildrenOf(const uint256& prev_hash) const
+{
+    return m_by_prev.count(prev_hash) > 0;
+}
+
+size_t OrphanBlockManager::EraseExpired(int64_t now)
+{
+    size_t count = 0;
+
+    for (auto it = m_orphans.begin(); it != m_orphans.end(); ) {
+        if (now - it->second.time_received > MAX_ORPHAN_AGE_SECONDS) {
+            const uint256 hash = it->first;
+
+            // Clean up SeenStakes before erasing.
+            if (it->second.block->IsProofOfStake()) {
+                g_seen_stakes.ForgetOrphan(it->second.block->vtx[1]);
+            }
+
+            // EraseInternal invalidates the iterator, so advance first.
+            ++it;
+            EraseInternal(hash);
+            ++count;
+        } else {
+            ++it;
+        }
+    }
+
+    return count;
+}
+
+size_t OrphanBlockManager::Size() const
+{
+    return m_orphans.size();
+}
+
+void OrphanBlockManager::Clear()
+{
+    m_orphans.clear();
+    m_by_prev.clear();
+}
+
+std::unique_ptr<CBlock> OrphanBlockManager::EraseInternal(const uint256& hash)
+{
+    auto it = m_orphans.find(hash);
+    if (it == m_orphans.end()) {
+        return nullptr;
+    }
+
+    const uint256 prev_hash = it->second.block->hashPrevBlock;
+    std::unique_ptr<CBlock> block = std::move(it->second.block);
+
+    m_orphans.erase(it);
+
+    // Remove the corresponding entry from the reverse index.
+    auto range = m_by_prev.equal_range(prev_hash);
+    for (auto mi = range.first; mi != range.second; ++mi) {
+        if (mi->second == hash) {
+            m_by_prev.erase(mi);
+            break;
+        }
+    }
+
+    return block;
+}
+
+void OrphanBlockManager::EvictRandom()
+{
+    if (m_orphans.empty()) {
+        return;
+    }
+
+    // Advance a random number of buckets into the unordered_map for
+    // approximately uniform random eviction.
+    size_t offset = GetRand<size_t>(m_orphans.size());
+    auto it = m_orphans.begin();
+    std::advance(it, offset);
+
+    const uint256 hash = it->first;
+
+    LogPrint(BCLog::LogFlags::VERBOSE, "OrphanBlockManager: evicting orphan %s (%.0f seconds old)",
+             hash.ToString(), static_cast<double>(GetTime() - it->second.time_received));
+
+    if (it->second.block->IsProofOfStake()) {
+        g_seen_stakes.ForgetOrphan(it->second.block->vtx[1]);
+    }
+
+    EraseInternal(hash);
+}
+
+const CBlock* OrphanBlockManager::FindRootBlock(const uint256& hash) const
+{
+    auto it = m_orphans.find(hash);
+    if (it == m_orphans.end()) {
+        return nullptr;
+    }
+
+    const CBlock* root = it->second.block.get();
+    size_t depth = 0;
+
+    // Walk back through the orphan chain. Bounded by map size to prevent
+    // infinite loops from any hypothetical circular references.
+    while (depth < m_orphans.size()) {
+        auto parent_it = m_orphans.find(root->hashPrevBlock);
+        if (parent_it == m_orphans.end()) {
+            break;
+        }
+        root = parent_it->second.block.get();
+        ++depth;
+    }
+
+    return root;
+}

--- a/src/node/orphan_blocks.cpp
+++ b/src/node/orphan_blocks.cpp
@@ -36,6 +36,9 @@ bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t n
     m_orphans.emplace(hash, std::move(entry));
     m_by_prev.emplace(prev_hash, hash);
 
+    LogPrint(BCLog::LogFlags::VERBOSE, "OrphanBlockManager: added orphan %s (prev=%s, map size %u)",
+             hash.ToString(), prev_hash.ToString(), m_orphans.size());
+
     return true;
 }
 
@@ -108,6 +111,10 @@ size_t OrphanBlockManager::EraseExpired(int64_t now)
     for (auto it = m_orphans.begin(); it != m_orphans.end(); ) {
         if (now - it->second.time_received > MAX_ORPHAN_AGE_SECONDS) {
             const uint256 hash = it->first;
+            const int64_t age = now - it->second.time_received;
+
+            LogPrint(BCLog::LogFlags::VERBOSE, "OrphanBlockManager: expiring orphan %s (age %" PRId64 "s, map size %u)",
+                     hash.ToString(), age, m_orphans.size());
 
             // Clean up SeenStakes before erasing.
             if (it->second.block->IsProofOfStake()) {
@@ -121,6 +128,11 @@ size_t OrphanBlockManager::EraseExpired(int64_t now)
         } else {
             ++it;
         }
+    }
+
+    if (count > 0) {
+        LogPrint(BCLog::LogFlags::VERBOSE, "OrphanBlockManager: expired %u orphans, %u remaining",
+                 count, m_orphans.size());
     }
 
     return count;

--- a/src/node/orphan_blocks.h
+++ b/src/node/orphan_blocks.h
@@ -6,13 +6,11 @@
 #define GRIDCOIN_NODE_ORPHAN_BLOCKS_H
 
 #include "main.h"
-#include "serialize.h"
 #include "uint256.h"
 
 #include <functional>
 #include <memory>
 #include <unordered_map>
-#include <unordered_set>
 
 class CBlock;
 
@@ -31,8 +29,8 @@ public:
     //! Maximum age in seconds before an orphan is eligible for eviction.
     static constexpr int64_t MAX_ORPHAN_AGE_SECONDS = 20 * 60;
 
-    //! Add an orphan block. Returns false if the block is a duplicate or the
-    //! map is full after expiry/eviction. The caller must hold cs_main.
+    //! Add an orphan block. Returns false if the block is a duplicate.
+    //! The caller must hold cs_main.
     bool Add(const uint256& hash, const CBlock& block, int64_t now);
 
     //! Process the orphan chain rooted at \p accepted_hash using breadth-first
@@ -61,7 +59,7 @@ public:
     //! Current number of stored orphans.
     size_t Size() const;
 
-    //! Remove all orphans.
+    //! Remove all orphans and clean up associated SeenStakes entries.
     void Clear();
 
 private:
@@ -78,8 +76,8 @@ private:
     //! claim it as their previous block.
     std::unordered_multimap<uint256, uint256, BlockHasher> m_by_prev;
 
-    //! Remove an orphan from all internal indices. Returns the coinstake
-    //! transaction (moved out) so the caller can clean up SeenStakes.
+    //! Remove an orphan from all internal indices. Returns the block
+    //! (moved out) so the caller can inspect it if needed.
     //! Returns nullptr if not found.
     std::unique_ptr<CBlock> EraseInternal(const uint256& hash);
 

--- a/src/node/orphan_blocks.h
+++ b/src/node/orphan_blocks.h
@@ -23,8 +23,10 @@ class CBlock;
 class OrphanBlockManager
 {
 public:
-    //! Maximum number of orphan blocks to hold in memory.
-    static constexpr size_t MAX_ORPHAN_BLOCKS = 750;
+    //! Maximum number of orphan blocks to hold in memory. Set above the
+    //! superblock interval (~960 blocks) to avoid evicting orphans from a
+    //! legitimate missing-block chain before it can be resolved.
+    static constexpr size_t MAX_ORPHAN_BLOCKS = 1000;
 
     //! Maximum age in seconds before an orphan is eligible for eviction.
     static constexpr int64_t MAX_ORPHAN_AGE_SECONDS = 20 * 60;

--- a/src/node/orphan_blocks.h
+++ b/src/node/orphan_blocks.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2024-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_NODE_ORPHAN_BLOCKS_H
+#define GRIDCOIN_NODE_ORPHAN_BLOCKS_H
+
+#include "main.h"
+#include "serialize.h"
+#include "uint256.h"
+
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+class CBlock;
+
+//!
+//! \brief Manages orphan blocks — blocks received before their parent.
+//!
+//! Replaces the legacy global mapOrphanBlocks / mapOrphanBlocksByPrev with
+//! a bounded, expiry-aware, testable container.
+//!
+class OrphanBlockManager
+{
+public:
+    //! Maximum number of orphan blocks to hold in memory.
+    static constexpr size_t MAX_ORPHAN_BLOCKS = 750;
+
+    //! Maximum age in seconds before an orphan is eligible for eviction.
+    static constexpr int64_t MAX_ORPHAN_AGE_SECONDS = 20 * 60;
+
+    //! Add an orphan block. Returns false if the block is a duplicate or the
+    //! map is full after expiry/eviction. The caller must hold cs_main.
+    bool Add(const uint256& hash, const CBlock& block, int64_t now);
+
+    //! Process the orphan chain rooted at \p accepted_hash using breadth-first
+    //! traversal. For each orphan whose parent has been accepted, calls
+    //! \p accept_fn. If it returns true, that orphan's children are queued.
+    //! All processed orphans are removed regardless of acceptance result.
+    //! Returns the count of orphans for which accept_fn returned true.
+    size_t ProcessQueue(
+        const uint256& accepted_hash,
+        std::function<bool(CBlock&)> accept_fn);
+
+    //! Get the root block of the orphan chain containing \p hash.
+    //! Returns nullptr if \p hash is not a known orphan.
+    const CBlock* GetRootBlock(const uint256& hash) const;
+
+    //! Returns true if \p hash is a known orphan.
+    bool Contains(const uint256& hash) const;
+
+    //! Returns true if any orphan claims \p prev_hash as its parent.
+    bool HasChildrenOf(const uint256& prev_hash) const;
+
+    //! Evict orphans older than MAX_ORPHAN_AGE_SECONDS relative to \p now.
+    //! Returns the number evicted.
+    size_t EraseExpired(int64_t now);
+
+    //! Current number of stored orphans.
+    size_t Size() const;
+
+    //! Remove all orphans.
+    void Clear();
+
+private:
+    struct OrphanEntry
+    {
+        std::unique_ptr<CBlock> block;
+        int64_t time_received;
+    };
+
+    //! Primary storage: orphan block hash -> entry.
+    std::unordered_map<uint256, OrphanEntry, BlockHasher> m_orphans;
+
+    //! Reverse index: parent block hash -> set of orphan block hashes that
+    //! claim it as their previous block.
+    std::unordered_multimap<uint256, uint256, BlockHasher> m_by_prev;
+
+    //! Remove an orphan from all internal indices. Returns the coinstake
+    //! transaction (moved out) so the caller can clean up SeenStakes.
+    //! Returns nullptr if not found.
+    std::unique_ptr<CBlock> EraseInternal(const uint256& hash);
+
+    //! Evict one random orphan to make room. Calls EraseInternal.
+    void EvictRandom();
+
+    //! Walk back through m_orphans to find the root of the chain containing
+    //! \p hash. Bounded by m_orphans.size() to prevent infinite loops.
+    const CBlock* FindRootBlock(const uint256& hash) const;
+};
+
+//! Global orphan block manager instance. Requires cs_main for all access.
+extern OrphanBlockManager g_orphan_blocks;
+
+#endif // GRIDCOIN_NODE_ORPHAN_BLOCKS_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(test_gridcoin
     multisig_tests.cpp
     netbase_tests.cpp
     net_tests.cpp
+    orphan_block_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     sanity_tests.cpp

--- a/src/test/orphan_block_tests.cpp
+++ b/src/test/orphan_block_tests.cpp
@@ -1,0 +1,336 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "node/orphan_blocks.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+//! Create a minimal test block with a given previous hash and a unique nTime
+//! so that each block produces a distinct hash. nVersion is set to 14 so that
+//! GetHash() uses SerializeHash (header-only, no scrypt).
+CBlock MakeTestBlock(const uint256& prev_hash, uint32_t unique_id)
+{
+    CBlock block;
+    block.nVersion = 14;
+    block.hashPrevBlock = prev_hash;
+    block.nTime = 1700000000 + unique_id;
+    block.nBits = 0x1d00ffff;
+    return block;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(orphan_block_tests)
+
+// ---------------------------------------------------------------------------
+// Basic add / contains / size
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(add_and_contains)
+{
+    OrphanBlockManager mgr;
+
+    CBlock block = MakeTestBlock(uint256(1), 1);
+    uint256 hash = block.GetHash();
+
+    BOOST_CHECK(mgr.Add(hash, block, 1000));
+    BOOST_CHECK(mgr.Contains(hash));
+    BOOST_CHECK_EQUAL(mgr.Size(), 1u);
+
+    // Duplicate rejected.
+    BOOST_CHECK(!mgr.Add(hash, block, 1000));
+    BOOST_CHECK_EQUAL(mgr.Size(), 1u);
+
+    mgr.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(has_children_of)
+{
+    OrphanBlockManager mgr;
+
+    uint256 parent_hash(42);
+    CBlock block = MakeTestBlock(parent_hash, 2);
+    uint256 hash = block.GetHash();
+
+    mgr.Add(hash, block, 1000);
+
+    BOOST_CHECK(mgr.HasChildrenOf(parent_hash));
+    BOOST_CHECK(!mgr.HasChildrenOf(hash));
+
+    mgr.Clear();
+}
+
+// ---------------------------------------------------------------------------
+// BFS orphan walker
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(process_queue_linear_chain)
+{
+    OrphanBlockManager mgr;
+
+    // Build a chain: A -> B -> C -> D
+    // A is the "accepted" block (not in the orphan map). B, C, D are orphans.
+    CBlock block_a = MakeTestBlock(uint256(), 10);
+    uint256 hash_a = block_a.GetHash();
+
+    CBlock block_b = MakeTestBlock(hash_a, 11);
+    uint256 hash_b = block_b.GetHash();
+
+    CBlock block_c = MakeTestBlock(hash_b, 12);
+    uint256 hash_c = block_c.GetHash();
+
+    CBlock block_d = MakeTestBlock(hash_c, 13);
+    uint256 hash_d = block_d.GetHash();
+
+    mgr.Add(hash_b, block_b, 1000);
+    mgr.Add(hash_c, block_c, 1000);
+    mgr.Add(hash_d, block_d, 1000);
+
+    BOOST_CHECK_EQUAL(mgr.Size(), 3u);
+
+    std::vector<uint256> accepted_order;
+    size_t count = mgr.ProcessQueue(hash_a, [&](CBlock& blk) -> bool {
+        accepted_order.push_back(blk.GetHash());
+        return true;
+    });
+
+    BOOST_CHECK_EQUAL(count, 3u);
+    BOOST_CHECK_EQUAL(mgr.Size(), 0u);
+
+    // BFS order: B first, then C, then D.
+    BOOST_REQUIRE_EQUAL(accepted_order.size(), 3u);
+    BOOST_CHECK(accepted_order[0] == hash_b);
+    BOOST_CHECK(accepted_order[1] == hash_c);
+    BOOST_CHECK(accepted_order[2] == hash_d);
+
+    mgr.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(process_queue_branching)
+{
+    OrphanBlockManager mgr;
+
+    // A -> B -> C
+    // A -> B -> D  (fork at B)
+    CBlock block_a = MakeTestBlock(uint256(), 20);
+    uint256 hash_a = block_a.GetHash();
+
+    CBlock block_b = MakeTestBlock(hash_a, 21);
+    uint256 hash_b = block_b.GetHash();
+
+    CBlock block_c = MakeTestBlock(hash_b, 22);
+    uint256 hash_c = block_c.GetHash();
+
+    CBlock block_d = MakeTestBlock(hash_b, 23);
+    uint256 hash_d = block_d.GetHash();
+
+    mgr.Add(hash_b, block_b, 1000);
+    mgr.Add(hash_c, block_c, 1000);
+    mgr.Add(hash_d, block_d, 1000);
+
+    std::vector<uint256> accepted;
+    size_t count = mgr.ProcessQueue(hash_a, [&](CBlock& blk) -> bool {
+        accepted.push_back(blk.GetHash());
+        return true;
+    });
+
+    BOOST_CHECK_EQUAL(count, 3u);
+    BOOST_CHECK_EQUAL(mgr.Size(), 0u);
+
+    // B must be first. C and D can be in either order.
+    BOOST_REQUIRE_EQUAL(accepted.size(), 3u);
+    BOOST_CHECK(accepted[0] == hash_b);
+    BOOST_CHECK((accepted[1] == hash_c && accepted[2] == hash_d) ||
+                (accepted[1] == hash_d && accepted[2] == hash_c));
+
+    mgr.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(process_queue_rejection_stops_subtree)
+{
+    OrphanBlockManager mgr;
+
+    // A -> B -> C -> D.  Reject C — D should still be removed but not accepted.
+    CBlock block_a = MakeTestBlock(uint256(), 30);
+    uint256 hash_a = block_a.GetHash();
+
+    CBlock block_b = MakeTestBlock(hash_a, 31);
+    uint256 hash_b = block_b.GetHash();
+
+    CBlock block_c = MakeTestBlock(hash_b, 32);
+    uint256 hash_c = block_c.GetHash();
+
+    CBlock block_d = MakeTestBlock(hash_c, 33);
+    uint256 hash_d = block_d.GetHash();
+
+    mgr.Add(hash_b, block_b, 1000);
+    mgr.Add(hash_c, block_c, 1000);
+    mgr.Add(hash_d, block_d, 1000);
+
+    std::vector<uint256> accepted;
+    size_t count = mgr.ProcessQueue(hash_a, [&](CBlock& blk) -> bool {
+        uint256 h = blk.GetHash();
+        if (h == hash_c) return false;  // reject C
+        accepted.push_back(h);
+        return true;
+    });
+
+    // B accepted, C rejected (not in accepted list), D never reached by walker
+    // because C's hash was not added to the work queue.
+    BOOST_CHECK_EQUAL(count, 1u);
+    BOOST_REQUIRE_EQUAL(accepted.size(), 1u);
+    BOOST_CHECK(accepted[0] == hash_b);
+
+    // B and C removed from maps. D remains as an orphan since its parent (C)
+    // was never accepted — its hash was never queued for processing.
+    BOOST_CHECK_EQUAL(mgr.Size(), 1u);
+    BOOST_CHECK(mgr.Contains(hash_d));
+
+    mgr.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(process_queue_no_orphans)
+{
+    OrphanBlockManager mgr;
+
+    // Processing a hash with no dependents is a no-op.
+    size_t count = mgr.ProcessQueue(uint256(99), [](CBlock&) { return true; });
+    BOOST_CHECK_EQUAL(count, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Root block lookup
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(get_root_block_chain)
+{
+    OrphanBlockManager mgr;
+
+    // Chain: (missing parent) -> A -> B -> C
+    uint256 missing(100);
+
+    CBlock block_a = MakeTestBlock(missing, 40);
+    uint256 hash_a = block_a.GetHash();
+
+    CBlock block_b = MakeTestBlock(hash_a, 41);
+    uint256 hash_b = block_b.GetHash();
+
+    CBlock block_c = MakeTestBlock(hash_b, 42);
+    uint256 hash_c = block_c.GetHash();
+
+    mgr.Add(hash_a, block_a, 1000);
+    mgr.Add(hash_b, block_b, 1000);
+    mgr.Add(hash_c, block_c, 1000);
+
+    // Root of C's chain is A (the earliest orphan).
+    const CBlock* root = mgr.GetRootBlock(hash_c);
+    BOOST_REQUIRE(root != nullptr);
+    BOOST_CHECK(root->GetHash() == hash_a);
+
+    // Root of A is itself.
+    root = mgr.GetRootBlock(hash_a);
+    BOOST_REQUIRE(root != nullptr);
+    BOOST_CHECK(root->GetHash() == hash_a);
+
+    // Unknown hash returns nullptr.
+    BOOST_CHECK(mgr.GetRootBlock(uint256(99)) == nullptr);
+
+    mgr.Clear();
+}
+
+// ---------------------------------------------------------------------------
+// Size cap and eviction
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(size_cap_enforced)
+{
+    OrphanBlockManager mgr;
+
+    // Fill to maximum.
+    for (size_t i = 0; i < OrphanBlockManager::MAX_ORPHAN_BLOCKS; ++i) {
+        CBlock block = MakeTestBlock(uint256(static_cast<uint8_t>(i % 256)), static_cast<uint32_t>(i + 50));
+        mgr.Add(block.GetHash(), block, 1000);
+    }
+    BOOST_CHECK_EQUAL(mgr.Size(), OrphanBlockManager::MAX_ORPHAN_BLOCKS);
+
+    // Adding one more should evict one, keeping size at max.
+    CBlock extra = MakeTestBlock(uint256(255), 9999);
+    BOOST_CHECK(mgr.Add(extra.GetHash(), extra, 1000));
+    BOOST_CHECK_EQUAL(mgr.Size(), OrphanBlockManager::MAX_ORPHAN_BLOCKS);
+    BOOST_CHECK(mgr.Contains(extra.GetHash()));
+
+    mgr.Clear();
+}
+
+// ---------------------------------------------------------------------------
+// Time-based expiry
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(expire_old_orphans)
+{
+    OrphanBlockManager mgr;
+
+    int64_t t0 = 1000;
+
+    CBlock old_block = MakeTestBlock(uint256(1), 60);
+    uint256 old_hash = old_block.GetHash();
+    mgr.Add(old_hash, old_block, t0);
+
+    CBlock new_block = MakeTestBlock(uint256(2), 61);
+    uint256 new_hash = new_block.GetHash();
+    mgr.Add(new_hash, new_block, t0 + OrphanBlockManager::MAX_ORPHAN_AGE_SECONDS);
+
+    BOOST_CHECK_EQUAL(mgr.Size(), 2u);
+
+    // Expire at a time that makes old_block stale but new_block still fresh.
+    int64_t expire_time = t0 + OrphanBlockManager::MAX_ORPHAN_AGE_SECONDS + 1;
+    size_t evicted = mgr.EraseExpired(expire_time);
+
+    BOOST_CHECK_EQUAL(evicted, 1u);
+    BOOST_CHECK(!mgr.Contains(old_hash));
+    BOOST_CHECK(mgr.Contains(new_hash));
+
+    mgr.Clear();
+}
+
+BOOST_AUTO_TEST_CASE(expire_cleans_reverse_index)
+{
+    OrphanBlockManager mgr;
+
+    uint256 parent(200);
+    CBlock block = MakeTestBlock(parent, 70);
+    uint256 hash = block.GetHash();
+
+    mgr.Add(hash, block, 1000);
+    BOOST_CHECK(mgr.HasChildrenOf(parent));
+
+    mgr.EraseExpired(1000 + OrphanBlockManager::MAX_ORPHAN_AGE_SECONDS + 1);
+
+    BOOST_CHECK(!mgr.HasChildrenOf(parent));
+    BOOST_CHECK_EQUAL(mgr.Size(), 0u);
+
+    mgr.Clear();
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(clear_empties_everything)
+{
+    OrphanBlockManager mgr;
+
+    for (uint32_t i = 0; i < 10; ++i) {
+        CBlock block = MakeTestBlock(uint256(i), 80 + i);
+        mgr.Add(block.GetHash(), block, 1000);
+    }
+    BOOST_CHECK_EQUAL(mgr.Size(), 10u);
+
+    mgr.Clear();
+    BOOST_CHECK_EQUAL(mgr.Size(), 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -22,6 +22,7 @@
 #include "gridcoin/staking/spam.h"
 #include "gridcoin/tally.h"
 #include "node/blockstorage.h"
+#include "node/orphan_blocks.h"
 #include "policy/fees.h"
 #include "serialize.h"
 #include "util.h"
@@ -2194,7 +2195,7 @@ bool AcceptBlock(CBlock& block, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(c
         }
 
         if (g_seen_stakes.ContainsProof(hashProof)
-            && mapOrphanBlocksByPrev.find(hash) == mapOrphanBlocksByPrev.end())
+            && !g_orphan_blocks.HasChildrenOf(hash))
         {
             return error(
                 "%s: ignored duplicate proof-of-stake (%s) for block %s",


### PR DESCRIPTION
## Summary

### Orphan block handling overhaul
- Replace unbounded global `mapOrphanBlocks` / `mapOrphanBlocksByPrev` with an encapsulated `OrphanBlockManager` class (`src/node/orphan_blocks.h`)
- Add size cap (`MAX_ORPHAN_BLOCKS = 1000`) with random eviction — bounds memory during forking events
- Add time-based expiry (20 minutes) for stale orphans whose parents never arrive
- Replace raw `new`/`delete` with `std::unique_ptr` ownership — eliminates leak risk
- BFS orphan walker and root-chain lookup preserved structurally
- All call sites in `main.cpp`, `validation.cpp` updated; old globals and `GetOrphanRoot()` removed
- 11 unit tests covering BFS walker (linear chain, branching, mid-chain rejection), root lookup, size cap/eviction, time expiry, and index cleanup

### Network hardening
- Add bounds on per-peer data structures to limit resource consumption
- Add inbound connection rate limiting per IP
- Harden deserialization paths against oversized inputs

## Motivation

The previous orphan handling had several deficiencies that cause excessive CPU and memory usage during serious forking events (e.g. protocol upgrades with a grace period):

1. **No eviction or size cap** — orphan blocks leaked forever if their parent never arrived
2. **No time-based expiry** — stale orphans from dead forks accumulated indefinitely
3. **Raw `new`/`delete`** — manual memory management
4. **Global mutable state** — impossible to unit test in isolation

The network hardening changes address several areas where peer-supplied data was not adequately bounded.

## Test plan

- [x] 11 new unit tests pass (`orphan_block_tests` suite)
- [x] Full existing test suite passes with no regressions
- [x] Testnet deployment during v14 fork — orphan expiry observed working correctly (25 orphans expired in one sweep after 20 min), zero duplicate stake rejections
- [x] Comparison: old-code instances leaked 142-221 orphans permanently; new-code instance stayed at 0
- [x] Verify orphan chain resolution after network partition/reconnect
- [x] Network hardening changes tested on isolated testnet and mainnet test node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>