### PR TITLE
qt: stop dropping a connecting block's coinstake from the tx model

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -7,6 +7,7 @@
 
 #include "node/ui_interface.h"
 #include "wallet/wallet.h"
+#include "main.h"
 #include <key_io.h>
 #include "util.h"
 #include "gridcoin/tx_message.h"
@@ -576,17 +577,49 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
             walletmodel->getEventQueue().push(GRC::TxRemovedPayload{hash});
             break;
         }
-        if (TransactionRecord::showTransaction(it->second, false, 0)) {
+        const CWalletTx& wtx = it->second;
+
+        bool visible = TransactionRecord::showTransaction(wtx, false, 0);
+
+        // showTransaction() hides a generated (coinstake/coinbase) tx whose
+        // block is not yet in the main chain. This handler, however, runs
+        // synchronously inside block connection: the wallet is notified of a
+        // block's transactions before SetBestChain advances pindexBest (see
+        // main.cpp), so the block being connected — and its own coinstake —
+        // transiently read as orphan. That is a false negative: the block is
+        // a split-second from becoming the tip, and without this guard its
+        // coinstake gets a TxRemoved and never enters the GUI model.
+        //
+        // Detect exactly that window: a block sitting directly on the current
+        // tip but not yet the tip itself is the one being connected right
+        // now. A genuine orphan has pprev != pindexBest and stays hidden, so
+        // -showorphans semantics are unchanged. For a current-era coinstake
+        // the orphan check is showTransaction()'s only false path, so this
+        // override cannot un-hide a tx filtered for any other reason.
+        if (!visible && (wtx.IsCoinStake() || wtx.IsCoinBase())) {
+            auto bi = mapBlockIndex.find(wtx.hashBlock);
+            if (bi != mapBlockIndex.end() && bi->second != nullptr
+                    && !bi->second->IsInMainChain()
+                    && bi->second->pprev == pindexBest) {
+                LogPrint(BCLog::LogFlags::VERBOSE,
+                         "NotifyTransactionChanged: %s is in the block being "
+                         "connected — keeping visible despite transient orphan state",
+                         hash.GetHex());
+                visible = true;
+            }
+        }
+
+        if (visible) {
             GRC::TxAddedPayload payload;
-            payload.records = TransactionRecord::decomposeTransaction(wallet, it->second);
+            payload.records = TransactionRecord::decomposeTransaction(wallet, wtx);
             if (!payload.records.isEmpty()) {
                 walletmodel->getEventQueue().push(std::move(payload));
             }
         } else {
-            // Tx is now filtered out (e.g. became an orphan coinstake).
-            // Ensure the consumer removes the row if it was previously
-            // visible — TxRemoved is a no-op if the tx isn't in
-            // cachedWallet.
+            // Tx is genuinely filtered out (a real orphan coinstake, or a
+            // legacy non-IsFromMe OP_RETURN). Ensure the consumer removes the
+            // row if it was previously visible — TxRemoved is a no-op if the
+            // tx isn't in cachedWallet.
             walletmodel->getEventQueue().push(GRC::TxRemovedPayload{hash});
         }
         break;


### PR DESCRIPTION
## Summary

GUI transaction-table regression from the #2944 event-queue redesign: after a resync, a **scattered subset of generated (coinstake / side-stake) transactions goes permanently missing** from the wallet's transaction list.

## Root cause

The #2944 producer — `WalletModel`'s `NotifyTransactionChanged` handler — runs **synchronously inside block connection**. The wallet is notified of a block's transactions (`SyncWithWallets` → `AddToWallet`) *before* `SetBestChain` advances `pindexBest`. So at notification time the block being connected has `pnext == nullptr` and `!= pindexBest` → `CBlockIndex::IsInMainChain()` is false → the block's own coinstake reads as an **orphan**.

`TransactionRecord::showTransaction()` hides orphan generated txs (`transactionrecord.cpp:15`), so the producer takes the `else` branch and pushes **`TxRemoved`** instead of `TxAdded`. The tx never enters the model, and nothing re-notifies it once the block settles. A restart while fully synced "heals" the list because `loadWallet()` then runs against a settled chain — which is exactly the behavior reported.

## Evidence

Traced on a public testnet A/B run (`debug=verbose`). For one missing tx — `75b5508d8fda620b39f97da8d4c53145022b5e862e8d8ad3294872c9228eb77f`, a side-stake coinstake at height 3181970 — the log shows two `NotifyTransactionChanged … status=2` (CT_UPDATED) lines, both fired **between** `ReorganizeChain: connect` and `SetBestChain: new best block` (i.e. before `pindexBest` advanced). Across the resync, 158,679 of 158,777 notifications were CT_UPDATED and `applyTxAdded`'s dedup log line appeared **0 times** — corroborating that the producer pushed `TxRemoved` for essentially all of them.

## Fix

Producer-side, contained to `walletmodel.cpp`. When `showTransaction()` hides a generated tx, additionally check whether its block is the one being connected *this instant*: directly on the current tip but not yet the tip itself — `pprev == pindexBest && !IsInMainChain()`. If so, keep it visible.

A block satisfies that predicate **iff** it is mid-connection: `!IsInMainChain()` for a connecting block forces `pprev == pindexBest`; a genuine orphan has `pprev != pindexBest` and stays hidden; and the reorg-disconnect path (`SyncWithWallets` `fConnect=false`) only calls `DisableTransaction` — it never fires `NotifyTransactionChanged` for a coinstake — so there is no transient false-positive window. For a current-era coinstake the orphan check is `showTransaction()`'s only false path, so the override can't un-hide a tx filtered for any other reason. `-showorphans` semantics are unchanged.

## Supersedes #2950

#2950 (closed) targeted a theorized stale-pre-snapshot-event race; verbose logs showed it dropped **zero** events — it never fixed this. This is the evidence-backed fix.

## Test plan

- [x] Testnet: restart a staking wallet's GUI into a mid-resync backlog → transaction table is complete (A/B against the unfixed `development` binary, same datadir snapshot — unfixed drops txs, this does not).
- [x] Genuine orphan coinstakes still hidden unless `-showorphans`.
- [x] Daemon / non-GUI builds unaffected (GUI-only change).

## Validation — public testnet A/B test

Verified on the **public testnet** using instance 6 (the PR GUI verification slot):

- **Baseline:** instance 6 was given a fresh public-testnet IBD, and a `snapper` snapshot of the datadir was taken at ~93% synced (height 2,960,945, ~220k blocks behind the ~3.18M tip). Both runs below restore the datadir from that single snapshot, so they start byte-identical.
- **Unfixed** (`development` tip — #2944 without this fix): restored to the baseline, GUI started, caught up the backlog → transaction table came up **missing a scattered subset of coinstake / side-stake transactions** (verified against a fully-synced reference wallet with the same keys, which shows the complete list).
- **Fixed** (this branch): restored to the *identical* baseline, GUI started, caught up → transaction table came up **complete**.
- Genuine orphan coinstakes stayed hidden (no `-showorphans`).

The unfixed-vs-fixed difference from a byte-identical baseline isolates this change as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)