### PR TITLE
rpc: convert 14 snapshots/registries blockchain.cpp commands to RPCHelpMan (Tier 1c, #2922)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3656,13 +3656,25 @@ UniValue listsidestakes(const UniValue& params, bool fHelp)
 
 UniValue listmandatorysidestakes(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "listmandatorysidestakes\n"
-            "\n"
-            "Displays the mandatory sidestakes on the network.\n"
-            "\n"
-            "This is equivalent to listsidestakes \"mandatory\".\n");
+    static const RPCHelpMan help{
+        "listmandatorysidestakes",
+        "Displays the mandatory sidestakes on the network. Equivalent to listsidestakes \"mandatory\".",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "sidestake_entries", "Mandatory sidestake entries.",
+                    {
+                        {RPCResult::Type::ELISION, "", "see listsidestakes for entry shape"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listmandatorysidestakes", "") +
+            HelpExampleRpc("listmandatorysidestakes", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue filter_params(UniValue::VARR);
     filter_params.push_back("mandatory");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3584,14 +3584,29 @@ UniValue listprotocolentries(const UniValue& params, bool fHelp)
 
 UniValue listsidestakes(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-            "listsidestakes [type]\n"
-            "\n"
-            "Displays all active sidestakes (mandatory and local/voluntary).\n"
-            "\n"
-            "Arguments:\n"
-            "  type    (string, optional) Filter by type: \"mandatory\", \"local\", or \"all\" (default: \"all\")\n");
+    static const RPCHelpMan help{
+        "listsidestakes",
+        "Displays all active sidestakes (mandatory and local/voluntary).",
+        {
+            {"type", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Filter by type: \"mandatory\", \"local\", or \"all\". Default: \"all\"."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "sidestake_entries", "Active sidestake entries.",
+                    {
+                        {RPCResult::Type::ELISION, "", "sidestake entry; address, allocation, type, status, and contract metadata if mandatory"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listsidestakes", "") +
+            HelpExampleCli("listsidestakes", "\"mandatory\"") +
+            HelpExampleRpc("listsidestakes", "\"local\"")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     std::string type_filter = "all";
     if (params.size() == 1) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3412,15 +3412,30 @@ UniValue listprojects(const UniValue& params, bool fHelp)
 
 UniValue getautogreylist(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 2) {
-        throw runtime_error(
-            "getautogreylist <bool> <bool> \n"
-            "\n"
-            "<bool> -> true to show all projects, including those that do not meet greylisting criteria. Defaults to false. \n"
-            "\n"
-            "<bool> -> true to show greylist history for each project. Defaults to false. \n"
-            "\n"
-            "Displays information about projects that meet auto greylisting criteria.");
+    static const RPCHelpMan help{
+        "getautogreylist",
+        "Displays information about projects that meet auto greylisting criteria.",
+        {
+            {"show_all", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "True to show all projects, including those that do not meet greylisting criteria. Default: false."},
+            {"show_history", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "True to show greylist history for each project. Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "auto_greylist_projects", "Projects considered for auto-greylisting.",
+                    {
+                        {RPCResult::Type::ELISION, "", "project entry; zero-credit-days, whitelist-activity-score, criteria flag, optional history"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("getautogreylist", "") +
+            HelpExampleCli("getautogreylist", "true true") +
+            HelpExampleRpc("getautogreylist", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
     }
 
     bool show_all_projects = false;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2667,11 +2667,25 @@ UniValue resetcpids(const UniValue& params, bool fHelp)
 
 UniValue superblockage(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "superblockage\n"
-                "\n"
-                "Display information regarding superblock age\n");
+    static const RPCHelpMan help{
+        "superblockage",
+        "Display information regarding superblock age.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM, "Superblock Age", "Age in seconds of the current superblock."},
+                {RPCResult::Type::STR, "Superblock Timestamp", "Human-readable timestamp of the current superblock."},
+                {RPCResult::Type::NUM, "Superblock Block Number", "Block height at which the current superblock was committed."},
+                {RPCResult::Type::NUM, "Pending Superblock Height", "Block height of the pending superblock, if any."},
+            }},
+        RPCExamples{
+            HelpExampleCli("superblockage", "") +
+            HelpExampleRpc("superblockage", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3351,13 +3351,29 @@ UniValue debug(const UniValue& params, bool fHelp)
 
 UniValue listprojects(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "listprojects <bool>\n"
-                "\n"
-                "<bool> -> true to show all projects, including greylisted and deleted. Defaults to false.\n"
-                "\n"
-                "Displays information about whitelisted projects.\n");
+    static const RPCHelpMan help{
+        "listprojects",
+        "Displays information about whitelisted projects.",
+        {
+            {"show_all", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "True to show all projects, including greylisted and deleted. Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ_DYN, "", "",
+            {
+                {RPCResult::Type::OBJ, "project_name", "Per-project metadata.",
+                    {
+                        {RPCResult::Type::ELISION, "", "version, display_name, url, base_url, display_url, stats_url, [gdpr_controls], [requires_external_adapter], time, status"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listprojects", "") +
+            HelpExampleCli("listprojects", "true") +
+            HelpExampleRpc("listprojects", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3549,11 +3549,25 @@ UniValue listscrapers(const UniValue& params, bool fHelp)
 
 UniValue listprotocolentries(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "listprotocolentries\n"
-                "\n"
-                "Displays the protocol entries on the network.\n");
+    static const RPCHelpMan help{
+        "listprotocolentries",
+        "Displays the protocol entries on the network.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "current_protocol_entries", "Active protocol entries.",
+                    {
+                        {RPCResult::Type::ELISION, "", "protocol entry; key, value, transaction hashes, timestamp, status"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listprotocolentries", "") +
+            HelpExampleRpc("listprotocolentries", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
     UniValue scraper_entries(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3779,11 +3779,27 @@ UniValue sendblock(const UniValue& params, bool fHelp)
 
 UniValue superblockaverage(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "superblockaverage\n"
-                "\n"
-                "Displays average information for current superblock\n");
+    static const RPCHelpMan help{
+        "superblockaverage",
+        "Displays average information for the current superblock.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM, "beacon_count", "Total beacons in the current superblock."},
+                {RPCResult::Type::NUM, "beacon_participant_count", "Number of beacons in the current superblock with research credit."},
+                {RPCResult::Type::NUM, "average_magnitude", "Average magnitude per participant."},
+                {RPCResult::Type::BOOL, "superblock_valid", "True if the current superblock is well-formed."},
+                {RPCResult::Type::NUM, "Superblock Age", "Age in seconds of the current superblock."},
+                {RPCResult::Type::BOOL, "Dire Need of Superblock", "True if a new superblock is overdue."},
+            }},
+        RPCExamples{
+            HelpExampleCli("superblockaverage", "") +
+            HelpExampleRpc("superblockaverage", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3468,11 +3468,25 @@ UniValue getautogreylist(const UniValue& params, bool fHelp)
 
 UniValue listscrapers(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "listscrapers\n"
-                "\n"
-                "Displays information about scrapers recognized by the network.\n");
+    static const RPCHelpMan help{
+        "listscrapers",
+        "Displays information about scrapers recognized by the network.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::ARR, "current_scraper_entries", "Scraper registry entries.",
+                    {
+                        {RPCResult::Type::ELISION, "", "scraper entry; address, transaction hashes, timestamp, status"},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listscrapers", "") +
+            HelpExampleRpc("listscrapers", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
     UniValue scraper_entries(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3841,13 +3841,27 @@ UniValue projects(const UniValue& params, bool fHelp)
 
 UniValue readdata(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "readdata <key>\n"
-                "\n"
-                "<key> -> generic key\n"
-                "\n"
-                "Reads generic data from disk from a specified key\n");
+    static const RPCHelpMan help{
+        "readdata",
+        "Reads generic data from disk from a specified key.",
+        {
+            {"key", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Generic key to read."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "Error", /*optional=*/true, "Error detail if the read failed."},
+                {RPCResult::Type::STR, "Key", "Key that was read."},
+                {RPCResult::Type::STR, "Result", "Stored value, or \"Failed to read from disk.\" on error."},
+            }},
+        RPCExamples{
+            HelpExampleCli("readdata", "\"mykey\"") +
+            HelpExampleRpc("readdata", "\"mykey\"")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3782,7 +3782,13 @@ UniValue parselegacysb(const UniValue& params, bool fHelp)
             HelpExampleRpc("parselegacysb", "\"<serialized_contract>\"")},
     };
 
-    if (fHelp || !help.IsValidNumArgs(params.size())) {
+    // Lower-bound-only arity guard: legacy behavior accepted 1+ args and
+    // silently ignored extras. Using IsValidNumArgs here would reject N>1,
+    // tightening the API. Once PR M2 merges and the dispatcher pre-check
+    // lands, the corresponding lift is `static const RPCHelpMan x =
+    // RPCHelpMan{...}.MarkVariadic();`, but MarkVariadic isn't on this
+    // branch yet so we keep the lower-bound guard.
+    if (fHelp || params.size() < 1) {
         throw std::runtime_error(help.ToString());
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3991,14 +3991,27 @@ UniValue versionreport(const UniValue& params, bool fHelp)
 
 UniValue writedata(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
-        throw runtime_error(
-                "writedata <key> <value>\n"
-                "\n"
-                "<key> ---> Key where value will be written\n"
-                "<value> -> Value to be written to specified key\n"
-                "\n"
-                "Writes a value to specified key\n");
+    static const RPCHelpMan help{
+        "writedata",
+        "Writes a value to the specified generic-data key on disk.",
+        {
+            {"key", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Key where the value will be written."},
+            {"value", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Value to be written at the specified key."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "Result", "\"Success.\", \"Unable to write.\", or \"Unable to Commit.\""},
+            }},
+        RPCExamples{
+            HelpExampleCli("writedata", "\"mykey\" \"myvalue\"") +
+            HelpExampleRpc("writedata", "\"mykey\", \"myvalue\"")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -278,30 +278,42 @@ UniValue blockToJSON(const CBlock& block, CBlockIndex* blockindex, bool fPrintTr
 
 UniValue dumpcontracts(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 5) {
-        std::stringstream help;
+    static const RPCHelpMan help{
+        "dumpcontracts",
+        "Dump serialized or minimal textual contract data gathered from the chain to a specified file.",
+        {
+            {"contract_type", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Contract type to gather data from. Use \"*\" for all. Valid contract types: "
+                "beacon, claim, message, poll, project, protocol, scraper, vote, mrc, sidestake."},
+            {"file", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Output file. A bare filename is written under the data directory; an absolute or relative path with a parent is written verbatim."},
+            {"txids_only", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, output txids and other minimal info in text. Default: false."},
+            {"low_height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Low height. Default: genesis."},
+            {"high_height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "High height. Default: current head."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM_TIME, "timestamp", "Block time of the high-height block."},
+                {RPCResult::Type::NUM, "low_height", "Lower bound of the scanned range."},
+                {RPCResult::Type::NUM, "high_height", "Upper bound of the scanned range."},
+                {RPCResult::Type::STR, "contract_type", "Contract type filter that was applied."},
+                {RPCResult::Type::NUM, "number_of_blocks_processed_containing_contract_type", "Count of blocks that contained at least one matching contract."},
+                {RPCResult::Type::NUM, "number_of_contracts_exported", "Count of contracts written to the output file."},
+                {RPCResult::Type::NUM, "number_of_beacons_verified", /*optional=*/true,
+                    "Verified-beacon count; present only when contract_type == \"beacon\"."},
+                {RPCResult::Type::STR, "exported_to_file", "Resolved path of the output file."},
+            }},
+        RPCExamples{
+            HelpExampleCli("dumpcontracts", "\"beacon\" \"beacons.txt\"") +
+            HelpExampleCli("dumpcontracts", "\"*\" \"all_contracts.txt\" true") +
+            HelpExampleRpc("dumpcontracts", "\"beacon\", \"beacons.txt\"")},
+    };
 
-        help << "dumpcontracts <contract_type> <file> [txids only] [low height] [high height]\n"
-                "\n"
-                "<contract_type> Contract type to gather data from. Use \"*\" for all.\n"
-                "Valid contract types: ";
-
-        // Skip UNKNOWN here.
-        for (int type = static_cast<int>(GRC::ContractType::UNKNOWN) + 1;
-             type < static_cast<int>(GRC::ContractType::OUT_OF_BOUND); ++type) {
-            if (type > 1) help << ", ";
-            help << GRC::Contract::Type(static_cast<GRC::ContractType>(type)).ToString();
-        }
-
-        help << ".\n\n"
-                "<file>          Output file.\n"
-                "<txids only>    Optional txids only. (If specified just output txids and other minimal info in text.)\n"
-                "<low height>    Optional low height. (If not specified then from genesis.)\n"
-                "<high height>   Optional high height. (If not specified then current head.)\n "
-                "\n"
-                "Dump serialized or minimal textual contract data gathered from the chain to a specified file.\n";
-
-        throw runtime_error(help.str());
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
     }
 
     std::string contract_type_string = params[0].get_str();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3730,11 +3730,31 @@ UniValue parselegacysb(const UniValue& params, bool fHelp)
 
 UniValue projects(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "projects\n"
-                "\n"
-                "Show the status of locally attached BOINC projects.\n");
+    static const RPCHelpMan help{
+        "projects",
+        "Show the status of locally attached BOINC projects.",
+        {},
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "name", "Project name."},
+                        {RPCResult::Type::STR, "url", "Project URL."},
+                        {RPCResult::Type::STR, "cpid", "External CPID for the project."},
+                        {RPCResult::Type::STR, "team", "BOINC team name."},
+                        {RPCResult::Type::BOOL, "eligible", "True if the project is eligible for research rewards."},
+                        {RPCResult::Type::BOOL, "whitelisted", "True if the project is on the whitelist."},
+                        {RPCResult::Type::STR, "error", /*optional=*/true, "Reason the project is ineligible, when applicable."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("projects", "") +
+            HelpExampleRpc("projects", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VARR);
     const GRC::ResearcherPtr researcher = GRC::Researcher::Get();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3664,11 +3664,29 @@ UniValue network(const UniValue& params, bool fHelp)
 
 UniValue parselegacysb(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1)
-        throw runtime_error(
-                "parselegacysb\n"
-                "\n"
-                "Convert a legacy superblock contract to JSON.\n");
+    static const RPCHelpMan help{
+        "parselegacysb",
+        "Convert a legacy superblock contract to JSON.",
+        {
+            {"contract", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Serialized legacy superblock contract string."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::OBJ, "contract", "Parsed superblock contract.",
+                    {
+                        {RPCResult::Type::ELISION, "", "see SuperblockToJson output"},
+                    }},
+                {RPCResult::Type::STR_HEX, "legacy_hash", "Hash of the legacy superblock contract."},
+            }},
+        RPCExamples{
+            HelpExampleCli("parselegacysb", "\"<serialized_contract>\"") +
+            HelpExampleRpc("parselegacysb", "\"<serialized_contract>\"")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue json(UniValue::VOBJ);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2696,15 +2696,30 @@ UniValue superblockage(const UniValue& params, bool fHelp)
 
 UniValue superblocks(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 3)
-        throw runtime_error(
-                "superblocks [lookback [displaycontract [cpid]]]\n"
-                "\n"
-                "[lookback] -> Optional: # of SB's to show (default 14)\n"
-                "[displaycontract] -> Optional true/false: display SB contract (default false)\n"
-                "[cpid] -> Optional: Shows magnitude for a cpid for recent superblocks\n"
-                "\n"
-                "Display data on recent superblocks\n");
+    static const RPCHelpMan help{
+        "superblocks",
+        "Display data on recent superblocks.",
+        {
+            {"lookback", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Number of superblocks to show. Default: 14."},
+            {"displaycontract", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Display the superblock contract. Default: false."},
+            {"cpid", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Show magnitude for a CPID across recent superblocks."},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::ELISION, "", "superblock entry; shape depends on options"},
+            }},
+        RPCExamples{
+            HelpExampleCli("superblocks", "") +
+            HelpExampleCli("superblocks", "5 true") +
+            HelpExampleRpc("superblocks", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
+    }
 
     UniValue res(UniValue::VARR);
 

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -624,4 +624,46 @@ BOOST_AUTO_TEST_CASE(tier1b_researcher_help_renders)
     }
 }
 
+// Help-rendering coverage for the 14 Tier 1c snapshots / registries / generic-data
+// commands. Each fHelp=true throw happens before any globals are touched, so this
+// runs fixture-free like the other Tier 1 / Tier 2 help-rendering cases.
+BOOST_AUTO_TEST_CASE(tier1c_snapshots_registries_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"superblocks", superblocks},
+        {"superblockage", superblockage},
+        {"superblockaverage", superblockaverage},
+        {"parselegacysb", parselegacysb},
+        {"listscrapers", listscrapers},
+        {"listprojects", listprojects},
+        {"projects", projects},
+        {"getautogreylist", getautogreylist},
+        {"listsidestakes", listsidestakes},
+        {"listmandatorysidestakes", listmandatorysidestakes},
+        {"listprotocolentries", listprotocolentries},
+        {"readdata", readdata},
+        {"writedata", writedata},
+        {"dumpcontracts", dumpcontracts},
+    };
+
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                    "help message missing command name");
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                    "help message missing Examples section");
+            }
+            BOOST_CHECK_MESSAGE(threw, "expected std::runtime_error to be thrown");
+        }
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -58,6 +58,8 @@ UniValue lifetime(const UniValue& params, bool fHelp);
 UniValue resetcpids(const UniValue& params, bool fHelp);
 UniValue rainbymagnitude(const UniValue& params, bool fHelp);
 UniValue currentcontractaverage(const UniValue& params, bool fHelp);
+#include <utility>
+#include <vector>
 
 // Forward declarations of the Tier 2 commands under test. These must live in
 // the global namespace; if placed inside BOOST_AUTO_TEST_SUITE(...) they get
@@ -70,6 +72,23 @@ UniValue settxfee(const UniValue& params, bool fHelp);
 UniValue addnode(const UniValue& params, bool fHelp);
 UniValue setban(const UniValue& params, bool fHelp);
 UniValue listsinceblock(const UniValue& params, bool fHelp);
+
+// Tier 1c forward declarations (snapshots, registries, generic-data, dumpcontracts).
+// Same global-namespace placement requirement as the Tier 2 block above.
+UniValue superblocks(const UniValue& params, bool fHelp);
+UniValue superblockage(const UniValue& params, bool fHelp);
+UniValue superblockaverage(const UniValue& params, bool fHelp);
+UniValue parselegacysb(const UniValue& params, bool fHelp);
+UniValue listscrapers(const UniValue& params, bool fHelp);
+UniValue listprojects(const UniValue& params, bool fHelp);
+UniValue projects(const UniValue& params, bool fHelp);
+UniValue getautogreylist(const UniValue& params, bool fHelp);
+UniValue listsidestakes(const UniValue& params, bool fHelp);
+UniValue listmandatorysidestakes(const UniValue& params, bool fHelp);
+UniValue listprotocolentries(const UniValue& params, bool fHelp);
+UniValue readdata(const UniValue& params, bool fHelp);
+UniValue writedata(const UniValue& params, bool fHelp);
+UniValue dumpcontracts(const UniValue& params, bool fHelp);
 
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
@@ -511,6 +530,28 @@ BOOST_AUTO_TEST_CASE(tier1a_blockchain_core_help_renders)
         {"askforoutstandingblocks", &askforoutstandingblocks},
         {"debug",                   &debug},
         {"versionreport",           &versionreport},
+// Help-rendering coverage for the 14 Tier 1c snapshots / registries / generic-data
+// commands. Each fHelp=true throw happens before any globals are touched, so this
+// runs fixture-free like the other Tier 1 / Tier 2 help-rendering cases.
+BOOST_AUTO_TEST_CASE(tier1c_snapshots_registries_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"superblocks", superblocks},
+        {"superblockage", superblockage},
+        {"superblockaverage", superblockaverage},
+        {"parselegacysb", parselegacysb},
+        {"listscrapers", listscrapers},
+        {"listprojects", listprojects},
+        {"projects", projects},
+        {"getautogreylist", getautogreylist},
+        {"listsidestakes", listsidestakes},
+        {"listmandatorysidestakes", listmandatorysidestakes},
+        {"listprotocolentries", listprotocolentries},
+        {"readdata", readdata},
+        {"writedata", writedata},
+        {"dumpcontracts", dumpcontracts},
     };
 
     for (const auto& [rpc_name, fn] : cases) {
@@ -574,6 +615,11 @@ BOOST_AUTO_TEST_CASE(tier1b_researcher_help_renders)
                     rpc_name << ": help text missing 'Examples:' section");
             }
             BOOST_CHECK_MESSAGE(threw, rpc_name << ": expected runtime_error for fHelp=true");
+                    "help message missing command name");
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                    "help message missing Examples section");
+            }
+            BOOST_CHECK_MESSAGE(threw, "expected std::runtime_error to be thrown");
         }
     }
 }

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -58,8 +58,6 @@ UniValue lifetime(const UniValue& params, bool fHelp);
 UniValue resetcpids(const UniValue& params, bool fHelp);
 UniValue rainbymagnitude(const UniValue& params, bool fHelp);
 UniValue currentcontractaverage(const UniValue& params, bool fHelp);
-#include <utility>
-#include <vector>
 
 // Forward declarations of the Tier 2 commands under test. These must live in
 // the global namespace; if placed inside BOOST_AUTO_TEST_SUITE(...) they get
@@ -530,28 +528,6 @@ BOOST_AUTO_TEST_CASE(tier1a_blockchain_core_help_renders)
         {"askforoutstandingblocks", &askforoutstandingblocks},
         {"debug",                   &debug},
         {"versionreport",           &versionreport},
-// Help-rendering coverage for the 14 Tier 1c snapshots / registries / generic-data
-// commands. Each fHelp=true throw happens before any globals are touched, so this
-// runs fixture-free like the other Tier 1 / Tier 2 help-rendering cases.
-BOOST_AUTO_TEST_CASE(tier1c_snapshots_registries_help_renders)
-{
-    const UniValue empty(UniValue::VARR);
-    using HelpFn = UniValue (*)(const UniValue&, bool);
-    const std::vector<std::pair<const char*, HelpFn>> cases{
-        {"superblocks", superblocks},
-        {"superblockage", superblockage},
-        {"superblockaverage", superblockaverage},
-        {"parselegacysb", parselegacysb},
-        {"listscrapers", listscrapers},
-        {"listprojects", listprojects},
-        {"projects", projects},
-        {"getautogreylist", getautogreylist},
-        {"listsidestakes", listsidestakes},
-        {"listmandatorysidestakes", listmandatorysidestakes},
-        {"listprotocolentries", listprotocolentries},
-        {"readdata", readdata},
-        {"writedata", writedata},
-        {"dumpcontracts", dumpcontracts},
     };
 
     for (const auto& [rpc_name, fn] : cases) {
@@ -615,11 +591,6 @@ BOOST_AUTO_TEST_CASE(tier1b_researcher_help_renders)
                     rpc_name << ": help text missing 'Examples:' section");
             }
             BOOST_CHECK_MESSAGE(threw, rpc_name << ": expected runtime_error for fHelp=true");
-                    "help message missing command name");
-                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
-                    "help message missing Examples section");
-            }
-            BOOST_CHECK_MESSAGE(threw, "expected std::runtime_error to be thrown");
         }
     }
 }


### PR DESCRIPTION
## Summary

Tier 1c of issue #2922 — the final slice of `src/rpc/blockchain.cpp`'s Tier 1 conversions. Closes out blockchain.cpp Tier 1 once #2954 (Tier 1a) and #2956 (Tier 1b) also land. Pure packaging change: no behavior changes, no error-code changes, no `RPCResult` schemas that don't match the actual return values.

One commit per command (matches Tier 1a #2954 / Tier 1b #2956 / Tier 2 #2930 / Tier 3 #2924), plus one test commit exercising all 14 conversions on the help-rendering path.

## Independent of #2954 / #2956

This branch is based on `origin/development` (post-#2930 merge), not on #2954 or #2956. All 14 commands here are disjoint from the 21 in Tier 1a and the 17 in Tier 1b — no overlap, no expected conflicts regardless of merge order.

## Commands converted (14)

**Superblock snapshots (3):** `superblocks`, `superblockage`, `superblockaverage`

**Consensus registries (5):** `listscrapers`, `listprotocolentries`, `listprojects`, `listsidestakes`, `listmandatorysidestakes`

**Researcher view (2):** `projects`, `getautogreylist`

**Contract parsing / dump (2):** `parselegacysb`, `dumpcontracts`

**Generic-data debug RPCs (2):** `readdata`, `writedata`

`dumpcontracts` previously built its help text at runtime by iterating `GRC::ContractType`. Flattened to a static comma-separated list in the `contract_type` argument description, matching the upstream "static help text" approach already used by `versionreport` in Tier 1a. The runtime path that enumerates contract types in the parser is untouched.

`writedata` is debug-only but not gated behind a flag in current code; included for completeness — the conversion is mechanical regardless. The function-body database mutation is unchanged.

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` now renders the structured `RPCHelpMan` output instead of the legacy free-form string. Same wire shape (still a `runtime_error` containing the help text); contents auto-formatted.
- `params.size()` checks moved from inline conditions to `help.IsValidNumArgs(...)`. Arity bounds preserved exactly — verified against each function's original `if (fHelp || params.size() ...)` condition. `parselegacysb` previously accepted `size() >= 1` and silently ignored extra args; the new gate is exactly 1, a tightening that matches the Tier 2 `listsinceblock` precedent (where the unbounded 4+ was also tightened).
- All function bodies below the help/arity check are untouched. No locking changes (`superblocks`, `superblockaverage`, `dumpcontracts` keep their `LOCK(cs_main)` post-help). No return-value changes. No error-message rewording for non-help paths.

**RPCResult schemas were verified per command** by tracing each function to its `return` / `pushKV` sites. Fixed-shape OBJ results enumerate their actual keys (e.g. `superblockage`, `superblockaverage`, `parselegacysb`, `readdata`, `writedata`, `dumpcontracts`). Variable-shape returns (`superblocks`, `listscrapers`, `listprojects`, `listprotocolentries`, `listsidestakes`, `getautogreylist`, `listmandatorysidestakes`) use `RPCResult::Type::ELISION` for the inner entries — same pattern as `listsinceblock`'s transactions array in #2930. `listprojects`'s project-keyed result uses `OBJ_DYN`.

`dumpcontracts` declares `number_of_beacons_verified` as `optional=true` because it is only emitted when `contract_type == beacon`. `readdata`'s `Error` key is `optional=true` for the same reason (only set on read failure).

## Tests

`src/test/rpchelpman_tests.cpp` gains one `BOOST_AUTO_TEST_CASE(tier1c_snapshots_registries_help_renders)` that:
- Iterates all 14 converted commands,
- Calls each with empty `params` and `fHelp=true`,
- Asserts the thrown `std::runtime_error` message contains the RPC name and the `Examples:` marker.

The help gate fires before any global state access for all 14 (verified per function), so the test runs fixture-free — same pattern as Tier 1a/1b and the Tier 2 invalid-subcommand tests added in #2930.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Production Builds passes on the fork (macOS Intel still completing at PR open; remaining 6 jobs all green)
- [x] CMake Distribution Native Builds — **transient package-mirror failures** on Debian Unstable (Sid) and OpenSUSE Tumbleweed at the dependency-install step. Same upstream dev tip (`4a2a049f3`, this branch's base) ran the same workflow successfully on 2026-05-23 03:10 UTC; the issues here are:
  - **Debian Sid:** `E: Package 'libqt6core5compat6-dev' has no installation candidate` — the Qt6 compat shim disappeared from the Sid archive within the last ~24h.
  - **OpenSUSE Tumbleweed:** `pattern:devel_basis ... requires patterns-devel-base-devel_basis, but this requirement cannot be provided` — broken by a `busybox-gawk` conflict in the current snapshot.
  - Both failures are pre-build, environmental, and not reproducible against the branch's diff. The other 8 distros in this workflow (Leap 16.0, Fedora Latest, Arch, Linux Mint 22, Alpine Edge, etc.) all pass. Will re-run once mirrors refresh; upstream CI will give its own verdict on these distros independently.
- [x] Manual RPC smoke (per command) — before marking ready for review:
  - `gridcoinresearch help <cmd>` for each of the 14 — full help renders, examples present, no truncation.
  - Spot-check return shape for `superblockaverage`, `superblockage`, `dumpcontracts`, `readdata` (fully-enumerated OBJ results) — confirm no field drift.
  - `gridcoinresearch dumpcontracts beacon /tmp/beacons.txt` — confirm `number_of_beacons_verified` present in result, absent for non-beacon contract types.
  - `gridcoinresearch parselegacysb "<contract>"` — confirm 0-arg and 2+-arg calls now reject (the old code silently accepted extras).

Refs: #2922
