### PR TITLE
qt: expose tables and lists to screen readers (issue #2604)

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -62,12 +62,14 @@ AddressBookPage::AddressBookPage(Mode mode, Tabs tab, QWidget* parent)
         ui->deleteButton->setVisible(true);
         ui->signMessageButton->setVisible(false);
         ui->addExistingButton->setVisible(false);
+        ui->tableView->setAccessibleName(tr("Sending addresses"));
         break;
     case ReceivingTab:
         ui->deleteButton->setVisible(false);
         ui->verifyMessageButton->setVisible(false);
         ui->signMessageButton->setVisible(true);
         ui->addExistingButton->setVisible(true);
+        ui->tableView->setAccessibleName(tr("Receiving addresses"));
         break;
     }
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -199,6 +199,19 @@ QVariant AddressTableModel::data(const QModelIndex &index, int role) const
             font = GUIUtil::bitcoinAddressFont();
         }
         return font;
+    } else if (role == Qt::AccessibleTextRole) {
+        // For screen readers (issue #2604). Column 0 (Label) returns a full row
+        // description ("Label \"<label>\", address <address>") so a screen-reader
+        // user gets the row context with one announcement; column 1 (Address)
+        // returns just the address with its column header for per-cell navigation.
+        const QString label = rec->label.isEmpty() ? tr("(no label)") : rec->label;
+        switch (column) {
+        case Label:
+            return tr("Label \"%1\", address %2").arg(label, rec->address);
+        case Address:
+            return tr("Address: %1").arg(rec->address);
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     } else if (role == TypeRole) {
         switch(rec->type)
         {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -380,18 +380,28 @@ void BitcoinGUI::createActions()
     openGuidesAction->setStatusTip(tr("Open the Gridcoin Guides"));
     openGuidesAction->setMenuRole(QAction::TextHeuristicRole);
 
-    // We use lambdas here to squash the argument to showNormalIfMinized.
-    connect(overviewAction, &QAction::triggered, this, [this]{ this->showNormalIfMinimized(); });
-    connect(overviewAction, &QAction::triggered, this, &BitcoinGUI::gotoOverviewPage);
-    connect(sendCoinsAction, &QAction::triggered, this, [this]{ this->showNormalIfMinimized(); });
-    connect(sendCoinsAction, &QAction::triggered, this, &BitcoinGUI::gotoSendCoinsPage);
-    connect(receiveCoinsAction, &QAction::triggered, this, [this]{ this->showNormalIfMinimized(); });
-    connect(receiveCoinsAction, &QAction::triggered, this, &BitcoinGUI::gotoReceiveCoinsPage);
-    connect(historyAction, &QAction::triggered, this, [this]{ this->showNormalIfMinimized(); });
-    connect(historyAction, &QAction::triggered, this, &BitcoinGUI::gotoHistoryPage);
-    connect(addressBookAction, &QAction::triggered, this, [this]{ this->showNormalIfMinimized(); });
-    connect(addressBookAction, &QAction::triggered, this, &BitcoinGUI::gotoAddressBookPage);
-    connect(votingAction, &QAction::triggered, this, &BitcoinGUI::gotoVotingPage);
+    // Drive tab navigation from QAction::toggled (the checked-state transition)
+    // rather than QAction::triggered. A screen reader activates these checkable
+    // toolbar buttons through the accessibility "toggle" path, which flips the
+    // checked state and emits toggled() but never triggered() -- so a
+    // triggered-based connection left assistive-technology users able to move
+    // the tab highlight but not actually change pages (issue #2604).
+    // toggled() fires for mouse, keyboard shortcut and accessibility activation
+    // alike; the checked-true filter ensures only the newly-selected tab (not
+    // the one being unchecked by the exclusive QActionGroup) navigates.
+    auto connectTabAction = [this](QAction* action, void (BitcoinGUI::*gotoPage)()) {
+        connect(action, &QAction::toggled, this, [this, gotoPage](bool checked) {
+            if (!checked) return;
+            this->showNormalIfMinimized();
+            (this->*gotoPage)();
+        });
+    };
+    connectTabAction(overviewAction, &BitcoinGUI::gotoOverviewPage);
+    connectTabAction(sendCoinsAction, &BitcoinGUI::gotoSendCoinsPage);
+    connectTabAction(receiveCoinsAction, &BitcoinGUI::gotoReceiveCoinsPage);
+    connectTabAction(historyAction, &BitcoinGUI::gotoHistoryPage);
+    connectTabAction(addressBookAction, &BitcoinGUI::gotoAddressBookPage);
+    connectTabAction(votingAction, &BitcoinGUI::gotoVotingPage);
 
     connect(websiteAction, &QAction::triggered, this, &BitcoinGUI::websiteClicked);
     connect(bxAction, &QAction::triggered, this, &BitcoinGUI::bxClicked);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -166,6 +166,7 @@ OverviewPage::OverviewPage(QWidget *parent) :
     // Recent Transactions
     ui->listTransactions->setItemDelegate(txdelegate);
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
+    ui->listTransactions->setAccessibleName(tr("Recent transactions"));
     updateTransactions();
 
     connect(ui->listTransactions, &QListView::clicked, this, &OverviewPage::handleTransactionClicked);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -708,6 +708,31 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         assert(false);
     case Qt::ToolTipRole:
         return formatTooltip(rec);
+    case Qt::AccessibleTextRole:
+        // For screen readers (issue #2604). Column 0 (Status) returns a full row
+        // description so QListView consumers (e.g. OverviewPage's recent-transactions
+        // list, which displays only the Status column with a custom delegate that
+        // composes multiple roles visually) get a meaningful announcement instead of
+        // silence. Other columns return "<header>: <value>" so QTableView consumers
+        // (transaction history) get contextual per-cell navigation.
+        switch (column) {
+        case Status:
+            return tr("%1, %2 %3, amount %4, %5")
+                .arg(formatTxDate(rec),
+                     formatTxType(rec),
+                     formatTxToAddress(rec, true),
+                     formatTxAmount(rec),
+                     rec->status.countsForBalance ? tr("confirmed") : tr("unconfirmed"));
+        case Date:
+            return tr("Date: %1").arg(formatTxDate(rec));
+        case Type:
+            return tr("Type: %1").arg(formatTxType(rec));
+        case ToAddress:
+            return tr("Address: %1").arg(formatTxToAddress(rec, true));
+        case Amount:
+            return tr("Amount: %1").arg(formatTxAmount(rec));
+        } // no default case, so the compiler can warn about missing cases
+        assert(false);
     case Qt::TextAlignmentRole:
         return column_alignments[index.column()];
     case Qt::ForegroundRole:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -112,6 +112,7 @@ TransactionView::TransactionView(QWidget *parent)
     view->setContextMenuPolicy(Qt::CustomContextMenu);
     view->setShowGrid(false);
     view->horizontalHeader()->setHighlightSections(false);
+    view->setAccessibleName(tr("Transaction history"));
     transactionView = view;
 
     QVBoxLayout *tableViewLayout = new QVBoxLayout();

--- a/src/qt/voting/additionalfieldstablemodel.cpp
+++ b/src/qt/voting/additionalfieldstablemodel.cpp
@@ -70,6 +70,24 @@ public:
             case AdditionalFieldsTableModel::Required:
                 return row->m_required;
             } // no default case, so the compiler can warn about missing cases
+            assert(false);
+
+        case Qt::AccessibleTextRole:
+            // For screen readers (issue #2604). Name column returns a one-shot
+            // row summary so the row is intelligible at first focus; other columns
+            // prepend the header for per-cell context.
+            switch (index.column()) {
+            case AdditionalFieldsTableModel::Name:
+                return tr("Field \"%1\", value \"%2\", %3")
+                    .arg(row->m_name,
+                         row->m_value,
+                         row->m_required ? tr("required") : tr("optional"));
+            case AdditionalFieldsTableModel::Value:
+                return tr("Value: %1").arg(row->m_value);
+            case AdditionalFieldsTableModel::Required:
+                return tr("Required: %1").arg(row->m_required ? tr("yes") : tr("no"));
+            } // no default case, so the compiler can warn about missing cases
+            assert(false);
         }
 
         return QVariant();

--- a/src/qt/voting/polldetails.cpp
+++ b/src/qt/voting/polldetails.cpp
@@ -26,6 +26,7 @@ PollDetails::PollDetails(QWidget* parent)
 
     ui->additionalFieldsTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     ui->additionalFieldsTableView->sortByColumn(AdditionalFieldsTableModel::Required, Qt::DescendingOrder);
+    ui->additionalFieldsTableView->setAccessibleName(tr("Poll additional fields"));
 }
 
 PollDetails::~PollDetails()

