### PR TITLE
ci: add Clang thread-safety analysis gate

### DIFF
--- a/.github/workflows/cmake_quality.yml
+++ b/.github/workflows/cmake_quality.yml
@@ -151,3 +151,58 @@ jobs:
              echo "Error: lint-all.sh not found."
              exit 1
           fi
+
+  # ----------------------------------------------------------------------
+  # JOB 3: Clang Thread Safety Analysis
+  # Compile-only gate. Clang's -Wthread-safety statically checks the
+  # GUARDED_BY / EXCLUSIVE_LOCKS_REQUIRED annotations (issue #2869); gcc
+  # ignores them entirely. WERROR_THREAD_SAFETY=ON promotes a stale or
+  # missing annotation to a build error. GUI is built here (ENABLE_GUI=ON)
+  # because the Sanitizers job builds with ENABLE_GUI=OFF and would not
+  # cover the Qt wallet code.
+  # ----------------------------------------------------------------------
+  thread-safety:
+    name: Thread Safety (Clang)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install System Deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake build-essential libboost-all-dev \
+            libssl-dev libdb++-dev libminiupnpc-dev libqrencode-dev \
+            qt6-base-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
+            libqt6charts6-dev libqt6svg6-dev libqt6core5compat6-dev \
+            libxkbcommon-dev libcurl4-openssl-dev libzip-dev zipcmp zipmerge \
+            ziptool ccache
+
+      - name: Restore Ccache
+        uses: actions/cache@v5
+        with:
+          path: /home/runner/.ccache
+          key: ccache-tsa-${{ github.sha }}
+          restore-keys: ccache-tsa-
+
+      - name: Setup Concurrency
+        run: |
+          if [ -z "$CMAKE_BUILD_PARALLEL_LEVEL" ]; then
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)" >> $GITHUB_ENV
+            echo "Concurrency: Auto-detected $(nproc) cores."
+          else
+            echo "Concurrency: Limit set externally to $CMAKE_BUILD_PARALLEL_LEVEL."
+          fi
+
+      - name: Configure (Thread Safety Analysis)
+        run: |
+          cmake -B build_tsa \
+            -DENABLE_GUI=ON \
+            -DENABLE_TESTS=OFF \
+            -DUSE_QT6=ON \
+            -DWERROR_THREAD_SAFETY=ON \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build (compile-only — analysis runs at compile time)
+        run: cmake --build build_tsa --target gridcoinresearch gridcoinresearchd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ option(USE_ASM_SCRYPT   "Enable scrypt assembly routines (requires GNU assembler
 # Optional functionality
 option(ENABLE_PIE       "Build position-independent executables" OFF)
 option(ENABLE_DEBUG_LOCKORDER "Enable run-time lock-order checking (DEBUG_LOCKORDER)" OFF)
+option(WERROR_THREAD_SAFETY "Promote Clang thread-safety diagnostics to build errors" OFF)
 option(ENABLE_QRENCODE  "Enable generation of QR Codes for receiving payments" OFF)
 option(ENABLE_UPNP      "Enable UPnP port mapping support" OFF)
 option(DEFAULT_UPNP     "Turn UPnP on startup" OFF)
@@ -325,17 +326,24 @@ endif()
 # attribute set. Detect rather than gating on CMAKE_CXX_COMPILER_ID so any
 # clang-compatible compiler picks it up (e.g. clang-cl on Windows).
 #
-# Kept warning-only during the incremental annotation rollout (#2869 Phases
-# 1-4). The corresponding -Wno-error= flags prevent the warning from being
-# promoted to an error if any future -Werror is added before the codebase
-# is fully annotated. Once the rollout is complete the -Wno-error= flags
-# can be dropped to make stale annotations a hard build failure.
+# By default thread-safety diagnostics are warning-only (the -Wno-error=
+# flags below): a stale or missing annotation does not break a normal build.
+# When WERROR_THREAD_SAFETY is set they are promoted to hard errors instead.
+# The "Thread Safety (Clang)" job in .github/workflows/cmake_quality.yml
+# builds with WERROR_THREAD_SAFETY=ON, so an annotation regression fails CI;
+# a local build can opt in the same way. See doc/developer-notes.md, section
+# "Clang thread-safety analysis".
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wthread-safety HAVE_CLANG_THREAD_SAFETY)
 if(HAVE_CLANG_THREAD_SAFETY)
     add_compile_options(-Wthread-safety)
-    add_compile_options(-Wno-error=thread-safety-analysis)
-    add_compile_options(-Wno-error=thread-safety-reference)
+    if(WERROR_THREAD_SAFETY)
+        add_compile_options(-Werror=thread-safety-analysis)
+        add_compile_options(-Werror=thread-safety-reference)
+    else()
+        add_compile_options(-Wno-error=thread-safety-analysis)
+        add_compile_options(-Wno-error=thread-safety-reference)
+    endif()
 endif()
 
 if(STATIC_LIBS)

