### PR TITLE
net: bump protocol version to 180329 for block v14 mandatory

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -70,6 +70,7 @@ public:
         consensus.BlockV12Height = 2671700;
         consensus.BlockV13Height = std::numeric_limits<int>::max();
         consensus.BlockV14Height = std::numeric_limits<int>::max();
+        consensus.ProtocolVersionGracePeriod = 900 * 7; // ~6.5 days
         consensus.PollV3Height = 2671700;
         consensus.ProjectV2Height = 2671700;
         consensus.AutoGreylistAuditHeight = std::numeric_limits<int>::max();
@@ -193,6 +194,7 @@ public:
         consensus.BlockV12Height = 1871830;
         consensus.BlockV13Height = 2870000;
         consensus.BlockV14Height = 3126500;
+        consensus.ProtocolVersionGracePeriod = 900 * 21; // ~19.6 days — extended because v14 fork preceded deployment
         consensus.PollV3Height = 1944820;
         consensus.ProjectV2Height = 1944820;
         consensus.AutoGreylistAuditHeight = 3111000;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -38,6 +38,11 @@ struct Params {
     int BlockV13Height;
     /** Block height at which v14 blocks are created (CLTV + CSV + BIP68) */
     int BlockV14Height;
+    /** Grace period in blocks after BlockV14Height before peers on the old
+      * protocol version are disconnected. Network-specific to allow testnet
+      * a longer window when the fork has already passed before deployment.
+      */
+    int ProtocolVersionGracePeriod;
     /** Block height at which poll v3 contract payloads are valid */
     int PollV3Height;
     /** Block height at which project v2 contracts are allowed */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2035,13 +2035,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        // Note the std::max is there to deal with the rollover of BlockV12Height + DISCONNECT_GRACE_PERIOD if
-        // BlockV12Height is set to std::numeric_limits<int>::max() which is the case during testing.
+        // Disconnect peers on old protocol versions after a grace period past the
+        // BlockV14Height activation height. Skip entirely if that fork is not yet
+        // activated (height == INT_MAX) to avoid signed integer overflow UB in the addition.
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION
             || (DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD
                 && pfrom->nVersion < PROTOCOL_VERSION
-                && pindexBest->nHeight > std::max(Params().GetConsensus().BlockV13Height,
-                                                  Params().GetConsensus().BlockV13Height + DISCONNECT_GRACE_PERIOD)
+                && Params().GetConsensus().BlockV14Height != std::numeric_limits<int>::max()
+                && pindexBest->nHeight > Params().GetConsensus().BlockV14Height
+                                             + Params().GetConsensus().ProtocolVersionGracePeriod
                 )
             ) {
             // disconnect from peers older than this proto version

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
 // network protocol versioning
 //
 //! The current protocol version
-static const int PROTOCOL_VERSION = 180328;
+static const int PROTOCOL_VERSION = 180329;
 
 //! Note that there may be special logic implemented for
 //! a hard fork that actually disconnects nodes less than
@@ -18,10 +18,7 @@ static const int PROTOCOL_VERSION = 180328;
 //! DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD to true.
 static const bool DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD = true;
 
-//! This is the number of blocks for the disconnect grace period if
-//! DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD is true. If it is false, this
-//! is inoperative.
-static const int DISCONNECT_GRACE_PERIOD = 900 * 7;
+//! The disconnect grace period is now per-network in Consensus::Params::ProtocolVersionGracePeriod.
 
 //! Disconnect from peers older than this proto version. This is absolute.
 static const int MIN_PEER_PROTO_VERSION = 180327;


### PR DESCRIPTION
## Summary

- Bump `PROTOCOL_VERSION` from 180328 to 180329
- Keep `MIN_PEER_PROTO_VERSION` at 180327 — the Natasha mainnet release will activate both v13 and v14 block heights nearly simultaneously, so mainnet peers jump from 180327 directly to 180329 (180328 was never released on mainnet). `MIN_PEER_PROTO_VERSION` cannot be bumped above 180327 until the release *after* Natasha, once all viable mainnet peers are on 180329.
- Update disconnect check in `main.cpp` to reference `BlockV14Height` instead of `BlockV13Height`
- Fix signed integer overflow UB: when `BlockV14Height` is `INT_MAX` (fork not yet activated on mainnet), the old code computed `INT_MAX + grace_period`, which is undefined behavior. The compiler optimized away the `std::max` protection, causing all peers on the previous protocol to be disconnected immediately. Fix by skipping the disconnect logic entirely when the fork height is not yet set.
- Move `DISCONNECT_GRACE_PERIOD` from a global constant in `version.h` to per-network `Consensus::Params::ProtocolVersionGracePeriod`:
  - **Mainnet**: `900 * 7` (6300 blocks, ~6.5 days)
  - **Testnet**: `900 * 21` (18900 blocks, ~19.6 days) — extended because the v14 fork preceded the protocol version deployment by ~9000+ blocks

### How the disconnect logic works

After `BlockV14Height + ProtocolVersionGracePeriod`, any peer with `nVersion < PROTOCOL_VERSION (180329)` is disconnected. This covers both 180327 and 180328 peers on testnet.

On mainnet, `BlockV14Height` is `INT_MAX` (not yet activated), so the grace period check is skipped entirely — 180327 peers connect normally. Once Natasha ships and v14 activates on mainnet, the grace period countdown begins. After `BlockV14Height + 6300` blocks (~6.5 days), peers still on 180327 will be disconnected.

## Test plan

- [x] Build passes
- [x] Verified mainnet node connects to 180327 peers (UB fix confirmed)
- [ ] Deploy to testnet and verify old-protocol peers are disconnected after grace period

🤖 Generated with [Claude Code](https://claude.com/claude-code)