--- a/src/qt/voting/polltab.cpp
+++ b/src/qt/voting/polltab.cpp
@@ -172,6 +172,11 @@ void PollTab::setVotingModel(VotingModel* model)
 
     ui->cards->setModel(m_polltable_model.get());
     ui->table->setModel(m_polltable_model.get());
+
+    // Accessibility (issue #2604): label both views so screen readers
+    // announce what list is being read.
+    ui->cards->setAccessibleName(tr("Polls (card view)"));
+    ui->table->setAccessibleName(tr("Polls (table view)"));
 }
 
 void PollTab::setPollFilterFlags(PollFilterFlag flags)

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -105,6 +105,44 @@ QVariant PollTableDataModel::data(const QModelIndex &index, int role) const
             }
             break;
 
+        case Qt::AccessibleTextRole:
+            // For screen readers (issue #2604). Title column returns a one-shot
+            // row summary so a screen reader announces the most-important fields
+            // (title, type, expiration, top answer) at row entry; other columns
+            // prepend the header name so per-cell navigation is self-contained.
+            switch (index.column()) {
+                case PollTableModel::Title:
+                    return tr("Poll \"%1\", type %2, expires %3, top answer %4")
+                        .arg(row->m_title,
+                             row->m_version >= 3 ? row->m_type_str : tr("(legacy)"),
+                             GUIUtil::dateTimeStr(row->m_expiration),
+                             row->m_top_answer.isEmpty() ? tr("none") : row->m_top_answer);
+                case PollTableModel::PollType:
+                    return tr("Poll type: %1")
+                        .arg(row->m_version >= 3 ? row->m_type_str : tr("(legacy)"));
+                case PollTableModel::Duration:
+                    return tr("Duration: %1").arg(QString::number(row->m_duration));
+                case PollTableModel::Expiration:
+                    return tr("Expires: %1").arg(GUIUtil::dateTimeStr(row->m_expiration));
+                case PollTableModel::WeightType:
+                    return tr("Weight type: %1").arg(row->m_weight_type_str);
+                case PollTableModel::TotalVotes:
+                    return tr("Total votes: %1").arg(QString::number(row->m_total_votes));
+                case PollTableModel::TotalWeight:
+                    return tr("Total weight: %1").arg(QString::number(row->m_total_weight));
+                case PollTableModel::VotePercentAVW:
+                    return tr("Percent of active vote weight: %1")
+                        .arg(QString::number(row->m_vote_percent_AVW, 'f', 4));
+                case PollTableModel::Validated:
+                    return tr("Validated: %1").arg(row->m_validated.toString());
+                case PollTableModel::TopAnswer:
+                    return tr("Top answer: %1")
+                        .arg(row->m_top_answer.isEmpty() ? tr("none") : row->m_top_answer);
+                case PollTableModel::StaleResults:
+                    return tr("Stale results: %1").arg(row->m_stale ? tr("yes") : tr("no"));
+            } // no default case, so the compiler can warn about missing cases
+            assert(false);
+
         case PollTableModel::SortRole:
             switch (index.column()) {
                 case PollTableModel::Title:

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -190,6 +190,7 @@ PollWizardDetailsPage::PollWizardDetailsPage(QWidget* parent)
 
     ui->additionalFieldsTableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     ui->additionalFieldsTableView->sortByColumn(AdditionalFieldsTableModel::Required, Qt::DescendingOrder);
+    ui->additionalFieldsTableView->setAccessibleName(tr("Poll additional fields"));
 
     ui->weightTypeList->addItem(tr("Balance"));
     ui->weightTypeList->addItem(tr("Magnitude+Balance"));


### PR DESCRIPTION
First pass at addressing the long-open accessibility report in issue #2604. Adds `Qt::AccessibleTextRole` handling to the four GUI models behind the reported "empty table" failure modes, plus `setAccessibleName` on the parent widgets so screen readers announce *which* list / table is being read.

## What's covered

| Commit | Model + view widgets | User-facing fix |
|---|---|---|
| 1 | `TransactionTableModel` + `TransactionView` table + `OverviewPage` listTransactions | Recent-transactions list and transaction history table announce row content instead of silence |
| 2 | `AddressTableModel` + `AddressBookPage` table (sending + receiving) | Address book entries announce label + address |
| 3 | `PollTableDataModel` + `PollTab` cards / table views | Poll list announces title, type, expiration, top answer |
| 4 | `AdditionalFieldsTableDataModel` + `PollDetails` and `PollWizardDetailsPage` views | Poll additional-fields table announces field name, value, and required/optional status |

Plus one related fix surfaced by the verification work below:

| 5 | `BitcoinGUI::createActions` toolbar wiring | The Overview / Send / Receive / History / Favorites / Voting tab buttons now switch pages when activated through the accessibility API, not only on a real mouse click |

## Pattern used

- Column 0 (the "primary" column — Status / Label / Title / Name) returns a one-shot row summary so a screen reader navigating row-by-row gets the most-important fields at first focus.
- Other columns prepend the column header ("Date: ...", "Amount: ...") so per-cell navigation in table views is self-contained.
- Pure additive — no existing visual rendering, sorting, or interaction paths change.

## Reference

Issue #2604 (original reporter: @Luly98, Nov 2022). The four failure modes called out in the issue body map directly onto the four commits in this PR.

## Verification

Functional verification done on macOS 14.8 (Qt 6.9.1) by driving the live macOS accessibility tree directly via `AXUIElement` — a small navigator that walks the AX tree in the same pre-order VoiceOver's `VO+Right` cursor follows and reads back what each step would announce. The host-VM key-chord conflicts with VoiceOver itself were intractable, but the tree the navigator sees *is* the tree VoiceOver consumes.

**Real-app result.** Freshly-restarted wallet with a date-limited transaction history; the navigator walked the History `QTableView` end-to-end and reported `entered table: YES, rows visited: 96, cells visited: 478` — **zero role-less cells**, every cell carrying this PR's `AccessibleText` strings ("Date: …", "Type: …", "Address: …", "Amount: …") plus the column-0 row summary. A separate `axdump` capture of the full live widget independently showed `AXTable "Transaction history" [AXRows=45866 AXColumns=5]`.

**Control.** A pure-Qt repro app (two `QTableView`s backed by `QStandardItemModel`, no Gridcoin code, answering only `Qt::AccessibleTextRole`) exposed the same `AXTable` / `AXRow` / `AXCell` structure — confirms the pattern itself is correct.

**Other surfaces.** The Overview recent-transactions `QListView`, the address book, the poll list, and the poll additional-fields view were each spot-checked via `axdump` and showed their respective row-summary text under `AXList` / `AXTable`.

Real-world feedback from screen-reader users (VoiceOver, Orca, NVDA, Narrator) on the announcement wording is still very welcome.

## Findings discovered during verification

Two *separate* accessibility issues surfaced. One is fixed in this PR; the other is split out:

- **Finding A — toolbar tabs didn't navigate via accessibility activation.** Activating a tab through the accessibility API (`AXPress`) toggled its checked state but `QAction::triggered` never fired, so the `QStackedWidget` didn't switch pages — a screen-reader user could move the tab highlight but couldn't actually change tabs. **Fixed in commit `cfe26d12f`** by driving `gotoXxxPage` off `QAction::toggled` (checked-true) instead of `triggered`. `toggled` fires for mouse, keyboard shortcut and accessibility activation alike, so all three paths now navigate, each exactly once.
- **Finding B — transaction-table AX interface degrades to role-less under per-block model churn.** A controlled before/after on the same widget (quiet wallet just after restart: 0 role-less cells; same wallet seconds later, receiving blocks: 140 of 590 cells role-less; and a `refreshWallet` model reset wedges the whole `AXTable` role-less permanently until the view is reconstructed) points at the per-block full-table `dataChanged` in `updateConfirmations` plus row-insert churn. Pre-existing, not caused by this PR — filed as **#2952** with the diagnosis and the proposed viewport-scoped, view-driven fix; that fix belongs with the post-#2944 transaction-model (`QList` → O(log N)) redesign rather than this PR.

## Out of scope (for this PR)

- Dialog widget audit (every `*dialog.cpp` / `*page.cpp` getting `setAccessibleName` on non-obvious labels and buttons) — could be a follow-up if real-world testing shows it's needed.
- The poll *card* view (kanban) uses its own widget hierarchy; this PR labels the parent view but doesn't restructure individual cards.
- Other accessibility issues the original reporter alluded to ("there are also a few other accessibility issues I would like to report") that were never enumerated. Those should be separate tickets.
