### PR TITLE
doc: update CLAUDE.md consensus-changes block-version note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Key threads: `ThreadStakeMiner` (block generation), `ThreadScraper`/`ThreadScrap
 
 ### Consensus Changes
 
-All consensus rule changes must be gated by block height or version. Current mainnet block version is 12; version 13 is in testnet/development. Consensus changes require hard fork coordination.
+All consensus rule changes must be gated by block height or version. Mainnet block-version activation heights are set in `src/chainparams.cpp` (`CMainParams`) — check there for the current, authoritative values rather than relying on this file. As of this writing: `BlockV13Height = 3989800`, `BlockV14Height = 3990000` (both set, scheduled as future mainnet activations at the time of this line's last update). Consensus changes require hard fork coordination.
 
 ## Test Conventions
 


### PR DESCRIPTION
## Summary

The existing text in `CLAUDE.md` asserted "Current mainnet block
version is 12; version 13 is in testnet/development", which had
become stale: v13 and v14 activation heights were set for mainnet
in the Natasha 5.5.0.0 release (`BlockV13Height = 3989800`,
`BlockV14Height = 3990000`).

Replace the specific stale claim with a pointer to
`src/chainparams.cpp` as the authoritative source, and include the
current concrete heights alongside an "at the time of this line's
last update" qualifier so future readers know to re-verify against
chainparams rather than trusting this file blindly.

## Test plan

- [x] Doc-only change, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)