### PR TITLE
rpc: convert 16 rawtransaction + htlc commands to RPCHelpMan (Tier 1 E3, #2922)

### DIFF
--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -9,6 +9,7 @@
 #include "policy/fees.h"
 #include "primitives/transaction.h"
 #include "rpc/protocol.h"
+#include "rpc/util.h"
 #include "server.h"
 #include "streams.h"
 #include "txdb.h"
@@ -23,22 +24,29 @@ extern uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsig
 
 UniValue createhtlc(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 4 || params.size() > 5)
-        throw runtime_error(
-            "createhtlc <receiver_addr> <sender_addr> <hash_hex> <timeout> [amount]\n"
-            "\n"
-            "Create a Hash Time-Locked Contract.\n"
-            "\n"
-            "Arguments:\n"
-            "1. receiver_addr   (string, required) Address of the receiver (claim path)\n"
-            "2. sender_addr     (string, required) Address of the sender (refund path)\n"
-            "3. hash_hex        (string, required) SHA256 hash of the preimage (64 hex chars)\n"
-            "4. timeout         (numeric, required) Absolute locktime for refund path\n"
-            "5. amount          (numeric, optional) Amount in GRC to fund the HTLC\n"
-            "\n"
-            "Returns a JSON object with the P2SH address and redeem script.\n"
-            "If amount is provided, funds the HTLC with a transaction.\n"
-            + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "createhtlc",
+        "Create a Hash Time-Locked Contract.\n"
+        "\n"
+        "Returns a JSON object with the P2SH address and redeem script. "
+        "If amount is provided, funds the HTLC with a transaction.\n"
+        "\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"receiver_addr", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the receiver (claim path)."},
+            {"sender_addr", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the sender (refund path)."},
+            {"hash_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "SHA256 hash of the preimage (64 hex chars)."},
+            {"timeout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Absolute locktime for the refund path."},
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "Amount in GRC to fund the HTLC."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "HTLC detail object including p2sh address, redeem_script, and optional fund tx."}}},
+        RPCExamples{
+            HelpExampleCli("createhtlc", "\"recv_addr\" \"send_addr\" \"<64-hex-hash>\" 500000 100") +
+            HelpExampleRpc("createhtlc", "\"recv_addr\", \"send_addr\", \"<64-hex-hash>\", 500000, 100")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -133,18 +133,25 @@ UniValue createhtlc(const UniValue& params, bool fHelp)
 
 UniValue claimhtlc(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 4)
-        throw runtime_error(
-            "claimhtlc <htlc_txid> <vout> <preimage_hex> <destination_addr>\n"
-            "\n"
-            "Claim an HTLC output using the preimage.\n"
-            "\n"
-            "Arguments:\n"
-            "1. htlc_txid        (string, required) Transaction ID of the HTLC funding tx\n"
-            "2. vout              (numeric, required) Output index of the HTLC\n"
-            "3. preimage_hex      (string, required) The preimage (hex encoded)\n"
-            "4. destination_addr  (string, required) Address to send claimed funds to\n"
-            + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "claimhtlc",
+        "Claim an HTLC output using the preimage.\n"
+        "\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"htlc_txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction ID of the HTLC funding tx."},
+            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Output index of the HTLC."},
+            {"preimage_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The preimage (hex encoded)."},
+            {"destination_addr", RPCArg::Type::STR, RPCArg::Optional::NO, "Address to send claimed funds to."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Claim result object including the spending txid."}}},
+        RPCExamples{
+            HelpExampleCli("claimhtlc", "\"<htlc_txid>\" 0 \"<preimage_hex>\" \"<dest_addr>\"") +
+            HelpExampleRpc("claimhtlc", "\"<htlc_txid>\", 0, \"<preimage_hex>\", \"<dest_addr>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     // Canonical order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
     // The wallet-registry lock is needed for the transactionAddedToMempool

--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -279,17 +279,24 @@ UniValue claimhtlc(const UniValue& params, bool fHelp)
 
 UniValue refundhtlc(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 3)
-        throw runtime_error(
-            "refundhtlc <htlc_txid> <vout> <destination_addr>\n"
-            "\n"
-            "Refund an HTLC output after the timeout has passed.\n"
-            "\n"
-            "Arguments:\n"
-            "1. htlc_txid        (string, required) Transaction ID of the HTLC funding tx\n"
-            "2. vout              (numeric, required) Output index of the HTLC\n"
-            "3. destination_addr  (string, required) Address to send refunded funds to\n"
-            + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "refundhtlc",
+        "Refund an HTLC output after the timeout has passed.\n"
+        "\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"htlc_txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction ID of the HTLC funding tx."},
+            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Output index of the HTLC."},
+            {"destination_addr", RPCArg::Type::STR, RPCArg::Optional::NO, "Address to send refunded funds to."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Refund result object including the spending txid."}}},
+        RPCExamples{
+            HelpExampleCli("refundhtlc", "\"<htlc_txid>\" 0 \"<dest_addr>\"") +
+            HelpExampleRpc("refundhtlc", "\"<htlc_txid>\", 0, \"<dest_addr>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     // Canonical order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
     // The wallet-registry lock is needed for the transactionAddedToMempool

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -410,9 +410,15 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
                 "If true, return an object instead of a hex string. Numeric values are also accepted "
                 "(any non-zero number is treated as true). Default: false."},
         },
-        RPCResult{RPCResult::Type::STR_HEX, "",
-            "Hex-encoded serialized transaction when verbose is false. When verbose is true, returns a JSON "
-            "object instead (containing 'hex' plus decoded transaction fields)."},
+        RPCResults{
+            RPCResult{RPCResult::Type::STR_HEX, "",
+                "Hex-encoded serialized transaction (verbose=false)."},
+            RPCResult{RPCResult::Type::OBJ, "", "Decoded transaction (verbose=true).",
+                {
+                    {RPCResult::Type::STR_HEX, "hex", "Serialized hex of the transaction."},
+                    {RPCResult::Type::ELISION, "", "Remaining fields match TxToJSON's shape."},
+                }},
+        },
         RPCExamples{
             HelpExampleCli("getrawtransaction", "\"<txid>\"") +
             HelpExampleCli("getrawtransaction", "\"<txid>\" true") +
@@ -474,6 +480,12 @@ UniValue listunspent(const UniValue& params, bool fHelp)
                     {
                         {RPCResult::Type::STR_HEX, "txid", "Transaction id."},
                         {RPCResult::Type::NUM, "vout", "Output index."},
+                        {RPCResult::Type::STR, "address", /*optional=*/true,
+                            "Destination address, when the output script is decodable to a single address."},
+                        {RPCResult::Type::STR, "label", /*optional=*/true,
+                            "Wallet-local label for the address (only present when the address is in the wallet's address book)."},
+                        {RPCResult::Type::STR, "account", /*optional=*/true,
+                            "Account label for the address (only present when -enableaccounts is set and the address is in the address book)."},
                         {RPCResult::Type::STR_HEX, "scriptPubKey", "Output script (hex)."},
                         {RPCResult::Type::STR_AMOUNT, "amount", "Output amount."},
                         {RPCResult::Type::NUM, "confirmations", "Confirmation count."},
@@ -585,8 +597,8 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
             {"utxo_size", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
                 "Target consolidation output size."},
             {"max_inputs", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
-                "Defaults and is clamped to the value returned by GetMaxInputsForConsolidationTxn() to prevent "
-                "transaction failures."},
+                "Maximum number of inputs to include in the consolidation transaction. "
+                "Defaults to 600 and is clamped to 600 to prevent transaction failures."},
             {"sweep_all_addresses", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
                 "If true, source inputs from all wallet addresses (output still goes to <address>). "
                 "Otherwise only the source address contributes inputs."},
@@ -1563,12 +1575,14 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
                             {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number."},
                         }},
                 }},
-            {"outputs", RPCArg::Type::OBJ, RPCArg::Optional::NO,
-                "A JSON object whose keys are Gridcoin addresses (values: GRC amount) or the special key \"data\" "
-                "with a hex-encoded value.",
+            {"outputs", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO,
+                "A JSON object whose keys are user-supplied Gridcoin addresses (with GRC-amount values), "
+                "plus the optional special key \"data\" carrying a hex-encoded value for an OP_RETURN output.",
                 {
-                    {"address", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "GRC amount to send to this address."},
-                    {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Hex-encoded data for an OP_RETURN output."},
+                    {"address", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                        "Any Gridcoin address. The value is the GRC amount to send to it. Repeat with different keys for multiple outputs."},
+                    {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
+                        "Hex-encoded data for an OP_RETURN output. Special key (not a Gridcoin address)."},
                 }},
         },
         RPCResult{RPCResult::Type::STR_HEX, "", "Hex-encoded serialized raw transaction."},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -989,21 +989,29 @@ UniValue consolidateunspent(const UniValue& params, bool fHelp)
 */
 UniValue consolidatemsunspent(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 3 || params.size() > 5)
-        throw runtime_error(
-                "consolidatemsunspent <address> <block-start> <block-end> [max-grc] [max-inputs]\n"
-                "\n"
-                "Searches a block range for a multisig address with unspent utxos\n"
-                "and consolidates them into a transaction ready for signing to\n"
-                "return to the same address in an consolidated amount.\n"
-                "consolidatemsunspent will also determine multi-sig type and ensure\n"
-                "the transaction does not exceed any size limits due to inputs.\n"
-                "\n"
-                "<address> ------------> Multi-signature address\n"
-                "<block-start> --------> Block number to start search from\n"
-                "<block-end> ----------> Block number to end search on\n"
-                "[max-grc] ------------> Highest uxto value to include in search results in halfords (0 is default)\n"
-                "[max-inputs] ---------> Maximum inputs desired. (If the calculated max inputs is less than defined here; argument is overridden)\n");
+    static const RPCHelpMan help{
+        "consolidatemsunspent",
+        "Search a block range for a multisig address with unspent UTXOs and consolidate them into a transaction\n"
+        "ready for signing, returning to the same address in a consolidated amount. The command determines the\n"
+        "multisig type and ensures the transaction does not exceed any size limits due to inputs.",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "Multi-signature address."},
+            {"block_start", RPCArg::Type::NUM, RPCArg::Optional::NO, "Block number to start search from."},
+            {"block_end", RPCArg::Type::NUM, RPCArg::Optional::NO, "Block number to end search on."},
+            {"max_grc", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Highest UTXO value to include in search results, in halfords (default: 0 = unlimited)."},
+            {"max_inputs", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Maximum inputs desired. If the calculated max inputs is less than this argument, it is overridden."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "",
+                "Consolidation result detail including the unsigned transaction; see source for shape."}}},
+        RPCExamples{
+            HelpExampleCli("consolidatemsunspent", "\"<ms_address>\" 1000000 1100000 0 50") +
+            HelpExampleRpc("consolidatemsunspent", "\"<ms_address>\", 1000000, 1100000, 0, 50")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue result(UniValue::VOBJ);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1818,11 +1818,20 @@ UniValue decoderawtransaction(const UniValue& params, bool fHelp)
 
 UniValue decodescript(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "decodescript <hex string>\n"
-                "\n"
-                "Decode a hex-encoded script.\n");
+    static const RPCHelpMan help{
+        "decodescript",
+        "Decode a hex-encoded script.",
+        {
+            {"hex_string", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex-encoded script data (empty is allowed)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Script detail and (when applicable) HTLC analysis; see source."}}},
+        RPCExamples{
+            HelpExampleCli("decodescript", "\"<hex>\"") +
+            HelpExampleRpc("decodescript", "\"<hex>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR });
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2030,41 +2030,40 @@ static UniValue SignRawTransactionHelper(const string& hexTx,
 
 UniValue signrawtransactionwithkey(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 4)
-        throw runtime_error(
-                "signrawtransactionwithkey \"hexstring\" [\"privatekey1\",...] "
-                "( [{\"txid\":\"id\",\"vout\":n,\"scriptPubKey\":\"hex\"},...] \"sighashtype\" )\n"
-                "\nSign inputs for raw transaction (serialized, hex-encoded).\n"
-                "The second argument is an array of base58-encoded private keys that will be the\n"
-                "only keys used to sign the transaction.\n"
-                "\nArguments:\n"
-                "1. \"hexstring\"           (string, required) The transaction hex string\n"
-                "2. \"privkeys\"            (array, required) A json array of base58-encoded private keys for signing\n"
-                "    [                      (json array of strings)\n"
-                "      \"privatekey\"          (string) private key in base58-encoding\n"
-                "      ,...\n"
-                "    ]\n"
-                "3. \"prevtxs\"             (array, optional) A json array of previous dependent transaction outputs\n"
-                "    [                      (json array of json objects)\n"
-                "      {\n"
-                "        \"txid\":\"id\",      (string, required) The transaction id\n"
-                "        \"vout\":n,         (numeric, required) The output number\n"
-                "        \"scriptPubKey\":\"hex\" (string, required) script key\n"
-                "      }\n"
-                "      ,...\n"
-                "    ]\n"
-                "4. \"sighashtype\"          (string, optional, default=ALL) The signature hash type. Must be one of\n"
-                "       \"ALL\"\n"
-                "       \"NONE\"\n"
-                "       \"SINGLE\"\n"
-                "       \"ALL|ANYONECANPAY\"\n"
-                "       \"NONE|ANYONECANPAY\"\n"
-                "       \"SINGLE|ANYONECANPAY\"\n"
-                "\nResult:\n"
-                "{\n"
-                "  \"hex\" : \"value\",       (string) The hex-encoded raw transaction with signature(s)\n"
-                "  \"complete\" : true|false  (boolean) If the transaction has a complete set of signatures\n"
-                "}\n");
+    static const RPCHelpMan help{
+        "signrawtransactionwithkey",
+        "Sign inputs for a raw (serialized, hex-encoded) transaction using the provided private keys.\n"
+        "The second argument is an array of base58-encoded private keys that will be the only keys used to sign.",
+        {
+            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction hex string."},
+            {"privkeys", RPCArg::Type::ARR, RPCArg::Optional::NO,
+                "A JSON array of base58-encoded private keys for signing.",
+                {{"privatekey", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A private key."}}},
+            {"prevtxs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+                "JSON array of previous dependent transaction outputs.",
+                {
+                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction id."},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Output number."},
+                            {"scriptPubKey", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex-encoded script."},
+                        }},
+                }},
+            {"sighashtype", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Signature hash type. One of: ALL, NONE, SINGLE, ALL|ANYONECANPAY, NONE|ANYONECANPAY, "
+                "SINGLE|ANYONECANPAY (default: ALL)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR_HEX, "hex", "Hex-encoded raw transaction with signature(s)."},
+                {RPCResult::Type::BOOL, "complete", "True if the transaction has a complete set of signatures."},
+            }},
+        RPCExamples{
+            HelpExampleCli("signrawtransactionwithkey", "\"<hex>\" \"[\\\"<wif>\\\"]\"") +
+            HelpExampleRpc("signrawtransactionwithkey", "\"<hex>\", [\"<wif>\"]")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR, UniValue::VARR, UniValue::VARR, UniValue::VSTR }, true);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2090,35 +2090,38 @@ UniValue signrawtransactionwithkey(const UniValue& params, bool fHelp)
 
 UniValue signrawtransactionwithwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 3)
-        throw runtime_error(
-                "signrawtransactionwithwallet \"hexstring\" "
-                "( [{\"txid\":\"id\",\"vout\":n,\"scriptPubKey\":\"hex\"},...] \"sighashtype\" )\n"
-                "\nSign inputs for raw transaction (serialized, hex-encoded) using wallet keys.\n"
-                "\nArguments:\n"
-                "1. \"hexstring\"           (string, required) The transaction hex string\n"
-                "2. \"prevtxs\"             (array, optional) A json array of previous dependent transaction outputs\n"
-                "    [                      (json array of json objects)\n"
-                "      {\n"
-                "        \"txid\":\"id\",      (string, required) The transaction id\n"
-                "        \"vout\":n,         (numeric, required) The output number\n"
-                "        \"scriptPubKey\":\"hex\" (string, required) script key\n"
-                "      }\n"
-                "      ,...\n"
-                "    ]\n"
-                "3. \"sighashtype\"          (string, optional, default=ALL) The signature hash type. Must be one of\n"
-                "       \"ALL\"\n"
-                "       \"NONE\"\n"
-                "       \"SINGLE\"\n"
-                "       \"ALL|ANYONECANPAY\"\n"
-                "       \"NONE|ANYONECANPAY\"\n"
-                "       \"SINGLE|ANYONECANPAY\"\n"
-                "\nResult:\n"
-                "{\n"
-                "  \"hex\" : \"value\",       (string) The hex-encoded raw transaction with signature(s)\n"
-                "  \"complete\" : true|false  (boolean) If the transaction has a complete set of signatures\n"
-                "}\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "signrawtransactionwithwallet",
+        "Sign inputs for a raw (serialized, hex-encoded) transaction using wallet keys.\n"
+        "\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction hex string."},
+            {"prevtxs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+                "JSON array of previous dependent transaction outputs.",
+                {
+                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction id."},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Output number."},
+                            {"scriptPubKey", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex-encoded script."},
+                        }},
+                }},
+            {"sighashtype", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Signature hash type. One of: ALL, NONE, SINGLE, ALL|ANYONECANPAY, NONE|ANYONECANPAY, "
+                "SINGLE|ANYONECANPAY (default: ALL)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR_HEX, "hex", "Hex-encoded raw transaction with signature(s)."},
+                {RPCResult::Type::BOOL, "complete", "True if the transaction has a complete set of signatures."},
+            }},
+        RPCExamples{
+            HelpExampleCli("signrawtransactionwithwallet", "\"<hex>\"") +
+            HelpExampleRpc("signrawtransactionwithwallet", "\"<hex>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR, UniValue::VARR, UniValue::VSTR }, true);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2136,23 +2136,45 @@ UniValue signrawtransactionwithwallet(const UniValue& params, bool fHelp)
 
 UniValue signrawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 4)
-        throw runtime_error(
-                "signrawtransaction <hex string> [{\"txid\":txid,\"vout\":n,\"scriptPubKey\":hex},...] [<privatekey1>,...] [sighashtype=\"ALL\"]\n"
-                "\n"
-                "DEPRECATED. Sign inputs for raw transaction (serialized, hex-encoded).\n"
-                "Use signrawtransactionwithkey or signrawtransactionwithwallet instead.\n"
-                "\n"
-                "Second optional argument (may be null) is an array of previous transaction outputs that\n"
-                "this transaction depends on but may not yet be in the blockchain.\n"
-                "Third optional argument (may be null) is an array of base58-encoded private\n"
-                "keys that, if given, will be the only keys used to sign the transaction.\n"
-                "Fourth optional argument is a string that is one of six values; ALL, NONE, SINGLE or\n"
-                "ALL|ANYONECANPAY, NONE|ANYONECANPAY, SINGLE|ANYONECANPAY.\n"
-                "Returns json object with keys:\n"
-                "  hex : raw transaction with signature(s) (hex-encoded string)\n"
-                "  complete : 1 if transaction has a complete set of signature (0 if not)\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "signrawtransaction",
+        "DEPRECATED. Sign inputs for a raw (serialized, hex-encoded) transaction.\n"
+        "Use signrawtransactionwithkey or signrawtransactionwithwallet instead.\n"
+        "\n"
+        "If the optional private-keys array is provided, those are the only keys used to sign;\n"
+        "otherwise the wallet's keys are used.\n"
+        "\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction hex string."},
+            {"prevtxs", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+                "JSON array of previous dependent transaction outputs (may be null).",
+                {
+                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction id."},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "Output number."},
+                            {"scriptPubKey", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex-encoded script."},
+                        }},
+                }},
+            {"privkeys", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+                "JSON array of base58-encoded private keys for signing (may be null).",
+                {{"privatekey", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A private key."}}},
+            {"sighashtype", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Signature hash type. One of: ALL, NONE, SINGLE, ALL|ANYONECANPAY, NONE|ANYONECANPAY, "
+                "SINGLE|ANYONECANPAY (default: ALL)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR_HEX, "hex", "Hex-encoded raw transaction with signature(s)."},
+                {RPCResult::Type::BOOL, "complete", "True if the transaction has a complete set of signatures."},
+            }},
+        RPCExamples{
+            HelpExampleCli("signrawtransaction", "\"<hex>\"") +
+            HelpExampleRpc("signrawtransaction", "\"<hex>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR, UniValue::VARR, UniValue::VARR, UniValue::VSTR }, true);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -567,43 +567,40 @@ UniValue listunspent(const UniValue& params, bool fHelp)
 
 UniValue consolidateunspent(const UniValue& params, bool fHelp)
 {
-    std::stringstream error_strm;
-
-    error_strm << "consolidateunspent <address> [UTXO size] [maximum number of inputs] [sweep all addresses] [sweep change]\n"
-                  "\n"
-                  "<address>:                  The Gridcoin address target for consolidation.\n"
-                  "\n"
-                  "[UTXO size]:                Optional parameter for target consolidation output size.\n"
-                  "\n"
-                  "[maximum number of inputs]: Defaults and clamped to "
-               << ToString(GetMaxInputsForConsolidationTxn())
-               << " maximum to prevent transaction failures.\n"
-                  "\n"
-                  "[sweep all addresses]:      Boolean to indicate whether all addresses should be used for inputs to the\n"
-                  "                            consolidation. If true, the source of the consolidation is all addresses and\n"
-                  "                            the output will be to the specified address, otherwise inputs will only be\n"
-                  "                            sourced from the same address.\n"
-                  "\n"
-                  "[sweep change]:             Boolean to indicate whether change associated with the address should be\n"
-                  "                            consolidated. If [sweep all addresses] is true then this is also forced true.\n"
-                  "\n"
-                  "consolidateunspent performs a single transaction to consolidate UTXOs to/on a given address. The optional\n"
-                  "parameter of UTXO size will result in consolidating UTXOs to generate the largest output possible less\n"
-                  "than that size or the total value of the specified maximum number of smallest inputs, whichever is less.\n"
-                  "\n"
-                  "The script is designed to be run repeatedly and will become a no-op if the UTXO's are consolidated such\n"
-                  "that no more meet the specified criteria. This is ideal for automated periodic scripting.\n"
-                  "\n"
-                  "To consolidate the entire wallet to one address do something like:\n"
-                  "\n"
-                  "consolidateunspent <address> <amount equal or larger than balance> 200 true repeatedly until there are\n"
-                  "no more UTXOs to consolidate.\n"
-                  "\n"
-                  "In all cases the address MUST exist in your wallet beforehand. If doing this for the purpose of creating\n"
-                  "a new smaller wallet, create a new address beforehand to serve as the target of the consolidation.\n";
-
-    if (fHelp || params.size() < 1 || params.size() > 5)
-        throw runtime_error(error_strm.str());
+    static const RPCHelpMan help{
+        "consolidateunspent",
+        "Performs a single transaction to consolidate UTXOs to/on a given address.\n"
+        "\n"
+        "The optional UTXO-size parameter results in consolidating UTXOs to generate the largest output possible\n"
+        "less than that size, or the total value of the specified maximum number of smallest inputs, whichever is less.\n"
+        "\n"
+        "The script is designed to be run repeatedly and will become a no-op once no UTXOs meet the criteria, making\n"
+        "it ideal for automated periodic scripting.\n"
+        "\n"
+        "The address MUST exist in your wallet beforehand. To consolidate the entire wallet to one address, run\n"
+        "consolidateunspent <addr> <amount-equal-or-larger-than-balance> 200 true repeatedly.",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The Gridcoin address target for consolidation. Must exist in the wallet."},
+            {"utxo_size", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                "Target consolidation output size."},
+            {"max_inputs", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Defaults and is clamped to the value returned by GetMaxInputsForConsolidationTxn() to prevent "
+                "transaction failures."},
+            {"sweep_all_addresses", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, source inputs from all wallet addresses (output still goes to <address>). "
+                "Otherwise only the source address contributes inputs."},
+            {"sweep_change", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, consolidate change associated with the address. Forced true when sweep_all_addresses is true."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Consolidation result detail; see source for the exact shape."}}},
+        RPCExamples{
+            HelpExampleCli("consolidateunspent", "\"<address>\" 10000 200 false false") +
+            HelpExampleRpc("consolidateunspent", "\"<address>\", 10000, 200, false, false")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     UniValue result(UniValue::VOBJ);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1648,30 +1648,38 @@ UniValue createrawtransaction(const UniValue& params, bool fHelp)
 
 UniValue fundrawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-                "fundrawtransaction \"hexstring\" ( options )\n"
-                "\nAdd inputs to a transaction until it has enough in value to meet its out value.\n"
-                "This will not modify existing inputs, and will add one change output to the outputs.\n"
-                "The inputs added will not be signed, use signrawtransaction for that.\n"
-                "\nNote: The transaction must have no existing inputs. Unlike Bitcoin Core's\n"
-                "fundrawtransaction, this command does not yet support adding funds to a\n"
-                "transaction that already has inputs.\n"
-                "\nArguments:\n"
-                "1. \"hexstring\"           (string, required) The hex string of the raw transaction\n"
-                "2. options               (object, optional)\n"
-                "   {\n"
-                "     \"changeAddress\"     (string, optional) The address to receive the change\n"
-                "     \"changePosition\"    (numeric, optional) The index of the change output\n"
-                "     \"includeWatching\"   (boolean, optional, default false) Also select inputs which are watch only\n"
-                "   }\n"
-                "\nResult:\n"
-                "{\n"
-                "  \"hex\":       \"value\", (string) The resulting raw transaction (hex-encoded string)\n"
-                "  \"fee\":       n,       (numeric) Fee in GRC the resulting transaction pays\n"
-                "  \"changepos\": n        (numeric) The position of the added change output, or -1\n"
-                "}\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "fundrawtransaction",
+        "Add inputs to a transaction until it has enough in value to meet its out value.\n"
+        "This will not modify existing inputs, and will add one change output to the outputs.\n"
+        "The inputs added will not be signed; use signrawtransaction for that.\n"
+        "\n"
+        "Note: The transaction must have no existing inputs. Unlike Bitcoin Core's fundrawtransaction,\n"
+        "this command does not yet support adding funds to a transaction that already has inputs.\n"
+        "\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex string of the raw transaction."},
+            {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                {
+                    {"changeAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Address to receive the change."},
+                    {"changePosition", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "Index of the change output."},
+                    {"includeWatching", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                        "Also select inputs which are watch-only. Default: false."},
+                }},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR_HEX, "hex", "The resulting raw transaction."},
+                {RPCResult::Type::STR_AMOUNT, "fee", "Fee in GRC the resulting transaction pays."},
+                {RPCResult::Type::NUM, "changepos", "Position of the added change output, or -1."},
+            }},
+        RPCExamples{
+            HelpExampleCli("fundrawtransaction", "\"<hex>\"") +
+            HelpExampleRpc("fundrawtransaction", "\"<hex>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR });
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1547,37 +1547,39 @@ UniValue scanforunspent(const UniValue& params, bool fHelp)
 
 UniValue createrawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
-        throw runtime_error(
-                "createrawtransaction [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,\"data\":\"hex\",...}\n"
-                "\nCreate a transaction spending the given inputs and creating new outputs.\n"
-                "Outputs can be addresses or data.\n"
-                "Returns hex-encoded raw transaction.\n"
-                "Note that the transaction's inputs are not signed, and\n"
-                "it is not stored in the wallet or transmitted to the network.\n"
-                "\nArguments:\n"
-                "1. \"transactions\"        (string, required) A json array of json objects\n"
-                "     [\n"
-                "       {\n"
-                "         \"txid\":\"id\",    (string, required) The transaction id\n"
-                "         \"vout\":n        (numeric, required) The output number\n"
-                "       }\n"
-                "       ,...\n"
-                "     ]\n"
-                "2. \"outputs\"             (string, required) a json object with outputs\n"
-                "    {\n"
-                "      \"address\": x.xxx   (numeric, required) The key is the bitcoin address, the value is the CURRENCY_UNIT amount\n"
-                "      \"data\": \"hex\",     (string, required) The key is \"data\", the value is hex encoded data\n"
-                "      ...\n"
-                "    }\n"
-                "\nResult:\n"
-                "\"transaction\"            (string) hex string of the transaction\n"
-                "\nExamples\n"
-                "createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"address\\\":0.01} "
-                "createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"data\\\":\\\"00010203\\\"} "
-                "createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"address\\\":0.01} "
-                "createrawtransaction \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"data\\\":\\\"00010203\\\"} \n"
-                );
+    static const RPCHelpMan help{
+        "createrawtransaction",
+        "Create a transaction spending the given inputs and creating new outputs.\n"
+        "Outputs can be addresses or data. Returns hex-encoded raw transaction.\n"
+        "Note that the transaction's inputs are not signed, and it is not stored in the wallet\n"
+        "or transmitted to the network.",
+        {
+            {"inputs", RPCArg::Type::ARR, RPCArg::Optional::NO,
+                "A JSON array of input objects.",
+                {
+                    {"", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "An input",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id."},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number."},
+                        }},
+                }},
+            {"outputs", RPCArg::Type::OBJ, RPCArg::Optional::NO,
+                "A JSON object whose keys are Gridcoin addresses (values: GRC amount) or the special key \"data\" "
+                "with a hex-encoded value.",
+                {
+                    {"address", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "GRC amount to send to this address."},
+                    {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Hex-encoded data for an OP_RETURN output."},
+                }},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "", "Hex-encoded serialized raw transaction."},
+        RPCExamples{
+            HelpExampleCli("createrawtransaction",
+                "\"[{\\\"txid\\\":\\\"<txid>\\\",\\\"vout\\\":0}]\" \"{\\\"S1Example\\\":0.01}\"") +
+            HelpExampleRpc("createrawtransaction",
+                "[{\"txid\":\"<txid>\",\"vout\":0}], {\"S1Example\":0.01}")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VARR, UniValue::VOBJ });
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1290,22 +1290,32 @@ UniValue consolidatemsunspent(const UniValue& params, bool fHelp)
 
 UniValue scanforunspent(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 3 || params.size() > 5 || params.size() == 4)
-        throw runtime_error(
-                "scanforunspent <address> <block-start> <block-end> [bool:export] [export-type]\n"
-                "\n"
-                "Searches a block range for a specified address with unspent utxos\n"
-                "and displays them in a json response with the option of exporting\n"
-                "to file\n"
-                "\n"
-                "Parameters required:\n"
-                "<address> --------> Multi-signature address\n"
-                "<block-start> ----> Block number to start search from\n"
-                "<block-end> ------> Block number to end search on\n"
-                "\n"
-                "Optional:\n"
-                "[export] ---------> Exports to a file in backup-dir/rpc in format of multisigaddress-datetime.type\n"
-                "[type] -----------> Export to a file with file type (xml, txt or json -- Required if export true)");
+    static const RPCHelpMan help{
+        "scanforunspent",
+        "Search a block range for a specified address with unspent UTXOs and display them as JSON,\n"
+        "with the option of exporting to a file.\n"
+        "\n"
+        "The export and type arguments must be supplied together (4-argument form is rejected).",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "Multi-signature address."},
+            {"block_start", RPCArg::Type::NUM, RPCArg::Optional::NO, "Block number to start search from."},
+            {"block_end", RPCArg::Type::NUM, RPCArg::Optional::NO, "Block number to end search on."},
+            {"export", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, export results to a file in backup-dir/rpc as multisigaddress-datetime.<type>."},
+            {"type", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Export file type: \"xml\", \"txt\", or \"json\". Required when export is true."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Scan result detail; see source for the exact shape."}}},
+        RPCExamples{
+            HelpExampleCli("scanforunspent", "\"<ms_address>\" 1000000 1100000") +
+            HelpExampleCli("scanforunspent", "\"<ms_address>\" 1000000 1100000 true json") +
+            HelpExampleRpc("scanforunspent", "\"<ms_address>\", 1000000, 1100000, true, \"json\"")},
+    };
+    // Preserve the legacy "either 3 or 5 args (4 rejected)" pattern: IsValidNumArgs allows 3..5,
+    // and a manual check rejects size==4 since params[4] is read whenever params.size() > 3.
+    if (fHelp || !help.IsValidNumArgs(params.size()) || params.size() == 4)
+        throw runtime_error(help.ToString());
 
     // Parameters
     bool fExport = false;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -453,15 +453,39 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
 
 UniValue listunspent(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 3)
-        throw runtime_error(
-                "listunspent [minconf=1] [maxconf=9999999]  [\"address\",...]\n"
-                "\n"
-                "Returns array of unspent transaction outputs\n"
-                "with between minconf and maxconf (inclusive) confirmations.\n"
-                "Optionally filtered to only include txouts paid to specified addresses.\n"
-                "Results are an array of Objects, each of which has:\n"
-                "{txid, vout, scriptPubKey, amount, confirmations}\n");
+    static const RPCHelpMan help{
+        "listunspent",
+        "Returns array of unspent transaction outputs with between minconf and maxconf (inclusive) confirmations.\n"
+        "Optionally filtered to only include txouts paid to specified addresses.",
+        {
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "The minimum confirmations to filter (default: 1)."},
+            {"maxconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "The maximum confirmations to filter (default: 9999999)."},
+            {"addresses", RPCArg::Type::ARR, RPCArg::Optional::OMITTED,
+                "Filter to only include UTXOs paid to these addresses.",
+                {
+                    {"address", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "An address."},
+                }},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR_HEX, "txid", "Transaction id."},
+                        {RPCResult::Type::NUM, "vout", "Output index."},
+                        {RPCResult::Type::STR_HEX, "scriptPubKey", "Output script (hex)."},
+                        {RPCResult::Type::STR_AMOUNT, "amount", "Output amount."},
+                        {RPCResult::Type::NUM, "confirmations", "Confirmation count."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listunspent", "") +
+            HelpExampleCli("listunspent", "6 9999999 \"[\\\"S1Example\\\"]\"") +
+            HelpExampleRpc("listunspent", "6, 9999999, [\"S1Example\"]")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VNUM, UniValue::VNUM, UniValue::VARR });
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1780,11 +1780,20 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
 
 UniValue decoderawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "decoderawtransaction <hex string>\n"
-                "\n"
-                "Return a JSON object representing the serialized, hex-encoded transaction\n");
+    static const RPCHelpMan help{
+        "decoderawtransaction",
+        "Return a JSON object representing the serialized, hex-encoded transaction.",
+        {
+            {"hex_string", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex-encoded transaction data."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "", "Decoded transaction detail; same shape as TxToJSON."}}},
+        RPCExamples{
+            HelpExampleCli("decoderawtransaction", "\"<hex>\"") +
+            HelpExampleRpc("decoderawtransaction", "\"<hex>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR });
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2208,11 +2208,19 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
 
 UniValue sendrawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 1)
-        throw runtime_error(
-                "sendrawtransaction <hex string>\n"
-                "\n"
-                "Submits raw transaction (serialized, hex-encoded) to local node and network\n");
+    static const RPCHelpMan help{
+        "sendrawtransaction",
+        "Submit a raw (serialized, hex-encoded) transaction to the local node and network.",
+        {
+            {"hex_string", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Hex-encoded transaction data."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "", "The transaction id."},
+        RPCExamples{
+            HelpExampleCli("sendrawtransaction", "\"<hex>\"") +
+            HelpExampleRpc("sendrawtransaction", "\"<hex>\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, { UniValue::VSTR });
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -24,6 +24,7 @@
 #include "policy/fees.h"
 #include "primitives/transaction.h"
 #include "protocol.h"
+#include "rpc/util.h"
 #include "server.h"
 #include "streams.h"
 #include "txdb.h"
@@ -397,14 +398,28 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) 
 
 UniValue getrawtransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-                "getrawtransaction <txid> [verbose=bool]\n"
-                "\n"
-                "If verbose is false, returns a string that is\n"
-                "serialized, hex-encoded data for <txid>.\n"
-                "If verbose is true, returns an Object\n"
-                "with information about <txid>\n");
+    static const RPCHelpMan help{
+        "getrawtransaction",
+        "Return raw transaction data.\n"
+        "\n"
+        "If verbose is false, returns a serialized, hex-encoded string for <txid>.\n"
+        "If verbose is true, returns an object with information about <txid>.",
+        {
+            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction id."},
+            {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, return an object instead of a hex string. Numeric values are also accepted "
+                "(any non-zero number is treated as true). Default: false."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "",
+            "Hex-encoded serialized transaction when verbose is false. When verbose is true, returns a JSON "
+            "object instead (containing 'hex' plus decoded transaction fields)."},
+        RPCExamples{
+            HelpExampleCli("getrawtransaction", "\"<txid>\"") +
+            HelpExampleCli("getrawtransaction", "\"<txid>\" true") +
+            HelpExampleRpc("getrawtransaction", "\"<txid>\", true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     uint256 hash;
     hash.SetHex(params[0].get_str());

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -153,6 +153,26 @@ UniValue scraperreport(const UniValue& params, bool fHelp);
 UniValue listmanifests(const UniValue& params, bool fHelp);
 UniValue getmpart(const UniValue& params, bool fHelp);
 
+// Tier 1 PR E3: src/rpc/rawtransaction.cpp + src/rpc/htlc.cpp commands.
+// Each function's converted body throws via help.ToString() before touching
+// any globals (cs_main, pwalletMain, mempool).
+UniValue getrawtransaction(const UniValue& params, bool fHelp);
+UniValue listunspent(const UniValue& params, bool fHelp);
+UniValue consolidateunspent(const UniValue& params, bool fHelp);
+UniValue consolidatemsunspent(const UniValue& params, bool fHelp);
+UniValue scanforunspent(const UniValue& params, bool fHelp);
+UniValue createrawtransaction(const UniValue& params, bool fHelp);
+UniValue fundrawtransaction(const UniValue& params, bool fHelp);
+UniValue decoderawtransaction(const UniValue& params, bool fHelp);
+UniValue decodescript(const UniValue& params, bool fHelp);
+UniValue signrawtransactionwithkey(const UniValue& params, bool fHelp);
+UniValue signrawtransactionwithwallet(const UniValue& params, bool fHelp);
+UniValue signrawtransaction(const UniValue& params, bool fHelp);
+UniValue sendrawtransaction(const UniValue& params, bool fHelp);
+UniValue createhtlc(const UniValue& params, bool fHelp);
+UniValue claimhtlc(const UniValue& params, bool fHelp);
+UniValue refundhtlc(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -827,6 +847,47 @@ BOOST_AUTO_TEST_CASE(tier1_e2_scrapers_help_renders)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(tier1_e3_rawtx_htlc_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"getrawtransaction", &getrawtransaction},
+        {"listunspent", &listunspent},
+        {"consolidateunspent", &consolidateunspent},
+        {"consolidatemsunspent", &consolidatemsunspent},
+        {"scanforunspent", &scanforunspent},
+        {"createrawtransaction", &createrawtransaction},
+        {"fundrawtransaction", &fundrawtransaction},
+        {"decoderawtransaction", &decoderawtransaction},
+        {"decodescript", &decodescript},
+        {"signrawtransactionwithkey", &signrawtransactionwithkey},
+        {"signrawtransactionwithwallet", &signrawtransactionwithwallet},
+        {"signrawtransaction", &signrawtransaction},
+        {"sendrawtransaction", &sendrawtransaction},
+        {"createhtlc", &createhtlc},
+        {"claimhtlc", &claimhtlc},
+        {"refundhtlc", &refundhtlc},
+    };
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                                    "help text missing command name: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                                    "help text missing Examples section: " << what);
+            }
+            BOOST_CHECK_MESSAGE(threw, "expected runtime_error from " << rpc_name);
+        }
+    }
+}
+
 
 
 


### PR DESCRIPTION
## Summary

Tier 1 E3 of issue #2922 — packages the legacy help-text-as-`runtime_error` pattern into `RPCHelpMan` for 16 commands: 13 in `src/rpc/rawtransaction.cpp` and 3 in `src/rpc/htlc.cpp`. Pure packaging change.

One commit per command + one test commit.

## Stacked on #2923 (merged)

Based on current `origin/development`. Companion to #2954/#2956/#2958 (Tier 1a/1b/1c), #2961 (D1), #2962 (D2), #2963 (D3), #2964 (E1), #2965 (E2).

## Commands converted

**rawtransaction.cpp (13):** `getrawtransaction`, `listunspent`, `consolidateunspent`, `consolidatemsunspent`, `scanforunspent`, `createrawtransaction`, `fundrawtransaction`, `decoderawtransaction`, `decodescript`, `signrawtransactionwithkey`, `signrawtransactionwithwallet`, `signrawtransaction`, `sendrawtransaction`

**htlc.cpp (3):** `createhtlc`, `claimhtlc`, `refundhtlc`

Notes:
- Three commands are not in the issue #2922 checklist but exist in the codebase and follow the same pattern, so they're included here: `fundrawtransaction`, `signrawtransactionwithkey`, `signrawtransactionwithwallet`. (The issue checklist should be updated to add them.)
- `scanforunspent`'s legacy arity check accepted either 3 or 5 args (rejecting 4); the conversion preserves this with `IsValidNumArgs(3..5)` + a manual `params.size() == 4` rejection.
- `HelpRequiringPassphrase` static-note convention applied to `fundrawtransaction`, `signrawtransactionwithwallet`, `signrawtransaction`, `createhtlc`, `claimhtlc`, `refundhtlc` — the legacy `" + HelpRequiringPassphrase()` runtime concatenation is replaced with the literal note text (`"Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted."`) since `RPCHelpMan` description strings must be compile-time literals.

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly (including `scanforunspent`'s either-3-or-5 quirk).
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes.
- The `HelpRequiringPassphrase` note text matches the current `HelpRequiringPassphrase()` output verbatim.

## Tests

`src/test/rpchelpman_tests.cpp` gains `BOOST_AUTO_TEST_CASE(tier1_e3_rawtx_htlc_help_renders)` that iterates all 16 commands, calls each with empty `params` and `fHelp=true`, and asserts the thrown `runtime_error` message contains the RPC name and the `Examples:` marker.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 16 — full help renders, examples present
  - Confirm `scanforunspent`'s either-3-or-5 arity (reject 4) preserved
  - Confirm `signrawtransaction*` JSON output unchanged vs pre-conversion
  - Confirm passphrase-requiring commands still throw the expected wallet-locked error when applicable

Refs: #2922