### PR TITLE
build: Fix ENABLE_QRENCODE option being no-op

### DIFF
--- a/src/config/gridcoin-config.h.cmake.in
+++ b/src/config/gridcoin-config.h.cmake.in
@@ -38,7 +38,7 @@
 #cmakedefine USE_ASM_SCRYPT
 
 #cmakedefine USE_DBUS
-#cmakedefine USE_QRCODE
+#cmakedefine ENABLE_QRENCODE
 
 #cmakedefine HAVE_STRERROR_R
 #cmakedefine STRERROR_R_CHAR_P

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -131,6 +131,10 @@ elseif(APPLE)
     )
 endif()
 
+if(ENABLE_QRENCODE)
+    target_sources(gridcoinqt PRIVATE qrcodedialog.cpp)
+endif()
+
 set_target_properties(gridcoinqt PROPERTIES
     AUTOMOC ON
     AUTORCC ON
@@ -173,6 +177,9 @@ if(USE_QT6)
 endif()
 if(USE_DBUS)
     target_link_libraries(gridcoinqt PUBLIC ${QT}::DBus)
+endif()
+if(ENABLE_QRENCODE)
+    target_link_libraries(gridcoinqt PUBLIC PkgConfig::QRENCODE)
 endif()
 
 if(APPLE)

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -15,7 +15,7 @@
 #include <QMessageBox>
 #include <QMenu>
 
-#ifdef USE_QRCODE
+#ifdef ENABLE_QRENCODE
 #include "qrcodedialog.h"
 #endif
 
@@ -40,7 +40,7 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
     ui->deleteButton->setIcon(QIcon());
 #endif
 
-#ifndef USE_QRCODE
+#ifndef ENABLE_QRENCODE
     ui->showQRCodeButton->setVisible(false);
 #endif
 
@@ -367,7 +367,7 @@ void AddressBookPage::changeFilter(const QString& needle)
 
 void AddressBookPage::on_showQRCodeButton_clicked()
 {
-#ifdef USE_QRCODE
+#ifdef ENABLE_QRENCODE
     QTableView *table = ui->tableView;
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 


### PR DESCRIPTION
I managed to miss it while working on the original CMake implementation. The option defined `ENABLE_QRENCODE`, which had no effect on the source because it relied on `USE_QRCODE` declaration instead.

I only noticed it now when I used `lddtree` to list library dependenices.