### PR TITLE
refactor: enable clang thread-safety analyzer and roll out annotations (#2869)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,22 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_PIE})
 # Set compiler flags
 if(APPLE)
     add_compile_options(-Wno-error=deprecated-declarations)
+endif()
+
+# Enable Clang Thread Safety Analysis where supported (issue #2869). The
+# analyzer ships in upstream Clang and Apple Clang; gcc has no equivalent
+# attribute set. Detect rather than gating on CMAKE_CXX_COMPILER_ID so any
+# clang-compatible compiler picks it up (e.g. clang-cl on Windows).
+#
+# Kept warning-only during the incremental annotation rollout (#2869 Phases
+# 1-4). The corresponding -Wno-error= flags prevent the warning from being
+# promoted to an error if any future -Werror is added before the codebase
+# is fully annotated. Once the rollout is complete the -Wno-error= flags
+# can be dropped to make stale annotations a hard build failure.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wthread-safety HAVE_CLANG_THREAD_SAFETY)
+if(HAVE_CLANG_THREAD_SAFETY)
+    add_compile_options(-Wthread-safety)
     add_compile_options(-Wno-error=thread-safety-analysis)
     add_compile_options(-Wno-error=thread-safety-reference)
 endif()

--- a/doc/thread_safety_phase1_report.md
+++ b/doc/thread_safety_phase1_report.md
@@ -1,11 +1,11 @@
-# Clang Thread Safety Analysis — Phase 1 report (issue #2869)
+# Clang Thread Safety Analysis — Phase 1 + Phase 2 report (issue #2869)
 
-Phase 1 of the issue #2869 multi-phase thread-safety rollout. Captures the build-system enablement, the canonical lock order it established, and a per-resolution breakdown of every warning the analyzer surfaced.
+The issue #2869 multi-phase thread-safety rollout. Captures the build-system enablement, the canonical lock order it established, a per-resolution breakdown of every warning the analyzer surfaced, and the deferral decisions taken to preserve historical lock-scope design intent.
 
 The phases are an internal organizing tool, not a release boundary:
 
-- **Phase 1 (this PR)**: enable the analyzer; annotate cs_main globals + their immediate call chains; annotate `setpwalletRegistered`; document Phase 2/3/4 deferrals in-code with `TODO(#2869 Phase N — area)` comments.
-- **Phase 2**: researcher/beacon, wallet, tally, mrc, block_rewards, contract, voting, miner, policy, block_finder.
+- **Phase 1**: enable the analyzer; annotate cs_main globals + their immediate call chains; annotate `setpwalletRegistered`; document Phase 2/3/4 deferrals in-code with `TODO(#2869 Phase N — area)` comments.
+- **Phase 2 (this PR)**: replace the Phase 1 `NO_THREAD_SAFETY_ANALYSIS` placeholders in: block_finder, tally, mrc + block_rewards + contract, wallet + rpcwallet, researcher/beacon, voting + miner + policy. One commit per sub-area; each commit ends warning-free.
 - **Phase 3**: scraper, quorum (lambda-capture analyzer issues).
 - **Phase 4**: network layer (`ProcessMessage`, `AlreadyHave`, `PushVersion`, `ArgsManager::GetBlocksDirPath`).
 
@@ -205,6 +205,71 @@ Every `LOCK*` added in Phase 1 was traced through its full call graph for orderi
 
 `LOCK2(cs_main, cs_vNodes)` in `AskForOutstandingBlocks` was verified consistent with `validation.cpp:1508` (the only other site in the daemon that combines those two locks), and no path anywhere takes `cs_vNodes → cs_main`.
 
+## Phase 2 — sub-area annotation commits
+
+Phase 2 replaces every Phase 1 `NO_THREAD_SAFETY_ANALYSIS` placeholder in the listed sub-areas with the right `EXCLUSIVE_LOCKS_REQUIRED(...)` annotation, pushing the lock requirement out to callers (per the user's "annotate then push to caller" pattern — eliminates inversion risk and surfaces missing locks at the API boundary, not later in the call chain). Each sub-area is one commit; each commit ends with `cmake --build build_clang --clean-first` producing zero `-Wthread-safety` warnings and `test_gridcoin` reporting `*** No errors detected`.
+
+| Commit | Sub-area | Functions promoted | Caller cascade |
+|---|---|---|---|
+| `42b1e9516` | `gridcoin/support/block_finder.cpp` | `BlockFinder::FindByHeight`, `FindByMinTime`, `FindByMinTimeFromGivenIndex`, `FindLatestSuperblock` | ~29 call sites across rpc/voting/scraper/superblock; almost all callers already held cs_main. `block_finder_tests.cpp` wrapped in `#pragma clang diagnostic` for `-Wno-thread-safety-analysis` (single-threaded test fixture mutates pindexBest directly). |
+| `849a06700` | `gridcoin/tally.cpp` | `RepairZeroCpidIndex`, `ActivateSnapshotAccrual` (private+public), `GetStartHeight`, `RebuildAccrualSnapshots`, `Tally::GetNewbieSuperblockAccrualCorrection`, `Initialize` (private+public), `ApplySuperblock` (private+public), `BuildAccrualSnapshots`, `TallySuperblockAccrual`, `Tally::GetMagnitudeUnit` | All callers reached cs_main via existing init/validation/RPC paths; `tally.h` already documented "Always lock cs_main before calling its methods" — the analyzer now enforces it piecewise. |
+| `3b33e8bbb` | `gridcoin/mrc.cpp` + `gridcoin/consensus/block_rewards.cpp` + `gridcoin/contract/contract.cpp` + `gridcoin/contract/message.cpp` | `MRC::ComputeMRCFee`, `MRCContractHandler::Validate/BlockValidate` overrides, `BlockRewardRules::CheckResearcherClaim/CheckMRCRewards/Check/CheckNoncruncherClaim`, `GRC::ReplayContracts`, `Contract::Body::ResetType`, `SelectMasterInputOutput`, `CreateContractTx`, `SendContractTx`, `GRC::SendContract` (both overloads). | `rpc/blockchain.cpp::addkey` RPC: scoped `LOCK(cs_main)` around the `SendContract` call. `mrc_tests.cpp::it_has_proper_fees_for_newbies`: `LOCK(cs_main)` added to fixture. |
+| `eb56f3a1c` | `wallet/wallet.cpp` + `wallet/rpcwallet.cpp` + `main.cpp` cascade | `CWallet::AddToWallet`, `AddToWalletIfInvolvingMe`, `ResendWalletTransactions`, `GetKeyBirthTimes` (cs_main + cs_wallet), `CWalletTx::RevalidateTransaction`, `CWalletTx::GetGeneratedType` inline forwarder, `::GetGeneratedType` free function, `WalletTxToJSON`, `ListTransactions` (rpcwallet); `SyncWithWallets` + free `ResendWalletTransactions` wrappers in `main.h`/`main.cpp`. | 3 lock promotions, all canonical: `SendMessages` and `resendtx` RPC `LOCK(cs_setpwalletRegistered)` → `LOCK2(cs_main, cs_setpwalletRegistered)`; `accounting_tests.cpp` `LOCK(cs_wallet)` → `LOCK2(cs_main, cs_wallet)`. This commit **eliminates the latent Phase 1 inversion risk** where SendMessages and resendtx held cs_setpwalletRegistered without cs_main. |
+| `20d800299` | `gridcoin/researcher.cpp` + Qt v3 beacon wizard | `GRC::GenerateBeaconKey`, `CheckBeaconTransactionViable`, `SendBeaconContract` (anon), `SendNewBeacon` (anon), `RenewBeacon` (anon), `GRC::SendBeaconContractV3` (cs_main + cs_wallet, since `RecentBeacons::Remember` requires the wallet lock). `Researcher::Accrual` / `AccrualNearLimit` LOCK moved up to cover `pindexBest`/`OutOfSyncByAge` reads (see "Known follow-up" below). `researcher.h` gains `#include "sync.h"`, `#include "wallet/wallet.h"`, `extern cs_main`/`extern pwalletMain`. | 2 new `LOCK2(cs_main, pwalletMain->cs_wallet)` in `researchermodel.cpp::generateBeaconKeyForV3` and `advertiseBeaconV3`. Mirrors the existing v2 `advertisebeacon` RPC pattern; both follow canonical lock order. |
+| `47f9ae1d8` | `gridcoin/voting/builders.cpp` + `voting/result.cpp` + `miner.cpp` + `policy/policy.cpp` | `MagnitudeClaimBuilder::FindBeaconTxid`, `MagnitudeClaimBuilder::BuildClaim`, `VoteClaimBuilder::BuildClaim`, `VoteBuilder::BuildContractTx`, `PollBuilder::SetPayloadVersion`, `ResolveSuperblockForPoll`, `ResolveMoneySupplyForPoll`, `SplitCoinStakeOutput`, `IsStandardTx`. `voting/builders.h` gains `#include "sync.h"` + `extern cs_main`. **`VoteResolver::GetMagnitudeFactor` deliberately retained as `NO_THREAD_SAFETY_ANALYSIS`** — see "Design constraint" below. | `rpc/voting.cpp::addpoll` + `qt/voting/votingmodel.cpp::createPoll` each get a NEW tight `LOCK(cs_main)` scoped to the `SetPayloadVersion` call only (per the `feedback_preserve_lock_scopes` lesson — do not widen the existing surrounding LOCK blocks). `coinstake_construction_tests.cpp` Tests 4 + 5 get `LOCK(cs_main)` (Test 6 already had `LOCK2`; the script_p2sh sign/set tests already held cs_main from prior work). |
+
+### Design constraint preserved — voting result calculation must not re-acquire cs_main
+
+Historical work in the voting subsystem (see comments around `qt/voting/votingmodel.cpp:351-360`: *"We do this because we have eliminated the cs_main lock to free up the GUI"* / *"on a recursive lock on cs_main before for the ENTIRE run, and this is certainly better"*) deliberately moved poll result calculation out from under cs_main because the chain walk + vote counting can take seconds to tens of seconds on a node with deep history. The current shape:
+
+```cpp
+// gridcoin/voting/result.cpp::PollResult::BuildFor — preserved exactly by Phase 2
+if (result.m_poll.IncludesMagnitudeWeight()) {
+    SuperblockPtr superblock;
+    uint64_t supply;
+    {
+        LOCK(cs_main);                                  // tight scope:
+        superblock = ResolveSuperblockForPoll(poll);    //   snapshot
+        supply     = ResolveMoneySupplyForPoll(poll);   //   snapshot
+    }                                                   // <-- release
+    counter.EnableMagnitudeWeight(std::move(superblock), supply);
+}
+...
+counter.CountVotes(result, poll_ref.Votes());           // long, lock-free
+```
+
+Phase 2 annotates `ResolveSuperblockForPoll` / `ResolveMoneySupplyForPoll` as `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` because the tight inner LOCK already satisfies them, but **`VoteResolver::GetMagnitudeFactor` (reached from `ProcessLegacyVote` inside the lock-free `CountVotes` loop) stays under `NO_THREAD_SAFETY_ANALYSIS`** with an updated TODO. The pragma block at `result.cpp:959-966` around the `ProcessLegacyVote` call site is retained for the same reason.
+
+Promoting `GetMagnitudeFactor` to `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` would force cs_main back across the entire `CountVotes` loop, undoing that historical work. The right fix is the standing voting-redesign work (committed votes with UTXO demarcation pinned at poll start, deterministic tallying without live chain reads) — at which point the legacy class is removed and the suppression goes with it.
+
+### Known follow-up — researcher Accrual lock scope
+
+In commit `20d800299`, `Researcher::Accrual()` and `Researcher::AccrualNearLimit()` had their internal `LOCK(cs_main)` moved up so the cs_main-guarded reads (`pindexBest`, `OutOfSyncByAge()`) happen under the lock. Hold time grows by a few microseconds in the common case (the `Tally::GetAccrual` walk dominates).
+
+These functions are called from `ResearcherModel::formatAccrual` on GUI refresh ticks. During heavy chain activity (block connect, reorg) the GUI thread will queue on cs_main slightly more than before. Not a practical issue at present, but if profiling ever flags it, the cleaner pattern is to snapshot `pindexBest` + height/time under a tight cs_main scope, drop the lock, then call `Tally::GetAccrual` with the snapshotted values — needs a signature change on the Tally side, so out of scope for Phase 2.
+
+### Lessons recorded for future phases
+
+| Lesson | Where it applies |
+|---|---|
+| Do not widen existing tight LOCK scopes when fixing a thread-safety warning; add a NEW scoped LOCK above. Inner brace scopes are intentional (bound contention + protect cs_main → cs_wallet ordering). | Followed in both `addpoll` RPC and `votingmodel.cpp::createPoll` SetPayloadVersion fixes. |
+| When a header annotation references a lock expression like `pwalletMain->cs_wallet`, the header must `#include "wallet/wallet.h"` so the analyzer can resolve the member-access type. Forward declaration of `CWallet` is not sufficient. | `researcher.h` had to pull in `wallet/wallet.h`; `voting/builders.h` only needed `sync.h` + `extern cs_main`. |
+| EXCLUSIVE_LOCKS_REQUIRED is preferable to internal acquisition when the caller chain can hold the lock — it eliminates inversion risk and surfaces missing locks at the API boundary. | Pattern from Phase 1 `cs_setpwalletRegistered` fix; reapplied throughout Phase 2. |
+| Pragma-suppressing a test case is acceptable when the test is single-threaded and the fixture mutates analyzer-tracked globals directly; adding `LOCK(cs_main)` in the test is preferable when the existing fixture already supports it. | `coinstake_construction_tests.cpp` Tests 4 + 5 got `LOCK(cs_main)` (fixture supports it); Phase 1 `block_finder_tests.cpp` got the pragma (fixture mutates pindexBest in setup). |
+
+### Remaining work — Phase 3 + Phase 4
+
+After Phase 2 ships, the following `NO_THREAD_SAFETY_ANALYSIS` sites remain, all in Phase 3+ territory:
+
+| Phase | File:line | Function | Why deferred |
+|---|---|---|---|
+| 3 | `gridcoin/scraper/scraper.cpp:6555` | `testnewsb` RPC | Touches converged scraper state; needs the broader scraper annotation pass. |
+| 3 | `gridcoin/quorum.cpp:1083, 1119, 1148, 1818` | `AddBeaconPartsData` + two lambdas + `Quorum::SuperblockNeeded` | The two lambdas are independently suppressed because the analyzer cannot see hold state through lambda captures — needs Phase 3 lambda strategy. |
+| 4 | `net.cpp:486` | `CNode::PushVersion` | Network layer; coupled with `ProcessMessage` / `AlreadyHave` annotation. |
+| 4 | `main.cpp:2206, 2236` | `AlreadyHave`, `ProcessMessage` | The two P2P entry points; ProcessMessage's reach is the broadest single annotation cascade in the codebase. |
+| 4 | `util/system.cpp:303` | `ArgsManager::GetBlocksDirPath` | Returns a reference to a `cs_args`-guarded cache; needs a return-by-value or a lifetime-tied accessor. |
+| — | `gridcoin/voting/result.cpp:697` | `VoteResolver::GetMagnitudeFactor` | **Permanent until voting-redesign lands.** See "Design constraint" above — promoting it would re-acquire cs_main across the entire CountVotes loop and undo the historical scope-reduction work. |
+
 ## End state
 
 ```
@@ -213,11 +278,11 @@ $ cmake --build build_clang --parallel 32 --target gridcoinresearchd gridcoinres
 [100%] Built target gridcoinresearch
 [100%] Built target test_gridcoin
 
-$ grep -c "warning:" /tmp/clang_build.log
+$ grep -c "warning:.*thread-safety" /tmp/clang_build.log
 0
 
 $ ./build_clang/src/test/test_gridcoin --log_level=warning
 *** No errors detected
 ```
 
-Phase 1 ships warning-free across the daemon, the Qt wallet, and the test binary under clang. The `-Wthread-safety-*` warnings the analyzer would emit are now Phase 2 (researcher/wallet/tally/...), Phase 3 (scraper/quorum lambdas), and Phase 4 (network) work — all suppressed with `NO_THREAD_SAFETY_ANALYSIS` and a TODO that names the lock and the caller-chain audit each phase needs.
+Phase 1 + Phase 2 ship warning-free across the daemon, the Qt wallet, and the test binary under clang. The `-Wthread-safety-*` warnings the analyzer would emit are now Phase 3 (scraper/quorum lambdas) and Phase 4 (network) work, plus the deliberate voting-redesign deferral — all suppressed with `NO_THREAD_SAFETY_ANALYSIS` and a TODO that names the lock and the caller-chain audit each phase needs.

--- a/doc/thread_safety_phase1_report.md
+++ b/doc/thread_safety_phase1_report.md
@@ -8,8 +8,14 @@ The phases are an internal organizing tool, not a release boundary:
 - **Phase 2**: replace the Phase 1 `NO_THREAD_SAFETY_ANALYSIS` placeholders in: block_finder, tally, mrc + block_rewards + contract, wallet + rpcwallet, researcher/beacon, voting + miner + policy. One commit per sub-area; each commit ends warning-free.
 - **Phase 3**: scraper + quorum (lambda-capture analyzer issues).
 - **Phase 4**: network layer (`ProcessMessage`, `AlreadyHave`, `PushVersion`, `ArgsManager::GetBlocksDirPath`).
+- **Follow-ups A/B/C/D** (post-Phase 4 coverage sweep): close remaining gaps surfaced by an end-state audit — `BeaconRegistry` cs_main contract (A), scraper internals (B), `CNode` per-node locks (C), and an alert/net `GUARDED_BY` sweep (D). See "Post-Phase 4 follow-ups" below.
 
-After Phase 4, exactly **one** `NO_THREAD_SAFETY_ANALYSIS` marker remains in the tree: `VoteResolver::GetMagnitudeFactor` at `src/gridcoin/voting/result.cpp`. It is held intentionally per the voting-redesign design constraint (see "Design constraint preserved" below) and will be removed when the voting-redesign work lands.
+After the four follow-ups, **two** `NO_THREAD_SAFETY_ANALYSIS` markers remain in production source:
+
+1. `VoteResolver::GetMagnitudeFactor` at `src/gridcoin/voting/result.cpp:700` — held intentionally per the voting-redesign design constraint (see "Design constraint preserved" below).
+2. `BeaconRegistry::GetBeaconChainletRoot`'s `ChainletErrorHandle` lambda body at `src/gridcoin/beacon.cpp:852` — analyzer cannot see hold-state through `[this]` lambda capture even though the enclosing `GetBeaconChainletRoot` is correctly `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`. Documented at the use site; will be revisited if/when the analyzer learns about lambda-capture flow.
+
+Both will fall out naturally as the relevant subsystem work lands.
 
 Each phase ends with the same invariant: `cmake --build build_clang --target gridcoinresearchd gridcoinresearch test_gridcoin` produces zero `-Wthread-safety-*` warnings and the boost test suite passes.
 
@@ -289,6 +295,25 @@ Phase 4 closes out the rollout. Resolves the remaining four `NO_THREAD_SAFETY_AN
 
 The Phase 4 P2P entry-point cleanups use the `WITH_LOCK(cs_main, return X)` snapshot pattern instead of acquiring cs_main across the full message-handler body. This avoids holding cs_main across the (potentially slow) downstream P2P work in `PushMessage`, `PushGetBlocks`, address store, etc. It does mean the snapshotted value can be slightly stale by the time the handler acts on it, but for height-threshold heuristics (protocol-version disconnect, ask-for-blocks throttle, peer-storage threshold) staleness is harmless — the handler is making a coarse-grained policy decision, not enforcing a consensus rule.
 
+## Post-Phase 4 follow-ups
+
+After Phase 4 closed out the rollout, a second-pass coverage audit surfaced four narrow gaps. Each was addressed as a focused commit; all four are pure annotation work with one exception (`fScraperActive` → `std::atomic<bool>` in Follow-up B). All commits end clang-warning-free.
+
+| Commit | Follow-up | Sub-area | Change |
+|---|---|---|---|
+| `630deb0e3` | A | `gridcoin/beacon.{h,cpp}` + researcher + accrual + diagnose + Qt + rpc/blockchain + tests | `BeaconRegistry`'s entire public API + `Researcher::Reload`/`Refresh` + `NewbieAccrualComputer` + `SnapshotAccrualComputer` + `block_rewards::CheckBeaconSignature` annotated `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`. Production-caller `LOCK(cs_main)` additions at `ResearcherModel::reload`, `Researcher::ChangeMode`, `VerifyCPIDHasRAC::hasActiveBeacon`, `rainbymagnitude` RPC (with downstream `LOCK2(cs_main, cs_wallet)` demoted to `LOCK(cs_wallet)`), `resetcpids` RPC, `StoreBeaconList` (WITH_LOCK snapshot for log line). `Researcher::Initialize` flattens its existing `LOCK2` scope to keep `Reload()` under cs_main. Test helpers (`AddTestBeacon` and friends) get per-function `NO_THREAD_SAFETY_ANALYSIS`. Adds the documented `ChainletErrorHandle` lambda suppression (the second remaining marker — see "End state"). |
+| `ab70f5d45` | B | `gridcoin/scraper/scraper.{h,cpp}` + `gridcoin/gridcoin.cpp` | `fScraperActive` → `std::atomic<bool>` (single startup write, scraper-thread reads — no lock needed; the only behavior-affecting change in the four follow-ups). `vuserpass` / `ndownloadsize` / `nuploadsize` annotated `GUARDED_BY(cs_Scraper)` to make the hoisted call-site `LOCK(cs_Scraper)` at `scraper.cpp:1640` clang-enforceable; the singleshot reentrant path (`ScraperGetSuperblockContract` → `ScraperSingleShot` → `Scraper(true)` from staking-miner/RPC threads) enters the same critical section, so the data is cs_Scraper-protected on every path. Cascade: `EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)` on `UserpassPopulated`, `class userpass` ctor/`import()`, and the four affected `DownloadProject*` / `ProcessProjectRacFileByCPID` helpers. `DownloadProjectPublicKeys` deliberately not annotated — it only touches `g_project_public_keys` under its own `cs_ProjectPublicKeys`, preserving the fine-grained-locking design. Prototype/definition consistency sweep across scraper.cpp for `ScraperHousekeeping`, `ScraperDirectoryAndConfigSanity`, `GetmScraperFileManifestHash`, `Insert/Delete/MarkScraperFileManifestEntry*`, `ScraperSendFileManifestContents`, `BinCScraperManifestsByScraper`, `ProcessProjectTeamFile`. `IsScraperMaximumManifestPublishingRateExceeded` in scraper.h gets `EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest)`. |
+| `11994d6c0` | C | `src/net.{h,cpp}` + `src/main.{h,cpp}` | `CNode` members annotated `GUARDED_BY`: `ssSend`/`nSendSize`/`nSendOffset`/`vSendMsg` → `cs_vSend`; `vRecvMsg`/`nRecvVersion` → `cs_vRecvMsg`; `setInventoryKnown`/`vInventoryToSend` → `cs_inventory`; `mapMisbehavior` → `cs_mapMisbehavior`. Methods annotated `EXCLUSIVE_LOCKS_REQUIRED`: `GetTotalRecvSize`/`ReceiveMsgBytes`/`SetRecvVersion` → `cs_vRecvMsg`; `BeginMessage`/`AbortMessage`/`EndMessage`/`PushFields` → `cs_vSend`; free `SocketSendData` → `pnode->cs_vSend` (forward decl reordered below `CNode` so the lock expression resolves); `ProcessMessages` → `pfrom->cs_vRecvMsg`. Call-site additions: scoped `LOCK(pfrom->cs_vSend)` around `ssSend.SetVersion` in the VERSION handler, around VERACK-time send-version flip, around the GETHEADERS/GETBLOCKS push paths in SendMessages, etc. Replaces the "requires LOCK(cs_X)" comments that previously documented the contract informally. |
+| `d4a52ceeb` | D | `src/alert.cpp` + `src/main.cpp` + `src/rpc/net.cpp` + `src/net.h` + `src/net.cpp` | Pure-annotation sweep of the remaining file-scope cs↔data pairs: `mapAlerts` → `GUARDED_BY(cs_mapAlerts)` (alert.cpp + 2 extern decls); `mapLocalHost`, `vAddedNodes`, `vOneShots` (file-static), `setservAddNodeAddresses` → `GUARDED_BY(cs_<paired>)`. All existing call sites already take the right lock; zero cascade needed. The `cs_*` declaration is moved above the data declaration where it wasn't already (clang requires the lock symbol to be in scope at the `GUARDED_BY` site). |
+
+### Notes on patterns confirmed during the follow-ups
+
+- **Scraper design philosophy** (Follow-up B). The scraper was written before C++11 atomics; cross-thread booleans / counters were either left racy or covered by an existing lock taken for some other reason. The right defaults now: (1) for a scalar with no existing call-site lock, prefer `std::atomic<T>`; (2) for data already inside a hoisted call-site lock, prefer honest `GUARDED_BY(lock)` over claiming "single-threaded" — the audit pass invalidated several apparent single-thread claims because the `ScraperSingleShot` path enters the same critical section as the main loop. Keep fine-grained locks scoped to specific data structures; do not fold ad-hoc state into a big `cs_Scraper` contract unless the data is in fact protected there.
+
+- **Lambda-capture suppression is acceptable** (Follow-up A's ChainletErrorHandle). The enclosing function (`GetBeaconChainletRoot`) is correctly annotated, but the analyzer can't trace hold-state through `[this]` captures into `Reset()`. The lambda-body suppression with an explanatory comment pointing back to the enclosing annotation is the right shape — restructuring the lambda would not improve safety.
+
+- **TRY_LOCK lock-order-avoidance pattern needs nothing extra** (audited during D). `sync.h:107` already declares `try_lock() EXCLUSIVE_TRYLOCK_FUNCTION(true)`, and the macro at `sync.h:256` propagates that annotation. The `if (lockX) { ... }` idiom in `net.cpp`'s `SendMessages` / `ProcessMessage` (`net.cpp:868,871,874,930,1083,1135,1877,1896,1899`) and the reversed-logic `cs_main` TRY_LOCK at `net.cpp:1888-1896` flow through TSA correctly. No suppressions required.
+
 ## End state
 
 ```
@@ -304,10 +329,16 @@ $ ./build_clang/src/test/test_gridcoin --log_level=warning
 *** No errors detected
 
 $ grep -rn 'NO_THREAD_SAFETY_ANALYSIS' src/ --include='*.cpp' --include='*.h' \
-    | grep -v 'threadsafety.h\|leveldb/port/thread_annotations.h'
+    | grep -v 'threadsafety.h\|leveldb/port/thread_annotations.h\|test/'
 src/gridcoin/voting/result.cpp:700:    Weight GetMagnitudeFactor() NO_THREAD_SAFETY_ANALYSIS
