### PR TITLE
superblock: fix by-project fallback to handle PPK/PACTC side-channel parts

### DIFF
--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -575,11 +575,19 @@ public:
     //! \brief Create a new validator for the provided superblock.
     //!
     //! \param superblock The superblock data to validate.
+    //! \param hint_bits  For testing by-project fallback validation.
+    //! \param height     Height of the block whose superblock is being
+    //!                   validated. Threaded through to ProjectResolver to
+    //!                   gate the PPK/PACTC skip-list extension behind
+    //!                   BlockV13Height.
     //!
-    SuperblockValidator(const SuperblockPtr& superblock, size_t hint_bits = 32)
+    SuperblockValidator(const SuperblockPtr& superblock,
+                        size_t hint_bits = 32,
+                        int height = std::numeric_limits<int>::max())
         : m_superblock(superblock)
         , m_quorum_hash(superblock->GetHash())
         , m_hint_shift(32 + std::clamp<size_t>(32 - hint_bits, 0, 32))
+        , m_height(height)
     {
     }
 
@@ -862,11 +870,17 @@ private: // SuperblockValidator classes
         //!
         //! \param projects Contains matching manifest parts hashes for each
         //! project hinted in the superblock.
+        //! \param height   Height of the block whose superblock is being
+        //!                 validated. Used to gate post-v13 side-channel
+        //!                 part inclusion (PACTC, PPK) in the reconstructed
+        //!                 convergence.
         //!
-        ProjectCombiner(std::map<std::string, ResolvedProject> projects)
+        ProjectCombiner(std::map<std::string, ResolvedProject> projects,
+                        int height = std::numeric_limits<int>::max())
             : m_projects(std::move(projects))
             , m_total_combinations(1)
             , m_current_combination(0)
+            , m_height(height)
         {
             for (auto& project_pair : reverse_iterate(m_projects)) {
                 project_pair.second.m_combiner_mask = m_total_combinations;
@@ -880,6 +894,7 @@ private: // SuperblockValidator classes
         ProjectCombiner()
             : m_total_combinations(0)
             , m_current_combination(0)
+            , m_height(std::numeric_limits<int>::max())
         {
         }
 
@@ -976,7 +991,7 @@ private: // SuperblockValidator classes
                 }
             }
 
-            AddBeaconPartsData(convergence, latest_manifest);
+            AddBeaconPartsData(convergence, latest_manifest, m_height);
 
             ++m_current_combination;
 
@@ -992,6 +1007,16 @@ private: // SuperblockValidator classes
 
         size_t m_total_combinations;  //!< Number of project part combinations.
         size_t m_current_combination; //!< Number of the combination to try.
+
+        //!
+        //! \brief Height of the block whose superblock is being validated.
+        //!
+        //! Threaded from SuperblockValidator so AddBeaconPartsData can gate
+        //! the PACTC/PPK inclusion (post-BlockV13Height) in the reconstructed
+        //! convergence, matching the scraper-side behavior at
+        //! scraper.cpp:5613-5627.
+        //!
+        const int m_height;
 
         //!
         //! \brief Fetch the project part data for the specified part hash.
@@ -1017,15 +1042,40 @@ private: // SuperblockValidator classes
         }
 
         //!
-        //! \brief Insert the beacon list and verified beacons part data from
-        //! the specified manifest into the provided convergence candidate.
+        //! \brief Insert the beacon list and (optionally) the side-channel
+        //! parts from the specified manifest into the provided convergence
+        //! candidate.
         //!
