### PR TITLE
qt: drop wallet events that predate the loadWallet snapshot

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -51,7 +51,8 @@ public:
     TransactionTablePriv(CWallet *wallet, WalletModel *walletModel, TransactionTableModel *parent):
             wallet(wallet),
             walletModel(walletModel),
-            parent(parent)
+            parent(parent),
+            m_event_seqno_watermark(0)
     {
     }
     CWallet *wallet;
@@ -64,6 +65,14 @@ public:
      */
     QList<TransactionRecord> cachedWallet;
 
+    /* Seqno watermark recorded by the most recent loadWallet() snapshot.
+     * loadWallet() rebuilds cachedWallet from a full mapWallet scan; any event
+     * later drained from the WalletEventQueue with a seqno below this value
+     * predates that snapshot and is stale. applyEventBatch() discards them —
+     * applying one (e.g. a stale TxRemoved) would corrupt the fresh model.
+     */
+    uint64_t m_event_seqno_watermark;
+
     /* Query entire wallet anew from core.
      */
     void loadWallet()
@@ -71,6 +80,15 @@ public:
         cachedWallet.clear();
         {
             LOCK2(cs_main, wallet->cs_wallet);
+
+            // Record the event-queue watermark as part of this snapshot. The
+            // producer (NotifyTransactionChanged) pushes under cs_wallet, so
+            // while this LOCK2 is held no event can be enqueued: every event
+            // already queued predates the mapWallet scan below and is stale,
+            // and every event pushed after this lock releases reflects
+            // post-snapshot state. applyEventBatch() drops anything below the
+            // watermark.
+            m_event_seqno_watermark = walletModel->getEventQueue().next_seqno();
 
             bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
             int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
@@ -124,7 +142,19 @@ public:
         const bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
         const int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
 
+        std::size_t skipped_stale = 0;
+
         for (const auto& ev : events) {
+            // Discard events that predate the most recent loadWallet()
+            // snapshot (see m_event_seqno_watermark). Such an event reflects
+            // wallet state already superseded by that full rebuild; applying
+            // it — most damagingly a stale TxRemoved — would drop a row the
+            // snapshot correctly loaded.
+            if (ev.seqno < m_event_seqno_watermark) {
+                ++skipped_stale;
+                continue;
+            }
+
             std::visit([&](auto&& payload) {
                 using P = std::decay_t<decltype(payload)>;
                 if constexpr (std::is_same_v<P, GRC::TxAddedPayload>) {
@@ -137,6 +167,14 @@ public:
                     // once per batch). No per-event row mutation here.
                 }
             }, ev.payload);
+        }
+
+        if (skipped_stale > 0) {
+            LogPrint(BCLog::LogFlags::VERBOSE,
+                     "applyEventBatch: dropped %u stale event(s) below loadWallet "
+                     "watermark seqno=%llu",
+                     static_cast<unsigned int>(skipped_stale),
+                     static_cast<unsigned long long>(m_event_seqno_watermark));
         }
     }
 

--- a/src/qt/wallet_event_queue.cpp
+++ b/src/qt/wallet_event_queue.cpp
@@ -58,4 +58,10 @@ std::size_t WalletEventQueue::size() const
     return m_queue.size();
 }
 
+uint64_t WalletEventQueue::next_seqno() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_next_seqno;
+}
+
 } // namespace GRC

--- a/src/qt/wallet_event_queue.h
+++ b/src/qt/wallet_event_queue.h
@@ -147,6 +147,21 @@ public:
     //!
     std::size_t size() const;
 
+    //!
+    //! \brief The seqno that the next push() will assign. Every event currently
+    //! in the queue — and every event ever drained — has a seqno strictly less
+    //! than this value; every future event will have one greater than or equal
+    //! to it.
+    //!
+    //! A consumer that takes a fresh full snapshot of wallet state captures
+    //! this as a watermark and discards any later-drained event whose seqno is
+    //! below it: such an event predates the snapshot and is stale. For the
+    //! watermark to be exact with respect to a concurrently-taken state
+    //! snapshot, it must be sampled while producers are blocked — e.g. under
+    //! cs_wallet, which every producer holds across its push() call.
+    //!
+    uint64_t next_seqno() const;
+
 private:
     mutable std::mutex      m_mutex;
     std::deque<WalletEvent> m_queue;


### PR DESCRIPTION
## Summary

Fixes a transaction-table regression introduced by the #2944 event-queue redesign: after a wallet load, **a random-looking subset of transactions can be permanently missing** from the GUI transaction list.

### The bug

`TransactionTableModelPriv::loadWallet()` rebuilds the model from a full `mapWallet` scan. The producer→consumer `WalletEventQueue` is **never synchronized with that snapshot**:

- The producer (`NotifyTransactionChanged`, on core threads) is subscribed in the `WalletModel` constructor and fires continuously as blocks connect.
- `loadWallet()` is a Qt-main-thread snapshot at some instant T.
- Events pushed *before* T stay queued and are applied as deltas *after* the snapshot.

A stale `TxRemoved` among those pre-snapshot events deletes a transaction that `loadWallet()` correctly loaded — and if no later notification re-adds it, the row is gone for good. It looks random because it depends on which txs happened to get a `showTransaction()`-false notification around the snapshot point.

It was missed in the original #2944 IBD/reorg testing because those wallets were loaded against an already-synced chain. It surfaced sharply while testing PR #2942 on macOS with a transplanted 39 MB staking wallet synced from ~160k blocks behind tip — a flood of transient-orphan coinstake notifications, exactly the pathological input.

### The fix

The `WalletEvent.seqno` field was designed for this — the queue header documents "resync from seqno N+1" semantics — but nothing used it.

- `WalletEventQueue::next_seqno()` (new) exposes the seqno the next `push()` will assign.
- `loadWallet()` records that value as a watermark **while holding `LOCK2(cs_main, cs_wallet)`**. Every producer pushes under `cs_wallet`, so no event can be enqueued between the `mapWallet` scan and the watermark capture — the snapshot and the watermark are mutually atomic.
- `applyEventBatch()` discards any event whose `seqno` is below the watermark: it predates the snapshot and is stale.

3 files, +60/-1. No behavior change in steady state — only pre-snapshot events are affected, and those were always wrong to apply.

## Test plan

- [ ] macOS/Linux: transplant a large staking wallet, start with the chain well behind tip; once synced, the transaction table matches the source wallet with no missing rows.
- [ ] Steady-state GUI operation unchanged (no events ever fall below the watermark).
- [ ] `VERBOSE` log shows a `applyEventBatch: dropped N stale event(s)` line on the first load when a backlog existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)