### PR TITLE
rpc: convert 9 scraper commands to RPCHelpMan (Tier 1 E2, #2922)

### DIFF
--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6336,11 +6336,20 @@ UniValue sendscraperfilemanifest(const UniValue& params, bool fHelp)
  */
 UniValue savescraperfilemanifest(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1 )
-        throw std::runtime_error(
-                "savescraperfilemanifest <hash>\n"
-                "Saves a CScraperManifest object to disk.\n"
-                );
+    static const RPCHelpMan help{
+        "savescraperfilemanifest",
+        "Save a CScraperManifest object to disk.",
+        {
+            {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+                "Hash of the manifest to save to disk."},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "True if the manifest was written successfully."},
+        RPCExamples{
+            HelpExampleCli("savescraperfilemanifest", "\"<hash>\"") +
+            HelpExampleRpc("savescraperfilemanifest", "\"<hash>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     bool ret = ScraperSaveCScraperManifestToFiles(uint256S(params[0].get_str()));
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6494,15 +6494,23 @@ UniValue ConvergedScraperStatsToJson(ConvergedScraperStats& ConvergedScraperStat
  */
 UniValue convergencereport(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw std::runtime_error(
-                "convergencereport [convergence_cache_details]\n"
-                "\n"
-                "convergence_cache_details: optional boolean to provide detailed output\n"
-                "from convergence cache\n"
-                "\n"
-                "Display local node report of scraper convergence.\n"
-                );
+    static const RPCHelpMan help{
+        "convergencereport",
+        "Display the local node's report of scraper convergence.",
+        {
+            {"convergence_cache_details", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, include detailed output from the convergence cache. Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "",
+                "Convergence report; the shape depends on the convergence_cache_details flag. See source."}}},
+        RPCExamples{
+            HelpExampleCli("convergencereport", "") +
+            HelpExampleCli("convergencereport", "true") +
+            HelpExampleRpc("convergencereport", "true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     auto scraper_sleep = []() { LOCK(cs_ScraperGlobals); return nScraperSleep; };
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6498,8 +6498,8 @@ UniValue convergencereport(const UniValue& params, bool fHelp)
         "convergencereport",
         "Display the local node's report of scraper convergence.",
         {
-            {"convergence_cache_details", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                "If true, include detailed output from the convergence cache. Default: false."},
+            {"convergence_cache_details", RPCArg::Type::BOOL, RPCArg::Default{false},
+                "If true, include detailed output from the convergence cache."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "",
             {{RPCResult::Type::ELISION, "",
@@ -6623,9 +6623,9 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
         "testnewsb",
         "Tests superblock formation.",
         {
-            {"hint_bits", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+            {"hint_bits", RPCArg::Type::NUM, RPCArg::Default{32},
                 "Number of bits for the reduced hash hint for the uncached test. "
-                "Clamped to a range of 4 to 32; default: 32 (the normal hint bits)."},
+                "Clamped to a range of 4 to 32 (32 = the normal hint bits)."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "",
             {{RPCResult::Type::ELISION, "", "Test report; see source for shape."}}},

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6366,11 +6366,23 @@ UniValue savescraperfilemanifest(const UniValue& params, bool fHelp)
  */
 UniValue deletecscrapermanifest(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1 )
-        throw std::runtime_error(
-                "deletecscrapermanifest <hash>\n"
-                "delete manifest object.\n"
-                );
+    static const RPCHelpMan help{
+        "deletecscrapermanifest",
+        "Delete a CScraperManifest entry from the global mapManifest map.\n"
+        "Deletion is immediate and does not create a grace-period entry in the pending-deleted-manifest map.\n"
+        "The underlying manifest object will not be deleted if a shared pointer to it is also held by the\n"
+        "global convergence cache.",
+        {
+            {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+                "Hash of the manifest to delete."},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "True if the manifest entry was deleted."},
+        RPCExamples{
+            HelpExampleCli("deletecscrapermanifest", "\"<hash>\"") +
+            HelpExampleRpc("deletecscrapermanifest", "\"<hash>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     LOCK(CScraperManifest::cs_mapManifest);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6855,11 +6855,19 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
  */
 UniValue scraperreport(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0 )
-        throw std::runtime_error(
-                "scraperreport\n"
-                "Report containing various statistics about the scraper.\n"
-                );
+    static const RPCHelpMan help{
+        "scraperreport",
+        "Report containing various statistics about the scraper.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "",
+                "Scraper diagnostics object including global scraper network sizes and converged-stats cache detail."}}},
+        RPCExamples{
+            HelpExampleCli("scraperreport", "") +
+            HelpExampleRpc("scraperreport", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     UniValue ret(UniValue::VOBJ);
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6619,13 +6619,23 @@ UniValue convergencereport(const UniValue& params, bool fHelp)
  */
 UniValue testnewsb(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1 )
-        throw std::runtime_error(
-                "testnewsb [hint bits]\n"
-                "Tests superblock formation. Optional parameter of the number of bits for the reduced hash hint for"
-                " uncached test.\n"
-                "This is limited to a range of 4 to 32, with 32 as the default (which is the normal hint bits).\n"
-                );
+    static const RPCHelpMan help{
+        "testnewsb",
+        "Tests superblock formation.",
+        {
+            {"hint_bits", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Number of bits for the reduced hash hint for the uncached test. "
+                "Clamped to a range of 4 to 32; default: 32 (the normal hint bits)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Test report; see source for shape."}}},
+        RPCExamples{
+            HelpExampleCli("testnewsb", "") +
+            HelpExampleCli("testnewsb", "16") +
+            HelpExampleRpc("testnewsb", "16")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     unsigned int nReducedCacheBits = 32;
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -5,6 +5,7 @@
 #include "main.h"
 #include "node/ui_interface.h"
 #include "random.h"
+#include "rpc/util.h"
 
 #include "gridcoin/appcache.h"
 #include "gridcoin/beacon.h"
@@ -6299,11 +6300,17 @@ Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bContrac
  */
 UniValue sendscraperfilemanifest(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0 )
-        throw std::runtime_error(
-                "sendscraperfilemanifest\n"
-                "Send a CScraperManifest object from the current ScraperFileManifest.\n"
-                );
+    static const RPCHelpMan help{
+        "sendscraperfilemanifest",
+        "Send a CScraperManifest object from the current ScraperFileManifest.",
+        {},
+        RPCResult{RPCResult::Type::BOOL, "", "True if the manifest was broadcast successfully."},
+        RPCExamples{
+            HelpExampleCli("sendscraperfilemanifest", "") +
+            HelpExampleRpc("sendscraperfilemanifest", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     CTxDestination AddressOut;
     CKey KeyOut;

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -6399,11 +6399,20 @@ UniValue deletecscrapermanifest(const UniValue& params, bool fHelp)
  */
 UniValue archivelog(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1 )
-        throw std::runtime_error(
-                "archivelog <log>\n"
-                "Immediately archives the specified log. Currently valid values are debug and scraper.\n"
-                );
+    static const RPCHelpMan help{
+        "archivelog",
+        "Immediately archive the specified log. Currently valid values are \"debug\" and \"scraper\".",
+        {
+            {"log", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Which log to archive: either \"debug\" or \"scraper\"."},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "True if the log was archived successfully."},
+        RPCExamples{
+            HelpExampleCli("archivelog", "debug") +
+            HelpExampleRpc("archivelog", "\"scraper\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     std::string sLogger = params[0].get_str();
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -945,8 +945,8 @@ UniValue listmanifests(const UniValue& params, bool fHelp)
         "listmanifests",
         "Show list of known ScraperManifest objects.",
         {
-            {"details", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                "If true, show full details of each manifest. Default: false."},
+            {"details", RPCArg::Type::BOOL, RPCArg::Default{false},
+                "If true, show full details of each manifest."},
             {"manifest_hash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
                 "Hash of a specific manifest. If omitted, all are returned."},
         },

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -1030,13 +1030,19 @@ UniValue listmanifests(const UniValue& params, bool fHelp)
 /** Provides hex string output of part object contents. */
 UniValue getmpart(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-    {
-        throw std::runtime_error(
-                "getmpart <hash>\n"
-                "Show content of CPart object.\n"
-                );
-    }
+    static const RPCHelpMan help{
+        "getmpart",
+        "Show content of a CPart object.",
+        {
+            {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hash of the CPart to look up."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "", "Hex-encoded CPart contents."},
+        RPCExamples{
+            HelpExampleCli("getmpart", "\"<hash>\"") +
+            HelpExampleRpc("getmpart", "\"<hash>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     LOCK(CSplitBlob::cs_mapParts);
 

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -12,6 +12,7 @@
 #include "net.h"
 #include "rpc/server.h"
 #include "rpc/protocol.h"
+#include "rpc/util.h"
 #ifdef SCRAPER_NET_PK_AS_ADDRESS
 #include <key_io.h>
 #endif
@@ -940,17 +941,24 @@ UniValue CScraperManifest::dentry::ToJson() const EXCLUSIVE_LOCKS_REQUIRED(CSpli
 /** RPC function to list manifests and optionally provide their contents in JSON form. */
 UniValue listmanifests(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 2)
-    {
-        throw std::runtime_error(
-                "listmanifests [bool details] [manifest hash]\n"
-                "\n"
-                "details: boolean to show details of manifests\n"
-                "manifest hash: hash of specific manifest (Not provided returns all.)"
-                "\n"
-                "Show list of known ScraperManifest objects.\n"
-                );
-    }
+    static const RPCHelpMan help{
+        "listmanifests",
+        "Show list of known ScraperManifest objects.",
+        {
+            {"details", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, show full details of each manifest. Default: false."},
+            {"manifest_hash", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
+                "Hash of a specific manifest. If omitted, all are returned."},
+        },
+        RPCResult{RPCResult::Type::OBJ_DYN, "", "Mapping of manifest hash to manifest detail",
+            {{RPCResult::Type::ELISION, "", "Manifest object; shape depends on the 'details' flag."}}},
+        RPCExamples{
+            HelpExampleCli("listmanifests", "") +
+            HelpExampleCli("listmanifests", "true") +
+            HelpExampleRpc("listmanifests", "true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
     UniValue obj(UniValue::VOBJ);
     UniValue subset(UniValue::VOBJ);
 

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -142,6 +142,17 @@ UniValue listresearcheraccounts(const UniValue& params, bool fHelp);
 UniValue inspectaccrualsnapshot(const UniValue& params, bool fHelp);
 UniValue parseaccrualsnapshotfile(const UniValue& params, bool fHelp);
 
+// Tier 1 PR E2: src/gridcoin/scraper/scraper.cpp + scraper_net.cpp commands.
+UniValue sendscraperfilemanifest(const UniValue& params, bool fHelp);
+UniValue savescraperfilemanifest(const UniValue& params, bool fHelp);
+UniValue deletecscrapermanifest(const UniValue& params, bool fHelp);
+UniValue archivelog(const UniValue& params, bool fHelp);
+UniValue convergencereport(const UniValue& params, bool fHelp);
+UniValue testnewsb(const UniValue& params, bool fHelp);
+UniValue scraperreport(const UniValue& params, bool fHelp);
+UniValue listmanifests(const UniValue& params, bool fHelp);
+UniValue getmpart(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -783,6 +794,40 @@ BOOST_AUTO_TEST_CASE(tier1_e1_mining_help_renders)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(tier1_e2_scrapers_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"sendscraperfilemanifest", &sendscraperfilemanifest},
+        {"savescraperfilemanifest", &savescraperfilemanifest},
+        {"deletecscrapermanifest", &deletecscrapermanifest},
+        {"archivelog", &archivelog},
+        {"convergencereport", &convergencereport},
+        {"testnewsb", &testnewsb},
+        {"scraperreport", &scraperreport},
+        {"listmanifests", &listmanifests},
+        {"getmpart", &getmpart},
+    };
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                                    "help text missing command name: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                                    "help text missing Examples section: " << what);
+            }
+            BOOST_CHECK_MESSAGE(threw, "expected runtime_error from " << rpc_name);
+        }
+    }
+}
+
 
 
 


### PR DESCRIPTION
## Summary

Tier 1 E2 of issue #2922 — packages the legacy help-text-as-`runtime_error` pattern into `RPCHelpMan` for 9 scraper-related commands across `src/gridcoin/scraper/scraper.cpp` (7 cmds) and `src/gridcoin/scraper/scraper_net.cpp` (2 cmds). Pure packaging change.

One commit per command + one test commit.

## Stacked on #2923 (merged)

Based on current `origin/development`. Companion to #2954/#2956/#2958 (Tier 1a/1b/1c), #2961 (D1), #2962 (D2), #2963 (D3), #2964 (E1).

## Commands converted

**scraper.cpp (7):** `sendscraperfilemanifest`, `savescraperfilemanifest`, `deletecscrapermanifest`, `archivelog`, `convergencereport`, `testnewsb`, `scraperreport`

**scraper_net.cpp (2):** `listmanifests`, `getmpart`

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly.
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes.

## Tests

`src/test/rpchelpman_tests.cpp` gains `BOOST_AUTO_TEST_CASE(tier1_e2_scrapers_help_renders)` that iterates all 9 commands, calls each with empty `params` and `fHelp=true`, and asserts the thrown `runtime_error` message contains the RPC name and the `Examples:` marker.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 9 — full help renders, examples present
  - Confirm scraper-specific commands (`sendscraperfilemanifest`, `convergencereport`, `testnewsb`) — verify behavior with a configured scraper environment

Refs: #2922