### PR TITLE
scraper: remove vestigial AuthenticationETagClear and unused global

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -101,7 +101,6 @@ std::vector<std::pair<std::string, std::string>> vuserpass;
  * in one project will have, in general, a different ID, than another project.
  */
 std::vector<std::pair<std::string, int64_t>> vprojectteamids;
-std::vector<std::string> vauthenicationetags;
 int64_t ndownloadsize = 0;
 int64_t nuploadsize = 0;
 
@@ -562,11 +561,6 @@ void DownloadProjectPublicKeys(const WhitelistSnapshot& projectWhitelist);
 bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& file, const std::string& etag,
                                  BeaconConsensus& Consensus, ScraperVerifiedBeacons& GlobalVerifiedBeaconsCopy,
                                  ScraperVerifiedBeacons& IncomingVerifiedBeacons, double& all_cpid_total_credit);
-/**
- * @brief Clears the authentication ETag auth.dat file
- */
-void AuthenticationETagClear();
-
 // Need to access from rpcblockchain.cpp
 extern UniValue SuperblockToJson(const Superblock& superblock);
 
@@ -1659,8 +1653,6 @@ void Scraper(bool bSingleShot)
                 }
             }
 
-            AuthenticationETagClear();
-
             // Note a lock on cs_StructScraperFileManifest is taken in StoreBeaconList,
             // and the block hash for the consensus block height is updated in the struct.
             if (!StoreBeaconList(pathScraper / "BeaconList.csv.gz"))
@@ -2039,13 +2031,6 @@ bool ScraperDirectoryAndConfigSanity()
     return true;
 }
 
-void AuthenticationETagClear()
-{
-    fs::path file = fs::current_path() / "auth.dat";
-
-    if (fs::exists(file))
-        fs::remove(file);
-}
 
 bool UserpassPopulated()
 {


### PR DESCRIPTION
## Summary
- Remove `AuthenticationETagClear()` which targeted a plain `auth.dat` in `fs::current_path()` that was never created by any code path. The function dates from the original standalone scraper integration (2018) where a companion `AuthenticationETagUpdate()` was declared but never implemented.
- Remove the unused `vauthenicationetags` global vector, also from the original integration.
- The actual GDPR-protected project authentication flow (`userpass.dat` → `vuserpass` → `CURLOPT_USERPWD`) is completely independent and unaffected.

## Background
Reported by iFoggz: running the daemon from a directory without write access (e.g. `su` to a service account while CWD is `/root/...`) would cause `fs::current_path() / "auth.dat"` to reference an inaccessible path. Investigation revealed the function was dead code — the file it targets is never created, and the per-project `<project>_auth.dat` files written by the `authdata` class are diagnostic records unrelated to this cleanup path.

## Test plan
- [x] Verified clean build (no warnings)
- [x] Confirm scraper operates normally (GDPR and non-GDPR projects download correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)