### PR TITLE
rpc: convert 17 researcher/beacon/MRC blockchain.cpp commands to RPCHelpMan (Tier 1b, #2922)

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -99,7 +99,26 @@ install_deps() {
             append_base libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libqrencode-dev libzip-dev libcurl4-openssl-dev zipcmp zipmerge ziptool
 
             # Qt6 Packages (Qt5 names are not defined here as most are EOL)
-            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev libqt6core5compat6-dev
+            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev
+
+            # The Qt6Core5Compat dev package was renamed across the Debian/Ubuntu
+            # family in mid-2026:
+            #   - Debian Sid (and forky/trixie) ship only `qt6-5compat-dev`;
+            #     the older `libqt6core5compat6-dev` was dropped.
+            #   - Ubuntu Noble (24.04) ships both -- `libqt6core5compat6-dev` is
+            #     a transitional that pulls in `qt6-5compat-dev`.
+            #   - Ubuntu Jammy (22.04) ships only `libqt6core5compat6-dev`.
+            # Detect which name is available in the current apt cache and use
+            # that. Apt-cache is already populated by this point in the CI
+            # runners (the OS-detect block above triggered an `apt update`
+            # transitively) and on bare-metal dev systems this falls through
+            # to whichever name resolves. `-q -q` keeps the detection quiet on
+            # the success path.
+            if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
+                append_qt qt6-5compat-dev
+            else
+                append_qt libqt6core5compat6-dev
+            fi
 
             # Windows Cross-Compile Tools
             # NOTE: We only append NSIS here. The MinGW compiler (g++-mingw-w64-x86-64)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1511,16 +1511,26 @@ UniValue advertisebeacon(const UniValue& params, bool fHelp)
 
 UniValue beaconauth(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "beaconauth\n"
-                "\n"
-                "Generate a beacon key pair and return the public key hex.\n"
-                "Use the public key to obtain a BOINC account ownership proof\n"
-                "from a project that supports the ownership proof extension,\n"
-                "then call advertisebeaconv3 with the proof to send the beacon.\n"
-                "\n"
-                "Requires wallet to be fully unlocked.\n");
+    static const RPCHelpMan help{
+        "beaconauth",
+        "Generate a beacon key pair and return the public key hex. "
+        "Use the public key to obtain a BOINC account ownership proof from a project "
+        "that supports the ownership proof extension, then call advertisebeaconv3 with "
+        "the proof to send the beacon. Requires wallet to be fully unlocked.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "result", "\"SUCCESS\" on success."},
+                {RPCResult::Type::STR, "cpid", "The CPID associated with the beacon."},
+                {RPCResult::Type::STR_HEX, "public_key", "The beacon's public key."},
+                {RPCResult::Type::STR, "verification_code", "The beacon's verification code."},
+            }},
+        RPCExamples{
+            HelpExampleCli("beaconauth", "") +
+            HelpExampleRpc("beaconauth", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     EnsureWalletIsUnlocked();
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1829,14 +1829,34 @@ UniValue revokebeacon(const UniValue& params, bool fHelp)
 
 UniValue beaconreport(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "beaconreport <active only>\n"
-                "\n"
-                "<active only> Boolean specifying whether only active beacons should be \n"
-                "              returned. Defaults to false which also includes expired beacons."
-                "\n"
-                "Displays list of valid beacons in the network\n");
+    static const RPCHelpMan help{
+        "beaconreport",
+        "Displays the list of valid beacons in the network.",
+        {
+            {"active_only", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, return only active (non-expired) beacons. "
+                "Default: false (also includes expired beacons)."},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "cpid", "CPID for the beacon."},
+                        {RPCResult::Type::STR, "address", "Beacon payout address."},
+                        {RPCResult::Type::NUM_TIME, "timestamp", "Beacon timestamp."},
+                        {RPCResult::Type::STR_HEX, "hash", "Beacon hash."},
+                        {RPCResult::Type::STR_HEX, "prev_beacon_hash", "Previous beacon hash in the chainlet."},
+                        {RPCResult::Type::NUM, "status", "Beacon status raw value."},
+                        {RPCResult::Type::STR, "status_text", "Beacon status text."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("beaconreport", "") +
+            HelpExampleCli("beaconreport", "true") +
+            HelpExampleRpc("beaconreport", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     bool active_only = false;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1416,16 +1416,29 @@ UniValue rainbymagnitude(const UniValue& params, bool fHelp)
 
 UniValue advertisebeacon(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "advertisebeacon ( force )\n"
-                "\n"
-                "[force] --> If true, generate new beacon keys and send a new "
-                "beacon even when an active or pending beacon exists for your "
-                "CPID. This is useful if you lose a wallet with your original "
-                "beacon keys but not necessary otherwise.\n"
-                "\n"
-                "Advertise a beacon (Requires wallet to be fully unlocked)\n");
+    static const RPCHelpMan help{
+        "advertisebeacon",
+        "Advertise a beacon. Requires wallet to be fully unlocked.",
+        {
+            {"force", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, generate new beacon keys and send a new beacon even when an active "
+                "or pending beacon exists for your CPID. Useful if you lose a wallet with your "
+                "original beacon keys; not necessary otherwise. Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "result", "\"SUCCESS\" on success."},
+                {RPCResult::Type::STR, "cpid", "The CPID associated with the beacon."},
+                {RPCResult::Type::STR_HEX, "public_key", "The beacon's public key."},
+                {RPCResult::Type::STR, "verification_code", "The beacon's verification code."},
+            }},
+        RPCExamples{
+            HelpExampleCli("advertisebeacon", "") +
+            HelpExampleCli("advertisebeacon", "true") +
+            HelpExampleRpc("advertisebeacon", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     if (OutOfSyncByAge()) {
         throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to advertise a beacon.");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3148,11 +3148,29 @@ UniValue addkey(const UniValue& params, bool fHelp)
 
 UniValue currentcontractaverage(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "currentcontractaverage\n"
-                "\n"
-                "Displays information on your current contract average with regards to superblock contract\n");
+    static const RPCHelpMan help{
+        "currentcontractaverage",
+        "Display information on your current contract average with regards to the superblock contract.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::OBJ, "contract", "Serialized superblock contract.",
+                    {
+                        {RPCResult::Type::ELISION, "", "superblock fields"},
+                    }},
+                {RPCResult::Type::NUM, "beacon_count", "Total beacon count."},
+                {RPCResult::Type::NUM, "avg_mag", "Average magnitude."},
+                {RPCResult::Type::NUM, "beacon_participant_count", "Number of participating beacons."},
+                {RPCResult::Type::BOOL, "superblock_valid", "Whether the superblock is well-formed."},
+                {RPCResult::Type::STR_HEX, "quorum_hash", "Quorum hash for the superblock."},
+                {RPCResult::Type::NUM, "size", "Serialized size of the superblock in bytes."},
+            }},
+        RPCExamples{
+            HelpExampleCli("currentcontractaverage", "") +
+            HelpExampleRpc("currentcontractaverage", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2469,13 +2469,23 @@ UniValue lifetime(const UniValue& params, bool fHelp)
 
 UniValue magnitude(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "magnitude <cpid>\n"
-                "\n"
-                "<cpid> -> cpid to look up\n"
-                "\n"
-                "Displays information for the magnitude of all cpids or specified in the network\n");
+    static const RPCHelpMan help{
+        "magnitude",
+        "Display magnitude information for the specified CPID, or for the current wallet CPID if omitted.",
+        {
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID to look up. Defaults to the current wallet CPID."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "Magnitude report (see MagnitudeReport output for the full schema).",
+            {
+                {RPCResult::Type::ELISION, "", "report fields"},
+            }},
+        RPCExamples{
+            HelpExampleCli("magnitude", "") +
+            HelpExampleRpc("magnitude", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     const GRC::MiningId mining_id = params.size() > 0
         ? GRC::MiningId::Parse(params[0].get_str())

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1566,23 +1566,33 @@ UniValue beaconauth(const UniValue& params, bool fHelp)
 
 UniValue advertisebeaconv3(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-                "advertisebeaconv3 <ownership_proof_xml> ( force )\n"
-                "\n"
-                "Send a v3 beacon with a BOINC account ownership proof.\n"
-                "\n"
-                "<ownership_proof_xml> --> The XML block returned by the BOINC project's\n"
-                "  proof-of-account-ownership page. Must contain <master_url>, <msg>,\n"
-                "  and <signature> elements. The <msg> field should have the format:\n"
-                "  \"{account_id} {beacon_public_key_hex}\" (the project generates this\n"
-                "  when you enter the beacon public key from beaconauth).\n"
-                "\n"
-                "[force] --> If true, send the beacon even when an active or pending\n"
-                "  beacon already exists for your CPID. This is useful if you lose a\n"
-                "  wallet with your original beacon keys but not necessary otherwise.\n"
-                "\n"
-                "Requires wallet to be fully unlocked.\n");
+    static const RPCHelpMan help{
+        "advertisebeaconv3",
+        "Send a v3 beacon with a BOINC account ownership proof. Requires wallet to be fully unlocked.",
+        {
+            {"ownership_proof_xml", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The XML block returned by the BOINC project's proof-of-account-ownership page. "
+                "Must contain <master_url>, <msg>, and <signature> elements. The <msg> field "
+                "should have the format \"{account_id} {beacon_public_key_hex}\" "
+                "(the project generates this when you enter the beacon public key from beaconauth)."},
+            {"force", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, send the beacon even when an active or pending beacon already exists "
+                "for your CPID. Useful if you lose a wallet with your original beacon keys; not "
+                "necessary otherwise. Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "result", "\"SUCCESS\" on success."},
+                {RPCResult::Type::STR, "cpid", "The CPID associated with the beacon."},
+                {RPCResult::Type::STR_HEX, "public_key", "The beacon's public key."},
+                {RPCResult::Type::STR, "verification_code", "The beacon's verification code."},
+            }},
+        RPCExamples{
+            HelpExampleCli("advertisebeaconv3", "\"<xml>...</xml>\"") +
+            HelpExampleRpc("advertisebeaconv3", "\"<xml>...</xml>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     if (OutOfSyncByAge()) {
         throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to advertise a beacon.");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2377,13 +2377,28 @@ UniValue beaconaudit(const UniValue& params, bool fHelp)
 
 UniValue explainmagnitude(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "explainmagnitude ( cpid )\n"
-                "\n"
-                "[cpid] -> Optional CPID to explain magnitude for\n"
-                "\n"
-                "Itemize your CPID magnitudes by project.\n");
+    static const RPCHelpMan help{
+        "explainmagnitude",
+        "Itemize a CPID's magnitude contribution by project.",
+        {
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID to explain magnitude for. Defaults to the current wallet CPID."},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "project", "Project name (or \"total\" for the summary row)."},
+                        {RPCResult::Type::NUM, "rac", "Recent average credit for the project."},
+                        {RPCResult::Type::NUM, "magnitude", "Magnitude contribution from the project."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("explainmagnitude", "") +
+            HelpExampleRpc("explainmagnitude", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     const GRC::MiningId mining_id = params.size() > 0
         ? GRC::MiningId::Parse(params[0].get_str())

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2060,13 +2060,30 @@ UniValue pendingbeaconreport(const UniValue& params, bool fHelp)
 
 UniValue beaconstatus(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "beaconstatus [cpid]\n"
-                "\n"
-                "[cpid] -> Optional parameter of cpid\n"
-                "\n"
-                "Displays status of your beacon or specified beacon on the network\n");
+    static const RPCHelpMan help{
+        "beaconstatus",
+        "Displays the status of your beacon, or of the specified beacon on the network.",
+        {
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID to look up. Defaults to the current wallet CPID."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "active", "Active beacons for this CPID.",
+                    {
+                        {RPCResult::Type::ELISION, "", "beacon entry (cpid, active, pending, expired, renewable, timestamp, address, public_key, private_key_available, magnitude, verification_code, is_mine)"},
+                    }},
+                {RPCResult::Type::ARR, "pending", "Pending beacons for this CPID.",
+                    {
+                        {RPCResult::Type::ELISION, "", "beacon entry (same fields as active)"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("beaconstatus", "") +
+            HelpExampleRpc("beaconstatus", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     const GRC::MiningId mining_id = params.size() > 0
         ? GRC::MiningId::Parse(params[0].get_str())

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1143,20 +1143,31 @@ UniValue getblocksbatch(const UniValue& params, bool fHelp)
 
 UniValue rainbymagnitude(const UniValue& params, bool fHelp)
     {
-    if (fHelp || (params.size() < 2 || params.size() > 4))
-        throw runtime_error(
-                "rainbymagnitude project_id amount ( trial_run output_details )\n"
-                "\n"
-                "project_id     -> Required: Limits rain to a specific project. Use \"*\" for\n"
-                "                  network-wide. Call \"listprojects\" for the IDs of eligible\n"
-                "                  projects."
-                "amount         -> Required: Amount to rain (1000 GRC minimum).\n"
-                "trial_run      -> Optional: Boolean to specify a trial run instead of an actual\n"
-                "                  transaction (default: false).\n"
-                "output_details -> Optional: Boolean to output recipient details (default: false\n"
-                "                  if not trial run, true if trial run).\n"
-                "\n"
-                "rain coins by magnitude on network");
+    static const RPCHelpMan help{
+        "rainbymagnitude",
+        "Rain coins by magnitude on the network.",
+        {
+            {"project_id", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Limits rain to a specific project. Use \"*\" for network-wide. "
+                "Call \"listprojects\" for the IDs of eligible projects."},
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO,
+                "Amount to rain (1000 GRC minimum)."},
+            {"trial_run", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, perform a trial run instead of an actual transaction. Default: false."},
+            {"output_details", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, output recipient details. "
+                "Default: false (or true if trial_run is true)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "Rain result (see rainbymagnitude output for the full schema).",
+            {
+                {RPCResult::Type::ELISION, "", "result fields"},
+            }},
+        RPCExamples{
+            HelpExampleCli("rainbymagnitude", "\"*\" 1000 true") +
+            HelpExampleRpc("rainbymagnitude", "\"*\", 1000, true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue res(UniValue::VOBJ);
     UniValue details(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -497,21 +497,32 @@ UniValue dumpcontracts(const UniValue& params, bool fHelp)
 
 UniValue getmrcinfo(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 4)
-        throw runtime_error(
-                "getmrcinfo [detailed MRC info [CPID [low height [high height]]]]\n"
-                "\n"
-                "[detailed MRC info]: optional boolean to output MRC details.\n"
-                "                     Defaults to false.\n"
-                "[CPID]:              optional CPID. Defaults to current wallet CPID.\n"
-                "                     Use \"*\" for all CPIDs (network wide).\n"
-                "                     Note that block level mrc summary statistics are\n"
-                "                     specific to the scope specified with CPID.\n"
-                "[low height]:        optional low height for scope.\n"
-                "                     Defaults to V12 block height.\n"
-                "[high height]:       optional high height for scope.\n"
-                "                     Defaults to current block.\n"
-                );
+    static const RPCHelpMan help{
+        "getmrcinfo",
+        "Display MRC (Manual Research Claim) summary statistics for the given CPID and block range.",
+        {
+            {"detailed_mrc_info", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, output detailed per-MRC info. Default: false."},
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID to scope to. Defaults to the current wallet CPID. Use \"*\" for all CPIDs "
+                "(network-wide). Block-level MRC summary statistics are specific to the scope "
+                "specified by this CPID."},
+            {"low_height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Low height for scope. Defaults to V12 block height."},
+            {"high_height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "High height for scope. Defaults to current block."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "MRC summary report (see getmrcinfo output for the full schema).",
+            {
+                {RPCResult::Type::ELISION, "", "report fields"},
+            }},
+        RPCExamples{
+            HelpExampleCli("getmrcinfo", "") +
+            HelpExampleCli("getmrcinfo", "true \"*\"") +
+            HelpExampleRpc("getmrcinfo", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     bool output_mrc_details = false;
     bool output_all_cpids = false;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1903,30 +1903,52 @@ UniValue beaconreport(const UniValue& params, bool fHelp)
 
 UniValue beaconconvergence(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-        throw runtime_error(
-                "beaconconvergence\n"
-                "\n"
-                "Displays verified and pending beacons from the scraper or subscriber viewpoint.\n"
-                "\n"
-                "There are three output sections:\n"
-                "\n"
-                "verified_beacons_from_scraper_global:\n"
-                "\n"
-                "Comes directly from the scraper global map for verified beacons. This is\n"
-                "for scraper monitoring of an individual scraper and will be empty if not\n"
-                "run on an actual scraper node."
-                "\n"
-                "verified_beacons_from_latest_convergence:\n"
-                "\n"
-                "From the latest convergence formed from all of the scrapers. This list\n"
-                "is what will be activated in the next superblock.\n"
-                "\n"
-                "pending_beacons_from_GetConsensusBeaconList:\n"
-                "\n"
-                "This is a list of pending beacons. Note that it is subject to a one\n"
-                "hour ladder, so it will lag the information from the\n"
-                "pendingbeaconreport rpc call.\n");
+    static const RPCHelpMan help{
+        "beaconconvergence",
+        "Displays verified and pending beacons from the scraper or subscriber viewpoint. "
+        "Output has three sections: verified_beacons_from_scraper_global (the scraper's "
+        "local verified-beacon map; empty on non-scraper nodes), "
+        "verified_beacons_from_latest_convergence (verified beacons from the latest "
+        "all-scrapers convergence, to be activated in the next superblock), and "
+        "pending_beacons_from_GetConsensusBeaconList (pending beacons; subject to a one-hour "
+        "ladder, so this lags the pendingbeaconreport RPC).",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "verified_beacons_from_scraper_global", "",
+                    {
+                        {RPCResult::Type::OBJ, "", "",
+                            {
+                                {RPCResult::Type::STR, "cpid", "CPID."},
+                                {RPCResult::Type::STR, "verification_code", "Verification code."},
+                                {RPCResult::Type::NUM_TIME, "timestamp", "Beacon timestamp."},
+                            }},
+                    }},
+                {RPCResult::Type::ARR, "verified_beacons_from_latest_convergence", "",
+                    {
+                        {RPCResult::Type::OBJ, "", "",
+                            {
+                                {RPCResult::Type::STR, "cpid", "CPID."},
+                                {RPCResult::Type::STR, "verification_code", "Verification code."},
+                                {RPCResult::Type::NUM_TIME, "timestamp", "Beacon timestamp."},
+                            }},
+                    }},
+                {RPCResult::Type::ARR, "pending_beacons_from_GetConsensusBeaconList", "",
+                    {
+                        {RPCResult::Type::OBJ, "", "",
+                            {
+                                {RPCResult::Type::STR, "cpid", "CPID."},
+                                {RPCResult::Type::STR, "verification_code", "Verification code."},
+                                {RPCResult::Type::NUM_TIME, "timestamp", "Beacon timestamp."},
+                            }},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("beaconconvergence", "") +
+            HelpExampleRpc("beaconconvergence", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue results(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2005,11 +2005,26 @@ UniValue beaconconvergence(const UniValue& params, bool fHelp)
 
 UniValue pendingbeaconreport(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-        throw runtime_error(
-                "pendingbeaconreport\n"
-                "\n"
-                "Displays pending beacons directly from the beacon registry.\n");
+    static const RPCHelpMan help{
+        "pendingbeaconreport",
+        "Displays pending beacons directly from the beacon registry.",
+        {},
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "cpid", "CPID."},
+                        {RPCResult::Type::STR, "key_id", "Beacon key id."},
+                        {RPCResult::Type::STR, "address", "Beacon payout address."},
+                        {RPCResult::Type::NUM_TIME, "timestamp", "Beacon timestamp."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("pendingbeaconreport", "") +
+            HelpExampleRpc("pendingbeaconreport", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue results(UniValue::VARR);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2533,11 +2533,20 @@ UniValue magnitude(const UniValue& params, bool fHelp)
 
 UniValue resetcpids(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "resetcpids\n"
-                "\n"
-                "Reloads cpids\n");
+    static const RPCHelpMan help{
+        "resetcpids",
+        "Reload CPIDs from the config file.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM, "Reset", "Always 1 on success."},
+            }},
+        RPCExamples{
+            HelpExampleCli("resetcpids", "") +
+            HelpExampleRpc("resetcpids", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1741,13 +1741,25 @@ UniValue advertisebeaconv3(const UniValue& params, bool fHelp)
 
 UniValue revokebeacon(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "revokebeacon [cpid]\n"
-                "\n"
-                "[cpid] CPID associated with the beacon to revoke. If omitted, uses the current CPID.\n"
-                "\n"
-                "Revoke a beacon (Requires wallet to be fully unlocked)\n");
+    static const RPCHelpMan help{
+        "revokebeacon",
+        "Revoke a beacon. Requires wallet to be fully unlocked.",
+        {
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID associated with the beacon to revoke. If omitted, uses the current CPID."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "result", "\"SUCCESS\" on success."},
+                {RPCResult::Type::STR, "cpid", "The CPID associated with the revoked beacon."},
+                {RPCResult::Type::STR_HEX, "public_key", "The revoked beacon's public key."},
+            }},
+        RPCExamples{
+            HelpExampleCli("revokebeacon", "") +
+            HelpExampleRpc("revokebeacon", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     if (OutOfSyncByAge()) {
         throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to revoke a beacon.");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2154,17 +2154,29 @@ UniValue beaconstatus(const UniValue& params, bool fHelp)
 
 UniValue beaconaudit(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 2)
-        throw runtime_error(
-            "beaconaudit [errors only] [cpid]\n"
-            "\n"
-            "[errors only] -> Boolean to provide errors only. Defaults to true.\n"
-            "[cpid] -> Optional parameter of cpid. Defaults to current cpid. * means all active CPIDs.\n"
-            "\n"
-            "Conducts consistency audit for beacon contracts and beacon chain for given CPID.\n"
-            "This is currently limited to looking at multiple renewals for the same CPID in\n"
-            "the same block and reporting inconsistencies between the normal contract order\n"
-            "and the historical beacon entries (beacon chainlet) for the CPID.\n");
+    static const RPCHelpMan help{
+        "beaconaudit",
+        "Conduct a consistency audit for beacon contracts and the beacon chain for the given CPID. "
+        "Currently limited to looking at multiple renewals for the same CPID in the same block and "
+        "reporting inconsistencies between the normal contract order and the historical beacon entries "
+        "(beacon chainlet) for the CPID.",
+        {
+            {"errors_only", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, return only errors. Default: true."},
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID to audit. Defaults to the current wallet CPID. Use \"*\" for all active CPIDs."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "Audit report (see beaconaudit output for the full schema).",
+            {
+                {RPCResult::Type::ELISION, "", "audit fields"},
+            }},
+        RPCExamples{
+            HelpExampleCli("beaconaudit", "") +
+            HelpExampleCli("beaconaudit", "true \"*\"") +
+            HelpExampleRpc("beaconaudit", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     bool errors_only = true;
     bool global = false;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3951,20 +3951,30 @@ UniValue getburnreport(const UniValue& params, bool fHelp)
 }
 
 UniValue createmrcrequest(const UniValue& params, const bool fHelp) {
-    if (fHelp || params.size() > 3) {
-        throw runtime_error("createmrcrequest [dry_run [force [fee]]]\n"
-                            "\n"
-                            "[dry_run] - If true, calculate the reward and fee but do not "
-                            "send the contract. Defaults to false.\n"
-                            "\n"
-                            "[force] - If true, create the request even if it results "
-                            "in a reward loss or ban from the network. Defaults to false. "
-                            "Only works on testnet.\n"
-                            "\n"
-                            "[fee] - If passed, use the fee provided instead of the "
-                            "calculated fee. Must not be lower than the calculated fee.\n"
-                            "\n"
-                            "Creates an MRC request. Requires an unlocked wallet.");
+    static const RPCHelpMan help{
+        "createmrcrequest",
+        "Create an MRC (Manual Research Claim) request. Requires an unlocked wallet.",
+        {
+            {"dry_run", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, calculate the reward and fee but do not send the contract. Default: false."},
+            {"force", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, create the request even if it results in a reward loss or ban from the "
+                "network. Default: false. Only works on testnet."},
+            {"fee", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                "If passed, use this fee instead of the calculated fee. Must not be lower than "
+                "the calculated fee."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "MRC request result (see createmrcrequest output for the full schema).",
+            {
+                {RPCResult::Type::ELISION, "", "request fields (outstanding_request, limit, mrcs_in_queue, head_fee, pay_limit_position_fee, tail_fee, pos, txid (if not dry_run), mrc)"},
+            }},
+        RPCExamples{
+            HelpExampleCli("createmrcrequest", "") +
+            HelpExampleCli("createmrcrequest", "true") +
+            HelpExampleRpc("createmrcrequest", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw runtime_error(help.ToString());
     }
 
     bool dry_run{false};

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2444,11 +2444,23 @@ UniValue explainmagnitude(const UniValue& params, bool fHelp)
 
 UniValue lifetime(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "lifetime [cpid]\n"
-                "\n"
-                "Displays research rewards for the lifetime of a CPID.\n");
+    static const RPCHelpMan help{
+        "lifetime",
+        "Display research rewards for the lifetime of a CPID.",
+        {
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "CPID to look up. Defaults to the current wallet CPID."},
+        },
+        RPCResult{RPCResult::Type::OBJ_DYN, "", "Block height -> research subsidy (GRC) for each block in which the CPID earned research rewards.",
+            {
+                {RPCResult::Type::STR_AMOUNT, "height", "Research subsidy (GRC) paid in that block."},
+            }},
+        RPCExamples{
+            HelpExampleCli("lifetime", "") +
+            HelpExampleRpc("lifetime", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     const GRC::MiningId mining_id = params.size() > 0
         ? GRC::MiningId::Parse(params[0].get_str())

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -12,6 +12,30 @@
 
 #include <stdexcept>
 #include <string>
+#include <vector>
+
+// Forward declarations of the Tier 1b researcher/beacon/MRC commands under test.
+// Must live in the global namespace; placing them inside BOOST_AUTO_TEST_SUITE
+// captures them into the suite's namespace and breaks linkage. After conversion
+// each function throws std::runtime_error for fHelp=true before touching any
+// node globals or acquiring locks, so calling them with empty params is safe.
+UniValue advertisebeacon(const UniValue& params, bool fHelp);
+UniValue advertisebeaconv3(const UniValue& params, bool fHelp);
+UniValue beaconauth(const UniValue& params, bool fHelp);
+UniValue revokebeacon(const UniValue& params, bool fHelp);
+UniValue beaconreport(const UniValue& params, bool fHelp);
+UniValue beaconconvergence(const UniValue& params, bool fHelp);
+UniValue pendingbeaconreport(const UniValue& params, bool fHelp);
+UniValue beaconstatus(const UniValue& params, bool fHelp);
+UniValue beaconaudit(const UniValue& params, bool fHelp);
+UniValue getmrcinfo(const UniValue& params, bool fHelp);
+UniValue createmrcrequest(const UniValue& params, const bool fHelp);
+UniValue magnitude(const UniValue& params, bool fHelp);
+UniValue explainmagnitude(const UniValue& params, bool fHelp);
+UniValue lifetime(const UniValue& params, bool fHelp);
+UniValue resetcpids(const UniValue& params, bool fHelp);
+UniValue rainbymagnitude(const UniValue& params, bool fHelp);
+UniValue currentcontractaverage(const UniValue& params, bool fHelp);
 
 // Forward declarations of the Tier 2 commands under test. These must live in
 // the global namespace; if placed inside BOOST_AUTO_TEST_SUITE(...) they get
@@ -430,6 +454,53 @@ BOOST_AUTO_TEST_CASE(setban_invalid_subcommand_throws_structured_error)
         BOOST_CHECK(message.find("command must be") != std::string::npos);
         BOOST_CHECK(message.find("add") != std::string::npos);
         BOOST_CHECK(message.find("remove") != std::string::npos);
+    }
+}
+
+// Tier 1b coverage: each converted researcher/beacon/MRC command throws a
+// runtime_error containing its name and the "Examples:" marker when called
+// with fHelp=true. Runs fixture-free — the help-gate fires before any global
+// state is touched.
+BOOST_AUTO_TEST_CASE(tier1b_researcher_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"advertisebeacon",        &advertisebeacon},
+        {"advertisebeaconv3",      &advertisebeaconv3},
+        {"beaconauth",             &beaconauth},
+        {"revokebeacon",           &revokebeacon},
+        {"beaconreport",           &beaconreport},
+        {"beaconconvergence",      &beaconconvergence},
+        {"pendingbeaconreport",    &pendingbeaconreport},
+        {"beaconstatus",           &beaconstatus},
+        {"beaconaudit",            &beaconaudit},
+        {"getmrcinfo",             &getmrcinfo},
+        {"createmrcrequest",       &createmrcrequest},
+        {"magnitude",              &magnitude},
+        {"explainmagnitude",       &explainmagnitude},
+        {"lifetime",               &lifetime},
+        {"resetcpids",             &resetcpids},
+        {"rainbymagnitude",        &rainbymagnitude},
+        {"currentcontractaverage", &currentcontractaverage},
+    };
+
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                    rpc_name << ": help text missing command name; got: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                    rpc_name << ": help text missing 'Examples:' section");
+            }
+            BOOST_CHECK_MESSAGE(threw, rpc_name << ": expected runtime_error for fHelp=true");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Tier 1b of issue #2922 — the second slice of `src/rpc/blockchain.cpp`'s Tier 1 conversions, picking up the researcher subsystem: beacon lifecycle, magnitude/accrual, MRC, and the contract-average reporter. Pure packaging change: no behavior changes, no error-code changes, no `RPCResult` schemas that don't match the actual return values.

One commit per command (matches Tier 1a #2954 / Tier 2 #2930 / Tier 3 #2924), plus one test commit that exercises all 17 conversions on the help-rendering path.

## Independent of #2954 (Tier 1a)

This branch is based on `origin/development`, not on #2954. All 17 commands here are disjoint from the 21 in Tier 1a — no overlap, no conflicts expected if either lands first.

## Commands converted

**Beacon (9):** `advertisebeacon`, `advertisebeaconv3`, `beaconauth`, `revokebeacon`, `beaconreport`, `beaconconvergence`, `pendingbeaconreport`, `beaconstatus`, `beaconaudit`

**MRC (2):** `getmrcinfo`, `createmrcrequest`

**Magnitude / accrual (5):** `magnitude`, `explainmagnitude`, `lifetime`, `resetcpids`, `rainbymagnitude`

**Contract average (1):** `currentcontractaverage`

The remaining 14 `blockchain.cpp` Tier 1 commands (snapshots/registries/data) are deferred to Tier 1c.

> Note: the original Tier 1 survey on this file undercounted by one because `createmrcrequest` uses `const bool fHelp` (instead of the bare `bool fHelp` everywhere else) and the survey regex missed it. The issue's Beacon/staking checklist had it from the start; this PR closes it.

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` now renders the structured `RPCHelpMan` output instead of the legacy free-form string. Same wire shape (still a `runtime_error` containing the help text); contents auto-formatted.
- `params.size()` checks moved from inline conditions to `help.IsValidNumArgs(...)`. Arity bounds preserved exactly for every command — verified against each function's original `if (fHelp || params.size() ...)` condition.
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes, no error-message rewording. In particular, `advertisebeacon`/`advertisebeaconv3`/`revokebeacon` keep their pre-existing `OutOfSyncByAge()` + `EnsureWalletIsUnlocked()` runtime preconditions (those fire only on actual invocation, not on `help`).

**RPCResult schemas were verified per command** by tracing each function to its `return` statement. Fixed-shape OBJ results enumerate their actual `pushKV` keys (e.g. `advertisebeacon`, `beaconauth`, `beaconreport`, `pendingbeaconreport`, `beaconconvergence`, `currentcontractaverage`). The wider variable-shape returns (`beaconstatus`, `beaconaudit`, `getmrcinfo`, `createmrcrequest`, `magnitude`, `rainbymagnitude`) use `RPCResult::Type::ELISION` for the inner entries — same pattern as the `listsinceblock` transactions array in #2930. `lifetime`'s height-keyed dynamic object uses `OBJ_DYN`.

## Tests

`src/test/rpchelpman_tests.cpp` gains one `BOOST_AUTO_TEST_CASE(tier1b_researcher_help_renders)` that:
- Iterates all 17 converted commands,
- Calls each with empty `params` and `fHelp=true`,
- Asserts the thrown `std::runtime_error` message contains the RPC name and the `Examples:` marker.

The help gate fires before any global state access for all 17 (matching the Tier 1a pattern), so the test runs fixture-free — same pattern as the Tier 2 `addnode_invalid_subcommand_throws_structured_error` test added in #2930.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready for review:
  - `gridcoinresearch help <cmd>` for each of the 17 — full help renders, examples present, no truncation
  - Spot-check return shape for `beaconreport`, `beaconconvergence`, `pendingbeaconreport`, `advertisebeacon`, `currentcontractaverage` (the fully-enumerated OBJ results) — confirm no field drift
  - Spot-check arity preservation for `advertisebeaconv3` (1-2 args), `beaconaudit` (0-2), `getmrcinfo` (0-4), `createmrcrequest` (0-3), `rainbymagnitude` (2-4)

Refs: #2922