### PR TITLE
build: define MAC_OSX on Apple builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_PIE})
 # Set compiler flags
 if(APPLE)
     add_compile_options(-Wno-error=deprecated-declarations)
+    # MAC_OSX gates macOS-specific code paths inherited from Bitcoin (data
+    # directory under ~/Library/Application Support, F_FULLFSYNC, getentropy,
+    # pthread thread names). The Autotools build defined it via configure.ac;
+    # the move to CMake dropped it, silently disabling those paths on macOS.
+    add_compile_definitions(MAC_OSX)
 endif()
 
 # Enable Clang Thread Safety Analysis where supported (issue #2869). The


### PR DESCRIPTION
## Summary

The autotools→CMake migration dropped the `MAC_OSX` define. The old `configure.ac` defined `MAC_OSX` for darwin hosts (Bitcoin-Core convention); the CMake port added no replacement in any `CMakeLists.txt`, `.cmake` module, or the `gridcoin-config.h.cmake.in` template. `git grep MAC_OSX` finds it only as `#ifdef` *usage* in 6 source files — defined nowhere.

So `MAC_OSX` is **undefined in every CMake build**, and the macOS-specific code paths it gates are silently compiled out:

- **`GetDefaultDataDir()`** (`src/util/system.cpp:788`) falls through to the Unix `~/.GridcoinResearch` branch instead of the correct `~/Library/Application Support/GridcoinResearch`.
- **`F_FULLFSYNC`** durable-fsync path (`system.cpp:1262`) — plain `fsync()` does **not** guarantee a platter flush on macOS; `F_FULLFSYNC` is required for true durability of block/wallet writes.
- The macOS **`getentropy()`** entropy source (`random.cpp:304`) — falls back to `/dev/urandom`.
- **`pthread` thread naming** (`util/threadnames.cpp:31`).

Confirmed empirically: the shipped 5.5.0.0 dmg binary contains the `.GridcoinResearch` (Unix-branch) string literal and **no** standalone `Application Support` literal — i.e. it was compiled with `MAC_OSX` undefined.

## Fix

`add_compile_definitions(MAC_OSX)` under the existing `if(APPLE)` block — reaches every TU, no config-header include audit needed.

## Impact

- **New macOS installs** land in the correct `~/Library/Application Support/GridcoinResearch`.
- **Existing GUI users are unaffected** — the Qt GUI persists its datadir choice and uses that, not the recomputed `GetDefaultDataDir()` default. (A 5.5.0.0 dmg today runs against a datadir created by a 2021 autotools-era install precisely because the GUI does not re-derive the path.)
- **`gridcoinresearchd` on macOS**: the default datadir moves from `~/.GridcoinResearch` to `~/Library/Application Support/GridcoinResearch` — a release-notes item; `-datadir=` overrides.
- Linux / Windows builds are unaffected (`if(APPLE)`-gated).

## Test plan

- [ ] macOS CI build (`cmake_production`) compiles cleanly with the previously-dead `MAC_OSX` paths now active.
- [x] macOS: a fresh run with no prior datadir / no persisted GUI setting creates `~/Library/Application Support/GridcoinResearch`.
- [ ] Linux/Windows builds unchanged.

## Validation

Manually validated on a macOS 14 VM (built via `build_targets.sh TARGET=macos`):

- Compiled cleanly with the previously-dead `MAC_OSX` paths now active — `F_FULLFSYNC` and `getentropy` build fine on current macOS.
- The built binary contains the bare `Application Support` datadir literal and no longer the Unix `.GridcoinResearch` literal — confirming `MAC_OSX` is defined and `GetDefaultDataDir()` takes the macOS branch.
- With the stale per-network QSettings `dataDir` key cleared, `gridcoinresearch -testnet` creates its datadir at the correct `~/Library/Application Support/GridcoinResearch/testnet`. (With the key present, the GUI keeps the persisted path — the stickiness that leaves existing users undisturbed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)