### PR TITLE
voting: initialize buildPollTable timer for daemon/RPC callers

### DIFF
--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -11,6 +11,7 @@
 #include "gridcoin/voting/result.h"
 #include "protocol.h"
 #include "server.h"
+#include "util/time.h"
 
 using namespace GRC;
 
@@ -166,6 +167,8 @@ UniValue PollResultToJson(const PollResult& result, const PollReference& poll_re
 
 UniValue PollResultToJson(const PollReference& poll_ref)
 {
+    g_timer.InitTimer("buildPollTable", LogInstance().WillLogCategory(BCLog::LogFlags::VOTE));
+
     GetPollRegistry().registry_traversal_in_progress = true;
 
     try {


### PR DESCRIPTION
## Summary

The `buildPollTable` MilliTimer was only initialized in the GUI path (`VotingModel::buildPollTable`). When poll results are queried via RPC on a headless daemon, `PollResult::BuildFor()` calls `GetTimes` with the uninitialized label, producing spurious warnings:

```
WARNING: GetTimes: Timer with specified label does not exist. Returning zeroed timer.
```

Initialize the timer at the RPC entry point (`PollResultToJson` in `rpc/voting.cpp`) rather than inside `BuildFor`, so each caller owns its timer initialization and the GUI path's timer is not reset mid-table-build.

## Test plan

- [x] Build passes
- [x] Reported by testnet user running headless daemon with RPC poll queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)