### PR TITLE
ci: avoid Leap devel_basis solver prompt

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -220,9 +220,11 @@ install_deps() {
                 sudo zypper --gpg-auto-import-keys refresh
             fi
 
-            # Pattern Install
-            echo "Installing devel_basis pattern..."
-            sudo zypper install -y -t pattern devel_basis
+            # Do not install openSUSE's devel_basis pattern directly here.
+            # On Leap 15.6 the pattern can ask zypper to downgrade libncurses6
+            # interactively, which breaks non-interactive CI. Install the build
+            # tools Gridcoin needs explicitly instead.
+            append_base binutils bison flex gettext-tools m4 make patch zlib-devel
 
             # Base common packages
             append_base libtool automake autoconf pkg-config python3 cmake git curl ccache doxygen graphviz libzstd-devel


### PR DESCRIPTION
## Summary
- replace the direct `devel_basis` pattern install in the openSUSE dependency path with explicit build-tool packages
- keep the existing Gridcoin/OpenSUSE package list intact so CI no longer stops on the Leap 15.6 libncurses6 solver prompt

Fixes #2928

## Verification
- Reproduced the current failure in `opensuse/leap:15.6`: `zypper --non-interactive install --auto-agree-with-licenses --no-recommends -t pattern devel_basis` exits 4 after asking whether to downgrade `libncurses6`.
- Verified the replacement explicit package set resolves non-interactively with `zypper --non-interactive install --auto-agree-with-licenses --dry-run ...` in `opensuse/leap:15.6`.
- `bash -n install_dependencies.sh`
- `git diff --check`

I did not run the full native Gridcoin build locally; this patch is scoped to unblocking dependency installation before the build step.