### PR TITLE
rpc: convert addnode/setban/settxfee/listsinceblock to RPCHelpMan (#2922)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -841,23 +841,34 @@ UniValue getdifficulty(const UniValue& params, bool fHelp)
 
 UniValue settxfee(const UniValue& params, bool fHelp)
 {
+    static const RPCHelpMan help{
+        "settxfee",
+        "Set the transaction fee per kB (rounded to the nearest 0.00000001 GRC). "
+        "Overwrites the paytxfee parameter.",
+        {
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO,
+                "The transaction fee in GRC/kB."},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "Returns true if successful."},
+        RPCExamples{
+            HelpExampleCli("settxfee", "0.00001") +
+            HelpExampleRpc("settxfee", "0.00001")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
+
     LOCK(cs_main);
 
     CTransaction txDummy;
+    const CAmount nMinFee = GetBaseFee(txDummy, GMF_SEND);
+    const CAmount amount = AmountFromValue(params[0]);
+    if (amount < nMinFee) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+            strprintf("txfee %s below minimum %s",
+                      FormatMoney(amount), FormatMoney(nMinFee)));
+    }
 
-    // Min Fee
-    CAmount nMinFee = GetBaseFee(txDummy, GMF_SEND);
-
-    if (fHelp || params.size() < 1 || params.size() > 1 || AmountFromValue(params[0]) < nMinFee)
-        throw runtime_error(
-                "settxfee <amount>\n"
-                "\n"
-                "<amount> is a real and is rounded to the nearest 0.00000001\n"
-                "\n"
-                "Sets the txfee for transactions\n");
-
-    nTransactionFee = AmountFromValue(params[0]);
-
+    nTransactionFee = amount;
     return true;
 }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -6,6 +6,7 @@
 
 #include "server.h"
 #include "protocol.h"
+#include <rpc/util.h>
 #include "alert.h"
 #include "wallet/wallet.h"
 #include "wallet/db.h"