-        //! \param convergence   Convergence to add the beacon parts to.
-        //! \param manifest_hash Identifies the manifest to fetch the parts from.
+        //! Mirrors the scraper-side convergence construction at
+        //! scraper.cpp:5611-5627: after the per-project supermajority check
+        //! selects a winning source manifest, pull BeaconList (always at
+        //! part 0) and any of the side-channel parts (VerifiedBeacons,
+        //! ProjectsAllCpidTotalCredits, ProjectPublicKeys) that the manifest
+        //! happens to carry. Absence of any side-channel part is not a
+        //! failure — scrapers emit them conditionally (e.g. VerifiedBeacons
+        //! only when beacons are pending verification; PPK only when
+        //! v3-beacon-capable projects are whitelisted).
+        //!
+        //! Side-channel-part integrity is inherited transitively: the
+        //! source manifest was already in supermajority for at least one
+        //! regular project, so its side-channel parts are trusted for this
+        //! convergence candidate, matching the scraper-side security model.
+        //!
+        //! \param convergence   Convergence to add the parts to.
+        //! \param manifest_hash Identifies the source manifest.
+        //! \param height        Height of the block whose superblock is
+        //!                      being validated. PACTC and PPK are only
+        //!                      included in the reconstructed convergence
+        //!                      at or after BlockV13Height — before that
+        //!                      the fallback did not handle these parts at
+        //!                      all (and scrapers did not emit them), so
+        //!                      preserving pre-v13 convergence contents
+        //!                      keeps the hard-fork story clean.
         //!
         static void AddBeaconPartsData(
             ConvergenceCandidate& convergence,
-            const uint256& manifest_hash)
+            const uint256& manifest_hash,
+            const int height)
         {
             LOCK(CScraperManifest::cs_mapManifest);
 
@@ -1040,13 +1090,13 @@ private: // SuperblockValidator classes
 
             const CScraperManifest_shared_ptr manifest = iter->second;
 
-            // If the manifest for the beacon list is now empty, we cannot
-            // proceed, but ProjectResolver should always select manifests
-            // with a beacon list part:
+            const bool include_extra_side_channel_parts = IsV13Enabled(height);
 
             // Note using fine-grained locking here to avoid lock-order issues and
             // also to deal with Clang potential false positive below.
-            std::vector<CScraperManifest::dentry>::iterator verified_beacons_entry_iter;
+            std::vector<CScraperManifest::dentry>::iterator verified_beacons_iter;
+            std::vector<CScraperManifest::dentry>::iterator pactc_iter;
+            std::vector<CScraperManifest::dentry>::iterator ppk_iter;
             {
                 LOCK(manifest->cs_manifest);
 
@@ -1057,35 +1107,50 @@ private: // SuperblockValidator classes
 
                 convergence.AddPart("BeaconList", manifest->vParts[0]);
 
-                // Find the offset of the verified beacons project part. Typically
-                // this exists at vParts offset 1 when a scraper verified at least
-                // one pending beacon. If it doesn't exist, omit the part from the
-                // reconstructed convergence:
-                verified_beacons_entry_iter = std::find_if(
-                            manifest->projects.begin(),
-                            manifest->projects.end(),
-                            [](const CScraperManifest::dentry& entry) {
-                    return entry.project == "VerifiedBeacons";
-                });
+                auto find_entry = [&manifest](const std::string& name) {
+                    return std::find_if(
+                        manifest->projects.begin(),
+                        manifest->projects.end(),
+                        [&name](const CScraperManifest::dentry& entry) {
+                            return entry.project == name;
+                        });
+                };
+
+                verified_beacons_iter = find_entry("VerifiedBeacons");
+
+                if (include_extra_side_channel_parts) {
+                    pactc_iter = find_entry("ProjectsAllCpidTotalCredits");
+                    ppk_iter = find_entry("ProjectPublicKeys");
+                } else {
+                    pactc_iter = manifest->projects.end();
+                    ppk_iter = manifest->projects.end();
+                }
             }
 
             // The manifest must be unlocked above and then relocked after cs_mapParts to avoid possible
             // deadlock due to lock order.
             LOCK2(CSplitBlob::cs_mapParts, manifest->cs_manifest);
 
-            if (verified_beacons_entry_iter == manifest->projects.end()) {
-                LogPrintf("ValidateSuperblock(): verified beacon project missing.");
-                return;
-            }
+            // Add a side-channel part to the convergence if the manifest
+            // carries it. Absent parts are silently skipped — scrapers emit
+            // these conditionally and the convergence is expected to omit
+            // them when the manifest did. Mirrors scraper.cpp:5622-5626.
+            auto add_optional_part = [&](const std::string& name,
+                                         std::vector<CScraperManifest::dentry>::iterator it) {
+                if (it == manifest->projects.end()) {
+                    return;
+                }
+                const size_t part_offset = it->part1;
+                if (part_offset == 0 || part_offset >= manifest->vParts.size()) {
+                    LogPrintf("ValidateSuperblock(): out-of-range part offset for %s.", name);
+                    return;
+                }
+                convergence.AddPart(name, manifest->vParts[part_offset]);
+            };
 
-            const size_t part_offset = verified_beacons_entry_iter->part1;
-
-            if (part_offset == 0 || part_offset >= manifest->vParts.size()) {
-                LogPrintf("ValidateSuperblock(): out-of-range verified beacon part.");
-                return;
-            }
-
-            convergence.AddPart("VerifiedBeacons", manifest->vParts[part_offset]);
+            add_optional_part("VerifiedBeacons", verified_beacons_iter);
+            add_optional_part("ProjectsAllCpidTotalCredits", pactc_iter);
+            add_optional_part("ProjectPublicKeys", ppk_iter);
         }
     }; // ProjectCombiner
 
