### PR TITLE
refactor: silence pre-existing TSan/UBSan findings surfaced during #2944 heap-corruption hunt

### DIFF
--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -689,6 +689,18 @@ CSHA256::CSHA256() : bytes(0)
 
 CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
 {
+    // Early-return on empty input so that we never compute `data + len` with a
+    // null `data`. `nullptr + 0` is undefined behaviour per ISO C++ (UBSan
+    // catches it), and several callers legitimately pass an empty span -- for
+    // instance, hashing the body of a Gridcoin P2P message with empty payload
+    // (verack et al.) goes through here with `data` possibly null and
+    // `len == 0`, since `std::vector::data()` may return nullptr when size()
+    // is 0. Behaviour is preserved: hashing zero bytes was already a no-op
+    // (state unchanged, `bytes` counter not incremented), so the early return
+    // is bit-for-bit identical to the previous control flow on len == 0
+    // inputs.
+    if (len == 0) return *this;
+
     const unsigned char* end = data + len;
     size_t bufsize = bytes % 64;
     if (bufsize && bufsize + len >= 64) {

--- a/src/gridcoin/account.h
+++ b/src/gridcoin/account.h
@@ -36,7 +36,7 @@ class ResearchAccount
 public:
     CAmount m_accrual;                    //!< Research accrued last superblock.
     CAmount m_total_research_subsidy;     //!< Total lifetime research paid.
-    uint32_t m_total_magnitude;           //!< Total lifetime magnitude sum.
+    uint64_t m_total_magnitude;           //!< Total lifetime magnitude sum.
     uint32_t m_accuracy;                  //!< Non-zero magnitude payment count.
 
     const CBlockIndex* m_first_block_ptr; //!< First block with research reward.

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -329,7 +329,7 @@ public:
             // used in accrual calculations, only reporting.
             if (mrc_researcher->m_magnitude > 0) {
                 account.m_accuracy++;
-                account.m_total_magnitude += pindex->pprev->Magnitude();
+                account.m_total_magnitude += static_cast<uint64_t>(pindex->pprev->Magnitude());
             }
 
             if (account.m_first_block_ptr == nullptr) {
@@ -438,7 +438,7 @@ public:
 
         if (pindex->Magnitude() > 0) {
             account.m_accuracy--;
-            account.m_total_magnitude -= pindex->Magnitude();
+            account.m_total_magnitude -= static_cast<uint64_t>(pindex->Magnitude());
         }
 
         pindex = FindLastRewardBlock(cpid, pindex);
@@ -488,7 +488,7 @@ public:
 
             if (mrc_researcher->m_magnitude > 0) {
                 account.m_accuracy--;
-                account.m_total_magnitude -= pindex->pprev->Magnitude();
+                account.m_total_magnitude -= static_cast<uint64_t>(pindex->pprev->Magnitude());
             }
 
             const CBlockIndex* last_block_pindex = FindLastRewardBlock(cpid, pindex);

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -281,11 +281,15 @@ public:
 
         account.m_total_research_subsidy += pindex->ResearchSubsidy();
 
-        // TODO: This probably doesn't work correctly given the implicit cast and should be removed. It isn't
-        // used in accrual calculations, only reporting.
+        // m_total_magnitude / m_accuracy back the AverageLifetimeMagnitude
+        // reporting only (not accrual / consensus). m_total_magnitude was
+        // historically uint32_t; the implicit (double -> uint32_t) cast in
+        // the += overflowed once the lifetime sum passed UINT_MAX, which
+        // UBSan reports. Widened to uint64_t in account.h, and the
+        // truncating double-to-integer cast is made explicit here.
         if (pindex->Magnitude() > 0) {
             account.m_accuracy++;
-            account.m_total_magnitude += pindex->Magnitude();
+            account.m_total_magnitude += static_cast<uint64_t>(pindex->Magnitude());
         }
 
         if (account.m_first_block_ptr == nullptr) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -44,7 +44,7 @@ extern void ThreadAppInit2(void* parg);
 using namespace std;
 CWallet* pwalletMain;
 extern bool fQtActive;
-extern bool bGridcoinCoreInitComplete;
+extern std::atomic<bool> bGridcoinCoreInitComplete;
 extern bool fConfChange;
 extern bool fEnforceCanonical;
 extern unsigned int nNodeLifespan;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,7 @@ int64_t nMinimumInputValue = 0;
 // Gridcoin - Rob Halford
 
 bool fQtActive = false;
-bool bGridcoinCoreInitComplete = false;
+std::atomic<bool> bGridcoinCoreInitComplete{false};
 
 // Mining status variables
 std::string    msMiningErrors;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3108,12 +3108,14 @@ bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRecvMsg)
 
         // Checksum
         CDataStream& vRecv = msg.vRecv;
-        // vRecv.data() is well-defined for an empty container; the previous
-        // &vRecv.begin()[0] dereferenced begin() to take its address,
-        // which UBSan reports as a null-pointer-of-type bind on a
-        // zero-length message (benign in practice because nMessageSize
-        // is then 0 and Hash() reads no bytes, but the UB itself was
-        // visible).
+        // The previous form `&vRecv.begin()[0]` dereferenced begin() to take
+        // its address, which UBSan reported as a null-pointer-of-type bind on
+        // a zero-length message. `vRecv.data()` is well-defined for an empty
+        // container, but the standard permits it to return nullptr when size()
+        // is 0 -- and passing that down to CSHA256::Write would then exhibit
+        // `nullptr + 0` UB inside the hash core. That root is closed (see
+        // CSHA256::Write's len == 0 guard in crypto/sha256.cpp), so
+        // empty-payload messages (verack et al.) hash cleanly here.
         uint256 hash = Hash(Span<std::byte>{vRecv.data(), nMessageSize});
 
         // We just received a message off the wire, harvest entropy from the time (and the message checksum)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2335,7 +2335,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
 
 
-        pfrom->addrLocal = addrMe;
+        pfrom->SetAddrLocal(addrMe);
         if (pfrom->fInbound && addrMe.IsRoutable())
         {
             SeenLocal(addrMe);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3108,7 +3108,13 @@ bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRecvMsg)
 
         // Checksum
         CDataStream& vRecv = msg.vRecv;
-        uint256 hash = Hash(Span<std::byte>{(std::byte*)&vRecv.begin()[0], nMessageSize});
+        // vRecv.data() is well-defined for an empty container; the previous
+        // &vRecv.begin()[0] dereferenced begin() to take its address,
+        // which UBSan reports as a null-pointer-of-type bind on a
+        // zero-length message (benign in practice because nMessageSize
+        // is then 0 and Hash() reads no bytes, but the UB itself was
+        // visible).
+        uint256 hash = Hash(Span<std::byte>{vRecv.data(), nMessageSize});
 
         // We just received a message off the wire, harvest entropy from the time (and the message checksum)
         RandAddEvent(ReadLE32(hash.begin()));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1376,7 +1376,16 @@ bool IsMiningAllowed(CWallet *pwallet)
         g_miner_status.AddError(GRC::MinerStatus::TESTNET_ONLY);
     }
 
-    if (vNodes.size() < GetMinimumConnectionsRequiredForStaking() || (!fTestNet && IsInitialBlockDownload())) {
+    // vNodes is mutated by ThreadSocketHandler / connection-accept paths
+    // under cs_vNodes; snapshot the size under the lock rather than racing
+    // the writers (TSan G3 at miner.cpp:1379). Mirrors the existing pattern
+    // at net.cpp:889-897.
+    size_t numNodes;
+    {
+        LOCK(cs_vNodes);
+        numNodes = vNodes.size();
+    }
+    if (numNodes < GetMinimumConnectionsRequiredForStaking() || (!fTestNet && IsInitialBlockDownload())) {
         g_miner_status.AddError(GRC::MinerStatus::OFFLINE);
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -65,7 +65,7 @@ std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(cs_mapLocalHost);
 static bool vfLimited[NET_MAX] GUARDED_BY(cs_mapLocalHost) = {};
 static CNode* pnodeLocalHost = nullptr;
 CAddress addrSeenByPeer(LookupNumeric("0.0.0.0", 0), nLocalServices);
-uint64_t nLocalHostNonce = 0;
+std::atomic<uint64_t> nLocalHostNonce{0};
 
 
 std::atomic<uint64_t> CNode::nTotalBytesRecv{ 0 };
@@ -486,7 +486,12 @@ void CNode::PushVersion()
     int64_t nTime = GetAdjustedTime();
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(LookupNumeric("0.0.0.0", 0)));
     CAddress addrMe = CAddress(CService(), nLocalServices);
-    GetRandBytes({(unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce)});
+    // GetRandBytes() writes raw bytes into the provided buffer; that's
+    // incompatible with memcpy'ing into a std::atomic's storage directly,
+    // so go through a local and store atomically.
+    uint64_t nonce;
+    GetRandBytes({(unsigned char*)&nonce, sizeof(nonce)});
+    nLocalHostNonce.store(nonce);
 
     // Snapshot the chain height under cs_main so this method can be called
     // from CNode construction (socket handler thread, no outer locks held)
@@ -504,7 +509,7 @@ void CNode::PushVersion()
         nTime,
         addrYou,
         addrMe,
-        nLocalHostNonce,
+        nLocalHostNonce.load(),
         FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
         nLocalBestHeight);
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -489,6 +489,16 @@ void CNode::PushVersion()
     // GetRandBytes() writes raw bytes into the provided buffer; that's
     // incompatible with memcpy'ing into a std::atomic's storage directly,
     // so go through a local and store atomically.
+    //
+    // The local `nonce` is what we send on the wire below -- the atomic
+    // store is only to publish it to ProcessMessage's self-connection
+    // sentinel check. Reading the atomic back here for the PushMessage
+    // payload would lose the value to a concurrent PushVersion() on
+    // another outbound connection that ran between our store() and
+    // load(). (The single-global-nonce design is still racy across
+    // multiple simultaneous outbound connections versus their respective
+    // self-connection echoes -- a separate per-connection-nonce follow-up
+    // is the proper fix; see PR #2957 commit message for context.)
     uint64_t nonce;
     GetRandBytes({(unsigned char*)&nonce, sizeof(nonce)});
     nLocalHostNonce.store(nonce);
@@ -509,7 +519,7 @@ void CNode::PushVersion()
         nTime,
         addrYou,
         addrMe,
-        nLocalHostNonce.load(),
+        nonce,
         FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
         nLocalBestHeight);
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -197,7 +197,7 @@ static int GetnScore(const CService& addr)
 // Is our peer's addrLocal potentially useful as an external IP source?
 bool IsPeerAddrLocalGood(CNode *pnode)
 {
-    CService addrLocal = pnode->addrLocal;
+    CService addrLocal = pnode->GetAddrLocal();
     return fDiscover && pnode->addr.IsRoutable() && addrLocal.IsRoutable() &&
            IsReachable(addrLocal);
 }
