### PR TITLE
ci: zypper dup before pattern install on OpenSUSE Tumbleweed

### DIFF
--- a/.github/workflows/cmake_distros.yml
+++ b/.github/workflows/cmake_distros.yml
@@ -34,7 +34,12 @@ jobs:
 
           - distro: OpenSUSE Tumbleweed
             image: opensuse/tumbleweed
-            prep_cmd: "zypper refresh && zypper install -y sudo which git"
+            # Rolling distro: dist-upgrade to align the container's snapshot
+            # with the current repo head before installing patterns/packages.
+            # Without this, pattern installs (e.g. devel_basis) can fail when
+            # the pattern was rebuilt against newer libs than the image ships
+            # — a recurring CI drift caused by Tumbleweed's release cadence.
+            prep_cmd: "zypper --non-interactive --gpg-auto-import-keys ref && zypper --non-interactive dup --auto-agree-with-licenses --allow-vendor-change && zypper install -y sudo which git"
             build_args: ""
 
           - distro: Arch Linux


### PR DESCRIPTION
## Summary

The Tumbleweed CI job intermittently fails at the `devel_basis` pattern install in `install_dependencies.sh`. This is rolling-distro drift: `opensuse/tumbleweed:latest` is a snapshot whose installed libraries can lag behind the live repo head. When the `patterns-devel-base-devel_basis` pattern RPM gets rebuilt against a newer library than the image ships, the resolver hits an unsatisfiable conflict; in `-y` mode the prompt falls through to cancel and zypper exits 4.

Most recent failure (from the post-merge run on #2933):

```
Problem: 1: the to be installed pattern:devel_basis-20170319-13.3.x86_64
requires 'patterns-devel-base-devel_basis', but this requirement cannot be provided
not installable providers: patterns-devel-base-devel_basis-20170319-13.3.x86_64[repo-oss]
 Solution 1: downgrade of libncurses6-6.6.20260509-104.1.x86_64 to libncurses6-6.6.20260418-103.1.x86_64
 Solution 2: do not install pattern:devel_basis
 Solution 3: break pattern:devel_basis by ignoring some of its dependencies
Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
##[error]Process completed with exit code 4.
```

The image ships `libncurses6-6.6.20260418-103.1`; the live repo has `libncurses6-6.6.20260509-104.1` (dated 2026-05-09), against which the pattern was rebuilt. This is recurring rather than one-off — Tumbleweed by design serves a moving target, and the gap between an image rebuild and a pattern rebuild will continue to land us in this state every few weeks.

## Fix

Add `zypper --non-interactive dup` to the Tumbleweed `prep_cmd` so the container's installed package set is aligned with current repo head before any pattern/package installs. This mirrors the existing Arch Linux prep (`pacman -Syyu --noconfirm`), which exists for the same reason.

```yaml
- distro: OpenSUSE Tumbleweed
  image: opensuse/tumbleweed
  prep_cmd: "zypper --non-interactive --gpg-auto-import-keys ref && zypper --non-interactive dup --auto-agree-with-licenses --allow-vendor-change && zypper install -y sudo which git"
  build_args: ""
```

## Scope

Intentionally scoped to the CI workflow rather than to `install_dependencies.sh`. A system-wide `dup` is appropriate for disposable CI containers but too disruptive for bare-metal Tumbleweed users running the dependency script on their daily-driver systems. The Tumbleweed `prep_cmd` is the right layer for CI-only drift mitigation.

## Test plan
- [x] CI run on this PR completes the Tumbleweed job successfully through `devel_basis` pattern install and the rest of the build.
- [x] Other Distribution Native Builds matrix entries (Fedora, Leap 16, Arch, Debian Sid, Mint 22, Alpine) remain unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)