@@ -1105,9 +1170,11 @@ private: // SuperblockValidator classes
         //!
         ProjectResolver(
             std::map<std::string, CandidatePartHashMap> candidate_parts,
-            mmCSManifestsBinnedByScraper manifests_by_scraper)
+            mmCSManifestsBinnedByScraper manifests_by_scraper,
+            int height = std::numeric_limits<int>::max())
             : m_manifests_by_scraper(std::move(manifests_by_scraper))
             , m_supermajority(NumScrapersForSupermajority(m_manifests_by_scraper.size()))
+            , m_height(height)
         {
             for (auto&& project_part_pair : candidate_parts) {
                 m_resolved_projects.emplace(
@@ -1168,7 +1235,7 @@ private: // SuperblockValidator classes
                 }
             }
 
-            return ProjectCombiner(std::move(m_resolved_projects));
+            return ProjectCombiner(std::move(m_resolved_projects), m_height);
         }
 
     private:
@@ -1202,6 +1269,14 @@ private: // SuperblockValidator classes
         std::map<std::string, std::set<ScraperID>> m_other_projects;
 
         //!
+        //! \brief Height of the block whose superblock is being validated.
+        //!
+        //! Used to gate the PPK/PACTC skip-list extension behind
+        //! BlockV13Height. See TallyProject().
+        //!
+        const int m_height;
+
+        //!
         //! \brief Record the supplied scraper ID for the specified project to
         //! track supermajority status.
         //!
@@ -1220,6 +1295,25 @@ private: // SuperblockValidator classes
             // stage:
             //
             if (project == "BeaconList" || project == "VerifiedBeacons") {
+                return nullptr;
+            }
+
+            // ProjectsAllCpidTotalCredits (added to manifests in 2025-01) and
+            // ProjectPublicKeys (added in 2026-02 for v3 beacon ownership
+            // proofs) are also manifest-level side-channel parts rather than
+            // BOINC projects, but were not added to the skip list above when
+            // the scraper started emitting them. The scraper's own roll-up
+            // (ScraperConstructConvergedManifestByProject) filters them, so
+            // cached-convergence and current-convergence validation paths are
+            // unaffected. The by-project fallback path is not: scrapers pass
+            // supermajority on both entries every cycle, and the
+            // "missing from superblock" check below rejects every modern
+            // superblock. Gated behind BlockV13Height so the rule change has
+            // a documented activation marker bundled with the v13 hard fork.
+            //
+            if (IsV13Enabled(m_height)
+                && (project == "ProjectsAllCpidTotalCredits"
+                    || project == "ProjectPublicKeys")) {
                 return nullptr;
             }
 
@@ -1278,6 +1372,9 @@ private: // SuperblockValidator fields
     const SuperblockPtr& m_superblock; //!< Points to the superblock to validate.
     const QuorumHash m_quorum_hash;    //!< Hash of the superblock to validate.
     const size_t m_hint_shift;         //!< For testing by-project combinations.
+    const int m_height;                //!< Height of the block being validated;
+                                       //!< threaded to ProjectResolver for the
+                                       //!< PPK/PACTC skip-list gate.
 
 private: // SuperblockValidator methods
 
@@ -1429,7 +1526,9 @@ private: // SuperblockValidator methods
             return false;
         }
 