@@ -216,7 +216,7 @@ void AdvertiseLocal(CNode *pnode)
         if (IsPeerAddrLocalGood(pnode) && (!addrLocal.IsRoutable() ||
              randomNumber == 0))
         {
-            addrLocal.SetIP(pnode->addrLocal);
+            addrLocal.SetIP(pnode->GetAddrLocal());
         }
         if (addrLocal.IsRoutable())
         {
@@ -600,6 +600,23 @@ bool CNode::MisbehavingAddr(const CAddress& addr, int howmuch)
     return false;
 }
 
+CService CNode::GetAddrLocal() const
+{
+    LOCK(cs_addrLocal);
+    return addrLocal;
+}
+
+void CNode::SetAddrLocal(const CService& addrLocalIn)
+{
+    LOCK(cs_addrLocal);
+    if (addrLocal.IsValid()) {
+        LogPrintf("WARN: %s: addrLocal already set for node %d: refusing to change from %s to %s",
+                  __func__, id, addrLocal.ToString(), addrLocalIn.ToString());
+    } else {
+        addrLocal = addrLocalIn;
+    }
+}
+
 void CNode::copyStats(CNodeStats &stats)
 {
     stats.id = id;
@@ -636,7 +653,8 @@ void CNode::copyStats(CNodeStats &stats)
     stats.dPingTime = (((double)nPingUsecTime) / 1e6);
     stats.dMinPing  = (((double)nMinPingUsecTime) / 1e6);
     stats.dPingWait = (((double)nPingUsecWait) / 1e6);
-    stats.addrLocal = addrLocal.IsValid() ? addrLocal.ToString() : "";
+    const CService al = GetAddrLocal();
+    stats.addrLocal = al.IsValid() ? al.ToString() : "";
 
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -203,9 +203,15 @@ public:
     std::atomic<uint64_t> nRecvBytes {0};
     int nRecvVersion GUARDED_BY(cs_vRecvMsg);
 
-    int64_t nLastSend;
-    int64_t nLastRecv;
-    int64_t nTimeConnected;
+    // These three were plain int64_t historically (Bitcoin-Core-inherited).
+    // ThreadSocketHandler2's inactivity-check loop reads them racily against
+    // the message-handler / connection-accept paths that write them; TSan
+    // surfaced races at net.cpp:751,1144,1158,1170,1179,1188 and elsewhere
+    // tracking the same addresses. Atomicising matches the pattern already
+    // used for nSendBytes / nRecvBytes / nTimeOffset directly above.
+    std::atomic<int64_t> nLastSend{0};
+    std::atomic<int64_t> nLastRecv{0};
+    std::atomic<int64_t> nTimeConnected{0};
     int64_t nNextRebroadcastTime;
     std::atomic<int64_t> nTimeOffset{0};
     CAddress addr;
@@ -260,10 +266,15 @@ public:
     std::multimap<int64_t, CInv> mapAskFor;
 
     // Ping time measurement:
-    // The pong reply we're expecting, or 0 if no pong expected.
-    uint64_t nPingNonceSent;
+    // The pong reply we're expecting, or 0 if no pong expected. Set on the
+    // ping-send path in SendMessages and cleared on the PONG receive path in
+    // ProcessMessage; read raw from ThreadSocketHandler2's timeout check. The
+    // companion nPingUsecTime / nMinPingUsecTime below were already atomic;
+    // atomicising these two closes the matching races (TSan main.cpp:2992 and
+    // net.cpp:1186).
+    std::atomic<uint64_t> nPingNonceSent{0};
     // Time (in usec) the last ping was sent, or 0 if no ping was ever sent.
-    int64_t nPingUsecStart;
+    std::atomic<int64_t> nPingUsecStart{0};
     // Last measured round-trip time.
     std::atomic<int64_t> nPingUsecTime{0};
     // Best measured round-trip time.

--- a/src/net.h
+++ b/src/net.h
@@ -100,7 +100,16 @@ extern bool fDiscover;
 void Discover(boost::thread_group& threadGroup);
 extern bool fUseUPnP;
 extern ServiceFlags nLocalServices;
-extern uint64_t nLocalHostNonce;
+// Local-host version nonce, randomised on every outgoing VERSION push and
+// compared against incoming VERSIONs to detect self-connection. It is a
+// global -- written on the socket-handler thread (PushVersion) and read on
+// the message-handler thread (ProcessMessage's "connected to ourself"
+// check), so it must be atomic; TSan G11 reports the race via a memcpy
+// into its raw storage from GetRandBytes. Note: the broader design is
+// imperfect (the same global is clobbered for each outbound connection,
+// so the per-connection nonce identity is lost), but that is a separate
+// follow-up; atomicising here just closes the data race.
+extern std::atomic<uint64_t> nLocalHostNonce;
 extern CAddress addrSeenByPeer;
 extern CAddrMan addrman;
 extern std::map<CInv, CDataStream> mapRelay;

--- a/src/net.h
+++ b/src/net.h
@@ -253,7 +253,12 @@ public:
     bool fOneShot;
     bool fClient;
     bool fInbound;
-    bool fNetworkNode;
+    // Atomic: written by ThreadOpenConnections2 (OpenNetworkConnection sets true
+    // after a successful outbound connection) and read by both
+    // ThreadSocketHandler2 (close-side bookkeeping) and the message-handler
+    // thread (first-messages "remember this address" path). No common lock --
+    // sibling of the same CNode-scalar pattern atomicised for G6-G10.
+    std::atomic<bool> fNetworkNode;
     bool fSuccessfullyConnected;
     std::atomic_bool fDisconnect;
     CSemaphoreGrant grantOutbound;

--- a/src/net.h
+++ b/src/net.h
@@ -216,7 +216,19 @@ public:
     std::atomic<int64_t> nTimeOffset{0};
     CAddress addr;
     std::string addrName;
-    CService addrLocal;
+    // addrLocal is the local address as seen by this peer (sent by them in
+    // their VERSION message). It is written once on the message-handler
+    // thread that processes that VERSION, and read concurrently by the GUI
+    // peers-table refresh (under cs_vNodes) and by net.cpp helpers
+    // (GetLocalAddress / IsPeerAddrLocalGood). The pre-existing pattern
+    // covered the readers (which hold cs_vNodes) but not the writer (which
+    // holds cs_vRecvMsg, a different mutex), surfaced as TSan G4/G5 races
+    // in CNetAddr::IsValid via CNode::copyStats.
+    //
+    // Use the GetAddrLocal()/SetAddrLocal() accessors below rather than
+    // touching the field directly.
+    mutable CCriticalSection cs_addrLocal;
+    CService addrLocal GUARDED_BY(cs_addrLocal);
     int nVersion;
     std::string strSubVer;
 	int nTrust;
@@ -589,6 +601,12 @@ public:
     //! \return The decayed misbehavior score.
     //!
     static int GetMisbehaviorAddr(const CAddress& addr);
+
+    // Thread-safe accessors for addrLocal. See the comment on the field
+    // above for the locking rationale.
+    CService GetAddrLocal() const LOCKS_EXCLUDED(cs_addrLocal);
+    void SetAddrLocal(const CService& addrLocalIn) LOCKS_EXCLUDED(cs_addrLocal);
+
     void copyStats(CNodeStats &stats);
 
     static void CopyNodeStats(std::vector<CNodeStats>& vstats);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -72,7 +72,7 @@ Q_IMPORT_PLUGIN(QSvgIconPlugin);
 #endif
 
 extern bool fQtActive;
-extern bool bGridcoinCoreInitComplete;
+extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -717,6 +717,11 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 window.setClientModel(nullptr);
                 window.setWalletModel(nullptr);
                 window.setResearcherModel(nullptr);
+                // Clear the voting model BEFORE the enclosing block exits and
+                // destroys the stack-allocated VotingModel: this propagates to
+                // PollTableModel::setModel(nullptr) which drains any in-flight
+                // QtConcurrent refresh worker still dereferencing the model.
+                window.setVotingModel(nullptr);
                 guiref = nullptr;
             }
             // Shutdown the core and its threads, but don't exit Bitcoin-Qt here

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -303,9 +303,15 @@ const PollItem* PollTableModel::rowItem(int row) const
 
 void PollTableModel::refresh()
 {
+    if (!m_voting_model) {
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: no voting model set, skipping refresh",
+                 __func__);
+
+        return;
+    }
+
     bool expected = false;
