### PR TITLE
build, qt: actually wire up ENABLE_QRENCODE (replaces #2914)

### DIFF
--- a/src/config/gridcoin-config.h.cmake.in
+++ b/src/config/gridcoin-config.h.cmake.in
@@ -36,7 +36,6 @@
 #cmakedefine USE_ASM_SCRYPT
 
 #cmakedefine USE_DBUS
-#cmakedefine USE_QRCODE
 
 #cmakedefine HAVE_STRERROR_R
 #cmakedefine STRERROR_R_CHAR_P

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -131,6 +131,11 @@ elseif(APPLE)
     )
 endif()
 
+if(ENABLE_QRENCODE)
+    target_sources(gridcoinqt PRIVATE qrcodedialog.cpp)
+    target_compile_definitions(gridcoinqt PRIVATE ENABLE_QRENCODE)
+endif()
+
 set_target_properties(gridcoinqt PROPERTIES
     AUTOMOC ON
     AUTORCC ON
@@ -173,6 +178,9 @@ if(USE_QT6)
 endif()
 if(USE_DBUS)
     target_link_libraries(gridcoinqt PUBLIC ${QT}::DBus)
+endif()
+if(ENABLE_QRENCODE)
+    target_link_libraries(gridcoinqt PUBLIC PkgConfig::QRENCODE)
 endif()
 
 if(APPLE)

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -15,7 +15,7 @@
 #include <QMessageBox>
 #include <QMenu>
 
-#ifdef USE_QRCODE
+#ifdef ENABLE_QRENCODE
 #include "qrcodedialog.h"
 #endif
 
@@ -40,7 +40,7 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
     ui->deleteButton->setIcon(QIcon());
 #endif
 
-#ifndef USE_QRCODE
+#ifndef ENABLE_QRENCODE
     ui->showQRCodeButton->setVisible(false);
 #endif
 
@@ -367,7 +367,7 @@ void AddressBookPage::changeFilter(const QString& needle)
 
 void AddressBookPage::on_showQRCodeButton_clicked()
 {
-#ifdef USE_QRCODE
+#ifdef ENABLE_QRENCODE
     QTableView *table = ui->tableView;
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -75,7 +75,9 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
     QAction *copyLabelAction = new QAction(tr("Copy &Label"), this);
     QAction *copyAddressAction = new QAction(ui->copyToClipboardButton->text(), this);
     QAction *editAction = new QAction(tr("&Edit"), this);
+#ifdef ENABLE_QRENCODE
     QAction *showQRCodeAction = new QAction(ui->showQRCodeButton->text(), this);
+#endif
     QAction *signMessageAction = new QAction(ui->signMessageButton->text(), this);
     QAction *verifyMessageAction = new QAction(ui->verifyMessageButton->text(), this);
     deleteAction = new QAction(ui->deleteButton->text(), this);
@@ -88,7 +90,9 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
     if(tab == SendingTab)
         contextMenu->addAction(deleteAction);
     contextMenu->addSeparator();
+#ifdef ENABLE_QRENCODE
     contextMenu->addAction(showQRCodeAction);
+#endif
     if(tab == ReceivingTab)
         contextMenu->addAction(signMessageAction);
     else if(tab == SendingTab)
@@ -99,7 +103,9 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
     connect(copyLabelAction, &QAction::triggered, this, &AddressBookPage::onCopyLabelAction);
     connect(editAction, &QAction::triggered, this, &AddressBookPage::onEditAction);
     connect(deleteAction, &QAction::triggered, this, &AddressBookPage::on_deleteButton_clicked);
+#ifdef ENABLE_QRENCODE
     connect(showQRCodeAction, &QAction::triggered, this, &AddressBookPage::on_showQRCodeButton_clicked);
+#endif
     connect(signMessageAction, &QAction::triggered, this, &AddressBookPage::on_signMessageButton_clicked);
     connect(verifyMessageAction, &QAction::triggered, this, &AddressBookPage::on_verifyMessageButton_clicked);
 


### PR DESCRIPTION
## Summary

Replaces #2914. @CyberTailor caught (via `lddtree`) that the `ENABLE_QRENCODE` CMake option has been a no-op since the CMake build was added — the option is declared, but nothing in the build defines a corresponding preprocessor symbol, and the Qt source code gates QR support on `#ifdef USE_QRCODE` (a CMake variable that is never set anywhere). The original PR proposed renaming the source-side macro to match the option, which is correct as far as it goes but stops one step short — the symbol still wouldn't reach the `#ifdef` sites, leaving the option inert. See [the close comment on #2914](https://github.com/gridcoin-community/Gridcoin-Research/pull/2914#issuecomment-4460714293) for the trace.

This PR finishes the job, and folds in a pre-existing UI bug that's only visible once QR actually works.

## Changes

**Commit 1 — `build: fix ENABLE_QRENCODE option being no-op`**

- `src/qt/CMakeLists.txt` — add a single conditional block that, when `ENABLE_QRENCODE` is on, adds `qrcodedialog.cpp` to the target, links `PkgConfig::QRENCODE`, **and adds `ENABLE_QRENCODE` as a `PRIVATE` compile definition on `gridcoinqt`**. The compile-def is the missing piece — it makes the symbol visible to every translation unit in the Qt target without needing a per-file `<config/gridcoin-config.h>` include.
- `src/config/gridcoin-config.h.cmake.in` — drop `#cmakedefine USE_QRCODE`. With the compile-def in place the config-header route is redundant, and the prior line never worked anyway (no `USE_QRCODE` CMake variable is set).
- `src/qt/addressbookpage.cpp` — rename the three `USE_QRCODE` preprocessor sites to `ENABLE_QRENCODE` so they match the actual option (same rename @CyberTailor proposed).

**Commit 2 — `qt: hide Show QR Code context menu action when QR support is disabled`**

Pre-existing UI bug uncovered by Commit 1: the toolbar button is hidden via the existing `#ifndef ENABLE_QRENCODE setVisible(false)` guard, but the matching context-menu action's creation, `addAction`, and `connect` calls (`addressbookpage.cpp:78`/`91`/`102` in the pre-PR file) run unconditionally. With `ENABLE_QRENCODE` off the menu item stays visible and silently does nothing. Wrapped all three sites in `#ifdef ENABLE_QRENCODE`.

## Behavior change

- `ENABLE_QRENCODE=OFF` (the default — what mainline distros currently build): no functional change. Only the gating macro name in `addressbookpage.cpp` changes, plus the now-hidden context menu item.
- `ENABLE_QRENCODE=ON`: QR code generation actually works for the first time since the CMake migration. Toolbar button visible, context menu item visible, dialog launches.

## Scope / build-script coverage

`build_targets.sh` already hardcodes `-DENABLE_QRENCODE=ON` in the **native** build path (line 332), and `install_dependencies.sh` already pulls `qrencode`/`libqrencode-dev`/`qrencode-devel` for every distro family. So after this PR, anyone running `./build_targets.sh TARGET=native` automatically gets working QR support with no extra args — and on Linux that's the path most distros build through.

The **depends** and **win64** paths don't pass `-DENABLE_QRENCODE` today. On Linux the depends path is only used by people on older distros or unusual environments where the native build doesn't work, so the practical coverage gap there is small. On Windows, however, depends is the **only** supported build path, so Windows users won't get QR support from this PR alone. Adding it for those paths is a larger follow-up: it needs a `depends/packages/qrencode.mk` recipe (the depends system builds everything from scratch in a sandbox) plus cross-compile linkage validation across the matrix. Deliberately leaving that out of scope here to keep this PR focused on the actual no-op fix; can open a tracker issue if/when there's appetite to tackle it.

## Test plan

- [ ] Configure + build with `-DENABLE_GUI=ON -DENABLE_QRENCODE=OFF` (default): builds clean, no `qrcodedialog.*` symbols in the binary, address book context menu has no "Show QR Code" item.
- [ ] Configure + build with `-DENABLE_GUI=ON -DENABLE_QRENCODE=ON`: builds clean, `qrencode` linkage shows up in `lddtree`, address book button visible + context menu item visible, "Show QR Code" actually launches the dialog.
- [ ] CI green across all distros.

Credit: @CyberTailor for the original find and the rename direction (kept in Commit 1; co-author noted in commit trailer). Closes #2914.
