### PR TITLE
gui: annotate NotifyTransactionChanged with EXCLUSIVE_LOCKS_REQUIRED

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -499,6 +499,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, 
 }
 
 static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)
 {
     LogPrint(BCLog::LogFlags::VERBOSE, "NotifyTransactionChanged %s status=%i", hash.GetHex(), status);
 
@@ -542,13 +543,21 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
     //     wallet.cpp:458  WalletUpdateSpent      — caller AddToWallet / AddToWalletIfInvolvingMe, both EXCLUSIVE_LOCKS_REQUIRED(cs_main); LOCK(cs_wallet)
     //     wallet.cpp:475  WalletUpdateSpent      — same
     //     wallet.cpp:3057 UpdatedTransaction     — reached via validation.cpp (cs_main required on entry); LOCK(cs_wallet)
-    //   The AssertLockHeld() calls below document and (in DEBUG_LOCKORDER
-    //   builds) enforce this; any future callsite missing a lock trips them.
+    //   This function is annotated EXCLUSIVE_LOCKS_REQUIRED(cs_main,
+    //   wallet->cs_wallet) so the Clang thread-safety analyzer accepts the
+    //   AssertLockHeld() calls and the mapWallet reads in the CT_NEW /
+    //   CT_UPDATED branch. The AssertLockHeld() calls additionally enforce
+    //   the requirement at runtime in DEBUG_LOCKORDER builds.
     //
     //   CT_DELETED callsites (main.cpp:1290, wallet.cpp:1349) DO NOT hold
     //   either lock — the tx has already been erased. The TxRemoved payload
     //   carries only the hash, so no wallet lookup or showTransaction call
-    //   is needed.
+    //   is needed; that branch touches nothing the annotation guards. The
+    //   EXCLUSIVE_LOCKS_REQUIRED annotation therefore over-claims for the
+    //   CT_DELETED path — harmless, because the handler is invoked only
+    //   through boost::signals2, which the analyzer cannot trace, so no
+    //   caller is ever checked against the annotation; its sole effect is
+    //   to satisfy the analyzer inside the CT_NEW / CT_UPDATED branch.
     switch (status) {
     case CT_NEW:
     case CT_UPDATED:


### PR DESCRIPTION
## Summary

Follow-up to #2944. The static `NotifyTransactionChanged` producer handler added to `walletmodel.cpp` in #2944 emits four `-Wthread-safety-analysis` warnings under a Clang build:

```
walletmodel.cpp:556  calling 'AssertLockHeldInternal<…>' requires holding mutex 'cs_main' exclusively
walletmodel.cpp:557  calling 'AssertLockHeldInternal<…>' requires holding mutex 'wallet->cs_wallet' exclusively
walletmodel.cpp:558  reading variable 'mapWallet' requires holding mutex 'wallet->cs_wallet'
walletmodel.cpp:559  reading variable 'mapWallet' requires holding mutex 'wallet->cs_wallet'
```

## Cause

The handler's `CT_NEW / CT_UPDATED / CT_UPDATING` branch calls `AssertLockHeld(cs_main)` / `AssertLockHeld(wallet->cs_wallet)` and reads `wallet->mapWallet` (`GUARDED_BY(cs_wallet)`), but the function itself carries no lock annotation. `AssertLockHeldInternal` is `EXCLUSIVE_LOCKS_REQUIRED(cs)` — so `AssertLockHeld` *propagates* the lock requirement to its enclosing function rather than establishing lock state, and an un-annotated enclosing function is flagged.

The handler genuinely does run with both locks held: every reachable `CT_NEW`/`CT_UPDATED` callsite was audited during #2944 and the audit is recorded in the comment block above the `switch`. The function simply never declared the fact to the analyzer.

## Fix

Annotate the handler `EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)`. All four warnings clear; `gridcoinqt` builds warning-free under Clang.

The annotation over-claims for the `CT_DELETED` branch, which holds neither lock — but that branch touches nothing the annotation guards (no `mapWallet` access, no `AssertLockHeld`), and the handler is invoked only through `boost::signals2`, which the analyzer cannot trace, so no caller is ever checked against the annotation. Its sole effect is to satisfy the analyzer inside the `CT_NEW`/`CT_UPDATED` branch. The comment block is updated to explain this. No behavioural change — annotation and comment only.

## Why #2944 didn't catch it

The GCC builds ignore `-Wthread-safety` entirely, and the CI Clang job does not promote thread-safety diagnostics to errors (`-Wno-error=thread-safety-*` from the #2869 rollout is still in place). No build run during #2944 review would have shown these. Surfaced by a local Clang/macOS build.

## Test plan

- [ ] `gridcoinqt` builds warning-free under Clang (`-Wthread-safety-analysis` clean) — verified locally.
- [ ] GCC build unaffected (`EXCLUSIVE_LOCKS_REQUIRED` is a no-op there; already used pervasively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)