-    if (!m_voting_model ||
-        !m_refresh_in_flight.compare_exchange_strong(expected, true)) {
+    if (!m_refresh_in_flight.compare_exchange_strong(expected, true)) {
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh already in flight, skipping",
                  __func__);
 

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -261,11 +261,31 @@ PollTableModel::~PollTableModel()
 
 void PollTableModel::setModel(VotingModel* model)
 {
+    if (m_voting_model == model) {
+        return;
+    }
+
+    // If we are detaching from a model (e.g. shutdown of the GUI sets this to
+    // nullptr before VotingModel goes out of scope), ensure any in-flight
+    // refresh worker has finished dereferencing it. PollTableModel's destructor
+    // also waitForFinished()s, but by then VotingModel may already have been
+    // destroyed -- it is a stack object in StartGridcoinQt() whose scope ends
+    // before BitcoinGUI / VotingPage / PollTableModel are torn down. Draining
+    // here, while VotingModel is still alive, closes that UAF window.
+    if (m_voting_model) {
+        m_refresh_future.waitForFinished();
+        disconnect(m_voting_model, &VotingModel::newVoteReceived,
+                   this, &PollTableModel::handlePollStaleFlag);
+    }
+
     m_voting_model = model;
 
-    // Connect poll stale handler to newVoteReceived signal from voting model, which propagates
-    // from the core.
-    connect(m_voting_model, &VotingModel::newVoteReceived, this, &PollTableModel::handlePollStaleFlag);
+    if (m_voting_model) {
+        // Connect poll stale handler to newVoteReceived signal from voting model,
+        // which propagates from the core.
+        connect(m_voting_model, &VotingModel::newVoteReceived,
+                this, &PollTableModel::handlePollStaleFlag);
+    }
 }
 
 void PollTableModel::setPollFilterFlags(PollFilterFlag flags)
@@ -320,7 +340,13 @@ void PollTableModel::refresh()
 
     LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh dispatched", __func__);
 
-    m_refresh_future = QtConcurrent::run([this]() {
+    // Capture the enclosing function name as a string literal so log lines
+    // emitted from inside the worker lambda print "PollTableModel::refresh"
+    // (the enclosing function) rather than "operator()" (which is what
+    // __func__ resolves to inside a lambda body).
+    const char* const func_name = __func__;
+
+    m_refresh_future = QtConcurrent::run([this, func_name]() {
         RenameThread("PollTableModel_refresh");
         util::ThreadSetInternalName("PollTableModel_refresh");
 
@@ -361,7 +387,7 @@ void PollTableModel::refresh()
             },
             Qt::QueuedConnection);
 
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh worker complete", __func__);
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh worker complete", func_name);
     });
 }
 

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -10,6 +10,7 @@
 #include "util/threadnames.h"
 
 #include <QtConcurrentRun>
+#include <QPointer>
 #include <QSortFilterProxyModel>
 #include <QStringList>
 
@@ -246,7 +247,16 @@ PollTableModel::PollTableModel(QObject* parent)
 
 PollTableModel::~PollTableModel()
 {
-    // Nothing to do yet...
+    // Block until any in-flight refresh worker is done dereferencing `this`.
+    // refresh() captures `this` directly to read m_voting_model /
+    // m_filter_flags / m_data_model and to write m_refresh_in_flight; without
+    // this wait the worker can touch those members after PollTableModel is
+    // destroyed (use-after-free during GUI shutdown). A default-constructed
+    // QFuture is already in the finished state, so this is a no-op when no
+    // refresh has ever been launched. (The queued reload-on-the-GUI-thread
+    // lambda guards its own captures with QPointer, so it remains safe even
+    // if the event queue drains after the model is gone.)
+    m_refresh_future.waitForFinished();
 }
 
 void PollTableModel::setModel(VotingModel* model)
