### PR TITLE
test: re-enable coinstake_construction_tests.cpp on the #2877 chain

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -6,13 +6,7 @@ endif()
 add_executable(test_gridcoin
     bip68_tests.cpp
     checkpoints_tests.cpp
-    # FIXME(#2877): coinstake_construction_tests.cpp is DISABLED. It was added by
-    # PR F3 and calls CreateGridcoinReward/CreateRestOfTheBlock/CreateMRCRewards
-    # with F3's parameter order, but the linear chain uses E2's review-fixed
-    # signatures. It must be updated to E2's signatures and the CMutableTransaction
-    # build pattern. Tracked for a dedicated follow-up PR — do NOT re-enable until
-    # the test file itself is fixed.
-    # coinstake_construction_tests.cpp
+    coinstake_construction_tests.cpp
     csv_tests.cpp
     dos_tests.cpp
     accounting_tests.cpp

--- a/src/test/coinstake_construction_tests.cpp
+++ b/src/test/coinstake_construction_tests.cpp
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_reward_application)
     GRC::Claim claim;
 
     LOCK(cs_main);
-    BOOST_CHECK(CreateGridcoinReward(block, pindex->pprev, nReward, claim, coinbase, coinstake));
+    BOOST_CHECK(CreateGridcoinReward(coinbase, coinstake, block, pindex->pprev, nReward, claim));
 
     // Reward should be positive (block subsidy + fees at minimum)
     BOOST_CHECK(nReward > 0);
@@ -263,11 +263,11 @@ BOOST_AUTO_TEST_CASE(mrc_outputs_appended)
     // First create the reward so the claim is populated
     int64_t nReward = 0;
     GRC::Claim claim;
-    BOOST_CHECK(CreateGridcoinReward(block, pindex->pprev, nReward, claim, coinbase, coinstake));
+    BOOST_CHECK(CreateGridcoinReward(coinbase, coinstake, block, pindex->pprev, nReward, claim));
 
     // Add MRC researcher context and create an MRC
     pindex->pprev->AddMRCResearcherContext(cpid, 72, 0.0);
-    BOOST_CHECK(CreateRestOfTheBlock(block, pindex->pprev, mrc_map, coinbase, coinstake));
+    BOOST_CHECK(CreateRestOfTheBlock(block, coinbase, coinstake, pindex->pprev, mrc_map));
 
     GRC::MRC mrc;
     CAmount mrc_reward{0}, mrc_fee{0};
@@ -277,9 +277,8 @@ BOOST_AUTO_TEST_CASE(mrc_outputs_appended)
     uint32_t claim_contract_version = 2;
     size_t vout_before = coinstake.vout.size();
 
-    BOOST_CHECK(CreateMRCRewards(block, mrc_map, mrc_tx_map, nReward,
-                                 claim_contract_version, claim, wallet,
-                                 coinbase, coinstake));
+    BOOST_CHECK(CreateMRCRewards(coinbase, coinstake, block, mrc_map, mrc_tx_map,
+                                 nReward, claim_contract_version, claim, wallet));
 
     // MRC outputs should have been appended to coinstake
     BOOST_CHECK(coinstake.vout.size() > vout_before);
@@ -308,8 +307,8 @@ BOOST_AUTO_TEST_CASE(split_coinstake_distributes_reward)
     int64_t nMinStakeSplitValue = 800;
     double dEfficiency = 98.0;
 
-    SplitCoinStakeOutput(block, nReward, fEnableStakeSplit, fEnableSideStaking,
-                         nMinStakeSplitValue, dEfficiency, coinstake);
+    SplitCoinStakeOutput(coinstake, block, nReward, fEnableStakeSplit, fEnableSideStaking,
+                         nMinStakeSplitValue, dEfficiency);
 
     // Should have split into multiple outputs
     BOOST_CHECK(coinstake.vout.size() > 2);
@@ -353,8 +352,8 @@ BOOST_AUTO_TEST_CASE(sidestake_outputs_placed)
     int64_t nMinStakeSplitValue = 800;
     double dEfficiency = 98.0;
 
