### PR TITLE
build: remove busybox-gawk/-less on Tumbleweed before devel_basis install

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -250,6 +250,32 @@ install_deps() {
             fi
 
             # Pattern Install
+            #
+            # On Tumbleweed (rolling release), the base image as of
+            # snapshot ~20260523 ships busybox-gawk (and busybox-less),
+            # both of which `provide` the generic `gawk` / `less` capability.
+            # `patterns-devel-base-devel_basis` requires the canonical GNU
+            # gawk; zypper refuses the install with "not installable
+            # providers" because busybox-gawk already owns the `gawk`
+            # provider slot. Remove the busybox shims first so the devel
+            # pattern can pull in the real GNU tools.
+            #
+            # Safe for non-CI / bare-metal developer use too: on a system
+            # that's about to install patterns-devel-base-devel_basis, the
+            # canonical GNU gawk/less are what's actually wanted -- the
+            # busybox-* variants are minimal alternates the pattern will
+            # replace anyway. The `|| true` keeps this idempotent: if the
+            # busybox packages aren't installed (e.g. an existing fully
+            # provisioned dev box) the rm is a no-op.
+            #
+            # Leap and other openSUSE flavours don't hit this in their
+            # current snapshots, so the workaround is gated on Tumbleweed
+            # only.
+            if [[ "$IS_TUMBLEWEED" == "true" ]]; then
+                echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less, if present)..."
+                sudo zypper rm -y busybox-gawk busybox-less 2>/dev/null || true
+            fi
+
             echo "Installing devel_basis pattern..."
             sudo zypper install -y -t pattern devel_basis
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -264,16 +264,21 @@ install_deps() {
             # that's about to install patterns-devel-base-devel_basis, the
             # canonical GNU gawk/less are what's actually wanted -- the
             # busybox-* variants are minimal alternates the pattern will
-            # replace anyway. The `|| true` keeps this idempotent: if the
-            # busybox packages aren't installed (e.g. an existing fully
-            # provisioned dev box) the rm is a no-op.
+            # replace anyway.
             #
             # Leap and other openSUSE flavours don't hit this in their
-            # current snapshots, so the workaround is gated on Tumbleweed
-            # only.
-            if [[ "$IS_TUMBLEWEED" == "true" ]]; then
-                echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less, if present)..."
-                sudo zypper rm -y busybox-gawk busybox-less 2>/dev/null || true
+            # current snapshots, so the workaround is gated on Tumbleweed.
+            # The `rpm -q --quiet` guard skips the rm entirely on systems
+            # where neither shim is installed (e.g. an already-provisioned
+            # dev box) -- no zypper noise and no exit-code dance. When the
+            # rm does run, stderr stays visible so a real removal failure
+            # (repo lock, network, solver problem) surfaces in the CI /
+            # shell log rather than masquerading as the downstream
+            # devel_basis install failure.
+            if [[ "$IS_TUMBLEWEED" == "true" ]] \
+                && { rpm -q --quiet busybox-gawk || rpm -q --quiet busybox-less; }; then
+                echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less)..."
+                sudo zypper rm -y busybox-gawk busybox-less
             fi
 
             echo "Installing devel_basis pattern..."


### PR DESCRIPTION
## Problem

The `OpenSUSE Tumbleweed` job in `cmake_distros.yml` has been failing on every PR-against-`development` run since roughly 2026-05-23 with:

```
Problem: 1: the to be installed pattern:devel_basis-20170319-13.3.x86_64 requires
  'patterns-devel-base-devel_basis', but this requirement cannot be provided
not installable providers: patterns-devel-base-devel_basis-20170319-13.3.x86_64[repo-oss]

 Solution 1: deinstallation of busybox-gawk-1.37.0-41.4.noarch
 Solution 2: do not install pattern:devel_basis-20170319-13.3.x86_64
 Solution 3: break pattern:devel_basis-20170319-13.3.x86_64 by ignoring some of its dependencies

Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
##[error]Process completed with exit code 4.
```

The Tumbleweed runner image (rolling) recently picked up `busybox-gawk` (and `busybox-less`) in its base layer alongside the standard `actions/checkout` setup packages. Both register as providers of the symbolic `gawk` / `less` capabilities. `patterns-devel-base-devel_basis` requires the canonical GNU implementations, and zypper's solver refuses to install the pattern when the busybox providers already own the slots. In non-interactive `zypper install -y`, zypper exits 4 instead of auto-selecting a solution.

## Evidence it is image-level, not PR-level

The latest `development`-branch `CMake Distribution Native Builds` run prior to this regression succeeded at 2026-05-23T17:03:31Z. The next run (PR #2957 against `development`) failed at 2026-05-24T02:14:10Z on the same Tumbleweed job — ~9 hours apart. Neither the PR nor `development` changed in a way that touches `install_dependencies.sh` or the runner image setup between those points; what changed was the Tumbleweed image picking up `busybox-gawk-1.37.0-41.4` in its base.

## Fix

In the Tumbleweed branch of `install_dependencies.sh`, remove `busybox-gawk` and `busybox-less` before requesting `patterns-devel-base-devel_basis`. The pattern install then proceeds normally and pulls in the canonical GNU gawk/less.

```diff
+if [[ "$IS_TUMBLEWEED" == "true" ]]; then
+    echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less, if present)..."
+    sudo zypper rm -y busybox-gawk busybox-less 2>/dev/null || true
+fi
 echo "Installing devel_basis pattern..."
 sudo zypper install -y -t pattern devel_basis
```

### Why this is safe outside CI

`install_dependencies.sh` is shared between CI runs and bare-metal developer use. The change is non-destructive for the latter:

- The user is *about to install* `patterns-devel-base-devel_basis`, which pulls in canonical GNU `gawk`/`less` as part of the devel pattern — that's the whole point of the pattern.
- `busybox-gawk`/`busybox-less` are minimal alternates the pattern is about to replace.
- `|| true` makes the call idempotent: on a system where the busybox shims aren't installed (e.g. an already-provisioned dev box) the `zypper rm` is a no-op.
- Gated on `IS_TUMBLEWEED == \"true\"` so Leap and other openSUSE flavours that don't ship the busybox shims in their current snapshots are untouched.

### Why not upstream

The cleanest fix is in Tumbleweed itself — either `patterns-devel-base-devel_basis` should declare a virtual `gawk` requirement rather than the canonical implementation, or `busybox-gawk` should not register as a `gawk` provider in a way that conflicts with the devel pattern. Either could surface in a refresh cycle and undo the immediate need for this workaround. Until that happens, our CI (and any new Tumbleweed user who clones and runs `install_dependencies.sh`) needs the workaround.

## Testing

- `bash -n install_dependencies.sh` — parses clean
- `shellcheck install_dependencies.sh` — no new warnings introduced (pre-existing SC2086 hits elsewhere in the file are untouched)
- `test/lint/lint-whitespace.sh` and `test/lint/lint-shell.sh` — both pass
- The fix itself will be exercised by this PR's own CI run on the Tumbleweed job

## Out of scope

- Pre-existing `SC2086` shellcheck hits at lines 413, 417, 432, 435 — quoting fixes that belong in a separate cleanup commit, not bundled with a single-issue CI repair.
- Wider audit of other distros' minimal-busybox vs devel-pattern interactions — none of the other openSUSE images on the CI matrix are currently hitting this, so a focused Tumbleweed-only fix is the right scope.