@@ -304,7 +314,7 @@ void PollTableModel::refresh()
 
     LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh dispatched", __func__);
 
-    (void) QtConcurrent::run([this]() {
+    m_refresh_future = QtConcurrent::run([this]() {
         RenameThread("PollTableModel_refresh");
         util::ThreadSetInternalName("PollTableModel_refresh");
 
@@ -322,20 +332,29 @@ void PollTableModel::refresh()
         // thread affinity is the GUI thread) runs reload() in the GUI
         // event loop, where every other access already happens.
         //
-        // m_refresh_in_flight is cleared only after the post is queued, so
-        // concurrent refresh() workers cannot reorder reloads on the GUI
-        // thread -- a second refresh() while a worker is mid-build sees
-        // the flag set and returns immediately. The GUI thread processes
-        // queued reloads FIFO.
+        // Both captures are wrapped in QPointer so the queued lambda is safe
+        // even if PollTableModel / PollTableDataModel are destroyed before
+        // the GUI event loop processes the post (e.g. shutdown race after
+        // the worker thread has already exited). m_refresh_in_flight is
+        // cleared in the GUI continuation -- after reload() actually runs --
+        // so the debounce covers build + queued mutation, not just the
+        // build; a stream of refresh() calls collapses to one full cycle
+        // at a time.
         QMetaObject::invokeMethod(
             m_data_model.get(),
-            [data_model = static_cast<PollTableDataModel*>(m_data_model.get()),
+            [data_model = QPointer<PollTableDataModel>(
+                 static_cast<PollTableDataModel*>(m_data_model.get())),
+             self = QPointer<PollTableModel>(this),
              rows = std::move(new_rows)]() mutable {
-                data_model->reload(std::move(rows));
+                if (data_model) {
+                    data_model->reload(std::move(rows));
+                }
+                if (self) {
+                    self->m_refresh_in_flight.store(false);
+                }
             },
             Qt::QueuedConnection);
 
-        m_refresh_in_flight.store(false);
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh worker complete", __func__);
     });
 }

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -293,15 +293,16 @@ const PollItem* PollTableModel::rowItem(int row) const
 
 void PollTableModel::refresh()
 {
-    if (!m_voting_model || !m_refresh_mutex.tryLock()) {
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: m_refresh_mutex is already taken, so tryLock failed",
+    bool expected = false;
+    if (!m_voting_model ||
+        !m_refresh_in_flight.compare_exchange_strong(expected, true)) {
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh already in flight, skipping",
                  __func__);
 
         return;
-    } else {
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: m_refresh_mutex trylock succeeded.",
-                 __func__);
     }
+
+    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh dispatched", __func__);
 
     (void) QtConcurrent::run([this]() {
         RenameThread("PollTableModel_refresh");
@@ -321,10 +322,11 @@ void PollTableModel::refresh()
         // thread affinity is the GUI thread) runs reload() in the GUI
         // event loop, where every other access already happens.
         //
-        // m_refresh_mutex is released only after the post is queued, so
+        // m_refresh_in_flight is cleared only after the post is queued, so
         // concurrent refresh() workers cannot reorder reloads on the GUI
-        // thread -- two workers serialize on the mutex, post in order,
-        // and the GUI thread processes the posts in FIFO order.
+        // thread -- a second refresh() while a worker is mid-build sees
+        // the flag set and returns immediately. The GUI thread processes
+        // queued reloads FIFO.
         QMetaObject::invokeMethod(
             m_data_model.get(),
             [data_model = static_cast<PollTableDataModel*>(m_data_model.get()),
@@ -333,9 +335,8 @@ void PollTableModel::refresh()
             },
             Qt::QueuedConnection);
 
-        m_refresh_mutex.unlock();
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: m_refresh_mutex lock released.",
-                 __func__);
+        m_refresh_in_flight.store(false);
+        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh worker complete", __func__);
     });
 }
 

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -307,8 +307,31 @@ void PollTableModel::refresh()
         RenameThread("PollTableModel_refresh");
         util::ThreadSetInternalName("PollTableModel_refresh");
 
-        static_cast<PollTableDataModel*>(m_data_model.get())
-            ->reload(m_voting_model->buildPollTable(m_filter_flags));
+        // Build the new poll table off the GUI thread (this is the slow
+        // bit -- AVW recompute, candidate iteration).
+        std::vector<PollItem> new_rows = m_voting_model->buildPollTable(m_filter_flags);
+
+        // Hand the result back to the GUI thread for the actual model
+        // mutation. m_rows is the std::vector backing a QAbstractItemModel
+        // the views read concurrently via rowCount() / index() / data();
+        // mutating it (and emitting layoutAboutToBeChanged / layoutChanged)
+        // from this worker violates Qt model thread-affinity -- TSan G16
+        // reports a real race against PollTableDataModel::rowCount on the
+        // main thread. A QueuedConnection invoke onto m_data_model (whose
+        // thread affinity is the GUI thread) runs reload() in the GUI
+        // event loop, where every other access already happens.
+        //
+        // m_refresh_mutex is released only after the post is queued, so
+        // concurrent refresh() workers cannot reorder reloads on the GUI
+        // thread -- two workers serialize on the mutex, post in order,
+        // and the GUI thread processes the posts in FIFO order.
+        QMetaObject::invokeMethod(
+            m_data_model.get(),
+            [data_model = static_cast<PollTableDataModel*>(m_data_model.get()),
+             rows = std::move(new_rows)]() mutable {
+                data_model->reload(std::move(rows));
+            },
+            Qt::QueuedConnection);
 
         m_refresh_mutex.unlock();
         LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: m_refresh_mutex lock released.",

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -11,6 +11,7 @@
 
 #include <atomic>
 #include <memory>
+#include <QFuture>
 #include <QSortFilterProxyModel>
 
 class PollTableDataModel : public QAbstractTableModel
@@ -86,14 +87,24 @@ private:
     VotingModel* m_voting_model;
     std::unique_ptr<PollTableDataModel> m_data_model;
     GRC::PollFilterFlag m_filter_flags;
-    // Debounce flag for refresh(). Held while a QtConcurrent worker is
-    // building the new poll table; cleared by the worker when the queued
-    // reload has been posted back to the GUI thread. Was historically a
+    // Debounce flag for refresh(). Set on the GUI thread when a refresh
+    // worker is launched, cleared inside the GUI continuation lambda once
+    // reload() has actually run. Covering the full build + queued reload
+    // (not just the build) prevents redundant background builds stacking
+    // up while a reload sits in the GUI event queue. Was historically a
     // QMutex (tryLock on the GUI thread, unlock from the worker) but Qt's
     // non-recursive QMutex requires same-thread unlock -- a std::atomic<bool>
     // here is the right primitive for "is there a refresh in flight," and
     // can be flipped from either thread.
     std::atomic<bool> m_refresh_in_flight{false};
+
+    // Handle to the in-flight QtConcurrent refresh worker (default-constructed
+    // QFuture is in the canceled/finished state, so the destructor's
+    // waitForFinished() is a no-op when no refresh has ever been launched).
+    // Held so the destructor can block until the worker has finished
+    // dereferencing `this` -- without it, the worker can touch m_voting_model
+    // / m_filter_flags / m_data_model after PollTableModel is destroyed.
+    QFuture<void> m_refresh_future;
 };
 
 #endif // GRIDCOIN_QT_VOTING_POLLTABLEMODEL_H

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -9,9 +9,9 @@
 #include "gridcoin/voting/filter.h"
 #include "qt/voting/votingmodel.h"
 
