### PR TITLE
consensus: set mainnet fork heights for Natasha mandatory

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -68,17 +68,17 @@ public:
         consensus.BlockV10Height = 1420000;
         consensus.BlockV11Height = 2053000;
         consensus.BlockV12Height = 2671700;
-        consensus.BlockV13Height = std::numeric_limits<int>::max();
-        consensus.BlockV14Height = std::numeric_limits<int>::max();
+        consensus.BlockV13Height = 3989800;
+        consensus.BlockV14Height = 3990000;
         consensus.ProtocolVersionGracePeriod = 900 * 7; // ~6.5 days
         consensus.PollV3Height = 2671700;
         consensus.ProjectV2Height = 2671700;
-        consensus.AutoGreylistAuditHeight = std::numeric_limits<int>::max();
+        consensus.AutoGreylistAuditHeight = 3989800;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
-        consensus.ProjectV4Height = std::numeric_limits<int>::max();
-        consensus.SuperblockV3Height = std::numeric_limits<int>::max();
+        consensus.ProjectV4Height = 3989800;
+        consensus.SuperblockV3Height = 3989800;
         // Immediately post zero payment interval fees 40% for mainnet
         consensus.InitialMRCFeeFractionPostZeroInterval = Fraction(2, 5);
         consensus.MRCZeroPaymentInterval = 14 * 24 * 60 * 60;


### PR DESCRIPTION
## Summary

Sets mainnet activation heights for the Natasha mandatory release, enabling v13 (Fern II) and v14 (HTLC) consensus rules and associated subsystem gates.

### Fork height calculations

Based on observed mainnet block rate from `getblockstats 1 30000` at height 3,927,815:

| Parameter | Value |
|-----------|-------|
| Observed block rate | ~1,016.15 blocks/day |
| Current height (at calculation time) | 3,927,815 |
| Target release date | ~5 days from calculation |
| Estimated release height | 3,927,815 + (5 × 1,016.15) = **~3,932,896** |
| v13 activation (8 weeks post-release) | 3,932,896 + (56 × 1,016.15) = **3,989,800** |
| v14 activation (200 blocks after v13) | 3,989,800 + 200 = **3,990,000** |

The 8-week window gives mainnet node operators sufficient time to upgrade after the release is published.

### Heights set

| Parameter | Height | What it enables |
|-----------|--------|-----------------|
| `BlockV13Height` | 3,989,800 | v13 blocks, CBR/magnitude unit adjustability via protocol entries, mandatory sidestakes |
| `BlockV14Height` | 3,990,000 | OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY, BIP68 sequence locks |
| `ProjectV4Height` | 3,989,800 | v4 project contracts (auto greylist override field) |
| `SuperblockV3Height` | 3,989,800 | v3 superblock contracts (all-CPID total credits for autogreylist) |
| `AutoGreylistAuditHeight` | 3,989,800 | Benefit-of-doubt autogreylist evaluation (no warmup needed — lookback window handles history) |

### Notes

- v13 and v14 activate nearly simultaneously (200 block gap) because both have been validated together on testnet since late 2025
- `MIN_PEER_PROTO_VERSION` remains at 180327 in this release — mainnet peers jump from 180327 directly to 180329 (180328 was only released on testnet). See PR #2906 for protocol version details.
- All heights match the pattern used on testnet, where `ProjectV4Height`, `SuperblockV3Height`, and `AutoGreylistAuditHeight` were set to the v13 height

## Test plan

- [x] Build passes
- [x] All heights validated on testnet since late 2025
- [x] Mainnet sync-from-genesis with new heights (should be no-op until activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Note that the new emission parameters according to the attached spreadsheet will be set on mainnet after the v14 height and a little time has passed for the network to stabilize.
[rebalancing+rewards_increase.xlsx](https://github.com/user-attachments/files/26335623/rebalancing%2Brewards_increase.xlsx)
