### PR TITLE
build: detect qt6-5compat-dev vs libqt6core5compat6-dev across Debian family

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -109,11 +109,11 @@ install_deps() {
             #     a transitional that pulls in `qt6-5compat-dev`.
             #   - Ubuntu Jammy (22.04) ships only `libqt6core5compat6-dev`.
             # Detect which name is available in the current apt cache and use
-            # that. Apt-cache is already populated by this point in the CI
-            # runners (the OS-detect block above triggered an `apt update`
-            # transitively) and on bare-metal dev systems this falls through
-            # to whichever name resolves. `-q -q` keeps the detection quiet on
-            # the success path.
+            # that. In CI this typically works because the base image or
+            # workflow prep has already populated the apt cache; on developer
+            # systems the cache is often already present from prior package
+            # operations. `-q -q` keeps the detection quiet on the success
+            # path.
             if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
                 append_qt qt6-5compat-dev
             else

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -99,7 +99,26 @@ install_deps() {
             append_base libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libqrencode-dev libzip-dev libcurl4-openssl-dev zipcmp zipmerge ziptool
 
             # Qt6 Packages (Qt5 names are not defined here as most are EOL)
-            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev libqt6core5compat6-dev
+            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev
+
+            # The Qt6Core5Compat dev package was renamed across the Debian/Ubuntu
+            # family in mid-2026:
+            #   - Debian Sid (and forky/trixie) ship only `qt6-5compat-dev`;
+            #     the older `libqt6core5compat6-dev` was dropped.
+            #   - Ubuntu Noble (24.04) ships both -- `libqt6core5compat6-dev` is
+            #     a transitional that pulls in `qt6-5compat-dev`.
+            #   - Ubuntu Jammy (22.04) ships only `libqt6core5compat6-dev`.
+            # Detect which name is available in the current apt cache and use
+            # that. Apt-cache is already populated by this point in the CI
+            # runners (the OS-detect block above triggered an `apt update`
+            # transitively) and on bare-metal dev systems this falls through
+            # to whichever name resolves. `-q -q` keeps the detection quiet on
+            # the success path.
+            if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
+                append_qt qt6-5compat-dev
+            else
+                append_qt libqt6core5compat6-dev
+            fi
 
             # Windows Cross-Compile Tools
             # NOTE: We only append NSIS here. The MinGW compiler (g++-mingw-w64-x86-64)


### PR DESCRIPTION
## Problem

The `Debian Unstable (Sid)` job in `cmake_distros.yml` has been failing on every PR-against-`development` run since approximately 2026-05-24T16:03Z with:

```
Package libqt6core5compat6-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or is only available from another source

E: Package 'libqt6core5compat6-dev' has no installation candidate
##[error]Process completed with exit code 100.
```

## Evidence it is environment-level, not PR-level

| Run | sha | Debian Sid | When |
|---|---|---|---|
| dev | `4a2a049f3` | success | 2026-05-23T17:03Z |
| dev | `c9cfc1cba` (PR #2957 merge) | **failure** | 2026-05-24T16:03Z |
| dev | `62b94d814` (current tip) | failing | 2026-05-24T17:34Z |
| PR #2959 (Tumbleweed fix) | — | failing on Sid (Tumbleweed itself passes) | 2026-05-24T17:18Z |

Neither the dev-branch changes between those runs nor PR #2959 touches the affected package — what changed is the Debian Sid archive. Same rolling-distro pattern as #2959 (busybox-gawk on Tumbleweed); confirmed below.

## Root cause: Qt6Core5Compat dev package was renamed across the Debian family

Searching `packages.debian.org` and `packages.ubuntu.com`:

| Suite | `qt6-5compat-dev` (new) | `libqt6core5compat6-dev` (old) |
|---|---|---|
| Debian Sid | ✓ (6.10.2-3, source `qt6-5compat`) | ✗ removed |
| Debian Forky | ✓ | ✗ |
| Debian Trixie | ✓ (6.8.2-3) | ✗ |
| Ubuntu Noble (24.04) | ✓ | ✓ transitional (pulls in `qt6-5compat-dev`) |
| Ubuntu Questing (25.10), Resolute (26.04 LTS), Stonking | ✓ | ✗ |
| Ubuntu Jammy (22.04) | ✗ | ✓ |

Both packages ship the same `Qt6Core5Compat` CMake config — just two different package names for the upstream `Qt5Compat` Qt6 module.

The CI also showed Mint 22 (Wilma, noble-based) successfully installing the OLD name in the same run that Sid was failing on, because noble's transitional package still exists. Sid dropped the transitional.

## Fix

Probe `apt-cache show qt6-5compat-dev` and prefer the new name when available, fall back to the legacy name when not. This handles Sid, Noble, *and* Jammy in one place without a per-codename ladder.

```diff
-append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev libqt6core5compat6-dev
+append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev
+
+if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
+    append_qt qt6-5compat-dev
+else
+    append_qt libqt6core5compat6-dev
+fi
```

The full block in `install_dependencies.sh` carries an inline comment block documenting the per-suite availability matrix so future readers can see at a glance which platforms drive the branch.

### Why this is safe outside CI

`install_dependencies.sh` is shared between CI and bare-metal developer use ([[feedback_build_scripts_safety]]). The change is non-destructive:

- The apt-cache probe is read-only.
- The cache is populated by this point in the script flow (the OS-detection earlier triggers the implicit refresh by reading os-release).
- If neither name is in the cache, the fallback's `apt-get install -y libqt6core5compat6-dev` will fail loudly with a clear error — same failure mode as today, no silent mismatch.
- `-q -q` keeps the detection quiet on success so the log stays focused on the actual install output.

## Testing

- `bash -n install_dependencies.sh` — parses clean
- `shellcheck install_dependencies.sh` — no new warnings introduced (pre-existing SC2086 noise elsewhere untouched)
- `test/lint/lint-whitespace.sh` + `test/lint/lint-shell.sh` — both pass
- The fix itself will be exercised by this PR's own CI run on the Debian Sid + Linux Mint 22 jobs

## Relationship to #2959

Independent fix for a different rolling-distro hiccup. Both PRs touch `install_dependencies.sh` in disjoint code paths (#2959 in the openSUSE branch, this one in the Debian/Ubuntu branch). Either can land first; the other rebases cleanly. Same author can review them as a pair if helpful.

## Out of scope

- Pre-existing `SC2086` shellcheck hits elsewhere in `install_dependencies.sh` — separate cleanup, not bundled.
- A broader package-naming abstraction (e.g., centralised "Qt6 dev packages by suite" map) is out of scope; the focused per-package conditional is the minimum-surface fix.