+#include <atomic>
 #include <memory>
 #include <QSortFilterProxyModel>
-#include <QMutex>
 
 class PollTableDataModel : public QAbstractTableModel
 {
@@ -86,7 +86,14 @@ private:
     VotingModel* m_voting_model;
     std::unique_ptr<PollTableDataModel> m_data_model;
     GRC::PollFilterFlag m_filter_flags;
-    QMutex m_refresh_mutex;
+    // Debounce flag for refresh(). Held while a QtConcurrent worker is
+    // building the new poll table; cleared by the worker when the queued
+    // reload has been posted back to the GUI thread. Was historically a
+    // QMutex (tryLock on the GUI thread, unlock from the worker) but Qt's
+    // non-recursive QMutex requires same-thread unlock -- a std::atomic<bool>
+    // here is the right primitive for "is there a refresh in flight," and
+    // can be flipped from either thread.
+    std::atomic<bool> m_refresh_in_flight{false};
 };
 
 #endif // GRIDCOIN_QT_VOTING_POLLTABLEMODEL_H

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -84,7 +84,13 @@ public slots:
     void handlePollStaleFlag(QString poll_txid_string);
 
 private:
-    VotingModel* m_voting_model;
+    // Initialized in-class so the early-return checks in setModel() and the
+    // truthy guard in refresh() never read uninitialized memory before the
+    // first explicit setModel(VotingModel*) call. The previous setModel()
+    // body wrote unconditionally, so reads-before-write never happened
+    // before; the new lifetime-aware setModel() reads first to handle
+    // detach (setModel(nullptr)), which made the lack of init reachable.
+    VotingModel* m_voting_model{nullptr};
     std::unique_ptr<PollTableDataModel> m_data_model;
     GRC::PollFilterFlag m_filter_flags;
     // Debounce flag for refresh(). Set on the GUI thread when a refresh

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3647,9 +3647,10 @@ UniValue MagnitudeReport(const GRC::Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     json.pushKV("Lifetime Research Paid", ValueFromAmount(account.m_total_research_subsidy));
     // Lifetime Magnitude Sum is a uint64_t now (previously uint32_t, which
     // overflowed for long-lived researchers and lost the high bits when
-    // narrowed to int here). Carry it as int64_t so the JSON value matches
-    // the underlying counter for the full realistic range.
-    json.pushKV("Lifetime Magnitude Sum", (int64_t)account.m_total_magnitude);
+    // narrowed to int here). UniValue::pushKV has a uint64_t overload, so
+    // push the value directly to preserve the full unsigned range without
+    // a signed-narrowing cast.
+    json.pushKV("Lifetime Magnitude Sum", account.m_total_magnitude);
     json.pushKV("Lifetime Magnitude Average", account.AverageLifetimeMagnitude());
     json.pushKV("Lifetime Payments", (int)account.m_accuracy);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3645,7 +3645,11 @@ UniValue MagnitudeReport(const GRC::Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     json.pushKV("Expected Earnings (Daily)", ValueFromAmount(calc->ExpectedDaily()));
 
     json.pushKV("Lifetime Research Paid", ValueFromAmount(account.m_total_research_subsidy));
-    json.pushKV("Lifetime Magnitude Sum", (int)account.m_total_magnitude);
+    // Lifetime Magnitude Sum is a uint64_t now (previously uint32_t, which
+    // overflowed for long-lived researchers and lost the high bits when
+    // narrowed to int here). Carry it as int64_t so the JSON value matches
+    // the underlying counter for the full realistic range.
+    json.pushKV("Lifetime Magnitude Sum", (int64_t)account.m_total_magnitude);
     json.pushKV("Lifetime Magnitude Average", account.AverageLifetimeMagnitude());
     json.pushKV("Lifetime Payments", (int)account.m_accuracy);
 

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -262,6 +262,45 @@ BOOST_AUTO_TEST_CASE(sha256_testvectors) {
     TestSHA256(test1, "a316d55510b49662420f49d145d42fb83f31ef8dc016aa4e32df049991a91e26");
 }
 
+BOOST_AUTO_TEST_CASE(sha256_empty_input_null_data) {
+    // Regression: CSHA256::Write(nullptr, 0) used to compute `nullptr + 0`
+    // inside the function body (`const unsigned char* end = data + len;`),
+    // which is undefined behaviour per ISO C++ and trips UBSan. Several
+    // callers can legitimately reach Write with a null data pointer and
+    // zero length -- e.g., `std::vector<unsigned char>::data()` is allowed
+    // to return nullptr when size() is 0, and Gridcoin P2P paths feed
+    // empty-payload message bodies (verack et al.) through Hash() via a
+    // CDataStream backed by such a vector. The fix is a `len == 0`
+    // early-return at the top of CSHA256::Write.
+    //
+    // The existing sha256_testvectors("", ...) test does NOT cover this
+    // path: it calls Write with `std::string("").data()`, which on
+    // libstdc++ returns a non-null pointer to the string's null terminator,
+    // so it only exercises Write(non_null_ptr, 0). This test exercises
+    // Write(nullptr, 0) directly.
+    const std::vector<unsigned char> empty_sha256 =
+        ParseHex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    unsigned char hash[CSHA256::OUTPUT_SIZE];
+
+    // 1) Pure empty Write with null data must still produce SHA256("").
+    CSHA256().Write(nullptr, 0).Finalize(hash);
+    BOOST_CHECK(std::memcmp(hash, empty_sha256.data(), CSHA256::OUTPUT_SIZE) == 0);
+
+    // 2) Interleaved null-data writes between real data must be identity:
+    //    Write(nullptr, 0) sandwiched around real input produces the same
+    //    hash as the real input alone (SHA256("abc")).
+    const std::string input = "abc";
+    const std::vector<unsigned char> abc_sha256 =
+        ParseHex("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    unsigned char interleaved[CSHA256::OUTPUT_SIZE];
+    CSHA256()
+        .Write(nullptr, 0)
+        .Write(reinterpret_cast<const uint8_t*>(input.data()), input.size())
+        .Write(nullptr, 0)
+        .Finalize(interleaved);
+    BOOST_CHECK(std::memcmp(interleaved, abc_sha256.data(), CSHA256::OUTPUT_SIZE) == 0);
+}
+
 BOOST_AUTO_TEST_CASE(sha512_testvectors) {
     TestSHA512("",
                "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -255,7 +255,12 @@ std::string GetFileContents(const fs::path filepath)
 #ifndef UPGRADERFLAG
 // avoid including unnecessary files for standalone upgrader
 
-static int64_t nTimeOffset = 0;
+// Atomic: written by the message-handler thread inside AddTimeData() (which
+// runs from ProcessMessage's VERSION-handling path) and read both there and
+// from the GUI thread via GetTimeOffset() -> GetAdjustedTime() (e.g. poll
+// expiry checks). No common lock; Bitcoin Core fixed the same pattern years
+// ago by making this atomic.
+static std::atomic<int64_t> nTimeOffset{0};
 
 int64_t GetTimeOffset()
 {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-unsigned int nWalletDBUpdated;
+std::atomic<unsigned int> nWalletDBUpdated{0};
 
 //
 // CDB

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -11,6 +11,7 @@
 #include "streams.h"
 #include "sync.h"
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
@@ -28,7 +29,15 @@ class CTxIndex;
 class CWallet;
 class CWalletTx;
 
-extern unsigned int nWalletDBUpdated;
+// Dirty-write counter incremented by every wallet write and polled by
+// ThreadFlushWalletDB to decide when to flush. Touched by every wallet-update
+// thread and read by the flush thread; making it atomic closes a TSan data
+// race covering all increment sites (walletdb.h Write* helpers + walletdb.cpp
+// WriteName/EraseName/WriteBestBlock) and the read sites in
+// ThreadFlushWalletDB. The default seq_cst operator++ / operator T() keep the
+// existing call sites unchanged (Bitcoin Core handles the same counter the
+// same way).
+extern std::atomic<unsigned int> nWalletDBUpdated;
 
 void ThreadFlushWalletDB(void* parg);
 

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -43,3 +43,31 @@ race:epoll_ctl
 
 # https://github.com/bitcoin/bitcoin/issues/23366
 race:std::__1::ios_base::*
+
+# Gridcoin scraper subsystem — per-instance cs_manifest lock-order false positives
+# -----------------------------------------------------------------------------
+# CScraperManifest objects each carry their own per-instance recursive_mutex
+# (cs_manifest). When the code legitimately iterates the manifest map and
+# acquires each manifest's cs_manifest in turn (BinCScraperManifestsByScraper,
+# ScraperCullAndBinCScraperManifests), TSan's lock-order graph records the
+# acquisitions as edges between distinct mutex addresses that nonetheless
+# semantically represent the SAME class of lock. Combined with the global
+# cs_mapParts / cs_ConvergedScraperStatsCache, TSan constructs a 3-4 hop cycle
+# in its graph that does not correspond to any concrete deadlock scenario:
+# the per-instance cs_manifest in different cycle nodes are different objects,
+# so no single thread is ever blocked waiting for a lock it (or a partner)
+# could deadlock against.
+#
+# The canonical real-lock ordering between the global mutexes is defended
+# in-source (scraper_net.cpp:701 holds LOCK2(cs_mapParts, manifest->cs_manifest)
+# in canonical order; main.cpp:2527 + :2679 document cs_main scoping rules
+# vs cs_mapManifest / cs_manifest). The cycle does not extend beyond the
+# scraper subsystem (no cs_main / cs_wallet / cs_vNodes participation in
+# any of the reported cycles).
+#
+# Validated on the cleanup-branch TSan binary's public-testnet run
+# (gridcoinresearch-5.5.0.2-sanitizer-cleanup-tsan-d27dd6440); 7335 reports
+# audited, all from this single class.
+deadlock:CScraperManifest
+deadlock:CSplitBlob
+deadlock:BinCScraperManifestsByScraper


### PR DESCRIPTION
Twenty-one commits cleaning up pre-existing data races and undefined behaviour surfaced by ThreadSanitizer + UndefinedBehaviorSanitizer instrumented runs on isolated testnet and (for the final two race findings) public testnet. **None of these is the heap-corruption target the underlying investigation is hunting** — they are sibling findings that came out of the same sanitizer-driven session, almost all are Bitcoin-Core-inherited patterns, and Bitcoin Core itself fixed several of them years ago. Each commit is self-contained.

## What led here

isolated-testnet node3 was running the merged [#2944](https://github.com/gridcoin-community/Gridcoin-Research/pull/2944) `gui-wallet-event-queue` build when it aborted with `double free or corruption (!prev)` — glibc heap-corruption `SIGABRT` on the GUI thread, detected in the scraper-log `QPlainTextEdit` block-trim path (`updateScraper` → `appendPlainText` → `setMaximumBlockCount` → `QTextBlockData::free`). node1 and node2 (both on `testnet_v13_checkpoint_removed`, pre-#2944) had not crashed — the differential pointed at #2944's code.

To investigate, an instrumented sibling branch was set up: `testnet_v13_development` = current `development` + cherry-picked checkpoint-removal hack (`25774441f`, so the binary syncs the isolated testnet), built once with `-fsanitize=address,undefined` (deployed to node3, replacing the crashed binary) and once with `-fsanitize=thread` (deployed to node2). Both built via the `cmake_quality.yml` `sanitizers` recipe with `-DENABLE_GUI=ON` — the CI job uses `ENABLE_GUI=OFF` so the entire `src/qt/` event-queue path is never run under sanitizers in CI, which is a real coverage gap for anything in that area.

Across ~24 hours of isolated-testnet runtime the TSan node surfaced **44 unique race-site SUMMARYs**. After auditing them, they split sharply into two groups:

### TSan tool-coverage artifacts (not real races)

The five `moc_clientmodel.cpp:177` hits on `ClientModel::qt_static_metacall` and the entire Qt/dbus/`libdbus`/`string_fortified.h` tail are **TSan instrumentation gaps inside an unsanitized `libQt6Core.so`**, not real races. Verified file-by-line against Qt 6.9.1 source:

- `qtbase/src/corelib/thread/qtsan_impl.h` line 10 gates every `QtTsan::mutex*` annotation on `__has_feature(thread_sanitizer) || defined(__SANITIZE_THREAD__)`. The distro `libQt6Core.so.6` was not compiled with TSan, so every `mutexPostLock`/`mutexPreUnlock` is a no-op — TSan sees zero synchronization through `QPostEventList::mutex` (a `QMutex`).
- The backup atomic — `QObjectPrivate::postedEvents.fetchAndAddRelease(1)` (producer side) / `fetchAndSubAcquire(1)` (consumer side) — *is* `std::atomic<T>::fetch_add(1, memory_order_acq_rel)` per `qatomic_cxx11.h:259/267`, which TSan natively tracks. But the actual atomic instructions are emitted inside `postEvent` / `sendPostedEvents` (`qcoreapplication.cpp` lines 1657 producer, 1865 consumer) — `.cpp` files compiled into the unsanitized `libQt6Core.so`, so the compiler did not insert `__tsan_atomic_*` interceptor calls there either.
- Result: Qt's queued-event mechanism carries **two independent happens-before edges** between producer and consumer (`QMutex` lock-pair *and* `std::atomic` release/acquire on the same counter), either of which is sufficient under the C++ memory model — but TSan can see neither half because both are in the unsanitized library. The synchronization is correct in source; TSan reports a phantom race anyway.

Cross-checked against every Qt install on the build host (system `/lib64/libQt6Core.so.6`, four QtCreator-bundled kits, QtDesignStudio, QtCreator's own bundle): zero `__tsan_*` symbols defined anywhere. Reaching real TSan coverage of the Qt event-dispatch path would require rebuilding Qt 6.9.1 with `-fsanitize=thread`. Out of scope here.

### Real Gridcoin-source findings

The remaining **16 findings** have racing stacks entirely in instrumented Gridcoin TUs (no `libQt6Core.so` frame in the synchronization path), so the reports are reliable. After per-finding triage, **all 16 are scalar / Qt-model races that cannot corrupt heap chunks** — they produce wrong values or stale data, not heap corruption. Most are Bitcoin-Core-inherited atomicisation/locking gaps that Bitcoin Core itself fixed years ago.

This PR closes all 16 + the 2 UBSan findings from the paired ASan+UBSan node3 run, plus two further sibling-class TSan findings (G17, G18) that only surfaced when the post-fix TSan binary was redeployed to a **public-testnet** instance where the realistic peer-connection churn and GUI poll-expiry pattern exposed race windows the isolated-testnet run had under-sampled.

## What this PR does NOT do

It does not fix the [#2944](https://github.com/gridcoin-community/Gridcoin-Research/pull/2944) heap-corruption target. After this audit, the remaining hypotheses for that crash are:

1. A heap bug inside Qt's machinery that would require TSan-instrumented Qt to localise (improbable but possible).
2. A single-thread heap bug (use-after-free / overflow / sequence error that isn't a data race per se). **ASan on node3 should catch this when it next happens** and is still running.

The hunt continues; this PR is the cleanup that fell out of it.

## The commits

### Original cleanup pass (9 commits)

| # | Commit | What |
|---|--------|------|
| 1 | `wallet: make nWalletDBUpdated atomic` | dirty-write counter — 16 increment sites in `walletdb.h`/`walletdb.cpp` plus 6 reader sites in `ThreadFlushWalletDB`. Bitcoin Core handles it the same way. Closes G12-G15. |
| 2 | `net: atomicise CNode timestamp / ping bookkeeping fields` | `nLastSend`, `nLastRecv`, `nTimeConnected`, `nPingNonceSent`, `nPingUsecStart`. The sibling fields (`nSendBytes`/`nRecvBytes`/`nTimeOffset`/`nPingUsecTime`/`nMinPingUsecTime`) were already atomic in the same class — this rounds out the set. Closes G2, G6-G10. |
| 3 | `mining: take cs_vNodes when reading vNodes.size() in IsMiningAllowed` | One-line lock + snapshot; mirrors the existing `net.cpp:889-897` pattern. Closes G3. |
| 4 | `net: protect CNode::addrLocal with its own mutex + accessors` | New per-node `cs_addrLocal`, `addrLocal GUARDED_BY(cs_addrLocal)`, `GetAddrLocal()` / `SetAddrLocal()` accessors. Mirrors Bitcoin Core's fix for the same field. Closes G4-G5. |
| 5 | `qt/voting: funnel PollTableDataModel::reload onto the GUI thread` | `PollTableModel::refresh()` was running `reload()` (model mutation + `layoutAboutToBeChanged`/`layoutChanged` emissions) on a `QtConcurrent` worker thread — a real `QAbstractItemModel` thread-affinity violation. Now posts the reload back via `QMetaObject::invokeMethod(..., Qt::QueuedConnection)`; the expensive `buildPollTable()` stays off-thread. Closes G16. |
| 6 | `init: make bGridcoinCoreInitComplete atomic` | One-shot init-completion flag; written by init thread, read by Qt main thread's splash-screen wait loop. Closes G1. |
| 7 | `researcher: widen ResearchAccount::m_total_magnitude to uint64_t` | `+= pindex->Magnitude()` (a `double`) overflowed `uint32_t` once the lifetime sum passed `UINT_MAX`. Widen the field, make the truncating cast explicit, carry the wider value through to the JSON output (`"Lifetime Magnitude Sum"`). Reporting-only — not accrual, not consensus. Resolves the in-code TODO that was already there. Closes UBSan tally finding. |
| 8 | `net: use CDataStream::data() instead of &begin()[0] for message-checksum span` | `&vRecv.begin()[0]` evaluates `*nullptr` for an empty payload (UBSan: reference-binding-to-null). `CDataStream::data()` is well-defined for empty containers. Benign in practice (zero-length `Hash` reads nothing), still UB. Closes UBSan main.cpp finding. |
| 9 | `net: atomicise nLocalHostNonce` | Global VERSION-nonce, randomised on the socket-handler thread and read on the message-handler thread's self-connection check. Commit message notes the broader design issue (single global clobbered per outbound connection means two simultaneous outbound connections lose per-connection nonce identity) as a separate follow-up. |

### Review fixups, rounds 1-3 (6 commits)

| # | Commit | What |
|---|--------|------|
| 10 | `qt/voting: debounce PollTableModel::refresh with an atomic flag, not a QMutex` | Copilot review caught real UB pre-existing in commit 5's `refresh()`: `m_refresh_mutex.tryLock()` on the GUI thread / `.unlock()` on the QtConcurrent worker thread violates Qt 6's non-recursive `QMutex` same-thread-unlock requirement. Replace with `std::atomic<bool> m_refresh_in_flight` driven by `compare_exchange_strong` — the right primitive for "is there a refresh in flight" and well-defined from either thread. |
| 11 | `qt/voting: harden PollTableModel refresh worker lifetime and tighten debounce` | Two coupled lifetime issues caught in the same review: (a) UAF — `~PollTableModel()` was empty but the worker captures `this` and the queued GUI lambda captured `m_data_model` as a raw pointer, so shutdown could destroy the model mid-build or mid-queued-event. Add `QFuture<void> m_refresh_future` + `waitForFinished()` in the dtor, wrap both captures in `QPointer<T>` (both classes are `QObject`s via their model bases). (b) Tighter debounce — move `m_refresh_in_flight.store(false)` from the worker into the GUI continuation lambda so the flag covers build + queued reload, not just build. |
| 12 | `researcher: make all m_total_magnitude double->uint64_t casts explicit` | Review pointed out that commit 7 only made one of four `+=/-= Magnitude()` sites explicit. Add `static_cast<uint64_t>(...)` to `tally.cpp:332` (MRC record), `:441` (Forget), `:491` (ForgetMRCRewardBlock); all four `m_total_magnitude` arithmetic sites now have matching explicit conversions. Reporting-only field, not consensus. |
| 13 | `rpc: push Lifetime Magnitude Sum via UniValue's uint64_t overload` | Commit 7 widened the field to `uint64_t` but the RPC pushKV at `rpc/blockchain.cpp:3652` was still `(int64_t)` casted. UniValue has a `pushKV(key, uint64_t)` overload (`univalue.h:132`); push the value directly to preserve the full unsigned range without a signed-narrowing cast. |
| 14 | `qt/voting: split PollTableModel::refresh early-return log paths` | `refresh()` previously OR'd the "no voting model set" guard with the "already-in-flight" CAS into one early return that logged "refresh already in flight, skipping" in either case. Split into two checks with distinct log messages so diagnostics are actionable. |
| 15 | `net: send PushVersion's locally-generated nonce, not the global atomic` | Commit 9's atomicisation introduced a subtle in-method store/load race: `nLocalHostNonce.store(nonce)` then `nLocalHostNonce.load()` passed to `PushMessage()`. A concurrent `PushVersion()` on another outbound connection can overwrite the global between the store and the load — this connection ends up sending whatever value was last stored. Pass the local `nonce` to `PushMessage()`; keep the atomic store for `ProcessMessage`'s self-connection sentinel. Per-`CNode` nonce remains the follow-up. |

### Public-testnet TSan exposure (2 commits)

The full cleanup branch was rebuilt as a `RelWithDebInfo` TSan binary and deployed to a public-testnet GUI instance to verify G1–G16 + the two UBSan items were silenced. Two additional sibling-class findings surfaced in the live peer mix that isolated testnet had under-sampled:

| # | Commit | What |
|---|--------|------|
| 16 | `net: atomicise CNode::fNetworkNode` (G17) | Bool field set by `ThreadOpenConnections2` in `OpenNetworkConnection` (net.cpp:1852) and read by both `ThreadSocketHandler2` (net.cpp:886, close-side bookkeeping) and the message-handler thread (main.cpp:3050, "remember this address" first-messages path). Same class as G2/G6-G10; the very next sibling field on the class (`fDisconnect`) was already `std::atomic_bool`. |
| 17 | `util: atomicise nTimeOffset global` (G18) | File-static `int64_t nTimeOffset` in util.cpp written by the message-handler thread inside `AddTimeData()` (util.cpp:284, :289) and read from the GUI thread via `GetTimeOffset()` → `GetAdjustedTime()` (e.g. `VotingModel::getExpiringPollsNotNotified()` poll-expiry checks at util.cpp:262). Bitcoin Core fixed the same pattern years ago by making it atomic. |

### Lock-order-inversion audit (1 commit)

The public-testnet TSan run also produced 7335 `lock-order-inversion (potential deadlock)` reports at `sync.h:154`. Audited; they collapse into a single class:

| # | Commit | What |
|---|--------|------|
| 18 | `test: suppress per-instance cs_manifest lock-order false positives` | All 7335 reports are TSan **per-instance lock conflation** — `CScraperManifest` objects each carry their own `cs_manifest` recursive mutex, and when the scraper legitimately iterates the manifest map (`BinCScraperManifestsByScraper`, `ScraperCullAndBinCScraperManifests`) and acquires each per-instance `cs_manifest` in turn, TSan's address-keyed lock-order graph treats those distinct mutex objects as edges in a single ordering relation. Combined with the two globals (`cs_mapParts`, `cs_ConvergedScraperStatsCache`), TSan constructs 3-4 hop cycles in the graph that don't correspond to any concrete deadlock scenario. The canonical real-lock orderings are already defended in source: `scraper_net.cpp:701` enforces `cs_mapParts → cs_manifest` via `LOCK2`; `main.cpp:2527` + `:2679` document `cs_main` scoping vs the scraper map locks. None of the reported cycles extend beyond the scraper subsystem — no `cs_main` / `cs_wallet` / `cs_vNodes` participation. Three suppression rules (`deadlock:CScraperManifest`, `deadlock:CSplitBlob`, `deadlock:BinCScraperManifestsByScraper`) keep future TSan audits focused on genuinely new lock-order findings. |

### Review fixups, rounds 4-5 (3 commits)

Two more Copilot review iterations after the audit landed; remaining findings clustered on the poll-table refresh worker's lifetime against `VotingModel` shutdown ordering, on the SHA256 empty-input UB that the earlier `vRecv.data()` commit had only pushed one level deeper, and a corresponding regression-test guard:

| # | Commit | What |
|---|--------|------|
| 19 | `qt/voting: drain refresh worker before VotingModel dies; fix __func__ in lambda` | Two findings in one commit. (a) UAF — the `QtConcurrent` refresh worker dereferences `m_voting_model->buildPollTable(...)`, but `m_voting_model` points at a stack-allocated `VotingModel` inside `StartGridcoinQt()` whose inner block exits before `BitcoinGUI`/`VotingPage`/`PollTableModel` are torn down, so commit 11's `waitForFinished()` in `~PollTableModel()` was draining *after* `VotingModel` had already been destroyed. Closed at the right teardown stage: `PollTableModel::setModel()` now handles `nullptr` and calls `waitForFinished()` while `VotingModel` is still alive, and `StartGridcoinQt()`'s cleanup sequence adds `window.setVotingModel(nullptr)` symmetric with the other model clears. (b) `__func__` inside the worker lambda resolves to the lambda's `operator()`, not the enclosing `PollTableModel::refresh` — capture the outer `__func__` as a `const char* const func_name` before launching and reference that from inside the lambda. |
| 20 | `crypto/sha256: early-return CSHA256::Write on empty input to fix nullptr+0 UB` | Commit 8's switch to `vRecv.data()` removed one empty-payload UB but exposed a deeper one: `std::vector::data()` may return `nullptr` when `size() == 0`, and the resulting `nullptr + 0` inside `CSHA256::Write`'s `const unsigned char* end = data + len;` is itself UB per ISO C++. Gridcoin protocol has well-defined empty-payload messages (`verack` et al.) whose SHA256("") checksum still has to compute, so we can't skip the hash at the call site. Add an `if (len == 0) return *this;` guard at the very top of `CSHA256::Write` — bit-for-bit behaviour-preserving on `len == 0` inputs (the downstream control flow was already a no-op for that case modulo the UB) and fixes every caller, not just the message-checksum path. Upstream Bitcoin Core (`master` at `de925455c8`) has the identical unfixed code; a small one-line upstream PR is the natural next step but is independent of this PR. |
| 21 | `test: add CSHA256::Write(nullptr, 0) regression case` | New `sha256_empty_input_null_data` test in `crypto_tests.cpp` directly exercises `CSHA256().Write(nullptr, 0).Finalize(...)` (asserting the canonical `e3b0c4…` SHA256("") digest) and `Write(nullptr,0).Write("abc",3).Write(nullptr,0).Finalize(...)` (asserting empty-write identity around real input — same digest as SHA256("abc")). The existing `sha256_testvectors("", ...)` case doesn't cover this path because `std::string("").data()` is non-null on libstdc++, so it only exercises `Write(non_null_ptr, 0)`. The new test is the actual UBSan tripwire for the nullptr+0 path. |

## Verification

The full cleanup branch (HEAD `44d05a2be`) was built with the `cmake_quality.yml` sanitizer recipe **adjusted in two ways** for deployment rather than CI test runs:

- `-DENABLE_GUI=ON` (CI uses OFF, the Qt event-queue coverage gap noted above)
- `-DCMAKE_BUILD_TYPE=RelWithDebInfo` (CI uses Debug; for a long-running monitor that needs to keep pace with peer traffic, `-O2 -g` + TSan is ~5-15× slower than native, vs `-O0 -g` + TSan at ~20-30× which is too slow to keep up)
- `-DUSE_ASM=ON` (CI uses OFF for sanitizer cleanliness; for the heap-corruption hunt this binary is paired with, the SHA assembler path needs to stay exercised)

Deployed to a public-testnet GUI instance with `TSAN_OPTIONS=suppressions=test/sanitizer_suppressions/tsan:halt_on_error=0:second_deadlock_stack=1:history_size=4`. Per-finding silencing check against the original catalogue:

| Original site | Hits in the post-fix run |
|---|---:|
| G1 — `src/init.cpp:888` | 0 |
| G2 — `src/main.cpp:2992` `nPingNonceSent=0` | 0 |
| G3 — `src/miner.cpp:1379` `vNodes.size` in `IsMiningAllowed` | 0 |
| G4 — `src/netaddress.cpp:211` `ip[16]` memcmp #1 | 0 |
| G5 — `src/netaddress.cpp:230` `ip[16]` memcmp #2 | 0 |
| G6 — `src/net.cpp:751` `nLastSend` in `SocketSendData` | 0 |
| G7 — `src/net.cpp:1144` `nTimeConnected` in `ThreadSocketHandler2` | 0 |
| G8 — `src/net.cpp:1158` `nLastRecv` / `nLastSend` in `ThreadSocketHandler2` | 0 |
| G9-G10 — `src/net.cpp:1186` `nPingNonceSent` / `nPingUsecStart` | 0 |
| G11 — `src/random.cpp:419` RNG output memcpy | 0 |
| G12 — `src/wallet/walletdb.cpp:39` `WriteBestBlock` | 0 |
| G13 — `src/wallet/walletdb.h:171` `WriteOrderPosNext` | 0 |
| G14 — `src/wallet/walletdb.h:119` `WriteTx` | 0 |
| G15 — `src/wallet/walletdb.cpp:634` `ThreadFlushWalletDB` | 0 |
| G16 — `src/qt/voting/polltablemodel.cpp:42` `rowCount` | 0 |
| UBSan tally float→unsigned | 0 |
| UBSan main.cpp reference-binding-to-null | 0 |
| G17 — `main.cpp:3050` `pfrom->fNetworkNode` (new, fixed in commit 16) | 0 after fix |
| G18 — `util.cpp:262` `nTimeOffset` (new, fixed in commit 17) | 0 after fix |

Both `gridcoinresearchd` (no GUI) and `gridcoinresearch` (Qt6 GUI) compile and link cleanly. No source changes are needed at the existing call sites for the atomicisations — `std::atomic<T>`'s implicit `operator T()` and `operator++` keep existing expressions valid, including the `tinyformat`/`ostream` formatting paths in `LogPrintf`.

The residual TSan output from the post-fix public-testnet run consists of (a) the per-instance scraper lock-order class addressed by the suppression in commit 18, and (b) the Qt-instrumentation-gap class documented in the "What led here" section above. Both are noise, not real findings.
