### PR TITLE
refactor: add license headers to script/sign and script/standard files

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #include "script/sign.h"
 #include "script/interpreter.h"
 #include "script/standard.h"

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -1,3 +1,8 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_SCRIPT_SIGN_H
 #define BITCOIN_SCRIPT_SIGN_H
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #include "script/standard.h"
 #include "keystore.h"
 #include "key.h"

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -1,3 +1,8 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_SCRIPT_STANDARD_H
 #define BITCOIN_SCRIPT_STANDARD_H
 


### PR DESCRIPTION
Follow-up to #2878.

PR #2878 extracted `script/sign.{h,cpp}` and `script/standard.{h,cpp}` from the monolithic `script.h`/`script.cpp`, but those four files did not carry the standard copyright/license header that the sibling extracted files (`script/script.{h,cpp}`, `script/interpreter.{h,cpp}`) retain.

@jamescowens flagged this during review of #2878 and noted he'd fix it in a small follow-up after the PSGT chain (#2877) landed. The chain merged on 2026-05-14 — this is that follow-up.

### Change

Adds the same four-line copyright/license header (identical to the sibling `script/` files) to the four files that were missing it:

- `src/script/sign.h`
- `src/script/sign.cpp`
- `src/script/standard.h`
- `src/script/standard.cpp`

Comment-only change; no functional effect.