-    SplitCoinStakeOutput(block, nReward, fEnableStakeSplit, fEnableSideStaking,
-                         nMinStakeSplitValue, dEfficiency, coinstake);
+    SplitCoinStakeOutput(coinstake, block, nReward, fEnableStakeSplit, fEnableSideStaking,
+                         nMinStakeSplitValue, dEfficiency);
 
     // Should have at least 3 outputs: empty + coinstake + sidestake
     BOOST_CHECK(coinstake.vout.size() >= 3);
@@ -408,11 +407,11 @@ BOOST_AUTO_TEST_CASE(full_pipeline_roundtrip)
     // Step 1: CreateGridcoinReward
     int64_t nReward = 0;
     GRC::Claim claim;
-    BOOST_CHECK(CreateGridcoinReward(block, pindex->pprev, nReward, claim, coinbase, coinstake));
+    BOOST_CHECK(CreateGridcoinReward(coinbase, coinstake, block, pindex->pprev, nReward, claim));
 
     // Step 2: CreateMRCRewards
     pindex->pprev->AddMRCResearcherContext(cpid, 72, 0.0);
-    BOOST_CHECK(CreateRestOfTheBlock(block, pindex->pprev, mrc_map, coinbase, coinstake));
+    BOOST_CHECK(CreateRestOfTheBlock(block, coinbase, coinstake, pindex->pprev, mrc_map));
 
     GRC::MRC mrc;
     CAmount mrc_reward{0}, mrc_fee{0};
@@ -420,17 +419,16 @@ BOOST_AUTO_TEST_CASE(full_pipeline_roundtrip)
     mrc_map[cpid] = {uint256{}, mrc};
 
     uint32_t claim_contract_version = 2;
-    CreateMRCRewards(block, mrc_map, mrc_tx_map, nReward,
-                     claim_contract_version, claim, wallet,
-                     coinbase, coinstake);
+    CreateMRCRewards(coinbase, coinstake, block, mrc_map, mrc_tx_map,
+                     nReward, claim_contract_version, claim, wallet);
 
     // Step 3: SplitCoinStakeOutput
     bool fEnableStakeSplit = true;
     bool fEnableSideStaking = false;
     int64_t nMinStakeSplitValue = 800;
     double dEfficiency = 98.0;
-    SplitCoinStakeOutput(block, nReward, fEnableStakeSplit, fEnableSideStaking,
-                         nMinStakeSplitValue, dEfficiency, coinstake);
+    SplitCoinStakeOutput(coinstake, block, nReward, fEnableStakeSplit, fEnableSideStaking,
+                         nMinStakeSplitValue, dEfficiency);
 
     // Convert to CTransaction and verify round-trip
     CTransaction ctx(coinstake);


### PR DESCRIPTION
## Summary

Re-enables `src/test/coinstake_construction_tests.cpp`, which was commented out of `src/test/CMakeLists.txt` during the #2877 PSGT chain restack.

**Why it was disabled:** the test file was added by PR F3 (#2901) and calls `CreateGridcoinReward` / `CreateRestOfTheBlock` / `CreateMRCRewards` / `SplitCoinStakeOutput` with F3's parameter order — coinbase/coinstake `CMutableTransaction` arguments last. The linear #2877 chain uses E2's (#2892) review-fixed signatures, which put those arguments first. It was never part of the testnet-validated build either (commented out on the synthetic integration branch).

**This PR** reorders all 10 call sites to the chain's signatures and re-enables the file. No production code changes — test-only.

## Stacking

Stacked on top of the #2877 chain — branched off the tip of G (#2909). **Do not merge until the chain lands on `development`.** Once it does, this PR's diff narrows to just the two test files.

## Test plan

- [x] `test_gridcoin` builds clean with the file re-enabled
- [x] `coinstake_construction_tests` suite passes — all 7 cases (`basic_coinstake_structure`, `gridcoin_reward_application`, `mrc_outputs_appended`, `split_coinstake_distributes_reward`, `sidestake_outputs_placed`, `full_pipeline_roundtrip`, `coinbase_claim_contract_preserved`)
- [ ] CI green after the #2877 chain merges and this is rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)