--- a/build_targets.sh
+++ b/build_targets.sh
@@ -42,8 +42,8 @@ print_help() {
     echo "  DEBUG_LOCKORDER=<bool> Enable run-time lock-order checking. Options: true, false."
     echo "                      Default: false"
     echo "  EXTRA_CMAKE_ARGS    Pass additional arguments to CMake (e.g. '-DBoost_USE_STATIC_LIBS=ON')"
-    echo "  CC=<path>           Override C compiler."
-    echo "  CXX=<path>          Override C++ compiler."
+    echo "  CC=<path>           Override C compiler (also read from the CC environment variable)."
+    echo "  CXX=<path>          Override C++ compiler (also read from the CXX environment variable)."
     echo "  --help, -h          Show this help message."
     echo ""
 }
@@ -114,8 +114,10 @@ USE_CCACHE="false"
 WITH_GUI="true"
 WITH_DOCS="false"
 USE_QT6="true"
-CC_OVERRIDE=""
-CXX_OVERRIDE=""
+# Seed from the conventional CC/CXX environment variables; a positional
+# CC=/CXX= argument (parsed below) still overrides them.
+CC_OVERRIDE="${CC:-}"
+CXX_OVERRIDE="${CXX:-}"
 MANUAL_QT_PATH=""
 DEBUG_LOCKORDER="false"
 EXTRA_ARGS=""

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -606,6 +606,38 @@ between the various components is a goal, with any necessary locking
 done by the components (e.g. see the self-contained `CKeyStore` class (in `src/keystore.h`)
 and its `cs_KeyStore` lock for example).
 
+### Clang thread-safety analysis
+
+Clang ships a static thread-safety analyzer that checks the `GUARDED_BY`,
+`EXCLUSIVE_LOCKS_REQUIRED` and related annotations at compile time — it
+verifies that a guarded variable is only touched while the right lock is
+held, and that a function annotated as requiring a lock is only called with
+that lock held. It is complementary to `DEBUG_LOCKORDER`: that flag checks
+lock *ordering* at runtime, the analyzer checks lock *coverage* at compile
+time.
+
+The analyzer only runs under Clang (and Apple Clang). **gcc ignores the
+annotations entirely**, so a gcc-only build never exercises them — a missing
+or stale annotation compiles cleanly. The build system auto-enables
+`-Wthread-safety` whenever the compiler supports it; by default the
+diagnostics are warning-only.
+
+**Do a Clang build before opening a PR** so the analyzer runs against your
+changes. `build_targets.sh` honors the `CC` / `CXX` environment variables:
+
+```bash
+CC=clang CXX=clang++ ./build_targets.sh TARGET=native BUILD_TYPE=RelWithDebInfo
+```
+
+The `Thread Safety (Clang)` job in `.github/workflows/cmake_quality.yml`
+builds with `-DWERROR_THREAD_SAFETY=ON`, which promotes the thread-safety
+diagnostics to hard errors — a PR that introduces an annotation violation
+fails CI. To reproduce that gate locally, pass the same option to CMake:
+
+```bash
+cmake -B build -DCMAKE_CXX_COMPILER=clang++ -DWERROR_THREAD_SAFETY=ON ...
+```
+
 Threads
 --------
 


### PR DESCRIPTION
## Summary

The `GUARDED_BY` / `EXCLUSIVE_LOCKS_REQUIRED` annotations added across the codebase in the issue #2869 rollout are only verified by **Clang's `-Wthread-safety` static analyzer**. gcc ignores the annotations entirely, so a missing or stale annotation compiles cleanly in a gcc build and is invisible to a gcc-only developer or CI job.

PR #2944 shipped four such warnings (in `walletmodel.cpp`'s `NotifyTransactionChanged` handler). They merged green because nothing in CI was running the analyzer; they only surfaced later on a developer's macOS (Apple Clang) build, and were fixed in PR #2946. This PR closes that gap so the next regression of this class fails CI instead.

## Changes

- **`CMakeLists.txt`** — new `WERROR_THREAD_SAFETY` option (default `OFF`). When `ON`, the thread-safety diagnostics are promoted from warnings to hard errors (`-Werror=thread-safety-analysis -Werror=thread-safety-reference`) instead of the default `-Wno-error=` downgrade. Normal builds are unaffected.
- **`.github/workflows/cmake_quality.yml`** — new `Thread Safety (Clang)` job. Compile-only Clang build with `WERROR_THREAD_SAFETY=ON` and `ENABLE_GUI=ON`. GUI is built deliberately: the existing Sanitizers job builds `ENABLE_GUI=OFF` and so would not cover the Qt wallet code — which is exactly where the #2944 warnings were.
- **`doc/developer-notes.md`** — new "Clang thread-safety analysis" section: what the analyzer checks, that gcc ignores it, and a recommendation to do a Clang build (`CC=clang CXX=clang++ ./build_targets.sh ...`) before opening a PR.

## Validation

A full clean Clang 19.1.7 build of the current `development` tip (GUI + daemon + tests, post-#2946) produces **zero `-Wthread-safety` warnings**, so the new job passes green from day one — it is purely a regression gate, no backlog to clear. Verified that `-DWERROR_THREAD_SAFETY=ON` injects `-Wthread-safety -Werror=thread-safety-analysis -Werror=thread-safety-reference` into the compile commands.

## Test plan

- [x] CI: the new `Thread Safety (Clang)` job builds clean against this branch.
- [x] CI: existing `Sanitizers` and `Lint` jobs unaffected.
- [x] A normal gcc build is unchanged (option defaults `OFF`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)