### PR TITLE
build: Restore Windows font rendering and disable CI notarization

### DIFF
--- a/.github/workflows/cmake_production.yml
+++ b/.github/workflows/cmake_production.yml
@@ -954,92 +954,20 @@ jobs:
 
   # ----------------------------------------------------------------------
   # JOB 4: Notarize macOS DMGs (tag pushes only)
+  # Disabled — Apple notarization service consistently times out at the
+  # 2-hour mark in CI. Notarization and stapling are performed locally
+  # using contrib/macdeploy/notarize-dmg.sh and the stapled DMGs are
+  # uploaded to the release manually.
   # ----------------------------------------------------------------------
-  notarize-macos:
-    name: Notarize and Staple macOS DMGs
-    needs: [macos-native-arm64, macos-native-intel]
-    runs-on: macos-14
-    if: startsWith(github.ref, 'refs/tags/')
-    env:
-      APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
-      APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-    steps:
-      - name: Download ARM64 DMG
-        uses: actions/download-artifact@v5
-        with:
-          name: gridcoin-macos-arm64-dmg
-          path: dmgs
-
-      - name: Download Intel DMG
-        uses: actions/download-artifact@v5
-        with:
-          name: gridcoin-macos-intel-dmg
-          path: dmgs
-
-      - name: Submit, Wait, and Staple
-        run: |
-          cd dmgs
-          mkdir -p ../notarized
-
-          for DMG in *.dmg; do
-            echo "=== Submitting: $DMG ==="
-            SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG" \
-              --apple-id "$APPLE_NOTARY_APPLE_ID" \
-              --password "$APPLE_NOTARY_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --output-format json 2>&1) || {
-              echo "WARNING: Submit failed for $DMG, skipping."
-              echo "$SUBMIT_OUTPUT"
-              continue
-            }
-            SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
-            echo "  Submission ID: $SUBMISSION_ID"
-
-            echo "=== Waiting for notarization (up to 2 hours) ==="
-            if xcrun notarytool wait "$SUBMISSION_ID" \
-              --apple-id "$APPLE_NOTARY_APPLE_ID" \
-              --password "$APPLE_NOTARY_PASSWORD" \
-              --team-id "$APPLE_TEAM_ID" \
-              --timeout 120m; then
-
-              echo "=== Stapling: $DMG ==="
-              xcrun stapler staple "$DMG"
-              xcrun stapler validate "$DMG"
-
-              # Copy stapled DMG with -notarized suffix for the release
-              NOTARIZED_NAME="${DMG%.dmg}-notarized.dmg"
-              cp "$DMG" "../notarized/$NOTARIZED_NAME"
-              echo "=== Done: $NOTARIZED_NAME ==="
-            else
-              echo "WARNING: Notarization timed out or failed for $DMG."
-              echo "The signed (non-notarized) DMG will still be published."
-              echo "You can manually notarize and staple later."
-            fi
-          done
-
-      - name: Upload Notarized ARM64 DMG
-        if: ${{ hashFiles('notarized/*arm64*') != '' }}
-        uses: actions/upload-artifact@v5
-        with:
-          name: gridcoin-macos-arm64-dmg-notarized
-          path: notarized/*arm64*.dmg
-          retention-days: 5
-
-      - name: Upload Notarized Intel DMG
-        if: ${{ hashFiles('notarized/*x86_64*') != '' }}
-        uses: actions/upload-artifact@v5
-        with:
-          name: gridcoin-macos-intel-dmg-notarized
-          path: notarized/*x86_64*.dmg
-          retention-days: 5
+  # notarize-macos:
+  #   ...
 
   # ----------------------------------------------------------------------
   # JOB 5: Deploy (GitHub Release)
   # ----------------------------------------------------------------------
   deploy:
     name: Create Release
-    needs: [depends-builds, notarize-macos, flatpak-build]
+    needs: [depends-builds, flatpak-build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:

--- a/contrib/macdeploy/notarize-dmg.sh
+++ b/contrib/macdeploy/notarize-dmg.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+#
+# notarize-dmg.sh — Submit signed DMGs to Apple for notarization and staple.
+#
+# This script replaces the CI notarization job which times out at 2 hours.
+# Run it on a macOS machine with valid Apple Developer credentials.
+#
+# Usage:
+#   ./contrib/macdeploy/notarize-dmg.sh <dmg-file> [<dmg-file> ...]
+#
+# Environment variables (or pass interactively):
+#   APPLE_ID    — Apple ID email for notarytool
+#   TEAM_ID     — Apple Developer Team ID
+#   PASSWORD    — App-specific password (or keychain profile name with --keychain-profile)
+#
+# Example:
+#   APPLE_ID=dev@example.com TEAM_ID=ABCDEF1234 PASSWORD=xxxx-xxxx-xxxx-xxxx \
+#     ./contrib/macdeploy/notarize-dmg.sh gridcoin-5.5.0.0-macos-arm64.dmg
+
+set -euo pipefail
+
+err() { echo "ERROR: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+APPLE_ID="${APPLE_ID:-}"
+TEAM_ID="${TEAM_ID:-}"
+PASSWORD="${PASSWORD:-}"
+
+if [ -z "$APPLE_ID" ]; then
+    read -rp "Apple ID: " APPLE_ID
+fi
+if [ -z "$TEAM_ID" ]; then
+    read -rp "Team ID: " TEAM_ID
+fi
+if [ -z "$PASSWORD" ]; then
+    read -rsp "App-specific password: " PASSWORD
+    echo
+fi
+
+[ -n "$APPLE_ID" ] || err "APPLE_ID is required."
+[ -n "$TEAM_ID" ] || err "TEAM_ID is required."
+[ -n "$PASSWORD" ] || err "PASSWORD is required."
+
+# ---------------------------------------------------------------------------
+# Process each DMG
+# ---------------------------------------------------------------------------
+[ $# -ge 1 ] || err "Usage: $0 <dmg-file> [<dmg-file> ...]"
+
+for DMG in "$@"; do
+    [ -f "$DMG" ] || err "File not found: $DMG"
+
+    echo "=== Submitting: $DMG ==="
+    SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG" \
+        --apple-id "$APPLE_ID" \
+        --password "$PASSWORD" \
+        --team-id "$TEAM_ID" \
+        --output-format json 2>&1) || {
+        echo "Submit failed for $DMG:"
+        echo "$SUBMIT_OUTPUT"
+        continue
+    }
+
+    SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+    echo "  Submission ID: $SUBMISSION_ID"
+
+    echo "=== Waiting for notarization ==="
+    if xcrun notarytool wait "$SUBMISSION_ID" \
+        --apple-id "$APPLE_ID" \
+        --password "$PASSWORD" \
+        --team-id "$TEAM_ID"; then
+
+        echo "=== Fetching log ==="
+        xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "$APPLE_ID" \
+            --password "$PASSWORD" \
+            --team-id "$TEAM_ID" || true
+
+        echo "=== Stapling: $DMG ==="
+        xcrun stapler staple "$DMG"
+        xcrun stapler validate "$DMG"
+        echo "=== Done: $DMG is notarized and stapled. ==="
+    else
+        echo "Notarization failed or timed out for $DMG."
+        echo "Fetching log for details:"
+        xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "$APPLE_ID" \
+            --password "$PASSWORD" \
+            --team-id "$TEAM_ID" || true
+    fi
+
+    echo
+done

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -155,7 +155,7 @@ endif
 $(package)_config_opts_freebsd := $$($(package)_config_opts_linux)
 
 $(package)_config_opts_mingw32 := -no-dbus
-$(package)_config_opts_mingw32 += -no-freetype
+$(package)_config_opts_mingw32 += -qt-freetype
 $(package)_config_opts_mingw32 += -no-pkg-config
 
 $(package)_config_opts += $($(package)_config_opts_$(host_os))


### PR DESCRIPTION
## Summary
- **Restore FreeType in Windows Qt depends build** — The Qt6 depends update (3f1e2a57e) changed `-qt-freetype` to `-no-freetype` for mingw32, breaking the `fontengine=freetype` setting that renders Inter OpenType fonts clearly on Windows. This one-line fix in `depends/packages/qt.mk` restores it.
- **Disable CI notarization** — Apple's notarization service consistently times out at the 2-hour CI limit. The `notarize-macos` job is disabled and removed from the deploy dependency chain. Code signing is unchanged.
- **Add local notarization script** — `contrib/macdeploy/notarize-dmg.sh` performs notarization and stapling locally on a macOS machine. Stapled DMGs are uploaded to the release manually.

## Test plan
- [x] Windows cross-compile build with `-qt-freetype` — fonts render correctly at 1080p/100% in dark mode
- [x] Verify Linux native build is unaffected (the `qt.mk` change is mingw32-only)
- [x] Verify tagged release workflow completes without the notarization job blocking deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)