-        ProjectResolver resolver(std::move(candidates), ScraperCullAndBinCScraperManifests());
+        ProjectResolver resolver(std::move(candidates),
+                                 ScraperCullAndBinCScraperManifests(),
+                                 m_height);
         ProjectCombiner combiner = resolver.ResolveProjectParts();
 
         LogPrint(BCLog::LogFlags::VERBOSE,
@@ -1559,7 +1658,7 @@ bool Quorum::ValidateSuperblockClaim(
             return error("%s: quorum hash mismatch.", __func__);
         }
 
-        return ValidateSuperblock(superblock);
+        return ValidateSuperblock(superblock, true, 32, pindex->nHeight);
     }
 
     const CTxDestination address = DecodeDestination(claim.m_quorum_address);
@@ -1591,11 +1690,12 @@ bool Quorum::ValidateSuperblockClaim(
 bool Quorum::ValidateSuperblock(
     const SuperblockPtr& superblock,
     const bool use_cache,
-    const size_t hint_bits)
+    const size_t hint_bits,
+    const int height)
 {
     using Result = SuperblockValidator::Result;
 
-    const Result result = SuperblockValidator(superblock, hint_bits).Validate(use_cache);
+    const Result result = SuperblockValidator(superblock, hint_bits, height).Validate(use_cache);
     std::string message;
 
     switch (result) {

--- a/src/gridcoin/quorum.h
+++ b/src/gridcoin/quorum.h
@@ -5,6 +5,7 @@
 #ifndef GRIDCOIN_QUORUM_H
 #define GRIDCOIN_QUORUM_H
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -125,13 +126,20 @@ public:
     //! \param superblock The superblock to validate.
     //! \param use_cache  If \c false, skip validation with the scraper cache.
     //! \param hint_bits  For testing by-project fallback validation.
+    //! \param height     Height of the block whose superblock is being
+    //!                   validated, used to gate the by-project fallback
+    //!                   skip-list extension behind BlockV13Height. Defaults
+    //!                   to INT_MAX so non-consensus callers (scraper self-
+    //!                   checks, unit tests) always apply the extended skip
+    //!                   list.
     //!
     //! \return \c true if local manifest data produces a matching superblock.
     //!
     static bool ValidateSuperblock(
         const SuperblockPtr& superblock,
         const bool use_cache = true,
-        const size_t hint_bits = 32);
+        const size_t hint_bits = 32,
+        const int height = std::numeric_limits<int>::max());
 
     //!
     //! \brief Get the current magnitude for the specified CPID.


### PR DESCRIPTION
## Summary

The validator's by-project fallback in `quorum.cpp` has been silently
non-functional since 2025-01-13, drifting out of sync with the scraper-
side convergence builder in two related ways:

1. `ProjectResolver::TallyProject` skip list (last updated 2020-06-23
   in `41910781a`) didn't include the two side-channel parts that
   scrapers later started emitting as entries in `manifest->projects`:
   `ProjectsAllCpidTotalCredits` (PACTC, since `79d7c3ff1` 2025-01-13)
   and `ProjectPublicKeys` (PPK, since `033e67faa` 2026-02-20, for v3
   beacon ownership-proof support). Scraper supermajority is reached
   on both every cycle, so when `ValidateSuperblock` falls through to
   the by-project path, it logs `"Converged project X missing from
   superblock"` and rejects every modern superblock.

2. `ProjectCombiner::AddBeaconPartsData` only handled `BeaconList` and
   `VerifiedBeacons` from the winning source manifest. The scraper-
   side convergence builder at `scraper.cpp:5611-5627` additionally
   pulls PACTC and PPK from the same manifest. Without mirroring that
   on the validator side, the reconstructed convergence's
   `GetScraperStatsByConvergedManifest` produces empty PACTC- and
   PPK-derived fields, so even after fixing (1) no modern on-chain
   superblock can hash-match via path 4 — the fallback remains
   non-functional.

## Why this is dormant on mainnet (no urgency, leisure release)

The cached-convergence path (`TryRecentPastConvergence`) is a pure
hash lookup and hits first during real block validation because
`PastConvergences` is populated by the scraper-side roll-up, which
already filters PPK/PACTC correctly. The broken fallback only runs
when paths 1-3 all miss simultaneously, which is rare on mainnet.
**The bug has been present for 15+ months without producing observable
consensus failures.** This PR is a leisure release — no upgrade
urgency — and fixes a dormant safety-net code path.

## Fix

- Extend `TallyProject`'s skip list to also bypass PACTC and PPK,
  matching `scraper.cpp:4337-4338`. Side-channel-part integrity is
  inherited transitively from the source manifest's per-project
  supermajority (the same security model the scraper uses).
- Rewrite `AddBeaconPartsData` to additionally include PACTC and PPK
  from the source manifest if present, mirroring `scraper.cpp:5611-5627`.
  Missing entries are silently skipped — scrapers emit these parts
  conditionally (VerifiedBeacons only with pending beacons; PPK only
  with v3-beacon-capable projects whitelisted) and the reconstructed
  convergence must tolerate their absence the same way the scraper-
  side builder does. This removes the "verified beacon project
  missing" hard-fail on legitimate empty-VerifiedBeacons cycles.

Both extensions are gated at `IsV13Enabled(m_height)` so the rule
change has a documented activation marker bundled with the v13 hard
fork. Block height is threaded from `Quorum::ValidateSuperblock` →
`SuperblockValidator::m_height` → `ProjectResolver::m_height` →
`ProjectCombiner::m_height` → `AddBeaconPartsData(..., height)` via
an optional parameter defaulting to `INT_MAX` so non-consensus
callers (scraper `testnewsb` self-checks, unit tests) always apply
post-v13 behavior regardless of chain state.

Both gate sites use the `IsV13Enabled()` helper from `chainparams.h`
rather than reading `Params().GetConsensus().BlockV13Height` directly,
so testnet `-blockv13height` config overrides are honored consistently
with the rest of the codebase.

## Fork-safety analysis

Unfixed nodes that reach path 4 will reject transiently and recover
on the next scraper cycle via path 2 (cached-convergence hash
compare), which is populated correctly on every binary because the
scraper-side roll-up has the correct filter. **No persistent fork is
possible from this fix.** This argued for leisure rather than
mandatory classification, validated empirically below.

## Testnet validation

Validated end-to-end on a 3-node isolated testnet running for 3 days
with a deliberate 2-patched / 1-unfixed split:

| Date / Time | Event | Result |
|---|---|---|
| 2026-04-23 00:19:28 | SB staked by **patched** node | Unfixed node accepted via path 1 in 1 second |
| 2026-04-24 00:20:16 | SB staked by **unfixed** node | Patched nodes accepted via path 1 in 1 second |
| 2026-04-25 00:21:20 | SB staked by patched node | All accepted via path 1 |
| 2026-04-25 04:42:17 | Multi-block reorg (3 disconnect / 4 connect) | Unfixed node converged with patched nodes via path 1/2 |

- Three SB transitions observed, both directions (patched↔unfixed
  staker), all accepted via `VALID_CURRENT` on every node.
- Multi-block reorg cleanly absorbed by the unfixed validator with
  no fallback invocation.
- ~20 single-block PoS-race reorgs evenly distributed across all
  three nodes (no binary-version asymmetry).
- Zero `AcceptBlock FAILED`, zero `InvalidChainFound`, zero permanent
  forks, all three nodes always at the same tip.

`testnewsb` self-check on the patched binary now reports
`VALID_BY_PROJECT - Matched supermajority by project.` for the
current-SB cache-disabled stress call when scraper state is consistent
with the SB, confirming the fallback is a functional recovery path
again rather than dormant broken code.

## Follow-ups (not in this PR)

- Extract `IsScraperSideChannelPart()` predicate to a shared header
  and replace the four `scraper.cpp` sites + the `quorum.cpp` site
  with calls to it. Same pattern as BlockRewardRules unification
  (#2880). Separate refactor PR.
- Unit test for the by-project fallback validation path. Existing
  test infrastructure builds single-manifest convergences but doesn't
  set up the multi-scraper supermajority context needed to exercise
  the fallback. Building that infrastructure is comparable in size to
  this fix and is better paired with the structural follow-up above
  (which provides a smaller surface to test directly).
- Quieten the `[grc-scraper]` `testnewsb` log noise on the
  cache-disabled stress paths so the cosmetic output doesn't read as
  consensus failures (a separate UX-quality change).

## Test plan

- [x] Builds clean against `development` (`cmake --build build`).
- [x] Existing `superblock_tests.cpp` continues to pass.
- [x] 3-day mixed-binary isolated testnet validation (see above).
- [x] Reviewer-side: run the test suite locally and confirm no
  regressions (`ctest --test-dir build`). (Satisfied by CI.)
  
🤖 Generated with [Claude Code](https://claude.com/claude-code)