### PR TITLE
rpc: convert 6 voting.cpp commands to RPCHelpMan (Tier 1 D3, #2922)

### DIFF
--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -613,13 +613,24 @@ UniValue addpoll(const UniValue& params, bool fHelp)
 
 UniValue listpolls(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw std::runtime_error(
-                "listpolls ( showfinished )\n"
-                "\n"
-                "[showfinished] -> If true, show finished polls as well.\n"
-                "\n"
-                "Lists poll details\n");
+    static const RPCHelpMan help{
+        "listpolls",
+        "Lists poll details for all currently active polls (or for all polls if showfinished is true).",
+        {
+            {"showfinished", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, show finished polls as well. Default: false."},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::ELISION, "", "Poll detail object; see 'getpollresults' / 'addpoll' for shape."},
+            }},
+        RPCExamples{
+            HelpExampleCli("listpolls", "") +
+            HelpExampleCli("listpolls", "true") +
+            HelpExampleRpc("listpolls", "true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     UniValue json(UniValue::VARR);
 

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -688,13 +688,22 @@ UniValue getpollresults(const UniValue& params, bool fHelp)
 
 UniValue getvotingclaim(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw std::runtime_error(
-                "getvotingclaim <poll_or_vote_id>\n"
-                "\n"
-                "<poll_or_vote_id> --> Transaction hash of the poll or vote.\n"
-                "\n"
-                "Display the claim for the specified poll or vote.\n");
+    static const RPCHelpMan help{
+        "getvotingclaim",
+        "Display the claim for the specified poll or vote.",
+        {
+            {"poll_or_vote_id", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+                "Transaction hash of the poll or vote."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "",
+                "Claim object; shape depends on whether the transaction is a poll (PollClaimToJson) or vote (VoteClaimToJson)."}}},
+        RPCExamples{
+            HelpExampleCli("getvotingclaim", "\"<txid>\"") +
+            HelpExampleRpc("getvotingclaim", "\"<txid>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     const uint256 id = uint256S(params[0].get_str());
 

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -846,17 +846,23 @@ UniValue votebyid(const UniValue& params, bool fHelp)
 
 UniValue votedetails(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw std::runtime_error(
-                "votedetails <poll_title_or_id>\n"
-                "\n"
-                "<poll_title_or_id> --> Title or ID of the poll.\n"
-                "\n"
-                "Display the vote details for the specified poll.\n"
-                "\n"
-                "Note that in the small chance that a blockchain reorg occurs during\n"
-                "the tally for the vote details, this call will return an error. Retrying\n"
-                "should succeed.");
+    static const RPCHelpMan help{
+        "votedetails",
+        "Display the vote details for the specified poll.\n"
+        "\n"
+        "Note that in the small chance that a blockchain reorg occurs during the tally for the vote details,\n"
+        "this call will return an error. Retrying should succeed.",
+        {
+            {"poll_title_or_id", RPCArg::Type::STR, RPCArg::Optional::NO, "Title or ID of the poll."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Vote details object; see source (VoteDetailsToJson) for shape."}}},
+        RPCExamples{
+            HelpExampleCli("votedetails", "\"Example Poll\"") +
+            HelpExampleRpc("votedetails", "\"Example Poll\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     const std::string title_or_id = params[0].get_str();
 

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -884,13 +884,19 @@ UniValue votedetails(const UniValue& params, bool fHelp)
 
 UniValue testpollnotification(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1) {
-        throw std::runtime_error(
-                "testpollnotification <poll txid>\n"
-                "\n"
-                "<poll txid> --> Transaction id of the poll to test notification.\n"
-                "\n"
-                "Test the poll notification system.\n");
+    static const RPCHelpMan help{
+        "testpollnotification",
+        "Test the poll notification system for the specified poll.",
+        {
+            {"poll_txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction ID of the poll to test notification."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("testpollnotification", "\"<txid>\"") +
+            HelpExampleRpc("testpollnotification", "\"<txid>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size())) {
+        throw std::runtime_error(help.ToString());
     }
 
     const uint256 txid = uint256S(params[0].get_str());

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -649,17 +649,23 @@ UniValue listpolls(const UniValue& params, bool fHelp)
 
 UniValue getpollresults(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw std::runtime_error(
-                "getpollresults <poll_title_or_id>\n"
-                "\n"
-                "<poll_title_or_id> --> Title or ID of the poll.\n"
-                "\n"
-                "Display the results for the specified poll.\n"
-                "\n"
-                "Note that in the small chance that a blockchain reorg occurs during\n"
-                "the tally for the poll, this call will return an error. Retrying\n"
-                "should succeed.");
+    static const RPCHelpMan help{
+        "getpollresults",
+        "Display the results for the specified poll.\n"
+        "\n"
+        "Note that in the small chance that a blockchain reorg occurs during the tally for the poll,\n"
+        "this call will return an error. Retrying should succeed.",
+        {
+            {"poll_title_or_id", RPCArg::Type::STR, RPCArg::Optional::NO, "Title or ID of the poll."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Poll result object; see source (PollResultToJson) for the exact shape."}}},
+        RPCExamples{
+            HelpExampleCli("getpollresults", "\"Example Poll\"") +
+            HelpExampleRpc("getpollresults", "\"Example Poll\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     const std::string title_or_id = params[0].get_str();
 

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -790,14 +790,27 @@ UniValue vote(const UniValue& params, bool fHelp)
 
 UniValue votebyid(const UniValue& params, bool fHelp)
 {
+    static const RPCHelpMan help{
+        "votebyid",
+        "Cast a vote for a poll.",
+        {
+            {"poll_id", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "ID (transaction hash) of the poll to vote for."},
+            {"choice_id", RPCArg::Type::NUM, RPCArg::Optional::NO,
+                "Numeric ID of a choice to vote for. Pass additional positional choice IDs for multi-choice polls."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "",
+                "Vote submission detail; see source (SubmitVote) — includes poll, vote_txid, and responses fields."}}},
+        RPCExamples{
+            HelpExampleCli("votebyid", "\"<poll_txid>\" 0") +
+            HelpExampleCli("votebyid", "\"<poll_txid>\" 0 1") +
+            HelpExampleRpc("votebyid", "\"<poll_txid>\", 0, 1")},
+    };
+    // Variadic positional: at least one choice_id is required (legacy minimum was 2 args total).
+    // RPCHelpMan does not model unbounded variadic, so keep the original lower-bound check and
+    // render help via the manifest above.
     if (fHelp || params.size() < 2)
-        throw std::runtime_error(
-            "votebyid <poll_id> <choice_id_1> ( choice_id_2... )\n"
-            "\n"
-            "<poll_id> --------> ID of the poll to vote for.\n"
-            "<choice_ids...> --> Numeric IDs of the choices to vote for.\n"
-            "\n"
-            "Cast a vote for a poll.\n");
+        throw std::runtime_error(help.ToString());
 
     if (OutOfSyncByAge()) {
         throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to vote.");

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -119,6 +119,17 @@ UniValue sendalert(const UniValue& params, bool fHelp);
 UniValue sendalert2(const UniValue& params, bool fHelp);
 UniValue getnetworkinfo(const UniValue& params, bool fHelp);
 
+// Tier 1 PR D3: src/rpc/voting.cpp non-deprecated commands. Each function's
+// converted body throws via help.ToString() before touching globals (the
+// poll registry, cs_main, pwalletMain), so calling these with fHelp=true
+// and an empty params array is safe in unit tests.
+UniValue listpolls(const UniValue& params, bool fHelp);
+UniValue getpollresults(const UniValue& params, bool fHelp);
+UniValue getvotingclaim(const UniValue& params, bool fHelp);
+UniValue votebyid(const UniValue& params, bool fHelp);
+UniValue votedetails(const UniValue& params, bool fHelp);
+UniValue testpollnotification(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -695,6 +706,37 @@ BOOST_AUTO_TEST_CASE(tier1_d2_net_remaining_help_renders)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(tier1_d3_voting_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"listpolls", &listpolls},
+        {"getpollresults", &getpollresults},
+        {"getvotingclaim", &getvotingclaim},
+        {"votebyid", &votebyid},
+        {"votedetails", &votedetails},
+        {"testpollnotification", &testpollnotification},
+    };
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                    rpc_name << ": help text missing command name; got: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                    rpc_name << ": help text missing 'Examples:' section");
+            }
+            BOOST_CHECK_MESSAGE(threw, rpc_name << ": expected runtime_error for fHelp=true");
+        }
+    }
+}
+
 
 // Help-rendering coverage for the 14 Tier 1c snapshots / registries / generic-data
 // commands. Each fHelp=true throw happens before any globals are touched, so this


### PR DESCRIPTION
## Summary

Tier 1 D3 of issue #2922 — packages the legacy help-text-as-`runtime_error` pattern into `RPCHelpMan` for 6 commands in `src/rpc/voting.cpp`. Pure packaging change.

`addpoll` was already converted (per-call `RPCHelpMan` for protocol-dependent poll types); `vote` (deprecated wrapper that delegates to `votebyid`) is converted separately in the deprecated batch.

One commit per command + one test commit.

## Stacked on #2923 (merged)

Based on current `origin/development`. Companion to #2954/#2956/#2958 (Tier 1a/1b/1c), #2961 (D1), #2962 (D2).

## Commands converted

`listpolls`, `getpollresults`, `getvotingclaim`, `votebyid`, `votedetails`, `testpollnotification`

Notes:
- `listpolls`, `getpollresults`, `votebyid`, `votedetails` returned variable-shape results; their top-level `Type::ANY` is wrapped in `OBJ + ELISION` so the Result section renders in help output. (Inner `Type::ANY` would trigger `CHECK_NONFATAL` in `RPCResult::ToSections`; `OBJ + ELISION` is the canonical "variable shape" replacement.)
- `votebyid` accepts an unbounded variadic positional list (`pollid title choice [title choice ...]`) — `IsValidNumArgs` can't express that, so the conversion keeps the manual lower-bound check and uses `help.ToString()` for help rendering.

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly (except `votebyid`'s unbounded upper bound, which is checked manually).
- All function bodies below the help/arity check are untouched.

## Tests

`src/test/rpchelpman_tests.cpp` gains `BOOST_AUTO_TEST_CASE(tier1_d3_voting_help_renders)` that iterates all 6 commands, calls each with empty `params` and `fHelp=true`, and asserts the thrown `runtime_error` message contains the RPC name and the `Examples:` marker.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 6 — full help renders, examples present
  - Confirm `listpolls`/`getpollresults` JSON output unchanged vs pre-conversion
  - Confirm `votebyid` variadic lower-bound (no args, only pollid+title without choice) still throws the help text

Refs: #2922