+src/gridcoin/beacon.cpp:852:    const auto ChainletErrorHandle = [this](...) NO_THREAD_SAFETY_ANALYSIS {
 ```
 
-All four phases ship warning-free across the daemon, the Qt wallet, and the test binary under clang. Exactly **one** `NO_THREAD_SAFETY_ANALYSIS` marker remains in the source tree: `VoteResolver::GetMagnitudeFactor`, held intentionally per the voting-redesign design constraint above. It will be removed when the voting-redesign work lands and the legacy `VoteResolver` class is retired.
+All four phases plus the four follow-ups ship warning-free across the daemon, the Qt wallet, and the test binary under clang. **Two** production-code `NO_THREAD_SAFETY_ANALYSIS` markers remain, both intentional:
+
+1. `VoteResolver::GetMagnitudeFactor` — voting-redesign design constraint (above).
+2. `BeaconRegistry::GetBeaconChainletRoot`'s `ChainletErrorHandle` lambda body — analyzer cannot reason about lock state through `[this]` capture; enclosing function is correctly annotated.
+
+A small number of pragma-block suppressions remain in production source — voting (deferred), the `Serialize()` template fallback in `serialize.h` (annotating it would force a contract onto every `T::Serialize` member fleet-wide), and test code (test fixtures run single-threaded and mutate analyzer-tracked globals directly).
 
 With this rollout complete, the `-Wno-error=thread-safety-analysis` and `-Wno-error=thread-safety-reference` downgrades that Phase 1 added to `CMakeLists.txt` can be dropped — a future change can promote stale annotations to hard build failures so newly-introduced races don't regress under the radar.

--- a/doc/thread_safety_phase1_report.md
+++ b/doc/thread_safety_phase1_report.md
@@ -1,0 +1,223 @@
+# Clang Thread Safety Analysis — Phase 1 report (issue #2869)
+
+Phase 1 of the issue #2869 multi-phase thread-safety rollout. Captures the build-system enablement, the canonical lock order it established, and a per-resolution breakdown of every warning the analyzer surfaced.
+
+The phases are an internal organizing tool, not a release boundary:
+
+- **Phase 1 (this PR)**: enable the analyzer; annotate cs_main globals + their immediate call chains; annotate `setpwalletRegistered`; document Phase 2/3/4 deferrals in-code with `TODO(#2869 Phase N — area)` comments.
+- **Phase 2**: researcher/beacon, wallet, tally, mrc, block_rewards, contract, voting, miner, policy, block_finder.
+- **Phase 3**: scraper, quorum (lambda-capture analyzer issues).
+- **Phase 4**: network layer (`ProcessMessage`, `AlreadyHave`, `PushVersion`, `ArgsManager::GetBlocksDirPath`).
+
+Each phase ends with the same invariant: `cmake --build build_clang --target gridcoinresearchd gridcoinresearch test_gridcoin` produces zero `-Wthread-safety-*` warnings and the boost test suite passes.
+
+## Build-system enablement
+
+The Clang Thread Safety Analyzer ships with upstream Clang and Apple Clang but is not in `-Wall`, so on Linux/Windows clang builds the analyzer was effectively dormant — every existing `GUARDED_BY` / `EXCLUSIVE_LOCKS_REQUIRED` annotation in the tree was aspirational documentation. The pre-existing block in `CMakeLists.txt` only downgraded `-Werror=thread-safety-*` inside `if(APPLE)`, implying the analyzer was on by default in Apple Clang and the build had pre-existing warnings there too.
+
+**Change**: replace the `if(APPLE)`-only block with a portable `check_cxx_compiler_flag(-Wthread-safety HAVE_CLANG_THREAD_SAFETY)` detection. When the flag is supported, enable `-Wthread-safety` and downgrade both `-Werror=thread-safety-analysis` and `-Werror=thread-safety-reference` on every platform. Kept warning-only across Phases 1–4; the `-Wno-error=` flags can be dropped after Phase 4 to promote stale annotations to hard build failures.
+
+## Pre-existing fix: `sync.h` negative-capability annotation
+
+Before any Phase 1 globals were annotated, the analyzer emitted 96 warnings from a single source:
+
+```cpp
+template <typename MutexType>
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs)
+    EXCLUSIVE_LOCKS_REQUIRED(!cs);
+```
+
+`cs` is a `MutexType*`. The `!cs` inside the attribute is evaluated before the analyzer sees it; on a pointer, `operator!` yields `bool`, not the negative-capability `const MutexType&` overload defined on `AnnotatedMixin`. The fix is to dereference inside the attribute:
+
+```cpp
+    EXCLUSIVE_LOCKS_REQUIRED(!(*cs));
+```
+
+Applied to both the `DEBUG_LOCKORDER` and no-debug declarations. **Annotation-only — callers were already correct.** Eliminated all 96 `-Wthread-safety-attributes` warnings before Phase 1 began counting cs_main warnings.
+
+## Canonical lock order established in Phase 1
+
+```
+cs_main -> cs_setpwalletRegistered -> cs_wallet -> subsystem locks
+```
+
+The wallet-registry lock (`cs_setpwalletRegistered`) was not previously part of the canonical order documented in `CLAUDE.md`. Phase 1 inserted it between `cs_main` and `cs_wallet` because the wallet-registry wrappers (`SyncWithWallets` and friends) iterate `setpwalletRegistered` and then dispatch into per-wallet methods that take `cs_wallet`. Acquisition at the call site (rather than inside the wrapper) avoids the inversion an inside-lock would have created with `sendrawtransaction`'s `LOCK2(cs_main, cs_wallet)` → `SyncWithWallets` path against the `SendMessages` → `ResendWalletTransactions` path (which holds no cs_main).
+
+## Globals annotated in Phase 1
+
+| Variable | File:line | Lock |
+|---|---|---|
+| `mapBlockIndex` | `src/main.h:76` | `cs_main` |
+| `pindexGenesisBlock` | `src/main.h:77` | `cs_main` |
+| `nBestHeight` | `src/main.h:82` | `cs_main` |
+| `nBestChainTrust` | `src/main.h:83` | `cs_main` |
+| `hashBestChain` | `src/main.h:84` | `cs_main` |
+| `pindexBest` | `src/main.h:85` | `cs_main` |
+| `setpwalletRegistered` | `src/main.h:89` | `cs_setpwalletRegistered` |
+
+`net.h`'s `vNodes` / `cs_vNodes` / `mapRelay` / `cs_mapRelay` and the `wallet.cs_wallet` mutex were already declared and partially annotated upstream; Phase 1 left those declarations as-is and resolved only the warnings that surfaced from the new cs_main `GUARDED_BY` additions.
+
+## Resolution log: annotation-only
+
+The function already runs with the relevant lock held by every observed caller; adding `EXCLUSIVE_LOCKS_REQUIRED` on the declaration just makes the existing contract enforceable. No behavior change.
+
+### Chain-state / block index
+
+| File:line | Function | Lock | Notes |
+|---|---|---|---|
+| `src/main.h:617` | `CBlockIndex::IsInMainChain` | `cs_main` | Reads `pindexBest`. |
+| `src/main.h:1080` | `CBlockLocator::GetDistanceBack` | `cs_main` | Iterates `mapBlockIndex`. |
+| `src/main.h:1101` | `CBlockLocator::GetBlockIndex` | `cs_main` | Iterates `mapBlockIndex` and reads `pindexGenesisBlock`. |
+| `src/main.h:1117` | `CBlockLocator::GetBlockHash` | `cs_main` | Iterates `mapBlockIndex`. |
+| `src/main.h:1133` | `CBlockLocator::GetHeight` | `cs_main` | Transitive: calls `GetBlockIndex`. |
+| `src/main.h:142` | `AbandonChainTo` | `cs_main` | Already had `AssertLockHeld(cs_main)`; analyzer now enforces it. |
+| `src/main.h:177` | `GetClaimByIndex` | `cs_main` | Reads `pindexBest`. |
+| `src/main.cpp:797` | `InvalidChainFound` (file-static) | `cs_main` | Reads / writes `pindexBest`, `nBestInvalidBlockTrust`. |
+| `src/main.cpp:1430` | `GridcoinServices` | `cs_main` | Walks chain. |
+| `src/main.h:124` (comment) | free `LoadBlockIndex` | takes `cs_main` internally | Documented contract in comment; callers MUST NOT hold cs_main. |
+| `src/dbwrapper.h:483, src/dbwrapper.cpp:472` | `CTxDB::LoadBlockIndex` / `LoadBlockIndexGuts` / file-static `InsertBlockIndex` | `cs_main` | Populate mapBlockIndex; called from the free `LoadBlockIndex` wrapper. |
+| `src/validation.h:73, 102, 108, 122, 124, 73` | `DisconnectInputs`, `GetDepthInMainChain`, `AddToBlockIndex`, `ValidateMRC` (both), `ConnectInputs`, `DisconnectBlock`, `ConnectBlock` | `cs_main` | Annotated on both declaration + definition. The previous redundant `LOCK(cs_main)` inside `AddToBlockIndex` was removed (was triggering "already-held" warnings on the recursive mutex). |
+| `src/validation.cpp:672` | `ReturnCurrentMoneySupply` (anonymous-namespace static) | `cs_main` | Walks pprev chain. |
+| `src/consensus/tx_verify.cpp:143` | `GetHeightForTxIndex` (file-static) | `cs_main` | Reads mapBlockIndex; sole caller `CheckSequenceLocks` already required cs_main. |
+| `src/rpc/blockchain.h:45` | `GRC::MockBlockIndex::InsertBlockIndex` | `cs_main` | Used by RPC and tests. |
+| `src/rpc/blockchain.cpp:189` | `blockToJSON` | `cs_main` | Iterates block txs; RPC callers already take cs_main. |
+| `src/rpc/blockchain.cpp:30, 31, 37, 40` | `MagnitudeReport`, `SuperblockReport`, `GetJSONVersionReport`, `TxToJSON` | `cs_main` | Annotation on both forward declarations + definitions. |
+| `src/wallet/rpcwallet.cpp:36` | `TxToJSON` forward decl | `cs_main` | Matches `rpc/blockchain.cpp` definition. |
+| `src/qt/transactiondesc.cpp:22` | `GetTxStakeBoincHashInfo` forward decl | `cs_main` | Sole caller `TransactionDesc::toHTML` takes `LOCK2(cs_main, wallet->cs_wallet)`. |
+| `src/rpc/rawtransaction.cpp:44` | `GetTxStakeBoincHashInfo` definition | `cs_main` | Same. |
+| `src/rpc/rawtransaction.cpp:327` | `TxToJSON` definition | `cs_main` | Production callers (`getrawtransaction`, `decoderawtransaction`, `sendrawtransaction`, `gettransaction` RPC) all take cs_main. |
+| `src/rpc/psgt.cpp:26, 52` | `AddHDKeypathIfAvailable`, `FillHDKeypaths` (file-static) | `wallet.cs_wallet` | Sole call sites take `LOCK2(cs_main, pwalletMain->cs_wallet)`. |
+| `src/gridcoin/gridcoin.cpp:133, 652, 701` | `VerifyCheckpoints`, `GRC::RebuildBeaconRegistry`, `GRC::Initialize` | `cs_main` | Init-time callers now take cs_main explicitly (see `init.cpp` real-acquisition list). `gridcoin.h` updated with matching annotations. |
+| `src/main.cpp` setpwalletRegistered wrappers (`SyncWithWallets`, `UpdatedTransaction`, `ResendWalletTransactions`, `EraseFromWallets`, `PrintWallets`, `Inventory`, `SetBestChain(CBlockLocator&)`, `GetTransaction(uint256,CWalletTx&)`) | `cs_setpwalletRegistered` | Hoisted to callers — see canonical lock order section above. |
+
+### Phase 2/3/4 placeholders (`NO_THREAD_SAFETY_ANALYSIS` + TODO)
+
+Phase 1 captures these so the daemon target builds clean today; Phase 2+ will replace each placeholder with the right lock annotation after the caller-chain audit each subsystem needs. The grep one-liner for the punch list is:
+
+```
+grep -rn 'TODO(#2869 Phase' src/
+```
+
+Grouped by phase target:
+
+- **Phase 2 — researcher/beacon** (`gridcoin/researcher.cpp`): `GenerateBeaconKey`, `CheckBeaconTransactionViable`, `SendBeaconContract`, `SendBeaconContractV3`, `Researcher::Accrual`, `Researcher::AccrualNearLimit`.
+- **Phase 2 — wallet** (`wallet/wallet.cpp`, `wallet/rpcwallet.cpp`): `CWallet::AddToWallet`, `CWallet::ResendWalletTransactions`, `CWalletTx::RevalidateTransaction`, `CWallet::GetKeyBirthTimes`, `GetGeneratedType`, `WalletTxToJSON`.
+- **Phase 2 — tally** (`gridcoin/tally.cpp`): `RepairZeroCpidIndex`, `ActivateSnapshotAccrual`, `GetStartHeight`, `RebuildAccrualSnapshots`, `Tally::GetNewbieSuperblockAccrualCorrection`.
+- **Phase 2 — mrc** (`gridcoin/mrc.cpp`): `MRC::ComputeMRCFee`, `MRCContractHandler::Validate`.
+- **Phase 2 — block_rewards** (`gridcoin/consensus/block_rewards.cpp`): `BlockRewardRules::CheckResearcherClaim`, `BlockRewardRules::CheckMRCRewards`.
+- **Phase 2 — contract** (`gridcoin/contract/contract.cpp`, `contract/message.cpp`): `GRC::ReplayContracts`, `Contract::Body::ResetType`, `SelectMasterInputOutput`.
+- **Phase 2 — voting** (`gridcoin/voting/builders.cpp`, `voting/result.cpp`): `PollBuilder::SetPayloadVersion`, `FindBeaconTxid`, `GetMagnitudeFactor`, `ResolveSuperblockForPoll`, `ResolveMoneySupplyForPoll`.
+- **Phase 2 — block_finder** (`gridcoin/support/block_finder.cpp`): `FindByHeight`, `FindByMinTime`, `FindByMinTimeFromGivenIndex`, `FindLatestSuperblock`. ~29 call sites across the codebase; cascade will dominate Phase 2 work.
+- **Phase 2 — miner** (`miner.cpp`): `SplitCoinStakeOutput`. Test paths in `coinstake_construction_tests.cpp` don't hold cs_main, blocking the required annotation.
+- **Phase 2 — policy** (`policy/policy.cpp`): `IsStandardTx`. Test paths in `script_p2sh_tests.cpp` don't hold cs_main.
+- **Phase 3 — scraper/quorum** (`gridcoin/quorum.cpp`, `scraper/scraper.cpp`): `AddBeaconPartsData` (+ two lambdas with their own NO_THREAD_SAFETY_ANALYSIS markers — the analyzer cannot see hold state through lambda captures), `Quorum::SuperblockNeeded`, `testnewsb` RPC.
+- **Phase 4 — net** (`main.cpp`, `net.cpp`, `util/system.cpp`): `AlreadyHave`, `ProcessMessage`, `CNode::PushVersion`, `ArgsManager::GetBlocksDirPath` (returns reference to cs_args-guarded cache).
+
+## Resolution log: real LOCK acquisitions added
+
+These are behavior changes (the previous code accessed guarded state without holding the lock) and warrant the most review.
+
+### Init-time wrappers — `src/init.cpp`
+
+Init runs single-threaded, so contention is theoretical. The locks document the contract the analyzer enforces on the called functions.
+
+| Call site | What it protects | Notes |
+|---|---|---|
+| `LOCK(cs_main)` around `txdb.LoadBlockIndex()` in `-loadblockindextest` path | `CTxDB::LoadBlockIndex` is now `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` | Scoped block; the free `LoadBlockIndex()` below takes cs_main internally and does not need this wrapper. |
+| `LOCK(cs_main)` at top of `-printblock` branch | `mapBlockIndex` iteration | Always-compiled debug path; runs only when arg supplied. |
+| `LOCK(cs_main)` after `RegisterWallet(pwalletMain)` (covers wallet rescan + `GRC::Initialize` through end of `AppInit2`) | `pindexBest` / `pindexGenesisBlock` / `mapBlockIndex` reads + the now-`EXCLUSIVE_LOCKS_REQUIRED(cs_main)` `GRC::Initialize` and friends | Scope intentionally wide because the rest of `AppInit2` is uncontended init. |
+| `LOCK(pwalletMain->cs_wallet)` moved to before the verbose-debug-print block in `AppInit2` | cs_wallet reads for `setKeyPool.size()` / `mapWallet.size()` / `mapAddressBook.size()` | cs_main is still held from the wallet-rescan block above; canonical order preserved. The two prior `LogPrintf` lines (mapBlockIndex.size, nBestHeight) move under the cs_wallet scope but were already under cs_main and there is no other lock the order could conflict with. |
+
+### `gridcoin/gridcoin.cpp` `CheckBlockIndex`
+
+Moved the existing `LOCK(cs_main)` up by 7 lines so it covers the `if (!pindexGenesisBlock)` early-return check (which now requires cs_main). No callers; no path change other than the lock being held briefly during a fast-return.
+
+### `validation.cpp` AddToBlockIndex
+
+Removed the inner `LOCK(cs_main)` (was redundant on a recursive mutex and triggered "acquiring mutex 'cs_main' that is already held" + "not held on every path through here" warnings on every exit). The function is now `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` from its declaration in `validation.h`, and both callers (`main.cpp:1957` inside `LoadBlockIndex` which takes cs_main, and `validation.cpp:1495` inside `AcceptBlock` which is itself `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`) hold the lock at the call site.
+
+### `main.cpp` `AskForOutstandingBlocks`
+
+`LOCK(cs_vNodes)` → `LOCK2(cs_main, cs_vNodes)`. The function reads `nBestHeight` inside the iteration, which now requires cs_main. The cs_main → cs_vNodes order matches the existing pattern in `validation.cpp:1508` (AcceptBlock's inventory-relay loop). Callers: `ForceReorganizeToHash` already holds cs_main; the two RPC entry points (`sendblock`, `askforoutstandingblocks`) previously made unprotected reads — `LOCK2` corrects both.
+
+### RPC entry points — `rpc/blockchain.cpp`, `rpc/mining.cpp`
+
+These RPCs previously read chain-state globals before acquiring `cs_main` (the read was racy with chain-tip changes). Phase 1 acquires cs_main at the right point. Where the read was a bounds check whose failure threw a JSON error, the original error-message ordering is preserved (block-validity error surfaces before batch-size error in `getblocksbatch`; `LogPrint("Getblockhash %d", nHeight)` still runs only on valid input).
+
+| File:line | RPC | Change |
+|---|---|---|
+| `src/rpc/blockchain.cpp:773` | `showblock` | Take cs_main before bounds check on `nBestHeight`. |
+| `src/rpc/blockchain.cpp:888` | `getblockhash` | Take cs_main; preserve "only LogPrint valid input" by ordering bounds check before the LogPrint inside the lock. |
+| `src/rpc/blockchain.cpp:911` | `getblock` | Take cs_main before `mapBlockIndex.count(hash)`. |
+| `src/rpc/blockchain.cpp:935` | `getblockbynumber` | Take cs_main before bounds check on `nBestHeight`. |
+| `src/rpc/blockchain.cpp:959` | `getblockbymintime` | Take cs_main before reading `pindexGenesisBlock` / `pindexBest`. |
+| `src/rpc/blockchain.cpp:987` | `getblocksbatch` | Single `LOCK(cs_main)` after parameter parsing so both the block-validity check (cs_main-protected) and the batch-size check (pure local) run in original order. |
+| `src/rpc/blockchain.cpp:2016` | `beaconaudit` | Take cs_main before `pindexBest->nHeight`. |
+| `src/rpc/mining.cpp:45` | `getstakinginfo` | Snapshot `nBestHeight` into a local inside the existing `LOCK2(cs_main, pwalletMain->cs_wallet)` block; report from the local. |
+| `src/rpc/mining.cpp:246` | `auditsnapshotaccrual` | Take `LOCK(cs_main)` before the `pindexBest` null-check (which previously ran unlocked). |
+| `src/rpc/mining.cpp:651` | `listresearcheraccounts` | Take `LOCK(cs_main)` before the `GRC::Tally::Accounts()` iteration that passes `pindexBest`. |
+| `src/rpc/rawtransaction.cpp:`consolidatemsunspent`, `scanforunspent` | scoped `LOCK(cs_main)` for the `nBestHeight` bounds check; the original `LOCK2(cs_main, pwalletMain->cs_wallet)` scope for the wallet work below is left intact (`feedback_preserve_lock_scopes` lesson). |
+
+### `cs_setpwalletRegistered` push-up
+
+The 8 surviving wallet-registry wrappers in `main.cpp` were annotated `EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)` and the lock was acquired at every call site, in the canonical cs_main → cs_setpwalletRegistered → cs_wallet order:
+
+| Call site | Pre-existing locks at call site | LOCK added |
+|---|---|---|
+| `validation.cpp:593` (DisconnectBlock → SyncWithWallets, per-tx loop) | cs_main | `LOCK(cs_setpwalletRegistered)` outside the loop |
+| `validation.cpp:1103` (ConnectBlock → SyncWithWallets, per-tx loop) | cs_main | same |
+| `validation.cpp:1171` (AddToBlockIndex → UpdatedTransaction) | cs_main | scoped `LOCK(cs_setpwalletRegistered)` around the call |
+| `main.cpp:597` (AcceptToMemoryPool → EraseFromWallets) | cs_main | scoped LOCK |
+| `main.cpp:1379` (SetBestChain chain-state writer → `::SetBestChain(locator)` wallet-notify) | cs_main | scoped LOCK |
+| `main.cpp:2028` (PrintBlockTree → PrintWallets) | cs_main (PrintBlockTree is `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`) | scoped LOCK |
+| `main.cpp:2567, 2702` (ProcessMessage → Inventory, two sites) | none formal (ProcessMessage is `NO_THREAD_SAFETY_ANALYSIS` — Phase 4) | scoped LOCK at each site |
+| `main.cpp:3219` (SendMessages → ResendWalletTransactions) | none | scoped LOCK |
+| `main.cpp:3293` (SendMessages → static `GetTransaction(inv.hash, wtx)`) | none | LOCK inside the `if (!fTrickleWait)` scope |
+| `rpc/rawtransaction.cpp:2113` (sendrawtransaction) | was `LOCK2(cs_main, pwalletMain->cs_wallet)` | rewritten as three sequenced LOCKs in canonical order: `LOCK(cs_main); LOCK(cs_setpwalletRegistered); LOCK(pwalletMain->cs_wallet);` |
+| `rpc/htlc.cpp:141` (claimhtlc) | same | same rewrite |
+| `rpc/htlc.cpp:275` (refundhtlc) | same | same rewrite |
+| `wallet/rpcwallet.cpp:2706` (resendtx RPC) | none | scoped LOCK |
+
+The dead static wrapper `bool IsFromMe(CTransaction&)` was deleted (zero callers — all observed `IsFromMe` uses in qt/wallet/test code are `CWallet`/`CWalletTx` methods). `SetBestChain(const CBlockLocator&)` looked dead by the same grep but has a global-namespace-qualified caller at `main.cpp:1379` (`::SetBestChain(locator)`) and is retained.
+
+### Qt entry points
+
+| File:line | Function | Change |
+|---|---|---|
+| `src/qt/researcher/researchermodel.cpp:804` | `ResearcherModel::isV14Enabled` (one-line function) | `LOCK(cs_main)` at top for the `IsV14Enabled(nBestHeight)` read. |
+| `src/qt/voting/pollwizarddetailspage.cpp:312` | `PollWizardDetailsPage::initializePage` | Scoped `LOCK(cs_main)` around the `IsPollV3Enabled(nBestHeight)` read. |
+
+GUI thread holds no backend locks at entry to these slots/handlers; cs_main is the natural first acquisition.
+
+### Tests
+
+Four test cases manipulate `pindexBest` / `pindexGenesisBlock` / `nBestHeight` directly (`new CBlockIndex` then assignment, then `delete`). Tests are single-threaded and the wrappers are documented locally:
+
+- `src/test/gridcoin/superblock_tests.cpp` — `it_initializes_from_a_provided_scraper_convergence_v3` and `it_initializes_from_a_fallback_by_project_scraper_convergence_v3` each wrapped in `#pragma clang diagnostic push/pop` with `-Wno-thread-safety-analysis`.
+- `src/test/gridcoin/mrc_tests.cpp:it_properly_records_blocks` — pragma-bracketed iteration of `pindexGenesisBlock`.
+
+## Deadlock audit summary
+
+Every `LOCK*` added in Phase 1 was traced through its full call graph for ordering inversions. Two issues were found during review and fixed:
+
+1. **`cs_setpwalletRegistered` inside-lock pattern** — initially Phase 1 took the lock INSIDE the 8 wrapper functions. Reviewed and identified a real inversion: `SendMessages → ResendWalletTransactions` (no cs_main, no cs_wallet → would take cs_setpwalletRegistered then cs_wallet) inverted with `sendrawtransaction → LOCK2(cs_main, cs_wallet) → SyncWithWallets` (cs_wallet then cs_setpwalletRegistered). The cs_main mutex did not serialize the two threads because SendMessages doesn't hold cs_main. Fixed by hoisting the lock to callers and rewriting the RPC sites' `LOCK2` to sequenced LOCKs in canonical order.
+2. **`getblockhash` LogPrint conditionality** — first-pass move of the bounds check after `LOCK(cs_main)` left an unconditional `LogPrint("Getblockhash %d", nHeight)` between them, causing the previously-conditional log to fire for invalid input. Fixed by placing bounds check + throw before the LogPrint inside the lock.
+
+`LOCK2(cs_main, cs_vNodes)` in `AskForOutstandingBlocks` was verified consistent with `validation.cpp:1508` (the only other site in the daemon that combines those two locks), and no path anywhere takes `cs_vNodes → cs_main`.
+
+## End state
+
+```
+$ cmake --build build_clang --parallel 32 --target gridcoinresearchd gridcoinresearch test_gridcoin --clean-first
+[100%] Built target gridcoinresearchd
+[100%] Built target gridcoinresearch
+[100%] Built target test_gridcoin
+
+$ grep -c "warning:" /tmp/clang_build.log
+0
+
+$ ./build_clang/src/test/test_gridcoin --log_level=warning
+*** No errors detected
+```
+
+Phase 1 ships warning-free across the daemon, the Qt wallet, and the test binary under clang. The `-Wthread-safety-*` warnings the analyzer would emit are now Phase 2 (researcher/wallet/tally/...), Phase 3 (scraper/quorum lambdas), and Phase 4 (network) work — all suppressed with `NO_THREAD_SAFETY_ANALYSIS` and a TODO that names the lock and the caller-chain audit each phase needs.

--- a/doc/thread_safety_phase1_report.md
+++ b/doc/thread_safety_phase1_report.md
@@ -1,13 +1,15 @@
-# Clang Thread Safety Analysis — Phase 1 + Phase 2 report (issue #2869)
+# Clang Thread Safety Analysis — issue #2869 rollout report
 
 The issue #2869 multi-phase thread-safety rollout. Captures the build-system enablement, the canonical lock order it established, a per-resolution breakdown of every warning the analyzer surfaced, and the deferral decisions taken to preserve historical lock-scope design intent.
 
 The phases are an internal organizing tool, not a release boundary:
 
 - **Phase 1**: enable the analyzer; annotate cs_main globals + their immediate call chains; annotate `setpwalletRegistered`; document Phase 2/3/4 deferrals in-code with `TODO(#2869 Phase N — area)` comments.
-- **Phase 2 (this PR)**: replace the Phase 1 `NO_THREAD_SAFETY_ANALYSIS` placeholders in: block_finder, tally, mrc + block_rewards + contract, wallet + rpcwallet, researcher/beacon, voting + miner + policy. One commit per sub-area; each commit ends warning-free.
-- **Phase 3**: scraper, quorum (lambda-capture analyzer issues).
+- **Phase 2**: replace the Phase 1 `NO_THREAD_SAFETY_ANALYSIS` placeholders in: block_finder, tally, mrc + block_rewards + contract, wallet + rpcwallet, researcher/beacon, voting + miner + policy. One commit per sub-area; each commit ends warning-free.
+- **Phase 3**: scraper + quorum (lambda-capture analyzer issues).
 - **Phase 4**: network layer (`ProcessMessage`, `AlreadyHave`, `PushVersion`, `ArgsManager::GetBlocksDirPath`).
+
+After Phase 4, exactly **one** `NO_THREAD_SAFETY_ANALYSIS` marker remains in the tree: `VoteResolver::GetMagnitudeFactor` at `src/gridcoin/voting/result.cpp`. It is held intentionally per the voting-redesign design constraint (see "Design constraint preserved" below) and will be removed when the voting-redesign work lands.
 
 Each phase ends with the same invariant: `cmake --build build_clang --target gridcoinresearchd gridcoinresearch test_gridcoin` produces zero `-Wthread-safety-*` warnings and the boost test suite passes.
 
@@ -257,18 +259,35 @@ These functions are called from `ResearcherModel::formatAccrual` on GUI refresh 
 | EXCLUSIVE_LOCKS_REQUIRED is preferable to internal acquisition when the caller chain can hold the lock — it eliminates inversion risk and surfaces missing locks at the API boundary. | Pattern from Phase 1 `cs_setpwalletRegistered` fix; reapplied throughout Phase 2. |
 | Pragma-suppressing a test case is acceptable when the test is single-threaded and the fixture mutates analyzer-tracked globals directly; adding `LOCK(cs_main)` in the test is preferable when the existing fixture already supports it. | `coinstake_construction_tests.cpp` Tests 4 + 5 got `LOCK(cs_main)` (fixture supports it); Phase 1 `block_finder_tests.cpp` got the pragma (fixture mutates pindexBest in setup). |
 
-### Remaining work — Phase 3 + Phase 4
+## Phase 3 — scraper + quorum sub-area commits
 
-After Phase 2 ships, the following `NO_THREAD_SAFETY_ANALYSIS` sites remain, all in Phase 3+ territory:
+Phase 3 resolves the lambda-capture analyzer issues in `quorum.cpp` and the chain-state reads in the `testnewsb` scraper RPC.
 
-| Phase | File:line | Function | Why deferred |
-|---|---|---|---|
-| 3 | `gridcoin/scraper/scraper.cpp:6555` | `testnewsb` RPC | Touches converged scraper state; needs the broader scraper annotation pass. |
-| 3 | `gridcoin/quorum.cpp:1083, 1119, 1148, 1818` | `AddBeaconPartsData` + two lambdas + `Quorum::SuperblockNeeded` | The two lambdas are independently suppressed because the analyzer cannot see hold state through lambda captures — needs Phase 3 lambda strategy. |
-| 4 | `net.cpp:486` | `CNode::PushVersion` | Network layer; coupled with `ProcessMessage` / `AlreadyHave` annotation. |
-| 4 | `main.cpp:2206, 2236` | `AlreadyHave`, `ProcessMessage` | The two P2P entry points; ProcessMessage's reach is the broadest single annotation cascade in the codebase. |
-| 4 | `util/system.cpp:303` | `ArgsManager::GetBlocksDirPath` | Returns a reference to a `cs_args`-guarded cache; needs a return-by-value or a lifetime-tied accessor. |
-| — | `gridcoin/voting/result.cpp:697` | `VoteResolver::GetMagnitudeFactor` | **Permanent until voting-redesign lands.** See "Design constraint" above — promoting it would re-acquire cs_main across the entire CountVotes loop and undo the historical scope-reduction work. |
+| Commit | Sub-area | Functions / change |
+|---|---|---|
+| `848872500` | `gridcoin/quorum.cpp` + `quorum.h` + `miner.cpp` | `Quorum::SuperblockNeeded`, `Quorum::ValidateSuperblockClaim`, `AddSuperblockContractOrVote` (miner.cpp) → `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`. All four `SuperblockNeeded` callers already held cs_main. `ProjectCombiner::AddBeaconPartsData` lost its function-level NO_THREAD_SAFETY_ANALYSIS — it only takes scraper-subsystem locks. The two inner lambdas (`find_entry`, `add_optional_part`) were refactored from `[&manifest]` captures to take projects/vParts as explicit parameters so the analyzer can see that the values consumed are the ones the enclosing LOCK protects (lambda captures don't propagate hold-state). quorum.h gains `#include "sync.h"` + `extern cs_main`. No new LOCK statements; no behavior change. |
+| `fdabee989` | `gridcoin/scraper/scraper.cpp` | `testnewsb` RPC drops NO_THREAD_SAFETY_ANALYSIS. The first `LOCK(cs_ConvergedScraperStatsCache)` around `BindShared(..., pindexBest)` promoted to `LOCK2(cs_main, cs_ConvergedScraperStatsCache)` — canonical cs_main → subsystem, matches the existing pattern in `ScraperGetSuperblockContract`. The second `pindexBest` read (past-convergence path) gets a NEW tight `LOCK(cs_main)` released BEFORE the `Quorum::ValidateSuperblock` calls that follow (past-convergence validation can be slow and does not itself need cs_main — mirrors the result-calculation scope-reduction documented for `PollResult::BuildFor`). |
+
+### Lambda-capture lesson recorded
+
+Clang's thread-safety analyzer cannot reason about lock state through lambda captures. A `[&obj]` capture means the analyzer sees the lambda body accessing `obj` but cannot prove which lock (if any) protects `obj` at the call site. Two fixes:
+
+1. **Pass the relevant data into the lambda as a parameter** (preferred). The analyzer can then see that the value passed in is the one the enclosing LOCK protects. This is what the Phase 3 quorum commit did for both `find_project` and `add_optional_part`.
+2. **Restructure to inline the work**. Acceptable when the lambda is small.
+
+Anti-pattern: keeping the lambda capture and suppressing with `NO_THREAD_SAFETY_ANALYSIS` on the lambda body. The Phase 1 quorum.cpp shipped with this stopgap (which is exactly what Phase 3 cleaned up).
+
+## Phase 4 — network layer
+
+Phase 4 closes out the rollout. Resolves the remaining four `NO_THREAD_SAFETY_ANALYSIS` sites in the network layer.
+
+| Commit | Sub-area | Change |
+|---|---|---|
+| `2c9c8f817` | `util/system.cpp` + `.h`, `net.cpp`, `main.cpp` | Combined Phase 4 commit covering: `ArgsManager::GetBlocksDirPath` — return-by-value (TODO's documented preferred fix; zero callers in tree, so safe API change). `CNode::PushVersion` — internal `WITH_LOCK(cs_main, return nBestHeight)` snapshot (called from CNode construction on socket-handler thread with no outer locks; internal snapshot keeps the caller-side contract unchanged). `AlreadyHave` — `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`; ProcessMessage inv-handling caller already held cs_main; SendMessages getdata-loop caller (~main.cpp:3346) gets a NEW tight `LOCK(cs_main)` scoped around just the AlreadyHave call, explicitly released BEFORE the `LOCK(CScraperManifest::cs_mapManifest)` below per the canonical cs_main → subsystem order documented at main.cpp:2533. `ProcessMessage` — NO_THREAD_SAFETY_ANALYSIS removed; three chain-state reads got tight cs_main coverage: VERSION/ARIES protocol-disconnect height check (pindexBest->nHeight via WITH_LOCK snapshot), VERSION/ARIES ask-for-blocks probe (scoped LOCK around nBestHeight + pindexBest reads + PushGetBlocks), ADDR/GRIDADDR threshold check (nBestHeight inline WITH_LOCK snapshot). |
+
+### Snapshot pattern
+
+The Phase 4 P2P entry-point cleanups use the `WITH_LOCK(cs_main, return X)` snapshot pattern instead of acquiring cs_main across the full message-handler body. This avoids holding cs_main across the (potentially slow) downstream P2P work in `PushMessage`, `PushGetBlocks`, address store, etc. It does mean the snapshotted value can be slightly stale by the time the handler acts on it, but for height-threshold heuristics (protocol-version disconnect, ask-for-blocks throttle, peer-storage threshold) staleness is harmless — the handler is making a coarse-grained policy decision, not enforcing a consensus rule.
 
 ## End state
 
@@ -283,6 +302,12 @@ $ grep -c "warning:.*thread-safety" /tmp/clang_build.log
 
 $ ./build_clang/src/test/test_gridcoin --log_level=warning
 *** No errors detected
+
+$ grep -rn 'NO_THREAD_SAFETY_ANALYSIS' src/ --include='*.cpp' --include='*.h' \
+    | grep -v 'threadsafety.h\|leveldb/port/thread_annotations.h'
+src/gridcoin/voting/result.cpp:700:    Weight GetMagnitudeFactor() NO_THREAD_SAFETY_ANALYSIS
 ```
 
-Phase 1 + Phase 2 ship warning-free across the daemon, the Qt wallet, and the test binary under clang. The `-Wthread-safety-*` warnings the analyzer would emit are now Phase 3 (scraper/quorum lambdas) and Phase 4 (network) work, plus the deliberate voting-redesign deferral — all suppressed with `NO_THREAD_SAFETY_ANALYSIS` and a TODO that names the lock and the caller-chain audit each phase needs.
+All four phases ship warning-free across the daemon, the Qt wallet, and the test binary under clang. Exactly **one** `NO_THREAD_SAFETY_ANALYSIS` marker remains in the source tree: `VoteResolver::GetMagnitudeFactor`, held intentionally per the voting-redesign design constraint above. It will be removed when the voting-redesign work lands and the legacy `VoteResolver` class is retired.
+
+With this rollout complete, the `-Wno-error=thread-safety-analysis` and `-Wno-error=thread-safety-reference` downgrades that Phase 1 added to `CMakeLists.txt` can be dropped — a future change can promote stale annotations to hard build failures so newly-introduced races don't regress under the radar.

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -21,8 +21,8 @@
 
 using namespace std;
 
-map<uint256, CAlert> mapAlerts;
 CCriticalSection cs_mapAlerts;
+map<uint256, CAlert> mapAlerts GUARDED_BY(cs_mapAlerts);
 
 void CUnsignedAlert::SetNull()
 {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -140,7 +140,7 @@ bool EvaluateSequenceLocks(const CBlockIndex& block,
  * transaction), find the height of the block that contains it.
  * Returns 0 on failure.
  */
-static int GetHeightForTxIndex(const CTxIndex& txindex)
+static int GetHeightForTxIndex(const CTxIndex& txindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CBlock block;
     if (!ReadBlockFromDisk(block, txindex.pos.nFile, txindex.pos.nBlockPos,

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -472,7 +472,7 @@ bool CTxDB::WriteGenericData(const std::string& strKey,const std::string& strDat
     return Write(string(strKey), strData);
 }
 
-static CBlockIndex *InsertBlockIndex(const uint256& hash)
+static CBlockIndex *InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (hash.IsNull())
         return nullptr;
@@ -509,7 +509,7 @@ bool ReadBlockHeight(CTxDB& txdb, const uint256 hash, int& height)
 }
 } // anonymous namespace
 
-bool CTxDB::LoadBlockIndex()
+bool CTxDB::LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Load hashBestChain pointer to end of best chain
     if (!ReadHashBestChain(hashBestChain)) {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -483,9 +483,9 @@ public:
         return status;
     }
 
-    bool LoadBlockIndex();
+    bool LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 private:
-    bool LoadBlockIndexGuts();
+    bool LoadBlockIndexGuts() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 

--- a/src/gridcoin/accrual/newbie.h
+++ b/src/gridcoin/accrual/newbie.h
@@ -55,7 +55,7 @@ public:
         return m_magnitude_unit;
     }
 
-    int64_t AccrualAge() const override
+    int64_t AccrualAge() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (const BeaconOption beacon = GetBeaconRegistry().Try(m_cpid)) {
             return m_payment_time - beacon->m_timestamp;
@@ -64,7 +64,7 @@ public:
         return 0;
     }
 
-    double AccrualDays() const override
+    double AccrualDays() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return AccrualAge() / 86400.0;
     }
@@ -94,7 +94,7 @@ public:
         return threshold;
     }
 
-    bool ExceededRecentPayments() const override
+    bool ExceededRecentPayments() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return RawAccrual() > PaymentPerDayLimit();
     }
@@ -104,12 +104,12 @@ public:
         return m_magnitude * m_magnitude_unit * COIN;
     }
 
-    CAmount RawAccrual() const override
+    CAmount RawAccrual() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return AccrualDays() * ExpectedDaily();
     }
 
-    CAmount Accrual() const override
+    CAmount Accrual() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (m_magnitude <= 0) {
             return 0;

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -99,7 +99,7 @@ public:
     //!
     //! \return Allocation fraction representing magnitude unit.
     //!
-    static Allocation GetMagnitudeUnit(CBlockIndex* index)
+    static Allocation GetMagnitudeUnit(CBlockIndex* index) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         CBlockIndex* sb_index = BlockFinder::FindLatestSuperblock(index);
 

--- a/src/gridcoin/accrual/snapshot.h
+++ b/src/gridcoin/accrual/snapshot.h
@@ -366,7 +366,7 @@ public:
         return GetMagnitudeUnit().ToDouble();
     }
 
-    int64_t AccrualAge() const override
+    int64_t AccrualAge() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // For the CPIDs that never staked a block, report the accrual age as
         // the time since the CPID advertised a beacon. This is not perfectly
@@ -393,7 +393,7 @@ public:
         return SnapshotCalculator::AccrualAge(m_account);
     }
 
-    double AccrualDays() const override
+    double AccrualDays() const override EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // Since this informational value is not consensus-critical, we use
         // floating-point arithmetic for readability:

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -850,7 +850,7 @@ Beacon_ptr BeaconRegistry::GetBeaconChainletRoot(Beacon_ptr beacon,
     // annotated EXCLUSIVE_LOCKS_REQUIRED(cs_main); the analyzer cannot see
     // hold-state through the lambda capture.
     const auto ChainletErrorHandle = [this](unsigned int i, Beacon_ptr beacon, std::string error_message) NO_THREAD_SAFETY_ANALYSIS {
-        error("%s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %s" PRId64 ", ctx_hash = %s,"
+        error("%s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %" PRId64 ", ctx_hash = %s,"
               "prev_beacon_ctx_hash = %s, status = %s: %s.",
               __func__,
               i,
@@ -861,7 +861,7 @@ Beacon_ptr BeaconRegistry::GetBeaconChainletRoot(Beacon_ptr beacon,
               beacon->StatusToString(),
               error_message);
 
-        std::string str_error = strprintf("ERROR: %s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %s"
+        std::string str_error = strprintf("ERROR: %s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %"
                                           PRId64 ", ctx_hash = %s, prev_beacon_ctx_hash = %s, status = %s: %s.",
                                           __func__,
                                           i,

--- a/src/gridcoin/beacon.cpp
+++ b/src/gridcoin/beacon.cpp
@@ -845,7 +845,11 @@ int BeaconRegistry::GetDBHeight()
 Beacon_ptr BeaconRegistry::GetBeaconChainletRoot(Beacon_ptr beacon,
                                                  std::shared_ptr<std::vector<std::pair<uint256, int64_t>>> beacon_chain_out)
 {
-    const auto ChainletErrorHandle = [this](unsigned int i, Beacon_ptr beacon, std::string error_message) {
+    // NO_THREAD_SAFETY_ANALYSIS: lambda captures `this` and calls Reset()
+    // which requires cs_main. The enclosing GetBeaconChainletRoot is
+    // annotated EXCLUSIVE_LOCKS_REQUIRED(cs_main); the analyzer cannot see
+    // hold-state through the lambda capture.
+    const auto ChainletErrorHandle = [this](unsigned int i, Beacon_ptr beacon, std::string error_message) NO_THREAD_SAFETY_ANALYSIS {
         error("%s: Beacon chainlet is corrupted at link %u for cpid %s: timestamp = %s" PRId64 ", ctx_hash = %s,"
               "prev_beacon_ctx_hash = %s, status = %s: %s.",
               __func__,

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -8,6 +8,7 @@
 #include "amount.h"
 #include "dbwrapper.h"
 #include "key.h"
+#include "sync.h"
 #include "gridcoin/contract/handler.h"
 #include "gridcoin/contract/payload.h"
 #include "gridcoin/contract/registry_db.h"
@@ -19,6 +20,8 @@
 
 class CTransaction;
 class CWallet;
+
+extern CCriticalSection cs_main;
 
 namespace GRC {
 
@@ -652,21 +655,21 @@ public:
     //!
     //! \return A reference to the beacons stored in the registry.
     //!
-    const BeaconMap& Beacons() const;
+    const BeaconMap& Beacons() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the collection of beacons awaiting verification.
     //!
     //! \return A reference to the pending beacon map stored in the registry.
     //!
-    const PendingBeaconMap& PendingBeacons() const;
+    const PendingBeaconMap& PendingBeacons() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the ownership proofs associated with pending beacons.
     //!
     //! \return A reference to the pending ownership proofs map.
     //!
-    const std::map<CKeyID, OwnershipProof>& PendingOwnershipProofs() const;
+    const std::map<CKeyID, OwnershipProof>& PendingOwnershipProofs() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Try to get the ownership proof for a pending beacon.
@@ -675,13 +678,13 @@ public:
     //!
     //! \return A pointer to the ownership proof if it exists, or nullptr.
     //!
-    const OwnershipProof* TryOwnershipProof(const CKeyID& key_id) const;
+    const OwnershipProof* TryOwnershipProof(const CKeyID& key_id) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the set of beacons that have expired while pending (awaiting verification)
     //! \return A reference to the expired pending beacon set.
     //!
-    const std::set<Beacon_ptr>& ExpiredBeacons() const;
+    const std::set<Beacon_ptr>& ExpiredBeacons() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the beacon for the specified CPID.
@@ -691,7 +694,7 @@ public:
     //! \return An object that either contains a reference to some beacon if
     //! it exists for the CPID or does not.
     //!
-    BeaconOption Try(const Cpid& cpid) const;
+    BeaconOption Try(const Cpid& cpid) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the beacon for the specified CPID if it did not expire.
@@ -702,7 +705,7 @@ public:
     //! \return An object that either contains a reference to some beacon if
     //! it is active for the CPID or does not.
     //!
-    BeaconOption TryActive(const Cpid& cpid, const int64_t now) const;
+    BeaconOption TryActive(const Cpid& cpid, const int64_t now) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the set of pending beacons for the specified CPID.
@@ -711,7 +714,7 @@ public:
     //!
     //! \return A set of pending beacons advertised for the supplied CPID.
     //!
-    std::vector<Beacon_ptr> FindPending(const Cpid& cpid) const;
+    std::vector<Beacon_ptr> FindPending(const Cpid& cpid) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Find a historical beacon entry from the beacon (txid) hash;
@@ -719,7 +722,7 @@ public:
     //! \return An object that either contains a reference to a historical
     //! beacon entry if found or does not.
     //!
-    const BeaconOption FindHistorical(const uint256& hash);
+    const BeaconOption FindHistorical(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a beacon is active for the specified CPID.
@@ -730,7 +733,7 @@ public:
     //! \return \c true if the registry contains an active beacon for the
     //! specified CPID.
     //!
-    bool ContainsActive(const Cpid& cpid, const int64_t now) const;
+    bool ContainsActive(const Cpid& cpid, const int64_t now) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a beacon is active for the specified CPID at
@@ -741,7 +744,7 @@ public:
     //! \return \c true if the registry contains an active beacon for the
     //! specified CPID.
     //!
-    bool ContainsActive(const Cpid& cpid) const;
+    bool ContainsActive(const Cpid& cpid) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Destroy the contract handler state in case of an error in loading
@@ -750,7 +753,7 @@ public:
     //! as a startup argument, because contract replay storage and full reversion has
     //! been implemented for beacons.
     //!
-    void Reset() override;
+    void Reset() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a beacon contract is valid.
@@ -761,7 +764,7 @@ public:
     //!
     //! \return \c true if the contract contains a valid beacon.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int &DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int &DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a beacon contract is valid including block context. This is used
@@ -772,14 +775,14 @@ public:
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Register a beacon from contract data.
     //!
     //! \param ctx References the beacon contract and associated context.
     //!
-    void Add(const ContractContext& ctx) override;
+    void Add(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Deregister the beacon specified by contract data. Note this is the
@@ -787,7 +790,7 @@ public:
     //!
     //! \param ctx References the beacon contract and associated context.
     //!
-    void Delete(const ContractContext& ctx) override;
+    void Delete(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Revert the registry state for the cpid to the state prior
@@ -796,7 +799,7 @@ public:
     //!
     //! \param ctx References the beacon contract and associated context.
     //!
-    void Revert(const ContractContext& ctx) override;
+    void Revert(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Activate the set of pending beacons verified in a superblock. This is called
@@ -807,7 +810,7 @@ public:
     //! \param height          Height of the superblock
     //!
     void ActivatePending(const std::vector<uint160>& beacon_ids,
-        const int64_t superblock_time, const uint256& block_hash, const int &height);
+        const int64_t superblock_time, const uint256& block_hash, const int &height) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Deactivate the set of beacons verified in a superblock. This is called in BlockDisconnectBatch
@@ -816,7 +819,7 @@ public:
     //!
     //! \param hash of the superblock.
     //!
-    void Deactivate(const uint256 superblock_hash);
+    void Deactivate(const uint256 superblock_hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Initialize the BeaconRegistry, which now includes restoring the state of the BeaconRegistry from
@@ -826,7 +829,7 @@ public:
     //! there is some issue in LevelDB beacon retrieval. (This will cause the contract replay to change scope
     //! and initialize the BeaconRegistry from contract replay and store in LevelDB.)
     //!
-    int Initialize() override;
+    int Initialize() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Gets the block height through which is stored in the beacon registry database.
@@ -872,7 +875,7 @@ public:
     //! \return root (advertisement) beacon entry smart shared pointer
     //!
     Beacon_ptr GetBeaconChainletRoot(Beacon_ptr beacon,
-                                     std::shared_ptr<std::vector<std::pair<uint256, int64_t>>> beacon_chain_out = nullptr);
+                                     std::shared_ptr<std::vector<std::pair<uint256, int64_t>>> beacon_chain_out = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Returns whether IsContract correction is needed in ReplayContracts during initialization

--- a/src/gridcoin/consensus/block_rewards.cpp
+++ b/src/gridcoin/consensus/block_rewards.cpp
@@ -307,7 +307,7 @@ bool BlockRewardRules::ValidateMandatorySidestakeOutputs(
 // Full claim validation
 // =============================================================================
 
-bool BlockRewardRules::Check(std::string& error_out) const
+bool BlockRewardRules::Check(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!m_block) {
         error_out = "BlockRewardRules::Check() requires a block (constructed with full validation state)";
@@ -325,7 +325,7 @@ bool BlockRewardRules::Check(std::string& error_out) const
 // CheckNoncruncherClaim
 // -----------------------------------------------------------------------------
 
-bool BlockRewardRules::CheckNoncruncherClaim(std::string& error_out) const
+bool BlockRewardRules::CheckNoncruncherClaim(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CAmount mrc_rewards = 0;
     CAmount mrc_staker_fees = 0;
@@ -363,10 +363,7 @@ bool BlockRewardRules::CheckNoncruncherClaim(std::string& error_out) const
 // CheckResearcherClaim
 // -----------------------------------------------------------------------------
 
-// TODO(#2869 Phase 2 — block_rewards): mapBlockIndex + ValidateMRC need
-// cs_main. Called from ConnectBlock (already cs_main-required); annotate as
-// EXCLUSIVE_LOCKS_REQUIRED in Phase 2 after the rest of the class is audited.
-bool BlockRewardRules::CheckResearcherClaim(std::string& error_out) const NO_THREAD_SAFETY_ANALYSIS
+bool BlockRewardRules::CheckResearcherClaim(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // For version 11 blocks and higher, just validate the reward and check the signature. No need for the rest
     // of these shenanigans.
@@ -539,14 +536,12 @@ bool BlockRewardRules::CheckReward(
 // CheckMRCRewards — validate MRC outputs in coinstake
 // -----------------------------------------------------------------------------
 
-// TODO(#2869 Phase 2 — block_rewards): mapBlockIndex + ValidateMRC need
-// cs_main. Called from ConnectBlock (already cs_main-required).
 bool BlockRewardRules::CheckMRCRewards(
     CAmount& mrc_rewards,
     CAmount& mrc_staker_fees,
     CAmount& mrc_fees,
     unsigned int& non_zero_outputs,
-    std::string& error_out) const NO_THREAD_SAFETY_ANALYSIS
+    std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const CTransaction& coinstake = m_block->vtx[1];
     const Claim& claim = m_block->GetClaim();

--- a/src/gridcoin/consensus/block_rewards.cpp
+++ b/src/gridcoin/consensus/block_rewards.cpp
@@ -648,7 +648,7 @@ bool BlockRewardRules::CheckMRCRewards(
 // CheckResearchReward — accrual lookup with newbie correction fallback
 // -----------------------------------------------------------------------------
 
-bool BlockRewardRules::CheckResearchReward(std::string& error_out) const
+bool BlockRewardRules::CheckResearchReward(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const Claim& claim = m_block->GetClaim();
 

--- a/src/gridcoin/consensus/block_rewards.cpp
+++ b/src/gridcoin/consensus/block_rewards.cpp
@@ -714,7 +714,7 @@ bool BlockRewardRules::CheckResearchReward(std::string& error_out) const EXCLUSI
 // CheckBeaconSignature — verify claim is signed by active beacon key
 // -----------------------------------------------------------------------------
 
-bool BlockRewardRules::CheckBeaconSignature(std::string& error_out) const
+bool BlockRewardRules::CheckBeaconSignature(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const Claim& claim = m_block->GetClaim();
     const CpidOption cpid = claim.m_mining_id.TryCpid();

--- a/src/gridcoin/consensus/block_rewards.cpp
+++ b/src/gridcoin/consensus/block_rewards.cpp
@@ -363,7 +363,10 @@ bool BlockRewardRules::CheckNoncruncherClaim(std::string& error_out) const
 // CheckResearcherClaim
 // -----------------------------------------------------------------------------
 
-bool BlockRewardRules::CheckResearcherClaim(std::string& error_out) const
+// TODO(#2869 Phase 2 — block_rewards): mapBlockIndex + ValidateMRC need
+// cs_main. Called from ConnectBlock (already cs_main-required); annotate as
+// EXCLUSIVE_LOCKS_REQUIRED in Phase 2 after the rest of the class is audited.
+bool BlockRewardRules::CheckResearcherClaim(std::string& error_out) const NO_THREAD_SAFETY_ANALYSIS
 {
     // For version 11 blocks and higher, just validate the reward and check the signature. No need for the rest
     // of these shenanigans.
@@ -536,12 +539,14 @@ bool BlockRewardRules::CheckReward(
 // CheckMRCRewards — validate MRC outputs in coinstake
 // -----------------------------------------------------------------------------
 
+// TODO(#2869 Phase 2 — block_rewards): mapBlockIndex + ValidateMRC need
+// cs_main. Called from ConnectBlock (already cs_main-required).
 bool BlockRewardRules::CheckMRCRewards(
     CAmount& mrc_rewards,
     CAmount& mrc_staker_fees,
     CAmount& mrc_fees,
     unsigned int& non_zero_outputs,
-    std::string& error_out) const
+    std::string& error_out) const NO_THREAD_SAFETY_ANALYSIS
 {
     const CTransaction& coinstake = m_block->vtx[1];
     const Claim& claim = m_block->GetClaim();

--- a/src/gridcoin/consensus/block_rewards.h
+++ b/src/gridcoin/consensus/block_rewards.h
@@ -75,7 +75,7 @@ public:
     //!
     //! Requires the full validation constructor.
     //!
-    bool Check(std::string& error_out) const;
+    bool Check(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // --- Shared spec types ---------------------------------------------------
 
@@ -204,8 +204,8 @@ private:
 
     // --- Full validation sub-checks ------------------------------------------
 
-    bool CheckResearcherClaim(std::string& error_out) const;
-    bool CheckNoncruncherClaim(std::string& error_out) const;
+    bool CheckResearcherClaim(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool CheckNoncruncherClaim(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     bool CheckReward(CAmount research_owed, CAmount& out_stake_owed,
                      CAmount mrc_staker_fees_owed, CAmount mrc_fees,
@@ -214,7 +214,7 @@ private:
 
     bool CheckMRCRewards(CAmount& mrc_rewards, CAmount& mrc_staker_fees,
                          CAmount& mrc_fees, unsigned int& non_zero_outputs,
-                         std::string& error_out) const;
+                         std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     bool CheckResearchReward(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool CheckBeaconSignature(std::string& error_out) const;

--- a/src/gridcoin/consensus/block_rewards.h
+++ b/src/gridcoin/consensus/block_rewards.h
@@ -217,7 +217,7 @@ private:
                          std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     bool CheckResearchReward(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    bool CheckBeaconSignature(std::string& error_out) const;
+    bool CheckBeaconSignature(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Legacy v9-v10 checks
     bool CheckResearchRewardLimit(std::string& error_out) const;

--- a/src/gridcoin/consensus/block_rewards.h
+++ b/src/gridcoin/consensus/block_rewards.h
@@ -9,6 +9,7 @@
 #include "primitives/transaction.h"
 #include "gridcoin/sidestake.h"
 #include "script.h"
+#include "sync.h"
 
 #include <string>
 #include <vector>
@@ -16,6 +17,7 @@
 class CBlock;
 class CBlockIndex;
 class CTransaction;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 
@@ -214,7 +216,7 @@ private:
                          CAmount& mrc_fees, unsigned int& non_zero_outputs,
                          std::string& error_out) const;
 
-    bool CheckResearchReward(std::string& error_out) const;
+    bool CheckResearchReward(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool CheckBeaconSignature(std::string& error_out) const;
 
     // Legacy v9-v10 checks

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -362,7 +362,10 @@ Contract GRC::MakeLegacyContract(
     return contract;
 }
 
-void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start)
+// TODO(#2869 Phase 2 — contract): pindexBest read needs cs_main. Caller in
+// gridcoin.cpp Initialize() holds it (added via init.cpp LOCK rollout in
+// Phase 1); annotate as EXCLUSIVE_LOCKS_REQUIRED once all callers verified.
+void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start) NO_THREAD_SAFETY_ANALYSIS
 {
     CBlockIndex*& pindex = pindex_start;
 
@@ -935,7 +938,12 @@ ContractPayload Contract::Body::ConvertFromLegacy(const ContractType type, uint3
     return ContractPayload::Make<EmptyPayload>();
 }
 
-void Contract::Body::ResetType(const ContractType type)
+// TODO(#2869 Phase 2 — contract): cs_main is expected to be held when
+// nBestHeight is read in the POLL/PROJECT/PROTOCOL/SCRAPER branches below
+// (see in-body comments). Phase 2 should annotate this as
+// EXCLUSIVE_LOCKS_REQUIRED(cs_main) and audit every caller (the tx-deserialize
+// path may not always hold cs_main).
+void Contract::Body::ResetType(const ContractType type) NO_THREAD_SAFETY_ANALYSIS
 {
     switch (type) {
         case ContractType::UNKNOWN:

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -362,10 +362,7 @@ Contract GRC::MakeLegacyContract(
     return contract;
 }
 
-// TODO(#2869 Phase 2 — contract): pindexBest read needs cs_main. Caller in
-// gridcoin.cpp Initialize() holds it (added via init.cpp LOCK rollout in
-// Phase 1); annotate as EXCLUSIVE_LOCKS_REQUIRED once all callers verified.
-void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start) NO_THREAD_SAFETY_ANALYSIS
+void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CBlockIndex*& pindex = pindex_start;
 
@@ -938,12 +935,13 @@ ContractPayload Contract::Body::ConvertFromLegacy(const ContractType type, uint3
     return ContractPayload::Make<EmptyPayload>();
 }
 
-// TODO(#2869 Phase 2 — contract): cs_main is expected to be held when
-// nBestHeight is read in the POLL/PROJECT/PROTOCOL/SCRAPER branches below
-// (see in-body comments). Phase 2 should annotate this as
-// EXCLUSIVE_LOCKS_REQUIRED(cs_main) and audit every caller (the tx-deserialize
-// path may not always hold cs_main).
-void Contract::Body::ResetType(const ContractType type) NO_THREAD_SAFETY_ANALYSIS
+// The in-body comments below note that cs_main is expected to be held when
+// the POLL/PROJECT/PROTOCOL/SCRAPER branches read nBestHeight. Annotated as
+// EXCLUSIVE_LOCKS_REQUIRED here; the cascade reaches into serializer paths
+// (Contract::Body::ResetType is called from Unserialize implementations of
+// CTransaction's body). Tx-deserialize call sites are tightened in this
+// same Phase 2 commit batch.
+void Contract::Body::ResetType(const ContractType type) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     switch (type) {
         case ContractType::UNKNOWN:

--- a/src/gridcoin/contract/contract.h
+++ b/src/gridcoin/contract/contract.h
@@ -10,6 +10,7 @@
 #include "gridcoin/contract/payload.h"
 #include "gridcoin/support/enumbytes.h"
 #include "serialize.h"
+#include "sync.h"
 
 #include <optional>
 #include <string>
@@ -18,6 +19,7 @@
 class CBlock;
 class CBlockIndex;
 class CTransaction;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 class RegistryBookmarks;
@@ -603,7 +605,7 @@ Contract MakeLegacyContract(
 //!
 //! \param pindex Block index to start with.
 //!
-void ReplayContracts(CBlockIndex *pindex_end, CBlockIndex *pindex_start = nullptr);
+void ReplayContracts(CBlockIndex *pindex_end, CBlockIndex *pindex_start = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Apply contracts from transactions in a block by passing them to the

--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -25,7 +25,8 @@ namespace {
 //!
 //! \return \c true if the wallet owns UTXOs for the master key address.
 //!
-bool SelectMasterInputOutput(CCoinControl& coin_control)
+// TODO(#2869 Phase 2 — contract/message): pindexBest read needs cs_main.
+bool SelectMasterInputOutput(CCoinControl& coin_control) NO_THREAD_SAFETY_ANALYSIS
 {
     const CTxDestination master_address = CWallet::MasterAddress(pindexBest->nHeight);
 

--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -25,8 +25,7 @@ namespace {
 //!
 //! \return \c true if the wallet owns UTXOs for the master key address.
 //!
-// TODO(#2869 Phase 2 — contract/message): pindexBest read needs cs_main.
-bool SelectMasterInputOutput(CCoinControl& coin_control) NO_THREAD_SAFETY_ANALYSIS
+bool SelectMasterInputOutput(CCoinControl& coin_control) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const CTxDestination master_address = CWallet::MasterAddress(pindexBest->nHeight);
 
@@ -63,7 +62,7 @@ bool SelectMasterInputOutput(CCoinControl& coin_control) NO_THREAD_SAFETY_ANALYS
 //!
 //! \return \c true if coin selection succeeded.
 //!
-bool CreateContractTx(CWalletTx& wtx_out, CReserveKey& reserve_key, CAmount burn_fee)
+bool CreateContractTx(CWalletTx& wtx_out, CReserveKey& reserve_key, CAmount burn_fee) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CCoinControl coin_control_out;
     CAmount applied_fee_out; // Unused
@@ -126,7 +125,7 @@ bool CreateContractTx(CWalletTx& wtx_out, CReserveKey& reserve_key, CAmount burn
 //! \return An empty string when successful or a description of the error that
 //! occurred. TODO: Refactor to remove string-based signaling.
 //!
-std::string SendContractTx(CWalletTx& wtx_new)
+std::string SendContractTx(CWalletTx& wtx_new) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CReserveKey reserve_key(pwalletMain);
 
@@ -196,7 +195,7 @@ std::string SendContractTx(CWalletTx& wtx_new)
 // Functions
 // -----------------------------------------------------------------------------
 
-std::pair<CWalletTx, std::string> GRC::SendContract(Contract contract)
+std::pair<CWalletTx, std::string> GRC::SendContract(Contract contract) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CMutableTransaction mtx;
     mtx.vContracts.emplace_back(std::move(contract));
@@ -207,7 +206,7 @@ std::pair<CWalletTx, std::string> GRC::SendContract(Contract contract)
     return SendContract(std::move(wtx));
 }
 
-std::pair<CWalletTx, std::string> GRC::SendContract(CWalletTx wtx)
+std::pair<CWalletTx, std::string> GRC::SendContract(CWalletTx wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (wtx.vContracts.empty()) {
         return std::make_pair(std::move(wtx), "Transaction contains no contract.");

--- a/src/gridcoin/contract/message.h
+++ b/src/gridcoin/contract/message.h
@@ -5,9 +5,12 @@
 #ifndef GRIDCOIN_CONTRACT_MESSAGE_H
 #define GRIDCOIN_CONTRACT_MESSAGE_H
 
+#include "sync.h"
+
 #include <string>
 
 class CWalletTx;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 
@@ -21,7 +24,7 @@ class Contract;
 //! \return Contains the finalized transaction and error message, if any.
 //! TODO: refactor to remove string-based signaling.
 //!
-std::pair<CWalletTx, std::string> SendContract(Contract contract);
+std::pair<CWalletTx, std::string> SendContract(Contract contract) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Send a transaction that contains a contract.
@@ -34,7 +37,7 @@ std::pair<CWalletTx, std::string> SendContract(Contract contract);
 //! \return Contains the finalized transaction and error message, if any.
 //! TODO: refactor to remove string-based signaling.
 //!
-std::pair<CWalletTx, std::string> SendContract(CWalletTx wtx);
+std::pair<CWalletTx, std::string> SendContract(CWalletTx wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 }
 
 #endif // GRIDCOIN_CONTRACT_MESSAGE_H

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -185,7 +185,7 @@ void InitializeSuperblockQuorum(const CBlockIndex* pindexBest)
 //!
 //! \return \c false if a problem occurs while loading the stored accrual state.
 //!
-bool InitializeResearchRewardAccounting(CBlockIndex* pindexBest)
+bool InitializeResearchRewardAccounting(CBlockIndex* pindexBest) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrintf("Gridcoin: initializing research reward accounting...");
     uiInterface.InitMessage(_("Initializing research reward accounting..."));
@@ -206,7 +206,7 @@ bool InitializeResearchRewardAccounting(CBlockIndex* pindexBest)
     return true;
 }
 
-void InitializeContracts(CBlockIndex* pindexBest)
+void InitializeContracts(CBlockIndex* pindexBest) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // This loop initializes the registry for each contract type in CONTRACT_TYPES_WITH_REG_DB.
     for (const auto& contract_type : RegistryBookmarks::CONTRACT_TYPES_WITH_REG_DB) {

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -130,7 +130,9 @@ void ShowBlockIndexCorruptedMessage()
 //! \return \c false if a checkpoint does not match its corresponding block
 //! index entry.
 //!
-bool VerifyCheckpoints(const CBlockIndex* const pindexBest)
+// Called from GRC::Initialize which holds cs_main (added via init.cpp LOCK
+// rollout in Phase 1).
+bool VerifyCheckpoints(const CBlockIndex* const pindexBest) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrintf("Gridcoin: verifying checkpoints...");
     uiInterface.InitMessage(_("Verifying checkpoints..."));
@@ -439,12 +441,12 @@ bool CheckBlockIndex()
     LogPrintf("Gridcoin: checking block index...");
     uiInterface.InitMessage(_("Checking block index..."));
 
+    LOCK(cs_main);
+
     if (!pindexGenesisBlock) {
         // No chain yet -- nothing to check.
         return true;
     }
-
-    LOCK(cs_main);
 
     // Pass 1: find dangling roots (pprev == null but not genesis). Each such
     // entry was created by LoadBlockIndex from a CDiskBlockIndex whose
@@ -647,7 +649,7 @@ extern bool fQtActive;
 // Functions
 // -----------------------------------------------------------------------------
 
-void GRC::RebuildBeaconRegistry()
+void GRC::RebuildBeaconRegistry() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -696,7 +698,7 @@ void GRC::RebuildBeaconRegistry()
     LogPrintf("INFO: %s: beacon registry rebuild complete in %dms.", __func__, GetTimeMillis() - start_ms);
 }
 
-bool GRC::Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest)
+bool GRC::Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrintf("Gridcoin: initializing...");
 

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -27,7 +27,7 @@ extern CCriticalSection cs_ScraperGlobals;
 extern bool fExplorer;
 extern unsigned int nScraperSleep;
 extern unsigned int nActiveBeforeSB;
-extern bool fScraperActive;
+extern std::atomic<bool> fScraperActive;
 extern bool fQtActive;
 
 void Scraper(bool bSingleShot = false);

--- a/src/gridcoin/gridcoin.h
+++ b/src/gridcoin/gridcoin.h
@@ -6,8 +6,10 @@
 #define GRIDCOIN_GRIDCOIN_H
 
 #include "fwd.h"
+#include "sync.h"
 
 class CScheduler;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 //!
@@ -18,7 +20,7 @@ namespace GRC {
 //!
 //! \return \c false if a problem occurs during initialization.
 //!
-bool Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest);
+bool Initialize(ThreadHandlerPtr threads, CBlockIndex* pindexBest) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief This closes the underlying research file to support the snapshot update
@@ -79,7 +81,7 @@ void NotifyPoll();
 //! completes in a few seconds; the wallet is briefly unresponsive but
 //! consistent. Issue #2865 / PR #2941.
 //!
-void RebuildBeaconRegistry();
+void RebuildBeaconRegistry() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 } // namespace GRC
 
 #endif // GRIDCOIN_GRIDCOIN_H

--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -83,7 +83,8 @@ bool MRC::WellFormed() const
     return true;
 }
 
-CAmount MRC::ComputeMRCFee() const
+// TODO(#2869 Phase 2 — mrc): mapBlockIndex lookup needs cs_main.
+CAmount MRC::ComputeMRCFee() const NO_THREAD_SAFETY_ANALYSIS
 {
     CAmount fee = 0;
 
@@ -266,7 +267,10 @@ uint256 MRC::GetHash() const
     return hasher.GetHash();
 }
 
-bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const
+// TODO(#2869 Phase 2 — mrc): ValidateMRC requires cs_main; once
+// IContractHandler::Validate is annotated, this cascades through the contract
+// dispatcher path.
+bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const NO_THREAD_SAFETY_ANALYSIS
 {
     // Fully validate the incoming MRC txn.
     return ValidateMRC(contract, tx, DoS);

--- a/src/gridcoin/mrc.cpp
+++ b/src/gridcoin/mrc.cpp
@@ -83,8 +83,7 @@ bool MRC::WellFormed() const
     return true;
 }
 
-// TODO(#2869 Phase 2 — mrc): mapBlockIndex lookup needs cs_main.
-CAmount MRC::ComputeMRCFee() const NO_THREAD_SAFETY_ANALYSIS
+CAmount MRC::ComputeMRCFee() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CAmount fee = 0;
 
@@ -267,16 +266,17 @@ uint256 MRC::GetHash() const
     return hasher.GetHash();
 }
 
-// TODO(#2869 Phase 2 — mrc): ValidateMRC requires cs_main; once
-// IContractHandler::Validate is annotated, this cascades through the contract
-// dispatcher path.
-bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const NO_THREAD_SAFETY_ANALYSIS
+// IContractHandler::Validate's contract is loosened here from the base-class
+// declaration: cs_main is required (mempool acceptance path holds it; ConnectBlock
+// holds it; tests run single-threaded). The base-class declaration in handler.h
+// is annotated similarly so the contract is visible polymorphically.
+bool GRC::MRCContractHandler::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Fully validate the incoming MRC txn.
     return ValidateMRC(contract, tx, DoS);
 }
 
-bool GRC::MRCContractHandler::BlockValidate(const ContractContext& ctx, int& DoS) const
+bool GRC::MRCContractHandler::BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return Validate(ctx.m_contract, ctx.m_tx, DoS);
 }

--- a/src/gridcoin/mrc.h
+++ b/src/gridcoin/mrc.h
@@ -11,12 +11,14 @@
 #include "gridcoin/cpid.h"
 #include "gridcoin/superblock.h"
 #include "serialize.h"
+#include "sync.h"
 #include "uint256.h"
 
 #include <optional>
 #include <stdexcept>
 
 class CPubKey;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 class MRC_error : public std::runtime_error
@@ -244,7 +246,7 @@ public:
     //! \brief ComputeMRCFee
     //! \return Amount of fee in Halfords
     //!
-    CAmount ComputeMRCFee() const;
+    CAmount ComputeMRCFee() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Sign an instance that claims research rewards.
@@ -332,7 +334,7 @@ public:
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Perform contextual validation for the provided contract including block context. This is used
@@ -343,7 +345,7 @@ public:
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Add is a noop here, because this is handled at the block level by the staker (in the miner) as with the claim.
     void Add(const ContractContext& ctx) override {}

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -1072,10 +1072,15 @@ private: // SuperblockValidator classes
         //!                      preserving pre-v13 convergence contents
         //!                      keeps the hard-fork story clean.
         //!
+        // TODO(#2869 Phase 3 — scraper/quorum): manifest->cs_manifest is held
+        // when these lambdas are invoked, but the analyzer cannot prove
+        // hold-state from inside a lambda body. Phase 3 should refactor to pass
+        // the relevant data into the lambda by value, or restructure to inline
+        // the work.
         static void AddBeaconPartsData(
             ConvergenceCandidate& convergence,
             const uint256& manifest_hash,
-            const int height)
+            const int height) NO_THREAD_SAFETY_ANALYSIS
         {
             LOCK(CScraperManifest::cs_mapManifest);
 
@@ -1107,7 +1112,11 @@ private: // SuperblockValidator classes
 
                 convergence.AddPart("BeaconList", manifest->vParts[0]);
 
-                auto find_entry = [&manifest](const std::string& name) {
+                // NO_THREAD_SAFETY_ANALYSIS: manifest->cs_manifest is held
+                // by the enclosing scope (line above), but the analyzer cannot
+                // see through the lambda capture. See TODO at top of this
+                // function (#2869 Phase 3).
+                auto find_entry = [&manifest](const std::string& name) NO_THREAD_SAFETY_ANALYSIS {
                     return std::find_if(
                         manifest->projects.begin(),
                         manifest->projects.end(),
@@ -1136,7 +1145,7 @@ private: // SuperblockValidator classes
             // these conditionally and the convergence is expected to omit
             // them when the manifest did. Mirrors scraper.cpp:5622-5626.
             auto add_optional_part = [&](const std::string& name,
-                                         std::vector<CScraperManifest::dentry>::iterator it) {
+                                         std::vector<CScraperManifest::dentry>::iterator it) NO_THREAD_SAFETY_ANALYSIS {
                 if (it == manifest->projects.end()) {
                     return;
                 }
@@ -1805,7 +1814,8 @@ bool Quorum::HasPendingSuperblock()
     return g_superblock_index.HasPending();
 }
 
-bool Quorum::SuperblockNeeded(const int64_t now)
+// TODO(#2869 Phase 3 — scraper/quorum): nBestHeight read needs cs_main.
+bool Quorum::SuperblockNeeded(const int64_t now) NO_THREAD_SAFETY_ANALYSIS
 {
     if (HasPendingSuperblock()) {
         return false;

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -1072,15 +1072,10 @@ private: // SuperblockValidator classes
         //!                      preserving pre-v13 convergence contents
         //!                      keeps the hard-fork story clean.
         //!
-        // TODO(#2869 Phase 3 — scraper/quorum): manifest->cs_manifest is held
-        // when these lambdas are invoked, but the analyzer cannot prove
-        // hold-state from inside a lambda body. Phase 3 should refactor to pass
-        // the relevant data into the lambda by value, or restructure to inline
-        // the work.
         static void AddBeaconPartsData(
             ConvergenceCandidate& convergence,
             const uint256& manifest_hash,
-            const int height) NO_THREAD_SAFETY_ANALYSIS
+            const int height)
         {
             LOCK(CScraperManifest::cs_mapManifest);
 
@@ -1097,8 +1092,9 @@ private: // SuperblockValidator classes
 
             const bool include_extra_side_channel_parts = IsV13Enabled(height);
 
-            // Note using fine-grained locking here to avoid lock-order issues and
-            // also to deal with Clang potential false positive below.
+            // Note using fine-grained locking here to avoid lock-order issues
+            // (cs_manifest must be released and re-acquired after cs_mapParts
+            // for the second block below, per the LOCK2 ordering note).
             std::vector<CScraperManifest::dentry>::iterator verified_beacons_iter;
             std::vector<CScraperManifest::dentry>::iterator pactc_iter;
             std::vector<CScraperManifest::dentry>::iterator ppk_iter;
@@ -1112,24 +1108,24 @@ private: // SuperblockValidator classes
 
                 convergence.AddPart("BeaconList", manifest->vParts[0]);
 
-                // NO_THREAD_SAFETY_ANALYSIS: manifest->cs_manifest is held
-                // by the enclosing scope (line above), but the analyzer cannot
-                // see through the lambda capture. See TODO at top of this
-                // function (#2869 Phase 3).
-                auto find_entry = [&manifest](const std::string& name) NO_THREAD_SAFETY_ANALYSIS {
+                // Inlined the previous find_entry lambda so the analyzer can
+                // see that cs_manifest (the lock guarding manifest->projects)
+                // is held — lambda captures don't propagate hold-state.
+                auto find_project = [](std::vector<CScraperManifest::dentry>& projects,
+                                       const std::string& name) {
                     return std::find_if(
-                        manifest->projects.begin(),
-                        manifest->projects.end(),
+                        projects.begin(),
+                        projects.end(),
                         [&name](const CScraperManifest::dentry& entry) {
                             return entry.project == name;
                         });
                 };
 
-                verified_beacons_iter = find_entry("VerifiedBeacons");
+                verified_beacons_iter = find_project(manifest->projects, "VerifiedBeacons");
 
                 if (include_extra_side_channel_parts) {
-                    pactc_iter = find_entry("ProjectsAllCpidTotalCredits");
-                    ppk_iter = find_entry("ProjectPublicKeys");
+                    pactc_iter = find_project(manifest->projects, "ProjectsAllCpidTotalCredits");
+                    ppk_iter = find_project(manifest->projects, "ProjectPublicKeys");
                 } else {
                     pactc_iter = manifest->projects.end();
                     ppk_iter = manifest->projects.end();
@@ -1144,22 +1140,33 @@ private: // SuperblockValidator classes
             // carries it. Absent parts are silently skipped — scrapers emit
             // these conditionally and the convergence is expected to omit
             // them when the manifest did. Mirrors scraper.cpp:5622-5626.
-            auto add_optional_part = [&](const std::string& name,
-                                         std::vector<CScraperManifest::dentry>::iterator it) NO_THREAD_SAFETY_ANALYSIS {
-                if (it == manifest->projects.end()) {
+            //
+            // The helper takes projects / vParts as parameters (rather than
+            // capturing manifest by reference) so the analyzer can see that
+            // the values consumed are the ones the enclosing LOCK2 protects;
+            // lambda captures don't propagate hold-state in the same way.
+            const auto add_optional_part = [&convergence](
+                                               const std::vector<CScraperManifest::dentry>& projects,
+                                               const std::vector<CSplitBlob::CPart*>& vParts,
+                                               const std::string& name,
+                                               const std::vector<CScraperManifest::dentry>::iterator it) {
+                if (it == projects.end()) {
                     return;
                 }
                 const size_t part_offset = it->part1;
-                if (part_offset == 0 || part_offset >= manifest->vParts.size()) {
+                if (part_offset == 0 || part_offset >= vParts.size()) {
                     LogPrintf("ValidateSuperblock(): out-of-range part offset for %s.", name);
                     return;
                 }
-                convergence.AddPart(name, manifest->vParts[part_offset]);
+                convergence.AddPart(name, vParts[part_offset]);
             };
 
-            add_optional_part("VerifiedBeacons", verified_beacons_iter);
-            add_optional_part("ProjectsAllCpidTotalCredits", pactc_iter);
-            add_optional_part("ProjectPublicKeys", ppk_iter);
+            add_optional_part(manifest->projects, manifest->vParts,
+                              "VerifiedBeacons", verified_beacons_iter);
+            add_optional_part(manifest->projects, manifest->vParts,
+                              "ProjectsAllCpidTotalCredits", pactc_iter);
+            add_optional_part(manifest->projects, manifest->vParts,
+                              "ProjectPublicKeys", ppk_iter);
         }
     }; // ProjectCombiner
 
@@ -1644,7 +1651,7 @@ void Quorum::ForgetVote(const CBlockIndex* const pindex)
 bool Quorum::ValidateSuperblockClaim(
     const Claim& claim,
     const SuperblockPtr& superblock,
-    const CBlockIndex* const pindex)
+    const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!SuperblockNeeded(pindex->nTime)) {
         return error("%s: superblock too early.", __func__);
@@ -1814,8 +1821,7 @@ bool Quorum::HasPendingSuperblock()
     return g_superblock_index.HasPending();
 }
 
-// TODO(#2869 Phase 3 — scraper/quorum): nBestHeight read needs cs_main.
-bool Quorum::SuperblockNeeded(const int64_t now) NO_THREAD_SAFETY_ANALYSIS
+bool Quorum::SuperblockNeeded(const int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (HasPendingSuperblock()) {
         return false;

--- a/src/gridcoin/quorum.h
+++ b/src/gridcoin/quorum.h
@@ -5,11 +5,15 @@
 #ifndef GRIDCOIN_QUORUM_H
 #define GRIDCOIN_QUORUM_H
 
+#include "sync.h"
+
 #include <limits>
 #include <string>
 #include <vector>
 
 class CBlockIndex;
+
+extern CCriticalSection cs_main;
 
 namespace GRC {
 
@@ -117,7 +121,7 @@ public:
     static bool ValidateSuperblockClaim(
         const Claim& claim,
         const SuperblockPtr& superblock,
-        const CBlockIndex* const pindex);
+        const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Validate the supplied superblock by comparing it to the node's
@@ -204,7 +208,7 @@ public:
     //! \return \c true if the age of the current superblock exceeds the
     //! protocol's superblock spacing parameter.
     //!
-    static bool SuperblockNeeded(const int64_t now);
+    static bool SuperblockNeeded(const int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Initialize the tally's superblock context.

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -606,7 +606,9 @@ bool CheckBeaconPrivateKey(const CWallet* const wallet, const CPubKey& public_ke
 
 } // anonymous namespace
 
-AdvertiseBeaconResult GRC::GenerateBeaconKey(const Cpid& cpid)
+// TODO(#2869 Phase 2 — researcher/beacon): Reads nBestHeight without holding
+// cs_main. Phase 2 should pass the height in or wrap the read in a LOCK.
+AdvertiseBeaconResult GRC::GenerateBeaconKey(const Cpid& cpid) NO_THREAD_SAFETY_ANALYSIS
 {
     LogPrintf("%s: Generating new keys for %s...", __func__, cpid.ToString());
 
@@ -673,7 +675,9 @@ bool SignBeaconPayload(BeaconPayload& payload)
 //! \return An error that describes why the wallet cannot send a beacon if
 //! a transaction will not succeed.
 //!
-BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid)
+// TODO(#2869 Phase 2 — researcher/beacon): mempool.mapTx iteration needs
+// cs_main; current caller chain does not consistently hold it.
+BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid) NO_THREAD_SAFETY_ANALYSIS
 {
     if (wallet->IsLocked()) {
         LogPrintf("WARNING: %s: Wallet locked.", __func__);
@@ -718,10 +722,11 @@ BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid)
 //! \return A variant that contains the new public key if successful or a
 //! description of the error that occurred.
 //!
+// TODO(#2869 Phase 2 — researcher/beacon): Reads nBestHeight without cs_main.
 AdvertiseBeaconResult SendBeaconContract(
     const Cpid& cpid,
     Beacon beacon,
-    ContractAction action = ContractAction::ADD)
+    ContractAction action = ContractAction::ADD) NO_THREAD_SAFETY_ANALYSIS
 {
     const BeaconError error = CheckBeaconTransactionViable(pwalletMain, cpid);
 
@@ -749,11 +754,13 @@ AdvertiseBeaconResult SendBeaconContract(
 
 } // anonymous namespace
 
+// TODO(#2869 Phase 2 — researcher/beacon): Reads nBestHeight and touches
+// g_recent_beacons (Try/Remember) without cs_main / cs_wallet held.
 AdvertiseBeaconResult GRC::SendBeaconContractV3(
     const Cpid& cpid,
     Beacon beacon,
     OwnershipProof proof,
-    const bool force)
+    const bool force) NO_THREAD_SAFETY_ANALYSIS
 {
     if (!IsV14Enabled(nBestHeight)) {
         LogPrintf("WARNING: %s: v3 beacons not yet active (requires v14).", __func__);
@@ -1395,7 +1402,10 @@ bool Researcher::HasRAC() const
     return false;
 }
 
-CAmount Researcher::Accrual() const
+// TODO(#2869 Phase 2 — researcher/beacon): Reads pindexBest BEFORE taking
+// cs_main below. Phase 2 should move the LOCK up to cover the early reads
+// (the race window is small but real).
+CAmount Researcher::Accrual() const NO_THREAD_SAFETY_ANALYSIS
 {
     const CpidOption cpid = m_mining_id.TryCpid();
 
@@ -1410,7 +1420,8 @@ CAmount Researcher::Accrual() const
     return Tally::GetAccrual(*cpid, now, pindexBest);
 }
 
-std::optional<CAmount> Researcher::AccrualNearLimit() const
+// TODO(#2869 Phase 2 — researcher/beacon): same shape as Accrual() above.
+std::optional<CAmount> Researcher::AccrualNearLimit() const NO_THREAD_SAFETY_ANALYSIS
 {
     const CpidOption cpid = m_mining_id.TryCpid();
     std::optional<CAmount> near_limit_accrual;

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1151,11 +1151,8 @@ Researcher::Researcher(
 
 void Researcher::Initialize()
 {
-    {
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-        g_recent_beacons.ImportRegistry(GetBeaconRegistry());
-    }
-
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    g_recent_beacons.ImportRegistry(GetBeaconRegistry());
     Reload();
 }
 
@@ -1519,7 +1516,10 @@ bool Researcher::ChangeMode(const ResearcherMode mode, std::string email)
     gArgs.ForceSetArg("-email", email);
     gArgs.ForceSetArg("-noncruncher", mode == ResearcherMode::NONCRUNCHER ? "1" : "0");
 
-    Reload();
+    {
+        LOCK(cs_main);
+        Reload();
+    }
 
     return true;
 }

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -606,9 +606,7 @@ bool CheckBeaconPrivateKey(const CWallet* const wallet, const CPubKey& public_ke
 
 } // anonymous namespace
 
-// TODO(#2869 Phase 2 — researcher/beacon): Reads nBestHeight without holding
-// cs_main. Phase 2 should pass the height in or wrap the read in a LOCK.
-AdvertiseBeaconResult GRC::GenerateBeaconKey(const Cpid& cpid) NO_THREAD_SAFETY_ANALYSIS
+AdvertiseBeaconResult GRC::GenerateBeaconKey(const Cpid& cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrintf("%s: Generating new keys for %s...", __func__, cpid.ToString());
 
@@ -675,9 +673,7 @@ bool SignBeaconPayload(BeaconPayload& payload)
 //! \return An error that describes why the wallet cannot send a beacon if
 //! a transaction will not succeed.
 //!
-// TODO(#2869 Phase 2 — researcher/beacon): mempool.mapTx iteration needs
-// cs_main; current caller chain does not consistently hold it.
-BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid) NO_THREAD_SAFETY_ANALYSIS
+BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (wallet->IsLocked()) {
         LogPrintf("WARNING: %s: Wallet locked.", __func__);
@@ -722,11 +718,10 @@ BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid) NO_T
 //! \return A variant that contains the new public key if successful or a
 //! description of the error that occurred.
 //!
-// TODO(#2869 Phase 2 — researcher/beacon): Reads nBestHeight without cs_main.
 AdvertiseBeaconResult SendBeaconContract(
     const Cpid& cpid,
     Beacon beacon,
-    ContractAction action = ContractAction::ADD) NO_THREAD_SAFETY_ANALYSIS
+    ContractAction action = ContractAction::ADD) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const BeaconError error = CheckBeaconTransactionViable(pwalletMain, cpid);
 
@@ -754,13 +749,11 @@ AdvertiseBeaconResult SendBeaconContract(
 
 } // anonymous namespace
 
-// TODO(#2869 Phase 2 — researcher/beacon): Reads nBestHeight and touches
-// g_recent_beacons (Try/Remember) without cs_main / cs_wallet held.
 AdvertiseBeaconResult GRC::SendBeaconContractV3(
     const Cpid& cpid,
     Beacon beacon,
     OwnershipProof proof,
-    const bool force) NO_THREAD_SAFETY_ANALYSIS
+    const bool force) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet)
 {
     if (!IsV14Enabled(nBestHeight)) {
         LogPrintf("WARNING: %s: v3 beacons not yet active (requires v14).", __func__);
@@ -820,7 +813,7 @@ namespace {
 //! \return A variant that contains the new public key if successful or a
 //! description of the error that occurred.
 //!
-AdvertiseBeaconResult SendNewBeacon(const Cpid& cpid)
+AdvertiseBeaconResult SendNewBeacon(const Cpid& cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // First, determine whether we can successfully send a beacon contract. The
     // wallet must be unlocked and hold a balance great enough to send a beacon
@@ -851,7 +844,7 @@ AdvertiseBeaconResult SendNewBeacon(const Cpid& cpid)
 //! \return A variant that contains the public key if successful or a
 //! description of the error that occurred.
 //!
-AdvertiseBeaconResult RenewBeacon(const Cpid& cpid, const Beacon& beacon)
+AdvertiseBeaconResult RenewBeacon(const Cpid& cpid, const Beacon& beacon) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!beacon.Renewable(GetAdjustedTime())) {
         LogPrintf("%s: Beacon renewal not needed", __func__);
@@ -1402,41 +1395,42 @@ bool Researcher::HasRAC() const
     return false;
 }
 
-// TODO(#2869 Phase 2 — researcher/beacon): Reads pindexBest BEFORE taking
-// cs_main below. Phase 2 should move the LOCK up to cover the early reads
-// (the race window is small but real).
-CAmount Researcher::Accrual() const NO_THREAD_SAFETY_ANALYSIS
+CAmount Researcher::Accrual() const
 {
     const CpidOption cpid = m_mining_id.TryCpid();
 
-    if (!cpid || !pindexBest) {
+    if (!cpid) {
+        return 0;
+    }
+
+    LOCK(cs_main);
+
+    if (!pindexBest) {
         return 0;
     }
 
     const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
 
-    LOCK(cs_main);
-
     return Tally::GetAccrual(*cpid, now, pindexBest);
 }
 
-// TODO(#2869 Phase 2 — researcher/beacon): same shape as Accrual() above.
-std::optional<CAmount> Researcher::AccrualNearLimit() const NO_THREAD_SAFETY_ANALYSIS
+std::optional<CAmount> Researcher::AccrualNearLimit() const
 {
     const CpidOption cpid = m_mining_id.TryCpid();
-    std::optional<CAmount> near_limit_accrual;
 
-    if (!cpid || !pindexBest) {
+    if (!cpid) {
+        return std::nullopt;
+    }
+
+    LOCK(cs_main);
+
+    if (!pindexBest) {
         return std::nullopt;
     }
 
     const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
 
-    LOCK(cs_main);
-
-    near_limit_accrual = Tally::AccrualNearLimit(*cpid, now, pindexBest);
-
-    return near_limit_accrual;
+    return Tally::AccrualNearLimit(*cpid, now, pindexBest);
 }
 
 ResearcherStatus Researcher::Status() const

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -491,7 +491,7 @@ public:
     //! to mint blocks that claim Proof-of-Research rewards. Otherwise, this
     //! method resets the wallet's mining context to non-cruncher mode.
     //!
-    static void Reload();
+    static void Reload() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Reload the wallet's researcher mining context from the supplied
@@ -503,7 +503,7 @@ public:
     //!
     static void Reload(
         MiningProjectMap projects,
-        BeaconError beacon_error = GRC::BeaconError::NONE);
+        BeaconError beacon_error = GRC::BeaconError::NONE) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Rescan the set of in-memory projects for eligible CPIDs without
@@ -515,7 +515,7 @@ public:
     //! application calls this method to update the researcher context with any
     //! newly eligible or ineligible CPIDs.
     //!
-    static void Refresh();
+    static void Refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the primary mining ID that identifies the owner of the wallet.

--- a/src/gridcoin/researcher.h
+++ b/src/gridcoin/researcher.h
@@ -7,6 +7,8 @@
 
 #include "amount.h"
 #include "key.h"
+#include "sync.h"
+#include "wallet/wallet.h"
 #include "gridcoin/cpid.h"
 
 #include <map>
@@ -14,8 +16,10 @@
 #include <string>
 #include <vector>
 
-class CWallet;
 class uint256;
+
+extern CCriticalSection cs_main;
+extern CWallet* pwalletMain;
 
 namespace GRC {
 
@@ -371,7 +375,7 @@ class OwnershipProof;
 //! \return A variant that contains the new public key if successful or a
 //! description of the error that occurred.
 //!
-AdvertiseBeaconResult GenerateBeaconKey(const Cpid& cpid);
+AdvertiseBeaconResult GenerateBeaconKey(const Cpid& cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Send a v3 beacon contract with an ownership proof.
@@ -388,7 +392,7 @@ AdvertiseBeaconResult SendBeaconContractV3(
     const Cpid& cpid,
     Beacon beacon,
     OwnershipProof proof,
-    const bool force = false);
+    const bool force = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet);
 
 //!
 //! \brief Manages the global BOINC researcher context.

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -88,21 +88,41 @@ CCriticalSection cs_VerifiedBeacons;
 CCriticalSection cs_ProjectPublicKeys;
 
 /**
- * @brief Flag that indicates whether the scraper is supposed to be active
+ * @brief Flag that indicates whether the scraper is supposed to be active.
+ *
+ * Written exclusively from GRC::Initialize() (gridcoin.cpp) at startup
+ * before any scraper thread runs; read on the scraper thread inside the
+ * main loop. atomic<bool> covers the cross-thread visibility.
  */
-bool fScraperActive = false;
+std::atomic<bool> fScraperActive {false};
 /**
  * @brief Vector of usernames and passwords for access to project sites which require logins to meet GPDR requirements
+ *
+ * Protected by cs_Scraper. All access paths — UserpassPopulated, the userpass
+ * utility class, and the DownloadProject* helpers — are reached only from the
+ * download section of Scraper() (the LOCK(cs_Scraper) at the start of the
+ * "section to download statistics" block). This covers both the main scraper
+ * thread loop and the reentrant ScraperSingleShot path (called by
+ * ScraperGetSuperblockContract from the staking miner thread, RPC threads,
+ * and ScraperHousekeeping); the singleshot path enters the same critical
+ * section.
  */
-std::vector<std::pair<std::string, std::string>> vuserpass;
+std::vector<std::pair<std::string, std::string>> vuserpass GUARDED_BY(cs_Scraper);
 /**
  * @brief Vector of team IDs for whitelisted teams across the different whitelisted projects. When the team requirement is
  * imposed this is important to correlate teams, since each project uses an independent ID for team names. I.e. Gridcoin
  * in one project will have, in general, a different ID, than another project.
+ *
+ * Currently unused; retained for future per-project team-id correlation work.
  */
 std::vector<std::pair<std::string, int64_t>> vprojectteamids;
-int64_t ndownloadsize = 0;
-int64_t nuploadsize = 0;
+/// Cumulative download/upload byte counts. Written by ProcessProjectRacFileByCPID
+/// and read from the "download size so far..." log line in Scraper(). Both call
+/// sites are inside the LOCK(cs_Scraper) covering the download section, so the
+/// data is effectively cs_Scraper-protected (the singleshot reentrant path also
+/// enters that critical section).
+int64_t ndownloadsize GUARDED_BY(cs_Scraper) = 0;
+int64_t nuploadsize GUARDED_BY(cs_Scraper) = 0;
 
 //!
 //! \brief Normalize a project master URL for consistent map key comparison.
@@ -300,19 +320,19 @@ void ScraperSingleShot();
  * testnewsb function (if the scraper log category is enabled).
  * @return Currently returns true. The boolean is reserved for future overall status of housekeeping.
  */
-bool ScraperHousekeeping();
+bool ScraperHousekeeping() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 /**
  * @brief Checks if vuserpass is populated and if empty, populates it
  * @return bool true if populated
  */
-bool UserpassPopulated();
+bool UserpassPopulated() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 /**
  * @brief Checks the scraper directory structure and files against the manifest and aligns/corrects as appropriate. Also
  * loads the TeamIDMap from file if REQUIRE_TEAM_WHITELIST_MEMBERSHIP is enabled and TeamIDs were saved to disk and loads
  * the VerifiedBeacons from disk.
  * @return
  */
-bool ScraperDirectoryAndConfigSanity();
+bool ScraperDirectoryAndConfigSanity() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 /**
  * @brief Stores the current beacon map to the provided file path
  * @param file
@@ -351,7 +371,7 @@ bool LoadTeamIDList(const fs::path& file);
  * manifest to the network if the scraper is active.
  * @return bool true if successful
  */
-uint256 GetmScraperFileManifestHash();
+uint256 GetmScraperFileManifestHash() EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest);
 /**
  * @brief Stores the mScraperFileManifest map to disk
  * @param file
@@ -371,21 +391,21 @@ bool LoadScraperFileManifest(const fs::path& file);
  * @param entry
  * @return bool true if successful
  */
-bool InsertScraperFileManifestEntry(ScraperFileManifestEntry& entry);
+bool InsertScraperFileManifestEntry(ScraperFileManifestEntry& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest);
 /**
  * @brief Deletes an entry from the mScraperFileManifest map and also deletes the corresponding file from disk, if it exists.
  * Also updates the mScraperFileManifest map hash and stores the hash in StructScraperFileManifest.nFileManifestMapHash.
  * @param entry
  * @return unsigned int of the number of elements erased
  */
-unsigned int DeleteScraperFileManifestEntry(ScraperFileManifestEntry& entry);
+unsigned int DeleteScraperFileManifestEntry(ScraperFileManifestEntry& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest);
 /**
  * @brief Marks a file manifest entry non-current in the mScraperFileManifest map and updates the
  * StructScraperFileManifest.nFileManifestMapHash.
  * @param entry
  * @return
  */
-bool MarkScraperFileManifestEntryNonCurrent(ScraperFileManifestEntry& entry);
+bool MarkScraperFileManifestEntryNonCurrent(ScraperFileManifestEntry& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest);
 /**
  * @brief Aligns the file manifest entries in the mScraperFileManifest map to the files present on disk. Deletes either/both
  * files and/or entries that are not present and have matching hashes in both.
@@ -468,13 +488,13 @@ bool ScraperSaveCScraperManifestToFiles(uint256 nManifestHash);
  * @param Key
  * @return bool true if successful
  */
-bool ScraperSendFileManifestContents(CTxDestination& Address, CKey& Key);
+bool ScraperSendFileManifestContents(CTxDestination& Address, CKey& Key) EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapManifest);
 /**
  * @brief Sorts the inventory of CScraperManifests by scraper and orders by manifest time, which is important for
  * convergence determination
  * @return mmCSManifestsBinnedByScraper
  */
-mmCSManifestsBinnedByScraper BinCScraperManifestsByScraper();
+mmCSManifestsBinnedByScraper BinCScraperManifestsByScraper() EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest);
 /**
  * @brief Sorts the inventory of CScraperManifests by scraper and orders by manifest time, which is important for
  * convergence determination. Also culls old manifest that do not meet retention rules.
@@ -519,14 +539,14 @@ bool ScraperConstructConvergedManifestByProject(const WhitelistSnapshot& project
  * @param projectWhitelist
  * @return bool true if successful
  */
-bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist);
+bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist) EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 /**
  * @brief Download the project team files and stores in the scraper data directory. This is used when
  * REQUIRE_TEAM_WHITELIST_MEMBERSHIP is true OR explorer mode is enabled.
  * @param projectWhitelist
  * @return bool true if successful
  */
-bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist);
+bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist) EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 /**
  * @brief Process project team file and populate TeamIDMap global
  * @param project
@@ -534,13 +554,13 @@ bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist);
  * @param etag
  * @return bool true if successful
  */
-bool ProcessProjectTeamFile(const std::string& project, const fs::path& file, const std::string& etag);
+bool ProcessProjectTeamFile(const std::string& project, const fs::path& file, const std::string& etag) EXCLUSIVE_LOCKS_REQUIRED(cs_TeamIDMap);
 /**
  * @brief Download project RAC (user) files (which have CPID level statistics) for each project on the provided whitelist.
  * @param projectWhitelist
  * @return bool true if successful
  */
-bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist);
+bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist) EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 /**
  * @brief Download project public keys for account ownership proof verification from whitelisted projects.
  * Fetches get_project_config.php for each project and extracts the account_ownership_public_key element.
@@ -560,7 +580,8 @@ void DownloadProjectPublicKeys(const WhitelistSnapshot& projectWhitelist);
  */
 bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& file, const std::string& etag,
                                  BeaconConsensus& Consensus, ScraperVerifiedBeacons& GlobalVerifiedBeaconsCopy,
-                                 ScraperVerifiedBeacons& IncomingVerifiedBeacons, double& all_cpid_total_credit);
+                                 ScraperVerifiedBeacons& IncomingVerifiedBeacons, double& all_cpid_total_credit)
+                                 EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper);
 // Need to access from rpcblockchain.cpp
 extern UniValue SuperblockToJson(const Superblock& superblock);
 
@@ -1184,7 +1205,7 @@ private:
     fsbridge::ifstream userpassfile;
 
 public:
-    userpass()
+    userpass() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
     {
         vuserpass.clear();
 
@@ -1202,7 +1223,7 @@ public:
             userpassfile.close();
     }
 
-    bool import()
+    bool import() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
     {
         vuserpass.clear();
         std::string inputdata;
@@ -1864,8 +1885,7 @@ bool ScraperHousekeeping() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
     return true;
 }
 
-// A lock on cs_Scraper should be taken before calling this function.
-bool ScraperDirectoryAndConfigSanity()
+bool ScraperDirectoryAndConfigSanity() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
 {
     auto explorer_mode = []() { LOCK(cs_ScraperGlobals); return fExplorer; };
     auto scraper_retain_noncurrent_files = []() { LOCK(cs_ScraperGlobals); return SCRAPER_RETAIN_NONCURRENT_FILES; };
@@ -2032,7 +2052,7 @@ bool ScraperDirectoryAndConfigSanity()
 }
 
 
-bool UserpassPopulated()
+bool UserpassPopulated() EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
 {
     if (vuserpass.empty())
     {
@@ -2057,7 +2077,7 @@ bool UserpassPopulated()
     return true;
 }
 
-bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist)
+bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist) EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
 {
     auto explorer_mode = []() { LOCK(cs_ScraperGlobals); return fExplorer; };
 
@@ -2172,7 +2192,7 @@ bool DownloadProjectHostFiles(const WhitelistSnapshot& projectWhitelist)
     return true;
 }
 
-bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist)
+bool DownloadProjectTeamFiles(const WhitelistSnapshot& projectWhitelist) EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
 {
     auto explorer_mode = []() { LOCK(cs_ScraperGlobals); return fExplorer; };
     auto require_team_whitelist_membership = []() { LOCK(cs_ScraperGlobals); return REQUIRE_TEAM_WHITELIST_MEMBERSHIP; };
@@ -2528,7 +2548,7 @@ void DownloadProjectPublicKeys(const WhitelistSnapshot& projectWhitelist)
     }
 }
 
-bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
+bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist) EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
 {
     auto explorer_mode = []() { LOCK(cs_ScraperGlobals); return fExplorer; };
 
@@ -2749,6 +2769,7 @@ bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
 bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& file, const std::string& etag,
                                  BeaconConsensus& Consensus, ScraperVerifiedBeacons& GlobalVerifiedBeaconsCopy,
                                  ScraperVerifiedBeacons& IncomingVerifiedBeacons, double& all_cpid_total_credit)
+                                 EXCLUSIVE_LOCKS_REQUIRED(cs_Scraper)
 {
     auto explorer_mode = []() { LOCK(cs_ScraperGlobals); return fExplorer; };
     auto require_team_whitelist_membership = []() { LOCK(cs_ScraperGlobals); return REQUIRE_TEAM_WHITELIST_MEMBERSHIP; };

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -96,7 +96,7 @@ CCriticalSection cs_ProjectPublicKeys;
  */
 std::atomic<bool> fScraperActive {false};
 /**
- * @brief Vector of usernames and passwords for access to project sites which require logins to meet GPDR requirements
+ * @brief Vector of usernames and passwords for access to project sites which require logins to meet GDPR requirements
  *
  * Protected by cs_Scraper. All access paths — UserpassPopulated, the userpass
  * utility class, and the DownloadProject* helpers — are reached only from the

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6551,8 +6551,7 @@ UniValue convergencereport(const UniValue& params, bool fHelp)
  * @param fHelp
  * @return report of test results
  */
-// TODO(#2869 Phase 3 — scraper): pindexBest reads in this RPC need cs_main.
-UniValue testnewsb(const UniValue& params, bool fHelp) NO_THREAD_SAFETY_ANALYSIS
+UniValue testnewsb(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 1 )
         throw std::runtime_error(
@@ -6594,7 +6593,9 @@ UniValue testnewsb(const UniValue& params, bool fHelp) NO_THREAD_SAFETY_ANALYSIS
     uint32_t nNewFormatSuperblockReducedContentHashFromUnderlyingManifestHint;
 
     {
-        LOCK(cs_ConvergedScraperStatsCache);
+        // pindexBest read below requires cs_main; canonical order is
+        // cs_main -> subsystem locks, so acquire cs_main first.
+        LOCK2(cs_main, cs_ConvergedScraperStatsCache);
 
         NewFormatSuperblock = SuperblockPtr::BindShared(
             Superblock::FromConvergence(ConvergedScraperStatsCache),
@@ -6731,9 +6732,15 @@ UniValue testnewsb(const UniValue& params, bool fHelp) NO_THREAD_SAFETY_ANALYSIS
         // SuperblockValidator class tests (past convergence)
         //
 
-        SuperblockPtr RandomPastSBPtr = SuperblockPtr::BindShared(
-            std::move(RandomPastSB),
-            pindexBest);
+        SuperblockPtr RandomPastSBPtr;
+        {
+            // pindexBest read requires cs_main; scoped tight so the
+            // ValidateSuperblock calls below run without cs_main held.
+            LOCK(cs_main);
+            RandomPastSBPtr = SuperblockPtr::BindShared(
+                std::move(RandomPastSB),
+                pindexBest);
+        }
 
         if (Quorum::ValidateSuperblock(RandomPastSBPtr))
         {

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -3242,7 +3242,7 @@ bool StoreBeaconList(const fs::path& file)
     BeaconConsensus Consensus = GetConsensusBeaconList();
 
     _log(logattribute::INFO, "StoreBeaconList", "ReadCacheSection element count: "
-         + ToString(GetBeaconRegistry().Beacons().size()));
+         + ToString(WITH_LOCK(cs_main, return GetBeaconRegistry().Beacons().size())));
     _log(logattribute::INFO, "StoreBeaconList", "mBeaconMap element count: "
          + ToString(Consensus.mBeaconMap.size()));
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -2521,8 +2521,11 @@ void DownloadProjectPublicKeys(const WhitelistSnapshot& projectWhitelist)
         g_project_public_keys_timestamp = GetAdjustedTime();
     }
 
-    _log(logattribute::INFO, __func__,
-         "Completed. " + ToString(g_project_public_keys.size()) + " project(s) have ownership proof public keys.");
+    {
+        LOCK(cs_ProjectPublicKeys);
+        _log(logattribute::INFO, __func__,
+             "Completed. " + ToString(g_project_public_keys.size()) + " project(s) have ownership proof public keys.");
+    }
 }
 
 bool DownloadProjectRacFilesByCPID(const WhitelistSnapshot& projectWhitelist)
@@ -6548,7 +6551,8 @@ UniValue convergencereport(const UniValue& params, bool fHelp)
  * @param fHelp
  * @return report of test results
  */
-UniValue testnewsb(const UniValue& params, bool fHelp)
+// TODO(#2869 Phase 3 — scraper): pindexBest reads in this RPC need cs_main.
+UniValue testnewsb(const UniValue& params, bool fHelp) NO_THREAD_SAFETY_ANALYSIS
 {
     if (fHelp || params.size() > 1 )
         throw std::runtime_error(

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -180,7 +180,7 @@ bool IsScraperAuthorizedToBroadcastManifests(CTxDestination& AddressOut, CKey& K
  * of the scraper is deemed too high. This is actually used in CScraperManifest::IsManifestAuthorized to ban
  * a scraper that is abusing the network by sending too many manifests over a very short period of time.
  */
-bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey);
+bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& PubKey) EXCLUSIVE_LOCKS_REQUIRED(CScraperManifest::cs_mapManifest);
 /**
  * @brief Generates a superblock (contract) from the current convergence. It will construct/update the convergence if needed.
  * @param bStoreConvergedStats

--- a/src/gridcoin/support/block_finder.cpp
+++ b/src/gridcoin/support/block_finder.cpp
@@ -7,11 +7,7 @@
 
 using namespace GRC;
 
-// TODO(#2869 Phase 2 — block_finder): nBestHeight / pindexGenesisBlock /
-// pindexBest reads need cs_main. 29 call sites across the codebase, some
-// already holding cs_main and some not. Annotate as required + audit callers
-// in Phase 2 rather than cascading Phase 1.
-CBlockIndex* BlockFinder::FindByHeight(int height) NO_THREAD_SAFETY_ANALYSIS
+CBlockIndex* BlockFinder::FindByHeight(int height) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // If the height is at the bottom half of the chain, start searching from
     // the start to the end, otherwise search backwards from the end.
@@ -35,7 +31,7 @@ CBlockIndex* BlockFinder::FindByHeight(int height) NO_THREAD_SAFETY_ANALYSIS
     return index;
 }
 
-CBlockIndex* BlockFinder::FindByMinTime(int64_t time) NO_THREAD_SAFETY_ANALYSIS
+CBlockIndex* BlockFinder::FindByMinTime(int64_t time) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Select starting point depending on time proximity. While this is not as
     // accurate as in the FindByHeight case it will still give us a reasonable
@@ -61,7 +57,7 @@ CBlockIndex* BlockFinder::FindByMinTime(int64_t time) NO_THREAD_SAFETY_ANALYSIS
 }
 
 // The arguments are passed by value on purpose.
-CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in) NO_THREAD_SAFETY_ANALYSIS
+CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CBlockIndex* index = index_in;
 
@@ -78,7 +74,7 @@ CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex*
     return index;
 }
 
-CBlockIndex* BlockFinder::FindLatestSuperblock(CBlockIndex* const index_in) NO_THREAD_SAFETY_ANALYSIS
+CBlockIndex* BlockFinder::FindLatestSuperblock(CBlockIndex* const index_in) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CBlockIndex* index = index_in;
 

--- a/src/gridcoin/support/block_finder.cpp
+++ b/src/gridcoin/support/block_finder.cpp
@@ -7,7 +7,11 @@
 
 using namespace GRC;
 
-CBlockIndex* BlockFinder::FindByHeight(int height)
+// TODO(#2869 Phase 2 — block_finder): nBestHeight / pindexGenesisBlock /
+// pindexBest reads need cs_main. 29 call sites across the codebase, some
+// already holding cs_main and some not. Annotate as required + audit callers
+// in Phase 2 rather than cascading Phase 1.
+CBlockIndex* BlockFinder::FindByHeight(int height) NO_THREAD_SAFETY_ANALYSIS
 {
     // If the height is at the bottom half of the chain, start searching from
     // the start to the end, otherwise search backwards from the end.
@@ -31,7 +35,7 @@ CBlockIndex* BlockFinder::FindByHeight(int height)
     return index;
 }
 
-CBlockIndex* BlockFinder::FindByMinTime(int64_t time)
+CBlockIndex* BlockFinder::FindByMinTime(int64_t time) NO_THREAD_SAFETY_ANALYSIS
 {
     // Select starting point depending on time proximity. While this is not as
     // accurate as in the FindByHeight case it will still give us a reasonable
@@ -57,7 +61,7 @@ CBlockIndex* BlockFinder::FindByMinTime(int64_t time)
 }
 
 // The arguments are passed by value on purpose.
-CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in)
+CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in) NO_THREAD_SAFETY_ANALYSIS
 {
     CBlockIndex* index = index_in;
 
@@ -74,7 +78,7 @@ CBlockIndex* BlockFinder::FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex*
     return index;
 }
 
-CBlockIndex* BlockFinder::FindLatestSuperblock(CBlockIndex* const index_in)
+CBlockIndex* BlockFinder::FindLatestSuperblock(CBlockIndex* const index_in) NO_THREAD_SAFETY_ANALYSIS
 {
     CBlockIndex* index = index_in;
 

--- a/src/gridcoin/support/block_finder.h
+++ b/src/gridcoin/support/block_finder.h
@@ -7,7 +7,10 @@
 
 #include <cstdint>
 
+#include "sync.h"
+
 class CBlockIndex;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 //!
@@ -26,7 +29,7 @@ public:
     //! \return The block with the height closest to \p nHeight if found, otherwise
     //! \a nullptr is returned.
     //!
-    static CBlockIndex* FindByHeight(int height);
+    static CBlockIndex* FindByHeight(int height) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Find block by time.
@@ -39,7 +42,7 @@ public:
     //! \return The youngest block which is not older than \p time, or the
     //! head of the chain if it is older than \p time.
     //!
-    static CBlockIndex* FindByMinTime(int64_t time);
+    static CBlockIndex* FindByMinTime(int64_t time) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Find block by time going forward from given index.
@@ -48,14 +51,14 @@ public:
     //! \return CBlockIndex pointing to the youngest block which is not older than \p time, or
     //! the head of the chain if it is older than \p time.
     //!
-    static CBlockIndex* FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in = nullptr);
+    static CBlockIndex* FindByMinTimeFromGivenIndex(int64_t time, CBlockIndex* const index_in = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Find the last superblock at or before the provided index.
     //! \param CBlockIndex from where to start.
     //! \return CBlockIndex pointing to the block containing the last superblock contract.
     //!
-    static CBlockIndex* FindLatestSuperblock(CBlockIndex * const index_in = nullptr);
+    static CBlockIndex* FindLatestSuperblock(CBlockIndex * const index_in = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 } // namespace GRC
 

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -49,8 +49,7 @@ bool g_newbie_snapshot_fix_enabled;
 //!
 //! \param pindex Index of the block to repair.
 //!
-// TODO(#2869 Phase 2 — tally): GetClaimByIndex requires cs_main.
-void RepairZeroCpidIndex(CBlockIndex* const pindex) NO_THREAD_SAFETY_ANALYSIS
+void RepairZeroCpidIndex(CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const ClaimOption claim = GetClaimByIndex(pindex);
 
@@ -194,7 +193,7 @@ public:
     //!
     //! \return \c true if the tally initialized without an error.
     //!
-    bool Initialize(CBlockIndex* pindex, SuperblockPtr current_superblock)
+    bool Initialize(CBlockIndex* pindex, SuperblockPtr current_superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         LogPrintf("Initializing research reward tally...");
 
@@ -510,7 +509,7 @@ public:
     //!
     //! \return \c false if an IO error occurred while processing the superblock.
     //!
-    bool ApplySuperblock(SuperblockPtr superblock)
+    bool ApplySuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // The network publishes version 2+ superblocks after the mandatory
         // switch to block version 11.
@@ -567,12 +566,9 @@ public:
     //! \return \c false if the snapshot system failed to initialize because of
     //! an error.
     //!
-    // TODO(#2869 Phase 2 — tally): pindexBest reads (snapshot rewind handling
-    // from issue #2865 Phase 2) need cs_main. Tally::ActivateSnapshotAccrual
-    // caller chain is via GRC::Initialize, which holds cs_main.
     bool ActivateSnapshotAccrual(
         const CBlockIndex* const baseline_pindex,
-        SuperblockPtr superblock) NO_THREAD_SAFETY_ANALYSIS
+        SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (!baseline_pindex || !IsV11Enabled(baseline_pindex->nHeight + 1)) {
             return false;
@@ -732,8 +728,7 @@ private:
     //! \brief Get the block index entry of the block when research accounting
     //! begins.
     //!
-    // TODO(#2869 Phase 2 — tally): pindexGenesisBlock read needs cs_main.
-    CBlockIndex* GetStartHeight() NO_THREAD_SAFETY_ANALYSIS
+    CBlockIndex* GetStartHeight() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // A node syncing from zero does not know the block index entry of the
         // starting height yet, so the tally will initialize without it.
@@ -761,7 +756,7 @@ private:
     //!
     //! \param superblock Incoming superblock to calculate rewards at.
     //!
-    void TallySuperblockAccrual(const SuperblockPtr& superblock)
+    void TallySuperblockAccrual(const SuperblockPtr& superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         const SnapshotCalculator calc(superblock.m_timestamp, m_current_superblock);
 
@@ -931,7 +926,7 @@ private:
     //!
     //! \return \c false if an IO error occurred.
     //!
-    bool BuildAccrualSnapshots()
+    bool BuildAccrualSnapshots() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (!BuildBaselineSnapshot()) {
             return false;
@@ -980,8 +975,7 @@ public:
     //!
     //! \return \c false if an error occurred.
     //!
-    // TODO(#2869 Phase 2 — tally): pindexBest read needs cs_main.
-    bool RebuildAccrualSnapshots() NO_THREAD_SAFETY_ANALYSIS
+    bool RebuildAccrualSnapshots() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         assert(m_snapshot_baseline_pindex != nullptr);
 
@@ -1021,7 +1015,7 @@ NetworkTally g_network_tally;       //!< Tracks legacy two-week network averages
 // Class: Tally
 // -----------------------------------------------------------------------------
 
-bool Tally::Initialize(CBlockIndex* pindex)
+bool Tally::Initialize(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pindex || !IsResearchAgeEnabled(pindex->nHeight)) {
         LogPrintf("Tally initialization not needed.");
@@ -1059,7 +1053,7 @@ bool Tally::Initialize(CBlockIndex* pindex)
     return true;
 }
 
-bool Tally::ActivateSnapshotAccrual(const CBlockIndex* const pindex)
+bool Tally::ActivateSnapshotAccrual(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrint(LogFlags::TALLY, "Activating snapshot accrual...");
 
@@ -1145,8 +1139,7 @@ CAmount Tally::AccrualNearLimit(
 //! \param cpid for which to calculate the accrual correction.
 //! \param superblock that is the high point of the accrual correction
 //!
-// TODO(#2869 Phase 2 — tally): mapBlockIndex + hashBestChain read need cs_main.
-CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const SuperblockPtr& current_superblock) NO_THREAD_SAFETY_ANALYSIS
+CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const SuperblockPtr& current_superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // This function was moved from the anonymous namespace and private, to public and made static, because it has
     // to be called from BlockRewardRules::Check() directly too. Why?
@@ -1449,7 +1442,7 @@ void Tally::ForgetRewardBlock(const CBlockIndex* const pindex)
     g_researcher_tally.ForgetMRCRewardBlock(pindex);
 }
 
-bool Tally::ApplySuperblock(SuperblockPtr superblock)
+bool Tally::ApplySuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_researcher_tally.ApplySuperblock(std::move(superblock));
 }

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -49,7 +49,8 @@ bool g_newbie_snapshot_fix_enabled;
 //!
 //! \param pindex Index of the block to repair.
 //!
-void RepairZeroCpidIndex(CBlockIndex* const pindex)
+// TODO(#2869 Phase 2 — tally): GetClaimByIndex requires cs_main.
+void RepairZeroCpidIndex(CBlockIndex* const pindex) NO_THREAD_SAFETY_ANALYSIS
 {
     const ClaimOption claim = GetClaimByIndex(pindex);
 
@@ -566,9 +567,12 @@ public:
     //! \return \c false if the snapshot system failed to initialize because of
     //! an error.
     //!
+    // TODO(#2869 Phase 2 — tally): pindexBest reads (snapshot rewind handling
+    // from issue #2865 Phase 2) need cs_main. Tally::ActivateSnapshotAccrual
+    // caller chain is via GRC::Initialize, which holds cs_main.
     bool ActivateSnapshotAccrual(
         const CBlockIndex* const baseline_pindex,
-        SuperblockPtr superblock)
+        SuperblockPtr superblock) NO_THREAD_SAFETY_ANALYSIS
     {
         if (!baseline_pindex || !IsV11Enabled(baseline_pindex->nHeight + 1)) {
             return false;
@@ -728,7 +732,8 @@ private:
     //! \brief Get the block index entry of the block when research accounting
     //! begins.
     //!
-    CBlockIndex* GetStartHeight()
+    // TODO(#2869 Phase 2 — tally): pindexGenesisBlock read needs cs_main.
+    CBlockIndex* GetStartHeight() NO_THREAD_SAFETY_ANALYSIS
     {
         // A node syncing from zero does not know the block index entry of the
         // starting height yet, so the tally will initialize without it.
@@ -975,7 +980,8 @@ public:
     //!
     //! \return \c false if an error occurred.
     //!
-    bool RebuildAccrualSnapshots()
+    // TODO(#2869 Phase 2 — tally): pindexBest read needs cs_main.
+    bool RebuildAccrualSnapshots() NO_THREAD_SAFETY_ANALYSIS
     {
         assert(m_snapshot_baseline_pindex != nullptr);
 
@@ -1139,7 +1145,8 @@ CAmount Tally::AccrualNearLimit(
 //! \param cpid for which to calculate the accrual correction.
 //! \param superblock that is the high point of the accrual correction
 //!
-CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const SuperblockPtr& current_superblock)
+// TODO(#2869 Phase 2 — tally): mapBlockIndex + hashBestChain read need cs_main.
+CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const SuperblockPtr& current_superblock) NO_THREAD_SAFETY_ANALYSIS
 {
     // This function was moved from the anonymous namespace and private, to public and made static, because it has
     // to be called from BlockRewardRules::Check() directly too. Why?

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1104,7 +1104,7 @@ CAmount Tally::MaxEmission(const int64_t payment_time)
     return NetworkTally::MaxEmission(payment_time) * COIN;
 }
 
-double Tally::GetMagnitudeUnit(CBlockIndex* const pindex)
+double Tally::GetMagnitudeUnit(CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (pindex->nVersion >= 11) {
         return SnapshotCalculator::GetMagnitudeUnit(pindex).ToDouble();

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -43,7 +43,7 @@ public:
     //!
     //! \return \c true if the tally initialized without an error.
     //!
-    static bool Initialize(CBlockIndex* pindex);
+    static bool Initialize(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Switch from legacy research age accrual calculations to the
@@ -54,7 +54,7 @@ public:
     //! \return \c false if the snapshot system failed to initialize because of
     //! an error.
     //!
-    static bool ActivateSnapshotAccrual(const CBlockIndex* const pindex);
+    static bool ActivateSnapshotAccrual(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /*
     //!
@@ -156,7 +156,7 @@ public:
     //!
     //! \param cpid for which to calculate the accrual correction.
     //!
-    static CAmount GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const SuperblockPtr& current_superblock);
+    static CAmount GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const SuperblockPtr& current_superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get an initialized research reward accrual calculator.
@@ -254,7 +254,7 @@ public:
     //!
     //! \return \c false if an IO error occurred while processing the superblock.
     //!
-    static bool ApplySuperblock(SuperblockPtr superblock);
+    static bool ApplySuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Reset the account data to a state before the provided superblock.

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -8,8 +8,10 @@
 #include "amount.h"
 #include "gridcoin/account.h"
 #include "gridcoin/accrual/computer.h"
+#include "sync.h"
 
 class CBlockIndex;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 
@@ -99,7 +101,7 @@ public:
     //!
     //! \return Current magnitude unit adjusted for the specified block.
     //!
-    static double GetMagnitudeUnit(CBlockIndex * const pindex);
+    static double GetMagnitudeUnit(CBlockIndex * const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get a traversable object for the research accounts stored in

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -567,7 +567,8 @@ private:
     //!
     //! \return The hash of the transaction for the beacon contract if found.
     //!
-    std::optional<uint256> FindBeaconTxid(const Beacon& beacon) const
+    // TODO(#2869 Phase 2 — voting): pindexBest read + chain walk need cs_main.
+    std::optional<uint256> FindBeaconTxid(const Beacon& beacon) const NO_THREAD_SAFETY_ANALYSIS
     {
         // TODO: This is rather slow, but we only need to do it once per vote.
         // Store a reference to a wallet's beacon transactions and rewrite the
@@ -892,7 +893,8 @@ PollBuilder::PollBuilder(PollBuilder&& builder) = default;
 PollBuilder::~PollBuilder() = default;
 PollBuilder& PollBuilder::operator=(PollBuilder&& builder) = default;
 
-PollBuilder PollBuilder::SetPayloadVersion(uint32_t version)
+// TODO(#2869 Phase 2 — voting): nBestHeight read needs cs_main.
+PollBuilder PollBuilder::SetPayloadVersion(uint32_t version) NO_THREAD_SAFETY_ANALYSIS
 {
     bool v3_enabled = IsPollV3Enabled(nBestHeight);
 

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -484,7 +484,7 @@ public:
     //!
     //! \param claim The object to fill with the claim.
     //!
-    void BuildClaim(MagnitudeClaim& claim) const
+    void BuildClaim(MagnitudeClaim& claim) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (m_researcher->Magnitude().Scaled() == 0) {
             LogPrint(LogFlags::VOTE, "%s: skipped zero magnitude", __func__);
@@ -567,8 +567,7 @@ private:
     //!
     //! \return The hash of the transaction for the beacon contract if found.
     //!
-    // TODO(#2869 Phase 2 — voting): pindexBest read + chain walk need cs_main.
-    std::optional<uint256> FindBeaconTxid(const Beacon& beacon) const NO_THREAD_SAFETY_ANALYSIS
+    std::optional<uint256> FindBeaconTxid(const Beacon& beacon) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // TODO: This is rather slow, but we only need to do it once per vote.
         // Store a reference to a wallet's beacon transactions and rewrite the
@@ -749,7 +748,7 @@ public:
     //! \param vote Vote contract to generate the claim for.
     //! \param poll Determines how to generate a magnitude claim.
     //!
-    void BuildClaim(Vote& vote, const Poll& poll) const
+    void BuildClaim(Vote& vote, const Poll& poll) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         VoteWeightClaim& claim = vote.m_claim;
 
@@ -893,8 +892,7 @@ PollBuilder::PollBuilder(PollBuilder&& builder) = default;
 PollBuilder::~PollBuilder() = default;
 PollBuilder& PollBuilder::operator=(PollBuilder&& builder) = default;
 
-// TODO(#2869 Phase 2 — voting): nBestHeight read needs cs_main.
-PollBuilder PollBuilder::SetPayloadVersion(uint32_t version) NO_THREAD_SAFETY_ANALYSIS
+PollBuilder PollBuilder::SetPayloadVersion(uint32_t version) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     bool v3_enabled = IsPollV3Enabled(nBestHeight);
 
@@ -1348,7 +1346,7 @@ VoteBuilder VoteBuilder::AddResponse(const std::string& label)
     throw VotingError(strprintf(_("\"%s\" is not a valid poll choice."), label));
 }
 
-CWalletTx VoteBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version)
+CWalletTx VoteBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pwallet) {
         throw VotingError(_("No wallet available."));

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -5,10 +5,13 @@
 #ifndef GRIDCOIN_VOTING_BUILDERS_H
 #define GRIDCOIN_VOTING_BUILDERS_H
 
+#include "sync.h"
 #include "gridcoin/voting/poll.h"
 
 #include <memory>
 #include <vector>
+
+extern CCriticalSection cs_main;
 
 class CWallet;
 class CWalletTx;
@@ -49,7 +52,7 @@ public:
     //!
     //! \throws VotingError If the version is not valid for the current wallet height.
     //!
-    PollBuilder SetPayloadVersion(uint32_t version);
+    PollBuilder SetPayloadVersion(uint32_t version) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Set the type of the poll.
@@ -344,7 +347,7 @@ public:
     //!
     //! \throws VotingError If the constructed vote is malformed.
     //!
-    CWalletTx BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version);
+    CWalletTx BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 private:
     const Poll* m_poll;           //!< The poll to create a vote contract for.

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -691,7 +691,10 @@ public:
     //!
     //! https://github.com/gridcoin-community/Gridcoin-Research/issues/87
     //!
-    Weight GetMagnitudeFactor()
+    // TODO(#2869 Phase 2 — voting): pindexBest read needs cs_main. Per the
+    // standing voting-redesign work, this whole class is set to be replaced;
+    // suppress for now to keep Phase 1 in scope.
+    Weight GetMagnitudeFactor() NO_THREAD_SAFETY_ANALYSIS
     {
         if (m_magnitude_factor != 0) {
             return m_magnitude_factor;
@@ -1103,7 +1106,8 @@ private:
 //!
 //! \return Latest superblock active during the poll.
 //!
-SuperblockPtr ResolveSuperblockForPoll(const Poll& poll)
+// TODO(#2869 Phase 2 — voting): pindexBest walk needs cs_main.
+SuperblockPtr ResolveSuperblockForPoll(const Poll& poll) NO_THREAD_SAFETY_ANALYSIS
 {
     SuperblockPtr superblock = Quorum::CurrentSuperblock();
 
@@ -1138,7 +1142,8 @@ SuperblockPtr ResolveSuperblockForPoll(const Poll& poll)
 //! \return Money supply as of the last block in the poll window in units of
 //! 1/100000000 GRC.
 //!
-CAmount ResolveMoneySupplyForPoll(const Poll& poll)
+// TODO(#2869 Phase 2 — voting): pindexBest reads need cs_main.
+CAmount ResolveMoneySupplyForPoll(const Poll& poll) NO_THREAD_SAFETY_ANALYSIS
 {
     if (!poll.Expired(pindexBest->nTime)) {
         return pindexBest->nMoneySupply;

--- a/src/gridcoin/voting/result.cpp
+++ b/src/gridcoin/voting/result.cpp
@@ -691,9 +691,12 @@ public:
     //!
     //! https://github.com/gridcoin-community/Gridcoin-Research/issues/87
     //!
-    // TODO(#2869 Phase 2 — voting): pindexBest read needs cs_main. Per the
-    // standing voting-redesign work, this whole class is set to be replaced;
-    // suppress for now to keep Phase 1 in scope.
+    // TODO(#2869 — voting): pindexBest read needs cs_main. Reached from
+    // ProcessLegacyVote, whose call site already has a pragma suppression
+    // because the surrounding VoteResolver chain does not hold cs_main.
+    // The standing voting-redesign work replaces this legacy class entirely;
+    // leaving the suppression in place rather than restructuring caller
+    // chains that the redesign will remove.
     Weight GetMagnitudeFactor() NO_THREAD_SAFETY_ANALYSIS
     {
         if (m_magnitude_factor != 0) {
@@ -1106,8 +1109,7 @@ private:
 //!
 //! \return Latest superblock active during the poll.
 //!
-// TODO(#2869 Phase 2 — voting): pindexBest walk needs cs_main.
-SuperblockPtr ResolveSuperblockForPoll(const Poll& poll) NO_THREAD_SAFETY_ANALYSIS
+SuperblockPtr ResolveSuperblockForPoll(const Poll& poll) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     SuperblockPtr superblock = Quorum::CurrentSuperblock();
 
@@ -1142,8 +1144,7 @@ SuperblockPtr ResolveSuperblockForPoll(const Poll& poll) NO_THREAD_SAFETY_ANALYS
 //! \return Money supply as of the last block in the poll window in units of
 //! 1/100000000 GRC.
 //!
-// TODO(#2869 Phase 2 — voting): pindexBest reads need cs_main.
-CAmount ResolveMoneySupplyForPoll(const Poll& poll) NO_THREAD_SAFETY_ANALYSIS
+CAmount ResolveMoneySupplyForPoll(const Poll& poll) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!poll.Expired(pindexBest->nTime)) {
         return pindexBest->nMoneySupply;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1307,7 +1307,15 @@ bool AppInit2(ThreadHandlerPtr threads)
     if (gArgs.GetBoolArg("-loadblockindextest"))
     {
         CTxDB txdb("r");
-        txdb.LoadBlockIndex();
+        {
+            // CTxDB::LoadBlockIndex is EXCLUSIVE_LOCKS_REQUIRED(cs_main) because
+            // it populates mapBlockIndex / pindexBest / hashBestChain. At
+            // init-time the lock is uncontended, but acquiring it documents
+            // the contract and satisfies the analyzer. The free LoadBlockIndex()
+            // below takes cs_main internally and does not need this wrapper.
+            LOCK(cs_main);
+            txdb.LoadBlockIndex();
+        }
         PrintBlockTree();
         return false;
     }
@@ -1350,6 +1358,8 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     if (gArgs.IsArgSet("-printblock"))
     {
+        LOCK(cs_main); // init-time iteration of mapBlockIndex; lock uncontended here but
+                       // required by Phase 1 thread-safety annotations.
         string strMatch = gArgs.GetArg("-printblock", "");
         int nFound = 0;
         for (BlockMap::iterator mi = mapBlockIndex.begin(); mi != mapBlockIndex.end(); ++mi)
@@ -1471,6 +1481,11 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     RegisterWallet(pwalletMain);
+
+    // Init-time wallet rescan + GRC::Initialize reads pindexBest /
+    // pindexGenesisBlock / mapBlockIndex; take cs_main for the whole block
+    // (uncontended at init, required by Phase 1 thread-safety annotations).
+    LOCK(cs_main);
 
     CBlockIndex *pindexRescan = pindexBest;
     bool mrc_request_correction_scan_complete = false;
@@ -1643,11 +1658,13 @@ bool AppInit2(ThreadHandlerPtr threads)
     //// debug print
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE))
     {
+        // cs_main is still held from the wallet-rescan block above; here we
+        // only need cs_wallet for the wallet-side prints. Single-threaded
+        // init context regardless.
+        LOCK(pwalletMain->cs_wallet);
+
         LogPrintf("mapBlockIndex.size() = %" PRIszu,   mapBlockIndex.size());
         LogPrintf("nBestHeight = %d",            nBestHeight);
-
-        // So Clang doesn't complain, even though we are essentially single-threaded here.
-        LOCK(pwalletMain->cs_wallet);
 
         LogPrintf("setKeyPool.size() = %" PRIszu,      pwalletMain->setKeyPool.size());
         LogPrintf("mapWallet.size() = %" PRIszu,       pwalletMain->mapWallet.size());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2154,8 +2154,8 @@ bool LoadExternalBlockFile(FILE* fileIn, size_t file_size, unsigned int percent_
 // CAlert
 //
 
-extern map<uint256, CAlert> mapAlerts;
 extern CCriticalSection cs_mapAlerts;
+extern map<uint256, CAlert> mapAlerts GUARDED_BY(cs_mapAlerts);
 
 string GetWarnings(string strFor)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,17 +164,19 @@ void UnregisterWallet(CWallet* pwalletIn)
     }
 }
 
-// check whether the passed transaction is from us
-bool static IsFromMe(CTransaction& tx)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        if (pwallet->IsFromMe(tx))
-            return true;
-    return false;
-}
+// Canonical lock order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
+// Each wrapper iterates setpwalletRegistered (GUARDED_BY cs_setpwalletRegistered)
+// and dispatches into pwallet methods that take pwallet->cs_wallet. Callers
+// MUST hold cs_setpwalletRegistered before invoking these wrappers; this is
+// enforced by EXCLUSIVE_LOCKS_REQUIRED. Holding the lock at the call site
+// (rather than taking it inside the wrapper) lets callers that also hold
+// cs_wallet establish the canonical order at acquisition time and avoids
+// the cs_setpwalletRegistered <-> cs_wallet inversion the inside-lock
+// pattern would otherwise create.
 
 // get the wallet transaction with the given hash (if it exists)
 bool static GetTransaction(const uint256& hashTx, CWalletTx& wtx)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         if (pwallet->GetTransaction(hashTx,wtx))
@@ -184,6 +186,7 @@ bool static GetTransaction(const uint256& hashTx, CWalletTx& wtx)
 
 // erases transaction with the given hash from all wallets
 void static EraseFromWallets(uint256 hash)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->EraseFromWallet(hash);
@@ -191,6 +194,7 @@ void static EraseFromWallets(uint256 hash)
 
 // make sure all wallets know about the given transaction, in the given block
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock, bool fUpdate, bool fConnect)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     if (!fConnect)
     {
@@ -215,6 +219,7 @@ void SyncWithWallets(const CTransaction& tx, const CBlock* pblock, bool fUpdate,
 
 // notify wallets about a new best chain
 void static SetBestChain(const CBlockLocator& loc)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->SetBestChain(loc);
@@ -222,6 +227,7 @@ void static SetBestChain(const CBlockLocator& loc)
 
 // notify wallets about an updated transaction
 void UpdatedTransaction(const uint256& hashTx)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->UpdatedTransaction(hashTx);
@@ -229,6 +235,7 @@ void UpdatedTransaction(const uint256& hashTx)
 
 // dump all wallets
 void static PrintWallets(const CBlock& block)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->PrintWallet(block);
@@ -236,6 +243,7 @@ void static PrintWallets(const CBlock& block)
 
 // notify wallets about an incoming inventory (for request counts)
 void static Inventory(const uint256& hash)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->Inventory(hash);
@@ -243,6 +251,7 @@ void static Inventory(const uint256& hash)
 
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->ResendWalletTransactions(fForce);
@@ -585,7 +594,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     ///// are we sure this is ok when loading transactions or restoring block txes
     // If updated, erase old tx from wallet
     if (ptxOld)
+    {
+        LOCK(cs_setpwalletRegistered);
         EraseFromWallets(ptxOld->GetHash());
+    }
 
     LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());
 
@@ -788,7 +800,7 @@ bool IsInitialBlockDownload()
             pindexBest->GetBlockTime() <  GetAdjustedTime() - 8 * 60 * 60);
 }
 
-void static InvalidChainFound(CBlockIndex* pindexNew)
+void static InvalidChainFound(CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     arith_uint256 nBestInvalidBlockTrust = pindexNew->GetBlockTrust();
     arith_uint256 nBestBlockTrust = pindexBest->GetBlockTrust();
@@ -1372,6 +1384,8 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
 
     if (!fIsInitialDownload) {
         const CBlockLocator locator(pindexNew);
+        // Canonical order: cs_main (held by SetBestChain) -> cs_setpwalletRegistered -> cs_wallet.
+        LOCK(cs_setpwalletRegistered);
         ::SetBestChain(locator);
     }
 
@@ -1421,7 +1435,7 @@ arith_uint256 CBlockIndex::GetBlockTrust() const
     return (~bnTarget / (bnTarget + 1)) + 1;
 }
 
-bool GridcoinServices()
+bool GridcoinServices() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Block version 9 tally transition:
     //
@@ -1483,7 +1497,7 @@ bool GridcoinServices()
 bool AskForOutstandingBlocks(uint256 hashStart)
 {
     int iAsked = 0;
-    LOCK(cs_vNodes);
+    LOCK2(cs_main, cs_vNodes);
     for (auto const& pNode : vNodes)
     {
                 if (!pNode->fClient && !pNode->fOneShot && (pNode->nStartingHeight > (nBestHeight - 144)))
@@ -1653,7 +1667,7 @@ FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszM
     return file;
 }
 
-bool AbandonChainTo(CBlockIndex* pindex_target, CTxDB& txdb)
+bool AbandonChainTo(CBlockIndex* pindex_target, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     assert(pindex_target != nullptr);
@@ -2021,7 +2035,12 @@ void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                   DateTimeStrFormat("%x %H:%M:%S", block.GetBlockTime()).c_str(),
                   block.vtx.size());
 
-        PrintWallets(block);
+        {
+            // PrintBlockTree is EXCLUSIVE_LOCKS_REQUIRED(cs_main); add the
+            // wallet-registry lock here in the canonical order before dispatch.
+            LOCK(cs_setpwalletRegistered);
+            PrintWallets(block);
+        }
 
         // put the main time-chain first
         vector<CBlockIndex*>& vNext = mapNext[pindex];
@@ -2178,7 +2197,13 @@ string GetWarnings(string strFor)
 // Messages
 //
 
-bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
+// TODO(#2869 Phase 4 — network layer): AlreadyHave reads mapBlockIndex
+// (via txdb.ContainsTx + the implicit chain lookups for BLOCK inv types)
+// from the P2P message-handler thread without holding cs_main. The Phase 4
+// network-layer pass will either (a) take cs_main here, or (b) push the
+// lock acquisition into ProcessMessage at a coarser granularity. Suppressed
+// during Phase 1 to keep the cascade focused on the global annotations.
+bool static AlreadyHave(CTxDB& txdb, const CInv& inv) NO_THREAD_SAFETY_ANALYSIS
 {
     switch (inv.type)
     {
@@ -2200,7 +2225,15 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv)
 }
 
 
-bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
+// TODO(#2869 Phase 4 — network layer): ProcessMessage reads pindexBest /
+// nBestHeight / mapBlockIndex and calls IsInMainChain() (now annotated
+// EXCLUSIVE_LOCKS_REQUIRED(cs_main)) from the P2P message-handler thread
+// without holding cs_main at the call sites. ProcessMessages (line 3034)
+// does not take cs_main at entry either. The Phase 4 net-layer pass will
+// systematically push the lock acquisition either into ProcessMessage at
+// the relevant branches or into ProcessMessages around the dispatch.
+// Suppressed during Phase 1 to keep the cascade focused on globals.
+bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived) NO_THREAD_SAFETY_ANALYSIS
 {
     LogPrint(BCLog::LogFlags::NOISY, "received: %s from %s (%" PRIszu " bytes)", strCommand, pfrom->addrName, vRecv.size());
 
@@ -2541,7 +2574,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 }
 
                 // Track requests for our stuff
-                Inventory(inv.hash);
+                {
+                    LOCK(cs_setpwalletRegistered);
+                    Inventory(inv.hash);
+                }
 
             }
         }
@@ -2676,7 +2712,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
 
             // Track requests for our stuff
-            Inventory(inv.hash);
+            {
+                LOCK(cs_setpwalletRegistered);
+                Inventory(inv.hash);
+            }
         }
     }
 
@@ -3186,8 +3225,14 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         pto->PushMessage(NetMsgType::PING, nonce);
     }
 
-    // Resend wallet transactions that haven't gotten in a block yet
-    ResendWalletTransactions();
+    // Resend wallet transactions that haven't gotten in a block yet.
+    // No outer locks held here in SendMessages; canonical order applies as
+    // cs_setpwalletRegistered -> cs_wallet (cs_main not needed by the
+    // wrapper itself; the wallet method's chain-state reads are TODO-Phase 2).
+    {
+        LOCK(cs_setpwalletRegistered);
+        ResendWalletTransactions();
+    }
 
     // Address refresh broadcast
     if (!IsInitialBlockDownload())
@@ -3261,6 +3306,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 if (!fTrickleWait)
                 {
                     CWalletTx wtx;
+                    LOCK(cs_setpwalletRegistered);
                     if (GetTransaction(inv.hash, wtx))
                         if (wtx.fFromMe)
                             fTrickleWait = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,7 @@ void static EraseFromWallets(uint256 hash)
 
 // make sure all wallets know about the given transaction, in the given block
 void SyncWithWallets(const CTransaction& tx, const CBlock* pblock, bool fUpdate, bool fConnect)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered)
 {
     if (!fConnect)
     {
@@ -251,7 +251,7 @@ void static Inventory(const uint256& hash)
 
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered)
 {
     for (auto const& pwallet : setpwalletRegistered)
         pwallet->ResendWalletTransactions(fForce);
@@ -3226,11 +3226,11 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
     }
 
     // Resend wallet transactions that haven't gotten in a block yet.
-    // No outer locks held here in SendMessages; canonical order applies as
-    // cs_setpwalletRegistered -> cs_wallet (cs_main not needed by the
-    // wrapper itself; the wallet method's chain-state reads are TODO-Phase 2).
+    // No outer locks held here in SendMessages; acquire in canonical order
+    // cs_main -> cs_setpwalletRegistered -> cs_wallet. cs_main is required
+    // for the wallet method's mapBlockIndex / pindexBest reads.
     {
-        LOCK(cs_setpwalletRegistered);
+        LOCK2(cs_main, cs_setpwalletRegistered);
         ResendWalletTransactions();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2197,13 +2197,7 @@ string GetWarnings(string strFor)
 // Messages
 //
 
-// TODO(#2869 Phase 4 — network layer): AlreadyHave reads mapBlockIndex
-// (via txdb.ContainsTx + the implicit chain lookups for BLOCK inv types)
-// from the P2P message-handler thread without holding cs_main. The Phase 4
-// network-layer pass will either (a) take cs_main here, or (b) push the
-// lock acquisition into ProcessMessage at a coarser granularity. Suppressed
-// during Phase 1 to keep the cascade focused on the global annotations.
-bool static AlreadyHave(CTxDB& txdb, const CInv& inv) NO_THREAD_SAFETY_ANALYSIS
+bool static AlreadyHave(CTxDB& txdb, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     switch (inv.type)
     {
@@ -2225,15 +2219,7 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv) NO_THREAD_SAFETY_ANALYSIS
 }
 
 
-// TODO(#2869 Phase 4 — network layer): ProcessMessage reads pindexBest /
-// nBestHeight / mapBlockIndex and calls IsInMainChain() (now annotated
-// EXCLUSIVE_LOCKS_REQUIRED(cs_main)) from the P2P message-handler thread
-// without holding cs_main at the call sites. ProcessMessages (line 3034)
-// does not take cs_main at entry either. The Phase 4 net-layer pass will
-// systematically push the lock acquisition either into ProcessMessage at
-// the relevant branches or into ProcessMessages around the dispatch.
-// Suppressed during Phase 1 to keep the cascade focused on globals.
-bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived) NO_THREAD_SAFETY_ANALYSIS
+bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
 {
     LogPrint(BCLog::LogFlags::NOISY, "received: %s from %s (%" PRIszu " bytes)", strCommand, pfrom->addrName, vRecv.size());
 
@@ -2282,11 +2268,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         // Disconnect peers on old protocol versions after a grace period past the
         // BlockV14Height activation height. Skip entirely if that fork is not yet
         // activated (height == INT_MAX) to avoid signed integer overflow UB in the addition.
+        const int nLocalBestHeight = WITH_LOCK(cs_main, return pindexBest ? pindexBest->nHeight : 0);
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION
             || (DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD
                 && pfrom->nVersion < PROTOCOL_VERSION
                 && Params().GetConsensus().BlockV14Height != std::numeric_limits<int>::max()
-                && pindexBest->nHeight > Params().GetConsensus().BlockV14Height
+                && nLocalBestHeight > Params().GetConsensus().BlockV14Height
                                              + Params().GetConsensus().ProtocolVersionGracePeriod
                 )
             ) {
@@ -2400,13 +2387,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;
-        if (!pfrom->fClient && !pfrom->fOneShot &&
-            (pfrom->nStartingHeight > (nBestHeight - 144)) &&
-             (nAskedForBlocks < 1 || (vNodes.size() <= 1 && nAskedForBlocks < 1)))
         {
-            nAskedForBlocks++;
-            pfrom->PushGetBlocks(pindexBest, uint256());
-            LogPrint(BCLog::LogFlags::NET, "Asked For blocks.");
+            LOCK(cs_main);
+            if (!pfrom->fClient && !pfrom->fOneShot &&
+                (pfrom->nStartingHeight > (nBestHeight - 144)) &&
+                 (nAskedForBlocks < 1 || (vNodes.size() <= 1 && nAskedForBlocks < 1)))
+            {
+                nAskedForBlocks++;
+                pfrom->PushGetBlocks(pindexBest, uint256());
+                LogPrint(BCLog::LogFlags::NET, "Asked For blocks.");
+            }
         }
 
         // Relay alerts
@@ -2452,7 +2442,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         // Don't store the node address unless they have block height > 50%
-        if (pfrom->nStartingHeight < (nBestHeight*.5)) return true;
+        if (pfrom->nStartingHeight < (WITH_LOCK(cs_main, return nBestHeight) * .5)) return true;
 
         // Store the new addresses
         vector<CAddress> vAddrOk;
@@ -3357,7 +3347,15 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
             continue;
         }
 
-        bool fAlreadyHave = AlreadyHave(txdb, inv);
+        // cs_main is required for the AlreadyHave call (mapBlockIndex
+        // lookup) and must be released before the cs_mapManifest scope
+        // below to preserve the canonical cs_main -> subsystem order
+        // documented at the inv-handling site near main.cpp:2533.
+        bool fAlreadyHave;
+        {
+            LOCK(cs_main);
+            fAlreadyHave = AlreadyHave(txdb, inv);
+        }
 
         // Check also the scraper data propagation system to see if it needs
         // this inventory object:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2367,7 +2367,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         // Change version
         pfrom->PushMessage(NetMsgType::VERACK);
-        pfrom->ssSend.SetVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
+        {
+            LOCK(pfrom->cs_vSend);
+            pfrom->ssSend.SetVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
+        }
 
 
         if (!pfrom->fInbound)
@@ -2428,6 +2431,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     }
     else if (strCommand == NetMsgType::VERACK)
     {
+        LOCK(pfrom->cs_vRecvMsg);
         pfrom->SetRecvVersion(min(pfrom->nVersion, PROTOCOL_VERSION));
     }
     else if (strCommand == NetMsgType::GRIDADDR || strCommand == NetMsgType::ADDR)
@@ -3050,8 +3054,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     return true;
 }
 
-// requires LOCK(cs_vRecvMsg)
-bool ProcessMessages(CNode* pfrom)
+bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRecvMsg)
 {
     //
     // Message format
@@ -3066,7 +3069,7 @@ bool ProcessMessages(CNode* pfrom)
     std::deque<CNetMessage>::iterator it = pfrom->vRecvMsg.begin();
     while (!pfrom->fDisconnect && it != pfrom->vRecvMsg.end()) {
         // Don't bother if send buffer is too full to respond anyway
-        if (pfrom->nSendSize >= SendBufferSize())
+        if (WITH_LOCK(pfrom->cs_vSend, return pfrom->nSendSize) >= SendBufferSize())
             break;
 
         // get next message

--- a/src/main.h
+++ b/src/main.h
@@ -73,20 +73,20 @@ typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CCriticalSection cs_tx_val_commit_to_disk;
-extern BlockMap mapBlockIndex;
-extern CBlockIndex* pindexGenesisBlock;
+extern BlockMap mapBlockIndex GUARDED_BY(cs_main);
+extern CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main);
 extern unsigned int nStakeMinAge;
 extern unsigned int nStakeMaxAge;
 extern unsigned int nNodeLifespan;
 extern int nCoinbaseMaturity;
-extern int nBestHeight;
-extern arith_uint256 nBestChainTrust;
-extern uint256 hashBestChain;
-extern CBlockIndex* pindexBest;
+extern int nBestHeight GUARDED_BY(cs_main);
+extern arith_uint256 nBestChainTrust GUARDED_BY(cs_main);
+extern uint256 hashBestChain GUARDED_BY(cs_main);
+extern CBlockIndex* pindexBest GUARDED_BY(cs_main);
 extern std::atomic<bool> g_reorg_in_progress;
 extern const std::string strMessageMagic;
 extern CCriticalSection cs_setpwalletRegistered;
-extern std::set<CWallet*> setpwalletRegistered;
+extern std::set<CWallet*> setpwalletRegistered GUARDED_BY(cs_setpwalletRegistered);
 // Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
 // Settings
@@ -112,12 +112,15 @@ class CTxIndex;
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
-void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = nullptr, bool fUpdate = false, bool fConnect = true);
-void UpdatedTransaction(const uint256& hashTx);
+void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = nullptr, bool fUpdate = false, bool fConnect = true) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
+void UpdatedTransaction(const uint256& hashTx) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state);
 bool CheckDiskSpace(uint64_t nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);
+// Takes cs_main internally; callers MUST NOT hold cs_main when calling
+// (the internal LOCK would deadlock under non-recursive locking; cs_main
+// is currently recursive but the annotation contract documents the intent).
 bool LoadBlockIndex(bool fAllowNew=true);
 void PrintBlockTree();
 double CoinToDouble(double surrogate);
@@ -136,7 +139,7 @@ bool LoadExternalBlockFile(FILE* fileIn, size_t file_size = 0,
 //! mapBlockIndex purge happen separately via CTxDB::CleanAbandonedRange and
 //! PurgeOrphanedBlockIndexEntries below. Phase 2 of issue #2865; see src/node/coherence.cpp
 //! and doc/block_corruption_recovery_design.md.
-bool AbandonChainTo(class CBlockIndex* pindex_target, class CTxDB& txdb);
+bool AbandonChainTo(class CBlockIndex* pindex_target, class CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //! Purge the abandoned CBlockIndex entries from in-memory mapBlockIndex AND from on-disk
 //! LevelDB (CDiskBlockIndex records). Called by the Phase 2 abandonment path after
@@ -171,13 +174,13 @@ bool AbandonChainTo(class CBlockIndex* pindex_target, class CTxDB& txdb);
 void PurgeOrphanedBlockIndexEntries(class CTxDB& txdb, std::vector<class CBlockIndex*>& abandoned)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex);
+GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
-void ResendWalletTransactions(bool fForce = false);
+void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
 bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/
@@ -614,7 +617,7 @@ public:
 
     arith_uint256 GetBlockTrust() const;
 
-    bool IsInMainChain() const
+    bool IsInMainChain() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return (pnext || this == pindexBest);
     }
@@ -1077,7 +1080,7 @@ public:
         vHave.push_back((!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet));
     }
 
-    int GetDistanceBack()
+    int GetDistanceBack() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // Retrace how far back it was in the sender's branch
         int nDistance = 0;
@@ -1098,7 +1101,7 @@ public:
         return nDistance;
     }
 
-    CBlockIndex* GetBlockIndex()
+    CBlockIndex* GetBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // Find the first block the caller has in the main chain
         for (auto const& hash : vHave)
@@ -1114,7 +1117,7 @@ public:
         return pindexGenesisBlock;
     }
 
-    uint256 GetBlockHash()
+    uint256 GetBlockHash() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // Find the first block the caller has in the main chain
         for (auto const& hash : vHave)
@@ -1130,7 +1133,7 @@ public:
         return (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet);
     }
 
-    int GetHeight()
+    int GetHeight() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         CBlockIndex* pindex = GetBlockIndex();
         if (!pindex)

--- a/src/main.h
+++ b/src/main.h
@@ -125,7 +125,7 @@ bool LoadBlockIndex(bool fAllowNew=true);
 void PrintBlockTree();
 double CoinToDouble(double surrogate);
 
-bool ProcessMessages(CNode* pfrom);
+bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRecvMsg);
 bool SendMessages(CNode* pto, bool fSendTrickle);
 bool LoadExternalBlockFile(FILE* fileIn, size_t file_size = 0,
                            unsigned int percent_start = 0, unsigned int percent_end = 100);

--- a/src/main.h
+++ b/src/main.h
@@ -112,7 +112,7 @@ class CTxIndex;
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
-void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = nullptr, bool fUpdate = false, bool fConnect = true) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
+void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = nullptr, bool fUpdate = false, bool fConnect = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered);
 void UpdatedTransaction(const uint256& hashTx) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state);
 bool CheckDiskSpace(uint64_t nAdditionalBytes=0);
@@ -180,7 +180,7 @@ int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
-void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
+void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered);
 bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -839,9 +839,13 @@ bool CreateCoinStake(CBlock &blocknew, CMutableTransaction& txnew, CKey &key,
     return kernel_found;
 }
 
+// TODO(#2869 Phase 2 — miner): pindexBest read for BlockRewardRules needs
+// cs_main. Miner call paths hold it; test paths in
+// coinstake_construction_tests.cpp do not, so we can't annotate as required
+// without restructuring those tests.
 void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, int64_t &nReward,
     bool &fEnableStakeSplit, bool &fEnableSideStaking,
-    int64_t &nMinStakeSplitValue, double &dEfficiency)
+    int64_t &nMinStakeSplitValue, double &dEfficiency) NO_THREAD_SAFETY_ANALYSIS
 {
     // When this function is called, CreateCoinStake and CreateGridcoinReward have already been called
     // and there will be a single coinstake output (besides the empty one) that has the combined stake + research

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1263,7 +1263,7 @@ bool SignStakeBlock(CBlock &block, CKey &key,
     return true;
 }
 
-void AddSuperblockContractOrVote(CMutableTransaction& mtxCoinbase, int64_t nBlockTime)
+void AddSuperblockContractOrVote(CMutableTransaction& mtxCoinbase, int64_t nBlockTime) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (OutOfSyncByAge()) {
         LogPrintf("AddSuperblockContractOrVote: Out of sync.");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -839,13 +839,9 @@ bool CreateCoinStake(CBlock &blocknew, CMutableTransaction& txnew, CKey &key,
     return kernel_found;
 }
 
-// TODO(#2869 Phase 2 — miner): pindexBest read for BlockRewardRules needs
-// cs_main. Miner call paths hold it; test paths in
-// coinstake_construction_tests.cpp do not, so we can't annotate as required
-// without restructuring those tests.
 void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, int64_t &nReward,
     bool &fEnableStakeSplit, bool &fEnableSideStaking,
-    int64_t &nMinStakeSplitValue, double &dEfficiency) NO_THREAD_SAFETY_ANALYSIS
+    int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // When this function is called, CreateCoinStake and CreateGridcoinReward have already been called
     // and there will be a single coinstake output (besides the empty one) that has the combined stake + research

--- a/src/miner.h
+++ b/src/miner.h
@@ -26,7 +26,7 @@ static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 
 void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, int64_t &nReward,
                           bool &fEnableStakeSplit, bool &fEnableSideStaking,
-                          int64_t &nMinStakeSplitValue, double &dEfficiency);
+                          int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency);
 bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -61,7 +61,7 @@ bool fDiscover = true;
 bool fUseUPnP = false;
 ServiceFlags nLocalServices = NODE_NETWORK;
 CCriticalSection cs_mapLocalHost;
-std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
+std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(cs_mapLocalHost);
 static bool vfLimited[NET_MAX] GUARDED_BY(cs_mapLocalHost) = {};
 static CNode* pnodeLocalHost = nullptr;
 CAddress addrSeenByPeer(LookupNumeric("0.0.0.0", 0), nLocalServices);
@@ -80,19 +80,19 @@ std::atomic<NodeId> CNode::nLastNodeId {-1};
 
 vector<CNode*> vNodes;
 CCriticalSection cs_vNodes;
-vector<std::string> vAddedNodes;
 CCriticalSection cs_vAddedNodes;
+vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
 
 map<CInv, CDataStream> mapRelay;
 deque<pair<int64_t, CInv> > vRelayExpiration;
 CCriticalSection cs_mapRelay;
 map<CInv, int64_t> mapAlreadyAskedFor;
 
-static deque<string> vOneShots;
 CCriticalSection cs_vOneShots;
+static deque<string> vOneShots GUARDED_BY(cs_vOneShots);
 
-set<CNetAddr> setservAddNodeAddresses;
 CCriticalSection cs_setservAddNodeAddresses;
+set<CNetAddr> setservAddNodeAddresses GUARDED_BY(cs_setservAddNodeAddresses);
 
 std::map<CAddress, std::pair<int, int64_t>> CNode::mapMisbehavior;
 CCriticalSection CNode::cs_mapMisbehavior;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -481,7 +481,9 @@ bool CNode::DisconnectNode(NodeId id)
     return false;
 }
 
-void CNode::PushVersion()
+// TODO(#2869 Phase 4 — net): Reads nBestHeight from CNode constructor path
+// (no cs_main held). Net layer needs its own thread-safety review.
+void CNode::PushVersion() NO_THREAD_SAFETY_ANALYSIS
 {
     int64_t nTime = GetAdjustedTime();
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(LookupNumeric("0.0.0.0", 0)));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -481,16 +481,20 @@ bool CNode::DisconnectNode(NodeId id)
     return false;
 }
 
-// TODO(#2869 Phase 4 — net): Reads nBestHeight from CNode constructor path
-// (no cs_main held). Net layer needs its own thread-safety review.
-void CNode::PushVersion() NO_THREAD_SAFETY_ANALYSIS
+void CNode::PushVersion()
 {
     int64_t nTime = GetAdjustedTime();
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(LookupNumeric("0.0.0.0", 0)));
     CAddress addrMe = CAddress(CService(), nLocalServices);
     GetRandBytes({(unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce)});
+
+    // Snapshot the chain height under cs_main so this method can be called
+    // from CNode construction (socket handler thread, no outer locks held)
+    // and from ProcessMessage without imposing cs_main on the call site.
+    const int nLocalBestHeight = WITH_LOCK(cs_main, return nBestHeight);
+
     LogPrint(BCLog::LogFlags::NET, "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s",
-        PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), addr.ToString());
+        PROTOCOL_VERSION, nLocalBestHeight, addrMe.ToString(), addrYou.ToString(), addr.ToString());
 
     //TODO: change `PushMessage()` to use ServiceFlags so we don't need to cast nLocalServices
     PushMessage(
@@ -502,7 +506,7 @@ void CNode::PushVersion() NO_THREAD_SAFETY_ANALYSIS
         addrMe,
         nLocalHostNonce,
         FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
-        nBestHeight);
+        nLocalBestHeight);
 }
 
 bool CNode::Misbehaving(int howmuch)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -738,8 +738,7 @@ int CNetMessage::readData(const char *pch, unsigned int nBytes)
 
 
 
-// requires LOCK(cs_vSend)
-void SocketSendData(CNode *pnode)
+void SocketSendData(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend)
 {
     std::deque<SerializeData>::iterator it = pnode->vSendMsg.begin();
 
@@ -828,8 +827,18 @@ void ThreadSocketHandler2(void* parg)
             vector<CNode*> vNodesCopy = vNodes;
             for (auto const& pnode : vNodesCopy)
             {
-                if (pnode->fDisconnect ||
-                    (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0 && pnode->ssSend.empty()))
+                // vRecvMsg / nSendSize / ssSend are guarded by per-node locks.
+                // Take them in canonical order (cs_vRecvMsg first, then cs_vSend)
+                // for the disconnect-eligibility check. Lazy: only if refcount
+                // has dropped to zero, since the test short-circuits otherwise.
+                bool empty_buffers = false;
+                if (pnode->GetRefCount() <= 0) {
+                    LOCK2(pnode->cs_vRecvMsg, pnode->cs_vSend);
+                    empty_buffers = pnode->vRecvMsg.empty()
+                                    && pnode->nSendSize == 0
+                                    && pnode->ssSend.empty();
+                }
+                if (pnode->fDisconnect || empty_buffers)
                 {
                     // remove from vNodes
                     vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());

--- a/src/net.h
+++ b/src/net.h
@@ -49,6 +49,8 @@ unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));
 void StartNode(void* parg);
 bool StopNode();
+// Declared below CNode (the EXCLUSIVE_LOCKS_REQUIRED annotation references
+// pnode->cs_vSend and needs the complete CNode type).
 void SocketSendData(CNode *pnode);
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;
@@ -189,17 +191,17 @@ public:
     // socket
     uint64_t nServices;
     SOCKET hSocket;
-    CDataStream ssSend;
-    size_t nSendSize; // total size of all vSendMsg entries
-    size_t nSendOffset; // offset inside the first vSendMsg already sent
-    std::atomic<uint64_t> nSendBytes {0};
-    std::deque<SerializeData> vSendMsg;
     CCriticalSection cs_vSend;
+    CDataStream ssSend GUARDED_BY(cs_vSend);
+    size_t nSendSize GUARDED_BY(cs_vSend); // total size of all vSendMsg entries
+    size_t nSendOffset GUARDED_BY(cs_vSend); // offset inside the first vSendMsg already sent
+    std::atomic<uint64_t> nSendBytes {0};
+    std::deque<SerializeData> vSendMsg GUARDED_BY(cs_vSend);
 
-    std::deque<CNetMessage> vRecvMsg;
     CCriticalSection cs_vRecvMsg;
+    std::deque<CNetMessage> vRecvMsg GUARDED_BY(cs_vRecvMsg);
     std::atomic<uint64_t> nRecvBytes {0};
-    int nRecvVersion;
+    int nRecvVersion GUARDED_BY(cs_vRecvMsg);
 
     int64_t nLastSend;
     int64_t nLastRecv;
@@ -233,8 +235,8 @@ protected:
 
     // Denial-of-service detection/prevention
     // ---------- address:port -- misbehavior - time
-    static std::map<CAddress, std::pair<int, int64_t>> mapMisbehavior;
     static CCriticalSection cs_mapMisbehavior;
+    static std::map<CAddress, std::pair<int, int64_t>> mapMisbehavior GUARDED_BY(cs_mapMisbehavior);
     // See protected GetMisbehavior() below.
     // int nMisbehavior;
 
@@ -252,9 +254,9 @@ public:
     uint256 hashCheckpointKnown; // ppcoin: known sent sync-checkpoint
 
     // inventory based relay
-    mruset<CInv> setInventoryKnown;
-    std::vector<CInv> vInventoryToSend;
     CCriticalSection cs_inventory;
+    mruset<CInv> setInventoryKnown GUARDED_BY(cs_inventory);
+    std::vector<CInv> vInventoryToSend GUARDED_BY(cs_inventory);
     std::multimap<int64_t, CInv> mapAskFor;
 
     // Ping time measurement:
@@ -352,8 +354,7 @@ public:
         return nRefCount;
     }
 
-    // requires LOCK(cs_vRecvMsg)
-    unsigned int GetTotalRecvSize()
+    unsigned int GetTotalRecvSize() EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)
     {
         unsigned int total = 0;
         for (auto const& msg : vRecvMsg)
@@ -361,11 +362,9 @@ public:
         return total;
     }
 
-    // requires LOCK(cs_vRecvMsg)
-    bool ReceiveMsgBytes(const char *pch, unsigned int nBytes);
+    bool ReceiveMsgBytes(const char *pch, unsigned int nBytes) EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg);
 
-    // requires LOCK(cs_vRecvMsg)
-    void SetRecvVersion(int nVersionIn)
+    void SetRecvVersion(int nVersionIn) EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)
     {
         nRecvVersion = nVersionIn;
         for (auto &msg : vRecvMsg)
@@ -438,23 +437,20 @@ public:
         mapAskFor.insert(std::make_pair(nRequestTime, inv));
     }
 
-    // A lock on cs_vSend must be taken before calling this function
-    void BeginMessage(const char* pszCommand)
+    void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
     {
         assert(ssSend.size() == 0);
         ssSend << CMessageHeader(pszCommand, 0);
     }
 
-    // A lock on cs_vSend must be taken before calling this function
-    void AbortMessage()
+    void AbortMessage() EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
     {
         ssSend.clear();
 
         LogPrint(BCLog::LogFlags::NOISY, "(aborted)");
     }
 
-    // A lock on cs_vSend must be taken before calling this function
-    void EndMessage()
+    void EndMessage() EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
     {
         if (ssSend.size() == 0)
             return;
@@ -485,13 +481,13 @@ public:
     void PushVersion();
 
     template<typename T>
-    void PushFields(T field)
+    void PushFields(T field) EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
     {
         ssSend << field;
     }
 
     template<typename T, typename... Tfields>
-    void PushFields(T field, Tfields... fields)
+    void PushFields(T field, Tfields... fields) EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
     {
         ssSend << field;
         PushFields(fields...);
@@ -596,6 +592,10 @@ public:
     friend class BanMan;
 
 };
+
+// Re-declared here (was forward-declared above CNode) so the
+// EXCLUSIVE_LOCKS_REQUIRED lock-expression can reference pnode->cs_vSend.
+void SocketSendData(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend);
 
 inline void RelayInventory(const CInv& inv)
 {

--- a/src/net.h
+++ b/src/net.h
@@ -61,7 +61,7 @@ struct LocalServiceInfo {
 };
 
 extern CCriticalSection cs_mapLocalHost;
-extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
+extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(cs_mapLocalHost);
 
 enum
 {
@@ -110,8 +110,8 @@ extern std::map<CInv, int64_t> mapAlreadyAskedFor;
 extern ThreadHandler* netThreads;
 
 
-extern std::vector<std::string> vAddedNodes;
 extern CCriticalSection cs_vAddedNodes;
+extern std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
 
 
 class CNodeStats

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -29,7 +29,9 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
     return whichType != TX_NONSTANDARD;
 }
 
-bool IsStandardTx(const CTransaction& tx)
+// TODO(#2869 Phase 2 — policy): nBestHeight reads need cs_main. Production
+// caller AcceptToMemoryPool holds it; tests in script_p2sh_tests.cpp do not.
+bool IsStandardTx(const CTransaction& tx) NO_THREAD_SAFETY_ANALYSIS
 {
     std::string reason = "";
     if (tx.nVersion > CTransaction::CURRENT_VERSION)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -29,9 +29,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
     return whichType != TX_NONSTANDARD;
 }
 
-// TODO(#2869 Phase 2 — policy): nBestHeight reads need cs_main. Production
-// caller AcceptToMemoryPool holds it; tests in script_p2sh_tests.cpp do not.
-bool IsStandardTx(const CTransaction& tx) NO_THREAD_SAFETY_ANALYSIS
+bool IsStandardTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     std::string reason = "";
     if (tx.nVersion > CTransaction::CURRENT_VERSION)

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -43,7 +43,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 /** Check for standard transaction types
     @return True if all outputs (scriptPubKeys) use only standard transaction forms
 */
-bool IsStandardTx(const CTransaction& tx);
+bool IsStandardTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Check for standard transaction types
     @param[in] tx   Transaction to check

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -803,6 +803,7 @@ BeaconStatus ResearcherModel::advertiseBeacon()
 
 bool ResearcherModel::isV14Enabled() const
 {
+    LOCK(cs_main);
     return IsV14Enabled(nBestHeight);
 }
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -853,6 +853,8 @@ QString ResearcherModel::generateBeaconKeyForV3()
         return QString();
     }
 
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     AdvertiseBeaconResult result = GenerateBeaconKey(*cpid);
 
     if (auto public_key = result.TryPublicKey()) {
@@ -900,6 +902,8 @@ BeaconStatus ResearcherModel::advertiseBeaconV3(const QString& ownership_proof_x
     if (!beacon_pubkey.IsValid()) {
         return BeaconStatus::ERROR_INVALID_PROOF_XML;
     }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     if (!pwalletMain->HaveKey(beacon_pubkey.GetID())) {
         return BeaconStatus::ERROR_MISSING_KEY;

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -674,7 +674,10 @@ std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
 
 void ResearcherModel::reload()
 {
-    Researcher::Reload();
+    {
+        LOCK(cs_main);
+        Researcher::Reload();
+    }
     resetResearcher(Researcher::Get());
 }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -19,7 +19,7 @@
 #include <QMessageBox>
 #include <string>
 
-std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const CMerkleTx& mtx);
+std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const CMerkleTx& mtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 std::vector<std::pair<std::string, std::string>> GetTxNormalBoincHashInfo(const CMerkleTx& mtx);
 
 QString ToQString(std::string s)

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -310,7 +310,10 @@ void PollWizardDetailsPage::initializePage()
 
         // Only populate poll additional field entries if version >= 3.
         bool v3_enabled = false;
-        v3_enabled = IsPollV3Enabled(nBestHeight);
+        {
+            LOCK(cs_main);
+            v3_enabled = IsPollV3Enabled(nBestHeight);
+        }
 
         if (v3_enabled) {
             poll_item.m_additional_field_entries.push_back(

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -465,8 +465,14 @@ VotingResult VotingModel::sendPoll(
     PollBuilder builder = PollBuilder();
 
     try {
-        builder = builder
-            .SetPayloadVersion(payload_version)
+        {
+            // SetPayloadVersion reads nBestHeight; the other setters do not.
+            // Scope cs_main tightly to just that call.
+            LOCK(cs_main);
+            builder = std::move(builder).SetPayloadVersion(payload_version);
+        }
+
+        builder = std::move(builder)
             .SetType(type_by_poll_payload_version)
             .SetTitle(title.toStdString())
             .SetDuration(duration_days)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1196,6 +1196,10 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
     //------- CPID -------------- beacon address -- Mag --- payment - suppressed
     std::map<GRC::Cpid, std::tuple<CTxDestination, double, CAmount, bool>> mCPIDRain;
 
+    // BeaconRegistry::TryActive needs cs_main; held across the iteration
+    // since each loop body does a TryActive lookup.
+    LOCK(cs_main);
+
     for (const auto& entry : mScraperConvergedStats)
     {
         // Only consider entries along the specified dimension
@@ -1324,7 +1328,8 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_MISC_ERROR, "No payments above 0.01 GRC qualify. Please recheck your specified amount.");
     }
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    // cs_main is already held from the beacon-lookup loop above; just take cs_wallet here.
+    LOCK(pwalletMain->cs_wallet);
 
     CWalletTx wtx;
     wtx.mapValue["comment"] = "Rain By Magnitude";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -27,17 +27,17 @@ using namespace std;
 
 bool AskForOutstandingBlocks(uint256 hashStart);
 bool ForceReorganizeToHash(uint256 NewHash);
-extern UniValue MagnitudeReport(const GRC::Cpid cpid);
-extern UniValue SuperblockReport(int lookback = 14, bool displaycontract = false, std::string cpid = "");
+extern UniValue MagnitudeReport(const GRC::Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+extern UniValue SuperblockReport(int lookback = 14, bool displaycontract = false, std::string cpid = "") EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 extern GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false,
                                                     bool bContractDirectFromStatsUpdate = false,
                                                     bool bFromHousekeeping = false);
 extern ScraperPendingBeaconMap GetPendingBeaconsForReport();
 extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
-extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version);
+extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 arith_uint256 GetChainTrust(const CBlockIndex* pindex);
 double CoinToDouble(double surrogate);
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 UniValue ContractToJson(const GRC::Contract& contract);
 
 UniValue MRCToJson(const GRC::MRC& mrc) {
@@ -186,7 +186,7 @@ UniValue SuperblockToJson(const GRC::SuperblockPtr& superblock)
     return SuperblockToJson(*superblock);
 }
 
-UniValue blockToJSON(const CBlock& block, CBlockIndex* blockindex, bool fPrintTransactionDetail)
+UniValue blockToJSON(const CBlock& block, CBlockIndex* blockindex, bool fPrintTransactionDetail) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     UniValue result(UniValue::VOBJ);
 
@@ -781,10 +781,11 @@ UniValue showblock(const UniValue& params, bool fHelp)
                 "Returns all information about the block at <index>\n");
 
     int nHeight = params[0].get_int();
-    if (nHeight < 0 || nHeight > nBestHeight)
-        throw runtime_error("Block number out of range\n");
 
     LOCK(cs_main);
+
+    if (nHeight < 0 || nHeight > nBestHeight)
+        throw runtime_error("Block number out of range\n");
 
     CBlockIndex* pblockindex = GRC::BlockFinder::FindByHeight(nHeight);
 
@@ -895,12 +896,13 @@ UniValue getblockhash(const UniValue& params, bool fHelp)
                 "Returns hash of block in best-block-chain at <index>\n");
 
     int nHeight = params[0].get_int();
+
+    LOCK(cs_main);
+
     if (nHeight < 0 || nHeight > nBestHeight)
         throw runtime_error("Block number out of range.");
 
     LogPrint(BCLog::LogFlags::NOISY, "Getblockhash %d", nHeight);
-
-    LOCK(cs_main);
 
     CBlockIndex* RPCpblockindex = GRC::BlockFinder::FindByHeight(nHeight);
 
@@ -920,10 +922,10 @@ UniValue getblock(const UniValue& params, bool fHelp)
     std::string strHash = params[0].get_str();
     uint256 hash = uint256S(strHash);
 
+    LOCK(cs_main);
+
     if (mapBlockIndex.count(hash) == 0)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-
-    LOCK(cs_main);
 
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hash];
@@ -943,10 +945,11 @@ UniValue getblockbynumber(const UniValue& params, bool fHelp)
                 "Returns details of a block with given block-number\n");
 
     int nHeight = params[0].get_int();
-    if (nHeight < 0 || nHeight > nBestHeight)
-        throw runtime_error("Block number out of range");
 
     LOCK(cs_main);
+
+    if (nHeight < 0 || nHeight > nBestHeight)
+        throw runtime_error("Block number out of range");
 
     CBlock block;
 
@@ -968,10 +971,10 @@ UniValue getblockbymintime(const UniValue& params, bool fHelp)
 
     int64_t nTimestamp = params[0].get_int64();
 
+    LOCK(cs_main);
+
     if (nTimestamp < pindexGenesisBlock->nTime || nTimestamp > pindexBest->nTime)
         throw runtime_error("Timestamp out of range. Cannot be below the time of the genesis block or above the time of the latest block");
-
-    LOCK(cs_main);
 
     CBlock block;
 
@@ -1032,6 +1035,12 @@ UniValue getblocksbatch(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Either a valid block number or block hash must be provided.");
     }
 
+    // cs_main is needed for the block-validity checks below (nBestHeight /
+    // mapBlockIndex) AND for the chain walk further down. Take it once here
+    // to preserve the original error-message order (block-validity error
+    // surfaces before batch-size error).
+    LOCK(cs_main);
+
     if (!block_hash_provided)
     {
         if (nHeight < 0 || nHeight > nBestHeight)
@@ -1055,8 +1064,6 @@ UniValue getblocksbatch(const UniValue& params, bool fHelp)
 
     bool transaction_details = false;
     if (params.size() > 2) transaction_details = params[2].get_bool();
-
-    LOCK(cs_main);
 
     g_timer.GetTimes("Finished validating parameters", __func__);
 
@@ -2052,6 +2059,8 @@ UniValue beaconaudit(const UniValue& params, bool fHelp)
     if (!global && !cpid) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "No beacon for non-cruncher.");
     }
+
+    LOCK(cs_main);
 
     // Only allow auditing when at or above block V11 threshold.
     if (!IsV11Enabled(pindexBest->nHeight)) {
@@ -3525,6 +3534,7 @@ UniValue networktime(const UniValue& params, bool fHelp)
 }
 
 UniValue SuperblockReport(int lookback, bool displaycontract, std::string cpid)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     UniValue results(UniValue::VARR);
 
@@ -3580,7 +3590,7 @@ UniValue SuperblockReport(int lookback, bool displaycontract, std::string cpid)
     return results;
 }
 
-UniValue MagnitudeReport(const GRC::Cpid cpid)
+UniValue MagnitudeReport(const GRC::Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     UniValue json(UniValue::VOBJ);
 
@@ -3623,6 +3633,7 @@ UniValue MagnitudeReport(const GRC::Cpid cpid)
 }
 
 UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const int64_t min_height = std::max<int64_t>(nBestHeight - lookback, 0);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2909,7 +2909,14 @@ UniValue addkey(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Not an admin contract type.");
     }
 
-    std::pair<CWalletTx, std::string> result = GRC::SendContract(contract);
+    std::pair<CWalletTx, std::string> result;
+    {
+        // GRC::SendContract is EXCLUSIVE_LOCKS_REQUIRED(cs_main) (Phase 2).
+        // Scope kept narrow to avoid blocking other RPCs across the wider
+        // construction work above.
+        LOCK(cs_main);
+        result = GRC::SendContract(contract);
+    }
     std::string error = result.second;
 
     if (!error.empty()) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -61,7 +61,7 @@ UniValue MRCToJson(const GRC::MRC& mrc) {
     return json;
 }
 
-UniValue ClaimToJson(const GRC::Claim& claim, CBlockIndex* pindex)
+UniValue ClaimToJson(const GRC::Claim& claim, CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     UniValue json(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -42,7 +42,7 @@ class MockBlockIndex : CDiskBlockIndex
     };
 
 public:
-    static CBlockIndex* InsertBlockIndex(const uint256& hash)
+    static CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (hash.IsNull())
             return nullptr;

--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -138,7 +138,12 @@ UniValue claimhtlc(const UniValue& params, bool fHelp)
             "4. destination_addr  (string, required) Address to send claimed funds to\n"
             + HelpRequiringPassphrase());
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    // Canonical order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
+    // The wallet-registry lock is needed for the SyncWithWallets dispatch
+    // after AcceptToMemoryPool below.
+    LOCK(cs_main);
+    LOCK(cs_setpwalletRegistered);
+    LOCK(pwalletMain->cs_wallet);
     EnsureWalletIsUnlocked();
 
     // Parse txid
@@ -272,7 +277,12 @@ UniValue refundhtlc(const UniValue& params, bool fHelp)
             "3. destination_addr  (string, required) Address to send refunded funds to\n"
             + HelpRequiringPassphrase());
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    // Canonical order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
+    // The wallet-registry lock is needed for the SyncWithWallets dispatch
+    // after AcceptToMemoryPool below.
+    LOCK(cs_main);
+    LOCK(cs_setpwalletRegistered);
+    LOCK(pwalletMain->cs_wallet);
     EnsureWalletIsUnlocked();
 
     // Parse txid

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -45,6 +45,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     double nCurrentDiff = 0;
     double nTargetDiff = 0;
     uint64_t nExpectedTime = 0;
+    int best_height = 0;
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
         nWeight = GRC::GetStakeWeight(*pwalletMain);
@@ -52,9 +53,10 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
         nCurrentDiff = GRC::GetCurrentDifficulty();
         nTargetDiff = GRC::GetTargetDifficulty();
         nExpectedTime = GRC::GetEstimatedTimetoStake();
+        best_height = nBestHeight;
     }
 
-    obj.pushKV("blocks", nBestHeight);
+    obj.pushKV("blocks", best_height);
     diff.pushKV("current", nCurrentDiff);
     diff.pushKV("target", nTargetDiff);
 
@@ -253,14 +255,14 @@ UniValue auditsnapshotaccrual(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "No data for non-cruncher.");
     }
 
-    if (!pindexBest) {
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Invalid chain.");
-    }
-
     UniValue result(UniValue::VOBJ);
     UniValue audit(UniValue::VARR);
 
     LOCK(cs_main);
+
+    if (!pindexBest) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Invalid chain.");
+    }
 
     if (!IsV11Enabled(nBestHeight + 1)) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "Wait for block v11 protocol");
@@ -658,6 +660,8 @@ UniValue listresearcheraccounts(const UniValue& params, bool fHelp)
     UniValue entries(UniValue::VARR);
 
     const int64_t now = GetAdjustedTime();
+
+    LOCK(cs_main);
 
     for (const auto& iter : GRC::Tally::Accounts())
     {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -17,8 +17,8 @@
 
 using namespace std;
 
-extern std::map<uint256, CAlert> mapAlerts;
 extern CCriticalSection cs_mapAlerts;
+extern std::map<uint256, CAlert> mapAlerts GUARDED_BY(cs_mapAlerts);
 
 UniValue getconnectioncount(const UniValue& params, bool fHelp)
 {

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -26,6 +26,7 @@ extern CWallet* pwalletMain;
 static void AddHDKeypathIfAvailable(const CWallet& wallet,
                                      const CPubKey& pubkey,
                                      std::map<CPubKey, KeyOriginInfo>& hd_keypaths)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     CKeyID keyid = pubkey.GetID();
     auto it = wallet.mapKeyMetadata.find(keyid);
@@ -52,6 +53,7 @@ static void AddHDKeypathIfAvailable(const CWallet& wallet,
 static void FillHDKeypaths(const CWallet& wallet,
                             const CScript& scriptPubKey,
                             std::map<CPubKey, KeyOriginInfo>& hd_keypaths)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
     std::vector<CKeyID> vKeys;
     ExtractAffectedKeys(wallet, scriptPubKey, vKeys);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -42,6 +42,7 @@ using namespace std;
 UniValue MRCToJson(const GRC::MRC& mrc);
 
 std::vector<std::pair<std::string, std::string>> GetTxStakeBoincHashInfo(const CMerkleTx& mtx)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!(mtx.IsCoinStake() || mtx.IsCoinBase())) {
         throw runtime_error("GetTxStakeBoincHashInfo: transaction is not a coinstake or coinbase");
@@ -323,7 +324,7 @@ UniValue ContractToJson(const GRC::Contract& contract)
     return out;
 }
 
-void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
+void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("version", tx.nVersion);
@@ -991,11 +992,14 @@ UniValue consolidatemsunspent(const UniValue& params, bool fHelp)
         nMaxInputs = params[4].get_int();
 
     // Parameter Sanity Check
-    if (nBlockStart < 1 || nBlockStart > nBestHeight || nBlockStart > nBlockEnd)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-start");
+    {
+        LOCK(cs_main);
+        if (nBlockStart < 1 || nBlockStart > nBestHeight || nBlockStart > nBlockEnd)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-start");
 
-    if (nBlockEnd < 1 || nBlockEnd > nBestHeight || nBlockEnd <= nBlockStart)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-end");
+        if (nBlockEnd < 1 || nBlockEnd > nBestHeight || nBlockEnd <= nBlockStart)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-end");
+    }
 
     if (nMaxValue < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Value must not be less than 0");
@@ -1285,11 +1289,14 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
     }
 
     // Parameter Sanity Check
-    if (nBlockStart < 1 || nBlockStart > nBestHeight || nBlockStart > nBlockEnd)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-start");
+    {
+        LOCK(cs_main);
+        if (nBlockStart < 1 || nBlockStart > nBestHeight || nBlockStart > nBlockEnd)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-start");
 
-    if (nBlockEnd < 1 || nBlockEnd > nBestHeight || nBlockEnd <= nBlockStart)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-end");
+        if (nBlockEnd < 1 || nBlockEnd > nBestHeight || nBlockEnd <= nBlockStart)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block-end");
+    }
 
     CTxDestination Address = DecodeDestination(sAddress);
 
@@ -2103,7 +2110,13 @@ UniValue sendrawtransaction(const UniValue& params, bool fHelp)
 
     RPCTypeCheck(params, { UniValue::VSTR });
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    // Canonical lock order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
+    // Acquired as sequenced LOCKs (rather than a LOCK2 + nested LOCK) so the
+    // analyzer sees the order at acquisition time. The wallet registry lock
+    // is needed for the SyncWithWallets dispatch below.
+    LOCK(cs_main);
+    LOCK(cs_setpwalletRegistered);
+    LOCK(pwalletMain->cs_wallet);
 
     // parse hex string from parameter
     vector<unsigned char> txData(ParseHex(params[0].get_str()));

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -496,8 +496,17 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
     EnsureWalletIsUnlocked();
 
-    PollBuilder builder = PollBuilder()
-        .SetPayloadVersion(payload_version)
+    PollBuilder builder;
+    {
+        // PollBuilder::SetPayloadVersion reads nBestHeight to validate the
+        // version against the current block-version gate. Hold cs_main only
+        // for that call; keep the remaining (non-chain-touching) chained
+        // setters outside to bound contention.
+        LOCK(cs_main);
+        builder = PollBuilder().SetPayloadVersion(payload_version);
+    }
+
+    builder = std::move(builder)
         .SetType(poll_type)
         .SetTitle(params[1].get_str())
         .SetDuration(params[2].get_int())

--- a/src/sync.h
+++ b/src/sync.h
@@ -57,7 +57,7 @@ std::string LocksHeld();
 template <typename MutexType>
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(cs);
 template <typename MutexType>
-void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(!(*cs));
 void DeleteLock(void* cs);
 bool LockStackEmpty();
 
@@ -75,7 +75,7 @@ inline void CheckLastCritical(void* cs, std::string& lockname, const char* guard
 template <typename MutexType>
 inline void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(cs) {}
 template <typename MutexType>
-void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(!cs) {}
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(!(*cs)) {}
 inline void DeleteLock(void* cs) {}
 inline bool LockStackEmpty() { return true; }
 #endif

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 
     wtx.mapValue["comment"] = "z";
 
-    LOCK(pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     pwalletMain->AddToWallet(wtx, &walletdb);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);

--- a/src/test/coinstake_construction_tests.cpp
+++ b/src/test/coinstake_construction_tests.cpp
@@ -307,6 +307,8 @@ BOOST_AUTO_TEST_CASE(split_coinstake_distributes_reward)
     int64_t nMinStakeSplitValue = 800;
     double dEfficiency = 98.0;
 
+    LOCK(cs_main);
+
     SplitCoinStakeOutput(coinstake, block, nReward, fEnableStakeSplit, fEnableSideStaking,
                          nMinStakeSplitValue, dEfficiency);
 
@@ -351,6 +353,8 @@ BOOST_AUTO_TEST_CASE(sidestake_outputs_placed)
     bool fEnableSideStaking = true;
     int64_t nMinStakeSplitValue = 800;
     double dEfficiency = 98.0;
+
+    LOCK(cs_main);
 
     SplitCoinStakeOutput(coinstake, block, nReward, fEnableStakeSplit, fEnableSideStaking,
                          nMinStakeSplitValue, dEfficiency);

--- a/src/test/gridcoin/beacon_tests.cpp
+++ b/src/test/gridcoin/beacon_tests.cpp
@@ -1002,6 +1002,16 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(BeaconPayload)
 
+// BeaconRegistry methods (Reset, Add, ActivatePending, Delete, Try,
+// FindPending, FindHistorical, Deactivate) are EXCLUSIVE_LOCKS_REQUIRED(cs_main).
+// These tests directly mutate the registry without acquiring cs_main (the
+// test fixtures are single-threaded). Suppress thread-safety warnings for
+// the test suite rather than wrapping every call.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+
 BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_invalid_payload)
 {
     const GRC::BeaconPayload payload;
@@ -1824,5 +1834,9 @@ BOOST_AUTO_TEST_CASE(beacon_registry_GetBeaconChainletRoot_test_2)
         BOOST_CHECK_EQUAL(circular_corruption_detected, true);
     }
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/block_finder_tests.cpp
+++ b/src/test/gridcoin/block_finder_tests.cpp
@@ -14,8 +14,10 @@
 // below). BlockFinder::* are EXCLUSIVE_LOCKS_REQUIRED(cs_main) under
 // Phase 2 of issue #2869; suppress the analyzer for this file rather than
 // take a lock the tests do not need.
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 
 namespace
 {
@@ -93,4 +95,6 @@ BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnLastBlockIfOlderThanTime)
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif

--- a/src/test/gridcoin/block_finder_tests.cpp
+++ b/src/test/gridcoin/block_finder_tests.cpp
@@ -9,6 +9,14 @@
 #include <array>
 #include <cstdint>
 
+// Tests run single-threaded and directly manipulate the chain-state globals
+// pindexBest / pindexGenesisBlock / nBestHeight (see BlockChain fixture
+// below). BlockFinder::* are EXCLUSIVE_LOCKS_REQUIRED(cs_main) under
+// Phase 2 of issue #2869; suppress the analyzer for this file rather than
+// take a lock the tests do not need.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+
 namespace
 {
     template<size_t Size>
@@ -84,3 +92,5 @@ BOOST_AUTO_TEST_CASE(FindBlockByTimeShouldReturnLastBlockIfOlderThanTime)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#pragma clang diagnostic pop

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -118,10 +118,18 @@ BOOST_AUTO_TEST_CASE(it_properly_records_blocks)
     pindex->pprev->pprev->pprev->pprev->AddMRCResearcherContext(cpid, 72, 0.0);
     pindex->pprev->pprev->pprev->pprev->pprev->pprev->SetResearcherContext(cpid, 72, 0.0);
 
-    CBlockIndex* index{pindexGenesisBlock};
-    while (index) {
-        GRC::Tally::RecordRewardBlock(index);
-        index = index->pnext;
+    {
+        // Test runs single-threaded; pindexGenesisBlock is a Setup-fixture-
+        // owned pointer, not the production global. Suppress the analyzer
+        // warning rather than introducing a cs_main lock the test doesn't need.
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+        CBlockIndex* index{pindexGenesisBlock};
+        while (index) {
+            GRC::Tally::RecordRewardBlock(index);
+            index = index->pnext;
+        }
+        #pragma clang diagnostic pop
     }
 
     BOOST_CHECK(account.m_last_block_ptr == pindex->pprev);

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -122,14 +122,18 @@ BOOST_AUTO_TEST_CASE(it_properly_records_blocks)
         // Test runs single-threaded; pindexGenesisBlock is a Setup-fixture-
         // owned pointer, not the production global. Suppress the analyzer
         // warning rather than introducing a cs_main lock the test doesn't need.
+        #if defined(__clang__)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+        #endif
         CBlockIndex* index{pindexGenesisBlock};
         while (index) {
             GRC::Tally::RecordRewardBlock(index);
             index = index->pnext;
         }
+        #if defined(__clang__)
         #pragma clang diagnostic pop
+        #endif
     }
 
     BOOST_CHECK(account.m_last_block_ptr == pindex->pprev);

--- a/src/test/gridcoin/mrc_tests.cpp
+++ b/src/test/gridcoin/mrc_tests.cpp
@@ -151,6 +151,8 @@ BOOST_AUTO_TEST_CASE(it_has_proper_fees_for_newbies)
     mrc.m_mining_id = cpid;
     mrc.m_research_subsidy = 72;
 
+    LOCK(cs_main);
+
     // Before:
     mrc.m_last_block_hash = pindex->pprev->pprev->GetBlockHash();
     BOOST_CHECK_EQUAL(mrc.ComputeMRCFee(), mrc.m_research_subsidy);

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -68,7 +68,7 @@ int64_t nBeaconCount = 0;
 //!
 //! \param cpid External CPID used in the test.
 //!
-void AddTestBeacon(const GRC::Cpid cpid)
+void AddTestBeacon(const GRC::Cpid cpid) NO_THREAD_SAFETY_ANALYSIS
 {
     // TODO: mock the beacon registry
     CPubKey public_key = CPubKey(ParseHex(
@@ -98,7 +98,7 @@ void AddTestBeacon(const GRC::Cpid cpid)
 //!
 //! \param cpid External CPID used in the test.
 //!
-void AddExpiredTestBeacon(const GRC::Cpid cpid)
+void AddExpiredTestBeacon(const GRC::Cpid cpid) NO_THREAD_SAFETY_ANALYSIS
 {
     // TODO: mock the beacon registry
     CPubKey public_key = CPubKey(ParseHex(
@@ -126,7 +126,7 @@ void AddExpiredTestBeacon(const GRC::Cpid cpid)
 //!
 //! \param cpid External CPID used in the test.
 //!
-void RemoveTestBeacon(const GRC::Cpid cpid)
+void RemoveTestBeacon(const GRC::Cpid cpid) NO_THREAD_SAFETY_ANALYSIS
 {
     // TODO: mock the beacon registry
     CPubKey public_key = CPubKey(ParseHex(
@@ -513,7 +513,15 @@ BOOST_AUTO_TEST_CASE(it_parses_a_set_of_project_xml_sections)
 
     // Clean up:
     gArgs.ForceSetArg("email", "");
+    // Reload requires cs_main but the test fixture is single-threaded.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     GRC::Researcher::Reload(GRC::MiningProjectMap());
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(it_skips_loading_project_xml_with_empty_project_names)
@@ -708,6 +716,14 @@ BOOST_AUTO_TEST_SUITE_END()
 // -----------------------------------------------------------------------------
 
 BOOST_AUTO_TEST_SUITE(Researcher)
+
+// Researcher::Reload/Refresh are EXCLUSIVE_LOCKS_REQUIRED(cs_main). Tests
+// invoke them directly on the single-threaded test fixture without acquiring
+// cs_main. Suppress thread-safety warnings for the suite.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 
 BOOST_AUTO_TEST_CASE(it_initializes_to_an_noncruncher)
 {
@@ -1829,5 +1845,9 @@ BOOST_AUTO_TEST_CASE(it_allows_pool_operators_to_load_pool_cpids)
     gArgs.ForceSetArg("pooloperator", "0");
     GRC::Researcher::Reload(GRC::MiningProjectMap());
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -751,6 +751,11 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
     }
 }
 
+// Tests run single-threaded and manipulate the chain-state globals directly
+// (pindexBest / pindexGenesisBlock / nBestHeight) without taking cs_main.
+// Pragma-suppress thread-safety in this case for the duration of the test.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
 {
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
@@ -830,6 +835,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
     delete pindexBest;
     delete pindexGenesisBlock;
 }
+#pragma clang diagnostic pop
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
 {
@@ -892,6 +898,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
     }
 }
 
+// Same single-threaded-test rationale as the v3 test above.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence_v3)
 {
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
@@ -986,6 +995,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
     delete pindexBest;
     delete pindexGenesisBlock;
 }
+#pragma clang diagnostic pop
 
 BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_binary_contract)
 {

--- a/src/test/gridcoin/superblock_tests.cpp
+++ b/src/test/gridcoin/superblock_tests.cpp
@@ -754,8 +754,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence)
 // Tests run single-threaded and manipulate the chain-state globals directly
 // (pindexBest / pindexGenesisBlock / nBestHeight) without taking cs_main.
 // Pragma-suppress thread-safety in this case for the duration of the test.
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
 {
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
@@ -835,7 +837,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergence_v3)
     delete pindexBest;
     delete pindexGenesisBlock;
 }
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence)
 {
@@ -899,8 +903,10 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
 }
 
 // Same single-threaded-test rationale as the v3 test above.
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergence_v3)
 {
     // This needs to be initialized, because the below FromConvergence call uses the AutoGreylist class, which in turn
@@ -995,7 +1001,9 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergen
     delete pindexBest;
     delete pindexGenesisBlock;
 }
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_binary_contract)
 {

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -296,7 +296,11 @@ std::optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) co
     return std::nullopt;
 }
 
-const fs::path& ArgsManager::GetBlocksDirPath()
+// TODO(#2869 Phase 4 — util): Returns reference to cs_args-guarded cache.
+// The cache is initialized-once-then-stable in practice, so the reference is
+// safe to use after the lock is dropped. A future cleanup could return by
+// value, or move the path off cs_args.
+const fs::path& ArgsManager::GetBlocksDirPath() NO_THREAD_SAFETY_ANALYSIS
 {
     LOCK(cs_args);
     fs::path& path = m_cached_blocks_path;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -296,11 +296,7 @@ std::optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) co
     return std::nullopt;
 }
 
-// TODO(#2869 Phase 4 — util): Returns reference to cs_args-guarded cache.
-// The cache is initialized-once-then-stable in practice, so the reference is
-// safe to use after the lock is dropped. A future cleanup could return by
-// value, or move the path off cs_args.
-const fs::path& ArgsManager::GetBlocksDirPath() NO_THREAD_SAFETY_ANALYSIS
+fs::path ArgsManager::GetBlocksDirPath()
 {
     LOCK(cs_args);
     fs::path& path = m_cached_blocks_path;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -210,7 +210,7 @@ public:
      *
      * @return Blocks path which is network specific
      */
-    const fs::path& GetBlocksDirPath();
+    fs::path GetBlocksDirPath();
 
     /**
      * Get data directory path

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -356,6 +356,7 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
 
 bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
     const CBlockIndex* pindexBlock, bool fBlock, bool fMiner)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Take over previous transactions' spent pointers
     // fBlock is true when this is called from AcceptBlock when a new best-block is added to the blockchain
@@ -564,6 +565,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
 }
 
 bool DisconnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Disconnect in reverse order
     bool bDiscTxFailed = false;
@@ -586,9 +588,13 @@ bool DisconnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex)
             return error("%s: WriteBlockIndex failed", __func__);
     }
 
-    // ppcoin: clean up wallet after disconnecting coinstake
-    for (auto const& tx : block.vtx)
-        SyncWithWallets(tx, &block, false, false);
+    // ppcoin: clean up wallet after disconnecting coinstake.
+    // Canonical order: cs_main (held by DisconnectBlock) -> cs_setpwalletRegistered -> cs_wallet.
+    {
+        LOCK(cs_setpwalletRegistered);
+        for (auto const& tx : block.vtx)
+            SyncWithWallets(tx, &block, false, false);
+    }
 
     if (bDiscTxFailed) return error("%s: DisconnectInputs failed", __func__);
     return true;
@@ -668,7 +674,7 @@ unsigned int GetMRCOutputLimit(const int& block_version, bool include_foundation
 // Gridcoin-specific ConnectBlock() routines:
 //
 namespace {
-int64_t ReturnCurrentMoneySupply(CBlockIndex* pindexcurrent)
+int64_t ReturnCurrentMoneySupply(CBlockIndex* pindexcurrent) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (pindexcurrent->pprev)
     {
@@ -899,6 +905,7 @@ unsigned int GetBlockScriptFlags(const CBlockIndex& block_index)
 }
 
 bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Check it again in case a previous version let a bad block in, but skip BlockSig checking
     if (!CheckBlock(block, state, pindex->nHeight, !fJustCheck, !fJustCheck, false, false))
@@ -1095,9 +1102,13 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockInd
             return error("%s: WriteBlockIndex failed", __func__);
     }
 
-    // Watch for transactions paying to me
-    for (auto const& tx : block.vtx)
-        SyncWithWallets(tx, &block, true);
+    // Watch for transactions paying to me.
+    // Canonical order: cs_main (held by ConnectBlock) -> cs_setpwalletRegistered -> cs_wallet.
+    {
+        LOCK(cs_setpwalletRegistered);
+        for (auto const& tx : block.vtx)
+            SyncWithWallets(tx, &block, true);
+    }
 
     return true;
 }
@@ -1151,7 +1162,10 @@ bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, 
     if (!txdb.TxnCommit())
         return false;
 
-    LOCK(cs_main);
+    // cs_main is required on entry (declared EXCLUSIVE_LOCKS_REQUIRED in
+    // validation.h). The previous explicit LOCK(cs_main) here was redundant on
+    // a recursive mutex and confused the thread-safety analyzer about exit-path
+    // hold state.
 
     // New best
     if (g_chain_trust.Favors(pindexNew))
@@ -1160,9 +1174,13 @@ bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, 
 
     if (pindexNew == pindexBest)
     {
-        // Notify UI to display prev block's coinbase if it was ours
+        // Notify UI to display prev block's coinbase if it was ours.
+        // Canonical order: cs_main (required on entry) -> cs_setpwalletRegistered.
         static uint256 hashPrevBestCoinBase;
-        UpdatedTransaction(hashPrevBestCoinBase);
+        {
+            LOCK(cs_setpwalletRegistered);
+            UpdatedTransaction(hashPrevBestCoinBase);
+        }
         hashPrevBestCoinBase = block.vtx[0].GetHash();
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -743,7 +743,7 @@ bool TryLoadSuperblock(
     CBlock& block,
     CValidationState& state,
     const CBlockIndex* const pindex,
-    const GRC::Claim& claim)
+    const GRC::Claim& claim) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     GRC::SuperblockPtr superblock = block.GetSuperblock(pindex);
 
@@ -792,7 +792,7 @@ bool GridcoinConnectBlock(
     CTxDB& txdb,
     const int64_t stake_value_in,
     const int64_t total_claimed,
-    const int64_t fees)
+    const int64_t fees) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const GRC::Claim& claim = block.GetClaim();
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -10,11 +10,13 @@
 #include "consensus/validation.h"
 #include "index/disktxpos.h"
 #include "primitives/transaction.h"
+#include "sync.h"
 
 #include <map>
 
 class CTxDB;
 class CBlockHeader;
+extern CCriticalSection cs_main;
 namespace Consensus {
     struct Params;
 }
@@ -68,7 +70,7 @@ const CTxOut& GetOutputFor(const CTxIn& input, const MapPrevTx& inputs);
 */
 CAmount GetValueIn(const CTransaction& tx, const MapPrevTx& inputs);
 
-bool DisconnectInputs(CTransaction& tx, CTxDB& txdb);
+bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Fetch from memory and/or disk. inputsRet keys are transaction hashes.
     @param[in] tx The transaction to fetch inputs for
@@ -93,17 +95,17 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
     @param[in] fMiner	true if called from CreateNewBlock
     @return Returns true if all checks succeed
     */
-bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner);
+bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge); // ppcoin: get transaction coin age
 
-int GetDepthInMainChain(const CTxIndex& txi);
+int GetDepthInMainChain(const CTxIndex& txi) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params);
 
-bool DisconnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex);
-bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck=false);
-bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, const uint256& hashProof);
+bool DisconnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, const uint256& hashProof) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true, bool fLoadingIndex=false);
 bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me);
 bool CheckBlockSignature(const CBlock& block);
@@ -116,7 +118,7 @@ unsigned int GetMandatorySideStakeOutputLimit(const int& block_version);
 Fraction FoundationSideStakeAllocation();
 CTxDestination FoundationSideStakeAddress();
 unsigned int GetMRCOutputLimit(const int& block_version, bool include_foundation_sidestake);
-bool ValidateMRC(const GRC::Contract &contract, const CTransaction& tx, int& DoS);
-bool ValidateMRC(const CBlockIndex* mrc_last_pindex, const GRC::MRC& mrc);
+bool ValidateMRC(const GRC::Contract &contract, const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool ValidateMRC(const CBlockIndex* mrc_last_pindex, const GRC::MRC& mrc) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // BITCOIN_VALIDATION_H

--- a/src/wallet/diagnose.h
+++ b/src/wallet/diagnose.h
@@ -533,6 +533,8 @@ public:
          * find if there is Active beacon
          */
 
+        LOCK(cs_main);
+
         const GRC::BeaconRegistry& beacons = GRC::GetBeaconRegistry();
         if (const GRC::CpidOption cpid = GRC::Researcher::Get()->Id().TryCpid()) {
             if (const GRC::BeaconOption beacon = beacons.Try(*cpid)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -33,7 +33,7 @@ static CCriticalSection cs_nWalletUnlockTime;
 
 extern void ThreadTopUpKeyPool(void* parg);
 extern void ThreadCleanWalletPassphrase(void* parg);
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 static void accountingDeprecationCheck()
 {
@@ -62,7 +62,9 @@ void EnsureWalletIsUnlocked()
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Wallet is unlocked for staking only.");
 }
 
-void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
+// TODO(#2869 Phase 2 — wallet/rpc): mapBlockIndex lookup needs cs_main.
+// RPC entry points should take cs_main before invoking.
+void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry) NO_THREAD_SAFETY_ANALYSIS
 {
     int confirms = wtx.GetDepthInMainChain();
     entry.pushKV("confirmations", confirms);
@@ -2701,7 +2703,10 @@ UniValue resendtx(const UniValue& params, bool fHelp)
                 "Re-send unconfirmed transactions.\n"
                 );
 
-    ResendWalletTransactions(true);
+    {
+        LOCK(cs_setpwalletRegistered);
+        ResendWalletTransactions(true);
+    }
 
     return NullUniValue;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -62,9 +62,7 @@ void EnsureWalletIsUnlocked()
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Wallet is unlocked for staking only.");
 }
 
-// TODO(#2869 Phase 2 — wallet/rpc): mapBlockIndex lookup needs cs_main.
-// RPC entry points should take cs_main before invoking.
-void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry) NO_THREAD_SAFETY_ANALYSIS
+void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     int confirms = wtx.GetDepthInMainChain();
     entry.pushKV("confirmations", confirms);
@@ -1402,7 +1400,7 @@ UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
 
  void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth,
                        bool fLong, UniValue& ret, const isminefilter& filter = ISMINE_SPENDABLE,
-                       bool stakes_only = false) EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
+                       bool stakes_only = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet)
  {
     int64_t nFee;
     string strSentAccount;
@@ -2704,7 +2702,7 @@ UniValue resendtx(const UniValue& params, bool fHelp)
                 );
 
     {
-        LOCK(cs_setpwalletRegistered);
+        LOCK2(cs_main, cs_setpwalletRegistered);
         ResendWalletTransactions(true);
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -489,10 +489,7 @@ void CWallet::MarkDirty()
     }
 }
 
-// TODO(#2869 Phase 2 — wallet): mapBlockIndex read for nTimeSmart estimation
-// needs cs_main. Many callers are during block connection where cs_main is
-// already held; some (rescan, txn import) are not.
-bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb) NO_THREAD_SAFETY_ANALYSIS
+bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     uint256 hash = wtxIn.GetHash();
     {
@@ -591,7 +588,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb) NO_THREA
 // Add a transaction to the wallet, or update it.
 // pblock is optional, but should be provided if the transaction is known to be in a block.
 // If fUpdate is true, existing transactions will be updated.
-bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate, bool fFindBlock)
+bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate, bool fFindBlock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     uint256 hash = tx.GetHash();
     {
@@ -1248,11 +1245,7 @@ void CWalletTx::RelayWalletTransaction()
    RelayWalletTransaction(txdb);
 }
 
-// TODO(#2869 Phase 2 — wallet): Reads nBestHeight in two places and calls
-// CWalletTx::GetDepthInMainChain without holding cs_main. The wallet
-// resend-timer path needs cs_main coverage; Phase 2 should either acquire
-// cs_main outside cs_wallet or restructure the iteration to snapshot heights.
-void CWallet::ResendWalletTransactions(bool fForce) NO_THREAD_SAFETY_ANALYSIS
+void CWallet::ResendWalletTransactions(bool fForce) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!fForce)
     {
@@ -1364,9 +1357,7 @@ void CWallet::ResendWalletTransactions(bool fForce) NO_THREAD_SAFETY_ANALYSIS
              txns_erased_from_wallet);
 }
 
-// TODO(#2869 Phase 2 — wallet): pindexBest->nHeight read without cs_main.
-// CheckContracts also needs cs_main coverage for its block_height argument.
-bool CWalletTx::RevalidateTransaction(CTxDB& txdb) NO_THREAD_SAFETY_ANALYSIS
+bool CWalletTx::RevalidateTransaction(CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CTransaction tx = (CTransaction) *this;
 
@@ -3067,11 +3058,7 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
     }
 }
 
-// TODO(#2869 Phase 2 — wallet): Walks the wallet against mapBlockIndex /
-// nBestHeight without cs_main. Currently declared EXCLUSIVE_LOCKS_REQUIRED on
-// cs_wallet only; Phase 2 should add cs_main to the contract (callers in
-// rpcdump.cpp would need to acquire it first).
-void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) NO_THREAD_SAFETY_ANALYSIS
+void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_wallet)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     mapKeyBirth.clear();
@@ -3137,9 +3124,7 @@ void CWallet::StoreLastBackupTime(const int64_t backup_time)
     CWalletDB(strWalletFile).WriteBackupTime(backup_time);
 }
 
-// TODO(#2869 Phase 2 — wallet): mapBlockIndex lookups need cs_main. RPC
-// callers should take cs_main before invoking.
-GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout) NO_THREAD_SAFETY_ANALYSIS
+GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CWalletTx wallettx;
     uint256 hashblock;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -489,7 +489,10 @@ void CWallet::MarkDirty()
     }
 }
 
-bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb)
+// TODO(#2869 Phase 2 — wallet): mapBlockIndex read for nTimeSmart estimation
+// needs cs_main. Many callers are during block connection where cs_main is
+// already held; some (rescan, txn import) are not.
+bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb) NO_THREAD_SAFETY_ANALYSIS
 {
     uint256 hash = wtxIn.GetHash();
     {
@@ -1245,7 +1248,11 @@ void CWalletTx::RelayWalletTransaction()
    RelayWalletTransaction(txdb);
 }
 
-void CWallet::ResendWalletTransactions(bool fForce)
+// TODO(#2869 Phase 2 — wallet): Reads nBestHeight in two places and calls
+// CWalletTx::GetDepthInMainChain without holding cs_main. The wallet
+// resend-timer path needs cs_main coverage; Phase 2 should either acquire
+// cs_main outside cs_wallet or restructure the iteration to snapshot heights.
+void CWallet::ResendWalletTransactions(bool fForce) NO_THREAD_SAFETY_ANALYSIS
 {
     if (!fForce)
     {
@@ -1357,7 +1364,9 @@ void CWallet::ResendWalletTransactions(bool fForce)
              txns_erased_from_wallet);
 }
 
-bool CWalletTx::RevalidateTransaction(CTxDB& txdb)
+// TODO(#2869 Phase 2 — wallet): pindexBest->nHeight read without cs_main.
+// CheckContracts also needs cs_main coverage for its block_height argument.
+bool CWalletTx::RevalidateTransaction(CTxDB& txdb) NO_THREAD_SAFETY_ANALYSIS
 {
     CTransaction tx = (CTransaction) *this;
 
@@ -3058,7 +3067,11 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
     }
 }
 
-void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+// TODO(#2869 Phase 2 — wallet): Walks the wallet against mapBlockIndex /
+// nBestHeight without cs_main. Currently declared EXCLUSIVE_LOCKS_REQUIRED on
+// cs_wallet only; Phase 2 should add cs_main to the contract (callers in
+// rpcdump.cpp would need to acquire it first).
+void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) NO_THREAD_SAFETY_ANALYSIS
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     mapKeyBirth.clear();
@@ -3124,7 +3137,9 @@ void CWallet::StoreLastBackupTime(const int64_t backup_time)
     CWalletDB(strWalletFile).WriteBackupTime(backup_time);
 }
 
-GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout)
+// TODO(#2869 Phase 2 — wallet): mapBlockIndex lookups need cs_main. RPC
+// callers should take cs_main before invoking.
+GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout) NO_THREAD_SAFETY_ANALYSIS
 {
     CWalletTx wallettx;
     uint256 hashblock;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -35,7 +35,7 @@ class CReserveKey;
 class COutput;
 class CCoinControl;
 
-GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout);
+GRC::MinedType GetGeneratedType(const CWallet *wallet, const uint256& tx, unsigned int vout) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 static const unsigned int DEFAULT_KEYPOOL_SIZE_PRE_HD = 1000;
@@ -225,7 +225,7 @@ public:
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 
-    void GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const;
+    void GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_wallet);
 
 
     /** Increment the next transaction order id
@@ -243,8 +243,8 @@ public:
     TxItems OrderedTxItems(std::list<CAccountingEntry>& acentries, std::string strAccount = "");
 
     void MarkDirty();
-    bool AddToWallet(const CWalletTx& wtxIn, CWalletDB *pwalletdb);
-    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate = false, bool fFindBlock = false);
+    bool AddToWallet(const CWalletTx& wtxIn, CWalletDB *pwalletdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate = false, bool fFindBlock = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool EraseFromWallet(uint256 hash);
     void WalletUpdateSpent(const CTransaction &tx, bool fBlock, CWalletDB* pwalletdb);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
@@ -259,7 +259,7 @@ public:
     //!
     //! \param fForce
     //!
-    void ResendWalletTransactions(bool fForce = false);
+    void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     int64_t GetBalance() const;
     int64_t GetUnconfirmedBalance() const;
     int64_t GetImmatureBalance() const;
@@ -893,9 +893,9 @@ public:
     void RelayWalletTransaction(CTxDB& txdb);
     void RelayWalletTransaction();
 
-    bool RevalidateTransaction(CTxDB& txdb);
+    bool RevalidateTransaction(CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    GRC::MinedType GetGeneratedType(uint32_t vout_offset) const
+    GRC::MinedType GetGeneratedType(uint32_t vout_offset) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return ::GetGeneratedType(pwallet, GetHash(), vout_offset);
     }


### PR DESCRIPTION
## Summary

Resolves #2869. Enables Clang's thread-safety analyzer on the build and rolls out the missing `GUARDED_BY` / `EXCLUSIVE_LOCKS_REQUIRED` annotations across the daemon, the Qt wallet, and the test binary. End state: **zero `-Wthread-safety-*` warnings** on a clean clang build, with two intentional `NO_THREAD_SAFETY_ANALYSIS` markers remaining (both documented).

Full per-phase writeup, decision log, deadlock audit, and end-state grep are in `doc/thread_safety_phase1_report.md` — that document is the authoritative reference for this PR. The summary below is just the map.

### Build enablement
- `CMakeLists.txt` portable detect of `-Wthread-safety` (was Apple-only). `-Werror=thread-safety-{analysis,reference}` downgraded to warning for the rollout; can be promoted to hard error once the PR lands.
- Pre-existing 96-warning fix in `sync.h` `AssertLockNotHeldInternal` (`!cs` on a pointer was evaluating `operator!` rather than the negative-capability overload — dereferenced inside the attribute).

### Canonical lock order established
`cs_main` → `cs_setpwalletRegistered` → `cs_wallet` → subsystem locks. The wallet-registry mutex slot was added between cs_main and cs_wallet; the wrappers (`SyncWithWallets` etc.) had to be hoisted to caller-side LOCK to avoid an inversion with `SendMessages → ResendWalletTransactions` against `sendrawtransaction → SyncWithWallets`. Deadlock audit details in the report.

### Phase commits (18 total)

**Phase 1** — analyzer enable + cs_main globals + setpwalletRegistered + Phase 2/3/4 placeholders.
- `06487d88a` Phase 1 rollout
- `29077e26e` Phase 1 report

**Phase 2** — replace placeholders sub-area by sub-area, one commit per sub-area, each ends warning-free.
- `42b1e9516` block_finder (29 call sites)
- `849a06700` tally + immediate callers
- `3b33e8bbb` mrc + block_rewards + contract
- `eb56f3a1c` wallet + immediate callers (eliminates the latent SendMessages/resendtx inversion identified during cs_setpwalletRegistered review)
- `20d800299` researcher/beacon + GUI callers
- `47f9ae1d8` voting + miner + policy (retains `VoteResolver::GetMagnitudeFactor` `NO_THREAD_SAFETY_ANALYSIS` — design constraint, see report)
- `815131312` report catch-up + voting design constraint capture

**Phase 3** — scraper + quorum (lambda-capture analyzer issues).
- `848872500` quorum + AddBeaconPartsData lambdas refactored to parameter-pass instead of capture
- `fdabee989` testnewsb scraper RPC

**Phase 4** — network layer.
- `2c9c8f817` `ProcessMessage` + `AlreadyHave` + `CNode::PushVersion` + `ArgsManager::GetBlocksDirPath`. Uses `WITH_LOCK(cs_main, ...)` snapshot pattern at P2P entry points to avoid holding cs_main across slow `PushMessage`/`PushGetBlocks` work.
- `f2250e358` Phase 3 + Phase 4 report catch-up

**Follow-ups A/B/C/D** — post-Phase-4 coverage audit closed four narrow gaps.
- `630deb0e3` Follow-up A: BeaconRegistry was 0% annotated in the baseline; entire public API annotated `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` with the researcher / accrual / block_rewards cascade. Adds a documented `ChainletErrorHandle` lambda `NO_THREAD_SAFETY_ANALYSIS` (analyzer can't see hold-state through `[this]` captures; enclosing function is correctly annotated).
- `ab70f5d45` Follow-up B: scraper internals. `fScraperActive` → `std::atomic<bool>` (single startup write, scraper-thread reads — the one behavior-affecting change in the follow-ups). `vuserpass` / `ndownloadsize` / `nuploadsize` annotated `GUARDED_BY(cs_Scraper)` because every access path (including the reentrant `ScraperGetSuperblockContract` → `ScraperSingleShot` → `Scraper(true)` from staking-miner/RPC threads) enters the same `LOCK(cs_Scraper)` at scraper.cpp:1640. `DownloadProjectPublicKeys` deliberately NOT folded into the cs_Scraper contract — it owns its own `cs_ProjectPublicKeys`, preserving the fine-grained-locking design.
- `11994d6c0` Follow-up C: `CNode` per-node locks. `cs_vSend` / `cs_vRecvMsg` / `cs_inventory` / `cs_mapMisbehavior` members + methods annotated. Replaces the existing informal \"requires LOCK(cs_X)\" comments.
- `d4a52ceeb` Follow-up D: pure-annotation sweep of remaining file-scope cs↔data pairs — `mapAlerts`, `mapLocalHost`, `vAddedNodes`, `vOneShots`, `setservAddNodeAddresses`. Zero cascade; documentation-only.
- `bdebb500f` doc: report updated with Follow-ups A/B/C/D + revised end state

### End state

\`\`\`
$ grep -rn 'NO_THREAD_SAFETY_ANALYSIS' src/ --include='*.cpp' --include='*.h' \\
    | grep -v 'threadsafety.h\\|leveldb/port/thread_annotations.h\\|test/'
src/gridcoin/voting/result.cpp:700:    Weight GetMagnitudeFactor() NO_THREAD_SAFETY_ANALYSIS
src/gridcoin/beacon.cpp:852:    const auto ChainletErrorHandle = [this](...) NO_THREAD_SAFETY_ANALYSIS {
\`\`\`

Both intentional. The voting one is held until the voting-redesign work lands (promoting it would force cs_main across the multi-second `CountVotes` loop — undoing historical work). The beacon one is a lambda-capture limitation of the analyzer; the enclosing function carries the correct annotation.

## Test plan

- [ ] `cmake -B build_clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DENABLE_GUI=ON -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- [ ] `cmake --build build_clang --parallel \$(nproc) --target gridcoinresearchd gridcoinresearch test_gridcoin --clean-first` produces zero `-Wthread-safety-*` warnings
- [ ] `./build_clang/src/test/test_gridcoin --log_level=warning` reports `*** No errors detected`
- [ ] Smoke a wallet startup on mainnet/testnet to verify no behavior regression at the init-time wrapper / cs_setpwalletRegistered LOCK additions
- [ ] Spot-check a few RPCs that gained scoped `LOCK(cs_main)` (`getblockhash`, `getblockbynumber`, `auditsnapshotaccrual`) under the wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)