@@ -35,15 +36,32 @@ UniValue getconnectioncount(const UniValue& params, bool fHelp)
 
 UniValue addnode(const UniValue& params, bool fHelp)
 {
-    string strCommand;
-    if (params.size() == 2)
-        strCommand = params[1].get_str();
-    if (fHelp || params.size() != 2 ||
-            (strCommand != "onetry" && strCommand != "add" && strCommand != "remove"))
-        throw runtime_error(
-                "addnode <node> <add|remove|onetry>\n"
-                "\n"
-                "Attempts add or remove <node> from the addnode list or try a connection to <node> once\n");
+    static const RPCHelpMan help{
+        "addnode",
+        "Attempts to add or remove a node from the addnode list, or try a connection to a node once.",
+        {
+            {"node", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The node (see getpeerinfo for nodes), as host[:port]."},
+            {"command", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "'add' to add a node to the list, 'remove' to remove a node from the list, "
+                "'onetry' to try a connection to the node once."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "result", "always \"ok\" on success"},
+            }},
+        RPCExamples{
+            HelpExampleCli("addnode", "\"192.168.0.6:32749\" \"onetry\"") +
+            HelpExampleRpc("addnode", "\"192.168.0.6:32749\", \"onetry\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
+
+    const string strCommand = params[1].get_str();
+    if (strCommand != "onetry" && strCommand != "add" && strCommand != "remove") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+            "command must be one of: \"add\", \"remove\", \"onetry\"");
+    }
 
     string strNode = params[0].get_str();
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -227,23 +227,36 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
 
 UniValue setban(const UniValue& params, bool fHelp)
 {
-    std::string strCommand;
+    static const RPCHelpMan help{
+        "setban",
+        "Attempts to add or remove an IP/Subnet from the banned list.",
+        {
+            {"subnet", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask "
+                "(default is /32 = single IP)."},
+            {"command", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list."},
+            {"bantime", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Time in seconds how long (or until when if [absolute] is set) the IP is banned. "
+                "0 or empty means using the default time of 24h which can also be overwritten "
+                "by the -bantime startup argument."},
+            {"absolute", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If set, the bantime must be an absolute timestamp in seconds since epoch (Jan 1 1970 GMT). "
+                "Defaults to false."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("setban", "\"192.168.0.6\" \"add\" 86400") +
+            HelpExampleCli("setban", "\"192.168.0.0/24\" \"add\"") +
+            HelpExampleRpc("setban", "\"192.168.0.6\", \"add\", 86400")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
-    if (!params[1].isNull())
-        strCommand = params[1].get_str();
-
-    if (fHelp || params.size() < 2 || params.size() > 4 || (strCommand != "add" && strCommand != "remove"))
-    {
-        throw runtime_error(
-                    "setban <ip or subnet> <command> [bantime] [absolute]\n"
-                    "\n"
-                    "add or remove an IP/Subnet from the banned list.\n"
-                    "subnet: The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP) \n"
-                    "command: 'add' to add an IP/Subnet to the list, 'remove' to remove an IP/Subnet from the list \n"
-                    "bantime: time in seconds how long (or until when if [absolute] is set) the IP is banned \n"
-                    "         (0 or empty means using the default time of 24h which can also be overwritten by the -bantime startup argument)\n"
-                    "absolute: Defaults to false. If set, the bantime must be an absolute timestamp in seconds since epoch (Jan 1 1970 GMT).\n"
-                    );
+    const std::string strCommand = params[1].get_str();
+    if (strCommand != "add" && strCommand != "remove") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+            "command must be \"add\" or \"remove\"");
     }
 
     if (!g_banman) {

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -21,6 +21,7 @@
 // these with fHelp=true and an empty params array is safe in unit tests.
 UniValue settxfee(const UniValue& params, bool fHelp);
 UniValue addnode(const UniValue& params, bool fHelp);
+UniValue setban(const UniValue& params, bool fHelp);
 
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
@@ -354,6 +355,21 @@ BOOST_AUTO_TEST_CASE(addnode_help_renders)
         BOOST_CHECK(what.find("addnode") != std::string::npos);
         BOOST_CHECK(what.find("node") != std::string::npos);
         BOOST_CHECK(what.find("onetry") != std::string::npos);
+        BOOST_CHECK(what.find("Examples:") != std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(setban_help_renders)
+{
+    const UniValue params(UniValue::VARR);
+    try {
+        setban(params, /*fHelp=*/true);
+        BOOST_FAIL("expected runtime_error");
+    } catch (const std::runtime_error& e) {
+        const std::string what{e.what()};
+        BOOST_CHECK(what.find("setban") != std::string::npos);
+        BOOST_CHECK(what.find("subnet") != std::string::npos);
+        BOOST_CHECK(what.find("bantime") != std::string::npos);
         BOOST_CHECK(what.find("Examples:") != std::string::npos);
     }
 }

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <rpc/util.h>
 
+#include <rpc/protocol.h>
 #include <tinyformat.h>
 #include <univalue.h>
 
@@ -388,6 +389,47 @@ BOOST_AUTO_TEST_CASE(listsinceblock_help_renders)
         BOOST_CHECK(what.find("target_confirmations") != std::string::npos);
         BOOST_CHECK(what.find("transactions") != std::string::npos);
         BOOST_CHECK(what.find("Examples:") != std::string::npos);
+    }
+}
+
+// Invalid-subcommand path for addnode: the JSONRPCError throw at net.cpp:62-63
+// fires before any LOCK(cs_vAddedNodes) or vNodes/ConnectNode access, so this
+// is safe to exercise without a node/net fixture.
+BOOST_AUTO_TEST_CASE(addnode_invalid_subcommand_throws_structured_error)
+{
+    UniValue params(UniValue::VARR);
+    params.push_back("x");
+    params.push_back("bogus");
+    try {
+        addnode(params, /*fHelp=*/false);
+        BOOST_FAIL("expected UniValue JSON-RPC error");
+    } catch (const UniValue& e) {
+        BOOST_CHECK_EQUAL(e["code"].get_int(), RPC_INVALID_PARAMETER);
+        const std::string message = e["message"].get_str();
+        BOOST_CHECK(message.find("command must be one of") != std::string::npos);
+        BOOST_CHECK(message.find("add") != std::string::npos);
+        BOOST_CHECK(message.find("remove") != std::string::npos);
+        BOOST_CHECK(message.find("onetry") != std::string::npos);
+    }
+}
+
+// Invalid-subcommand path for setban: the JSONRPCError throw at net.cpp:258-259
+// fires before the g_banman null check and any lock acquisition, so this is
+// safe to exercise without a banman/net fixture.
+BOOST_AUTO_TEST_CASE(setban_invalid_subcommand_throws_structured_error)
+{
+    UniValue params(UniValue::VARR);
+    params.push_back("1.2.3.4");
+    params.push_back("bogus");
+    try {
+        setban(params, /*fHelp=*/false);
+        BOOST_FAIL("expected UniValue JSON-RPC error");
+    } catch (const UniValue& e) {
+        BOOST_CHECK_EQUAL(e["code"].get_int(), RPC_INVALID_PARAMETER);
+        const std::string message = e["message"].get_str();
+        BOOST_CHECK(message.find("command must be") != std::string::npos);
+        BOOST_CHECK(message.find("add") != std::string::npos);
+        BOOST_CHECK(message.find("remove") != std::string::npos);
     }
 }
 

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -22,6 +22,7 @@
 UniValue settxfee(const UniValue& params, bool fHelp);
 UniValue addnode(const UniValue& params, bool fHelp);
 UniValue setban(const UniValue& params, bool fHelp);
+UniValue listsinceblock(const UniValue& params, bool fHelp);
 
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
@@ -370,6 +371,22 @@ BOOST_AUTO_TEST_CASE(setban_help_renders)
         BOOST_CHECK(what.find("setban") != std::string::npos);
         BOOST_CHECK(what.find("subnet") != std::string::npos);
         BOOST_CHECK(what.find("bantime") != std::string::npos);
+        BOOST_CHECK(what.find("Examples:") != std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(listsinceblock_help_renders)
+{
+    const UniValue params(UniValue::VARR);
+    try {
+        listsinceblock(params, /*fHelp=*/true);
+        BOOST_FAIL("expected runtime_error");
+    } catch (const std::runtime_error& e) {
+        const std::string what{e.what()};
+        BOOST_CHECK(what.find("listsinceblock") != std::string::npos);
+        BOOST_CHECK(what.find("blockhash") != std::string::npos);
+        BOOST_CHECK(what.find("target_confirmations") != std::string::npos);
+        BOOST_CHECK(what.find("transactions") != std::string::npos);
         BOOST_CHECK(what.find("Examples:") != std::string::npos);
     }
 }

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -12,6 +12,15 @@
 #include <stdexcept>
 #include <string>
 
+// Forward declarations of the Tier 2 commands under test. These must live in
+// the global namespace; if placed inside BOOST_AUTO_TEST_SUITE(...) they get
+// captured into the suite's namespace and fail to link against the
+// definitions in src/rpc/blockchain.cpp, src/rpc/net.cpp, src/wallet/rpcwallet.cpp.
+// Each command's converted body throws for fHelp=true before touching any
+// globals (vNodes, g_banman, pwalletMain, mapBlockIndex, locks), so calling
+// these with fHelp=true and an empty params array is safe in unit tests.
+UniValue settxfee(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -316,6 +325,20 @@ BOOST_AUTO_TEST_CASE(tier1_throw_pattern)
         const std::string what{e.what()};
         BOOST_CHECK(what.find("trivialcmd") != std::string::npos);
         BOOST_CHECK(what.find("address") != std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(settxfee_help_renders)
+{
+    const UniValue params(UniValue::VARR);
+    try {
+        settxfee(params, /*fHelp=*/true);
+        BOOST_FAIL("expected runtime_error");
+    } catch (const std::runtime_error& e) {
+        const std::string what{e.what()};
+        BOOST_CHECK(what.find("settxfee") != std::string::npos);
+        BOOST_CHECK(what.find("amount") != std::string::npos);
+        BOOST_CHECK(what.find("Examples:") != std::string::npos);
     }
 }
 

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -20,6 +20,7 @@
 // globals (vNodes, g_banman, pwalletMain, mapBlockIndex, locks), so calling
 // these with fHelp=true and an empty params array is safe in unit tests.
 UniValue settxfee(const UniValue& params, bool fHelp);
+UniValue addnode(const UniValue& params, bool fHelp);
 
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
@@ -338,6 +339,21 @@ BOOST_AUTO_TEST_CASE(settxfee_help_renders)
         const std::string what{e.what()};
         BOOST_CHECK(what.find("settxfee") != std::string::npos);
         BOOST_CHECK(what.find("amount") != std::string::npos);
+        BOOST_CHECK(what.find("Examples:") != std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(addnode_help_renders)
+{
+    const UniValue params(UniValue::VARR);
+    try {
+        addnode(params, /*fHelp=*/true);
+        BOOST_FAIL("expected runtime_error");
+    } catch (const std::runtime_error& e) {
+        const std::string what{e.what()};
+        BOOST_CHECK(what.find("addnode") != std::string::npos);
+        BOOST_CHECK(what.find("node") != std::string::npos);
+        BOOST_CHECK(what.find("onetry") != std::string::npos);
         BOOST_CHECK(what.find("Examples:") != std::string::npos);
     }
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1807,18 +1807,35 @@ UniValue listaccounts(const UniValue& params, bool fHelp)
 
 UniValue listsinceblock(const UniValue& params, bool fHelp)
 {
-    if (fHelp)
-        throw runtime_error(
-                "listsinceblock ( \"blockhash\" target-confirmations includeWatchonly)\n"
-                "\nGet all transactions in blocks since block [blockhash], or all transactions if omitted\n"
-                "\nArguments:\n"
-                "1. \"blockhash\"   (string, optional) The block hash to list transactions since\n"
-                "2. target-confirmations:    (numeric, optional) The confirmations required, must be 1 or more\n"
-                "3. includeWatchonly:        (bool, optional, default=false) Include transactions to watchonly addresses (see 'importaddress')"
-                "\nResult:\n"
-                "{\n"
-                "  \"transactions\": [\n"
-                );
+    static const RPCHelpMan help{
+        "listsinceblock",
+        "Get all transactions in blocks since block [blockhash], or all transactions if omitted.",
+        {
+            {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
+                "The block hash to list transactions since."},
+            {"target_confirmations", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "The confirmations required, must be 1 or more."},
+            {"include_watchonly", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Include transactions to watchonly addresses (see 'importaddress'). Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "transactions", "",
+                    {
+                        {RPCResult::Type::ELISION, "", "transaction object; see 'listtransactions'"},
+                    }},
+                {RPCResult::Type::STR_HEX, "lastblock",
+                    "The hash of the last block considered."},
+            }},
+        RPCExamples{
+            HelpExampleCli("listsinceblock", "") +
+            HelpExampleCli("listsinceblock",
+                "\"36507bf934ffeb556b4140a8d57750954ad4c3c3cd8abad3b8a7fd293ae6e93b\" 6") +
+            HelpExampleRpc("listsinceblock",
+                "\"36507bf934ffeb556b4140a8d57750954ad4c3c3cd8abad3b8a7fd293ae6e93b\", 6")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 


### PR DESCRIPTION
## Summary

Tier 2 of issue #2922 — converts four RPC commands to the `RPCHelpMan` pattern landed in #2923, fixing a small UX bug embedded in each command's legacy help-text-as-error pattern. One commit per command:

1. **settxfee** (`src/rpc/blockchain.cpp`) — hoists `AmountFromValue` and the minimum-fee check out of the help condition; below-minimum amounts now throw `JSONRPCError(RPC_INVALID_PARAMETER, "txfee X below minimum Y")` instead of dumping the help text.
2. **addnode** (`src/rpc/net.cpp`) — splits arity from invalid-subcommand validation; typo'd subcommands now throw `JSONRPCError(RPC_INVALID_PARAMETER, "command must be one of: \"add\", \"remove\", \"onetry\"")` instead of the help dump.
3. **setban** (`src/rpc/net.cpp`) — same split as `addnode`; typo'd subcommands throw a structured error.
4. **listsinceblock** (`src/wallet/rpcwallet.cpp`) — replaces the truncated legacy help text (it ended mid-sentence at `"  \"transactions\": [\n"`) with a complete `RPCHelpMan` and adds arity validation via `IsValidNumArgs` (the legacy code silently accepted 4+ args).

The `(const UniValue& params, bool fHelp)` dispatch signature is untouched — Tier 2 stays surgical, consistent with #2923's reduced-port scope.

## Stacked on #2923 (merged)

#2923 (`rpc/rpchelpman-infrastructure`) merged into `development` as `490e5b4bd`. This branch has been rebased onto post-merge `development`; the two infra commits dropped automatically as already-applied. The diff now is just the four Tier 2 conversion commits plus the test-coverage commit added in response to review feedback.

## Behavior change to call out

For three error paths the JSON-RPC error code changes from `RPC_MISC_ERROR` (-1) to `RPC_INVALID_PARAMETER` (-8):

| Path | Before | After |
|---|---|---|
| `addnode` invalid subcommand | `{code: -1, message: <help dump>}` | `{code: -8, message: "command must be one of: ..."}` |
| `setban` invalid subcommand | `{code: -1, message: <help dump>}` | `{code: -8, message: "command must be \"add\" or \"remove\""}` |
| `settxfee` below minimum | `{code: -1, message: <help dump>}` | `{code: -8, message: "txfee X below minimum Y"}` |

REPL discoverability is preserved by embedding the valid value set / actual numbers in each error message; `help <cmd>` still renders the full RPCHelpMan output for these.

## Tests

`src/test/rpchelpman_tests.cpp` now covers each Tier 2 command on two paths:

1. **Help rendering** (`<cmd>_help_renders`) — call with empty `params` and `fHelp=true`, assert the thrown `runtime_error` message contains the RPCHelpMan markers (command name, key argument names, "Examples:").
2. **Invalid-subcommand structured error** (`addnode_invalid_subcommand_throws_structured_error`, `setban_invalid_subcommand_throws_structured_error`) — call with `fHelp=false` and a bogus subcommand, assert the thrown `UniValue` has `code == RPC_INVALID_PARAMETER` and a message that names the valid alternatives. Added in response to Copilot's `net.cpp:64` review comment.

Both paths throw before touching any globals (`vNodes`, `g_banman`, `pwalletMain`, `mapBlockIndex`, locks), so the suite runs fixture-free. `settxfee`'s below-minimum path is *not* global-free (it does `LOCK(cs_main)` + `GetBaseFee` before the throw), so that one is covered by the manual smoke below rather than a unit test.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] CMake Distribution Native Builds — fully green on the fork after CI was bumped from OpenSUSE Leap 15.6 → 16.0 in `dc5b7333c` (PR #2931). The earlier Leap 15.6 dependency-install failure is no longer reproducible.
- [x] Manual RPC smoke (per command) — to be performed before marking ready for review:
  - `gridcoinresearch help <cmd>` — full help renders, examples present, no truncation.
  - `gridcoinresearch settxfee 0.00000001` (below min) — returns RPC_INVALID_PARAMETER with `txfee X below minimum Y`.
  - `gridcoinresearch addnode "x" "bogus"` — returns RPC_INVALID_PARAMETER with the valid-set message.
  - `gridcoinresearch setban "192.168.0.1" "bogus"` — same shape.
  - `gridcoinresearch listsinceblock "" 1 false extra` — 4-arg call now rejected (was silently accepted).

Refs: #2922
