### PR TITLE
voting: fix null pointer dereference in PollRegistry::DeletePoll

### DIFF
--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -1194,9 +1194,11 @@ void PollRegistry::DeletePoll(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIR
 
     PollReference* poll_ref = TryBy(payload->m_poll.m_title);
 
-    // Note this reference will effectively disappear once this function exits, but this is ok, because there will
-    // be no need to further reference it after this point for purposes of notification.
-    poll_ref->Notify(PollReference::PollNotificationType::POLL_DELETE);
+    if (poll_ref) {
+        // Note this reference will effectively disappear once this function exits, but this is ok, because there will
+        // be no need to further reference it after this point for purposes of notification.
+        poll_ref->Notify(PollReference::PollNotificationType::POLL_DELETE);
+    }
 
     m_polls.erase(ToLower(payload->m_poll.m_title));
 


### PR DESCRIPTION
## Summary

- Fix null pointer dereference crash in `PollRegistry::DeletePoll()` during chain reorganizations
- `TryBy()` returns nullptr when the poll being reverted was never fully connected to the registry; `DeletePoll` dereferenced it without a null check
- Add null guard before calling `Notify()`, matching the pattern already used by `DeleteVote()` on both of its `TryBy()` call sites

## Context

Crash observed on ARM (Odroid) during a reorg triggered by `DisconnectBlocksBatch`:

```
#0  GRC::PollReference::Notify (this=0x0, notify_type=POLL_DELETE) at voting/registry.cpp:791
#1  GRC::PollRegistry::DeletePoll (this=..., ctx=...) at voting/registry.cpp:1199
#2  GRC::PollRegistry::Delete (this=..., ctx=...) at voting/registry.cpp:1077
#3  DisconnectBlocksBatch (...) at main.cpp:1011
```

## Test plan

- [x] Code review: `DeleteVote()` already null-checks `TryBy()` on both paths — this aligns `DeletePoll()` with the same pattern
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)