### PR TITLE
rpc: convert 4 rpcdump commands to RPCHelpMan (Tier 1 F1, #2922)

### DIFF
--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -173,6 +173,13 @@ UniValue createhtlc(const UniValue& params, bool fHelp);
 UniValue claimhtlc(const UniValue& params, bool fHelp);
 UniValue refundhtlc(const UniValue& params, bool fHelp);
 
+// Tier 1 PR F1: src/wallet/rpcdump.cpp commands. Each function's converted
+// body throws via help.ToString() before touching pwalletMain or file IO.
+UniValue importprivkey(const UniValue& params, bool fHelp);
+UniValue importwallet(const UniValue& params, bool fHelp);
+UniValue dumpprivkey(const UniValue& params, bool fHelp);
+UniValue dumpwallet(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -887,6 +894,35 @@ BOOST_AUTO_TEST_CASE(tier1_e3_rawtx_htlc_help_renders)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(tier1_f1_rpcdump_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"importprivkey", &importprivkey},
+        {"importwallet", &importwallet},
+        {"dumpprivkey", &dumpprivkey},
+        {"dumpwallet", &dumpwallet},
+    };
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                                    "help text missing command name: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                                    "help text missing Examples section: " << what);
+            }
+            BOOST_CHECK_MESSAGE(threw, "expected runtime_error from " << rpc_name);
+        }
+    }
+}
+
 
 
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -343,14 +343,20 @@ UniValue dumpprivkey(const UniValue& params, bool fHelp)
 
 UniValue dumpwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "dumpwallet <filename>\n"
-            "\n"
-            "<filename> -> filename to dump wallet to\n"
-            "\n"
-            "Dumps all wallet keys in a human-readable format into the specified file.\n"
-            "If a path is not specified in the filename, the data directory is used.");
+    static const RPCHelpMan help{
+        "dumpwallet",
+        "Dumps all wallet keys in a human-readable format into the specified file.\n"
+        "If a path is not specified in the filename, the data directory is used.",
+        {
+            {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "Filename to dump the wallet to."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("dumpwallet", "\"wallet.dump\"") +
+            HelpExampleRpc("dumpwallet", "\"wallet.dump\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     EnsureWalletIsUnlocked();
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -177,7 +177,8 @@ UniValue importwallet(const UniValue& params, bool fHelp)
     static const RPCHelpMan help{
         "importwallet",
         "Imports keys from a wallet dump file (see dumpwallet).\n"
-        "If a path is not specified in the filename, the data directory is used.",
+        "If a path is not specified in the filename, the data directory is used.\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
         {
             {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "Filename of the wallet dump to import."},
         },
@@ -289,16 +290,23 @@ UniValue dumpprivkey(const UniValue& params, bool fHelp)
 {
     static const RPCHelpMan help{
         "dumpprivkey",
-        "Reveals the private key corresponding to <gridcoinaddress>.",
+        "Reveals the private key corresponding to <gridcoinaddress>.\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
         {
             {"gridcoinaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the requested key."},
-            {"dump_hex", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
-                "If true, also include the private and public keys as hex strings in the JSON output. "
-                "Default: false (only the base58 WIF is returned)."},
+            {"dump_hex", RPCArg::Type::BOOL, RPCArg::Default{false},
+                "If true, also include the private and public keys as hex strings in the JSON output."},
         },
-        RPCResult{RPCResult::Type::ANY, "",
-            "When dump_hex is false (default), returns the base58 WIF private key as a string. "
-            "When dump_hex is true, returns a JSON object with base58 and hex representations."},
+        RPCResults{
+            RPCResult{RPCResult::Type::STR, "",
+                "Base58 WIF private key (dump_hex=false)."},
+            RPCResult{RPCResult::Type::OBJ, "", "Multiple key encodings (dump_hex=true).",
+                {
+                    {RPCResult::Type::STR, "private_key", "Base58 WIF private key."},
+                    {RPCResult::Type::STR_HEX, "private_key_hex", "Hex-encoded private key."},
+                    {RPCResult::Type::STR_HEX, "public_key_hex", "Hex-encoded public key."},
+                }},
+        },
         RPCExamples{
             HelpExampleCli("dumpprivkey", "\"S1Example\"") +
             HelpExampleCli("dumpprivkey", "\"S1Example\" true") +
@@ -346,7 +354,8 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
     static const RPCHelpMan help{
         "dumpwallet",
         "Dumps all wallet keys in a human-readable format into the specified file.\n"
-        "If a path is not specified in the filename, the data directory is used.",
+        "If a path is not specified in the filename, the data directory is used.\n"
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
         {
             {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "Filename to dump the wallet to."},
         },

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -8,6 +8,7 @@
 #include <key_io.h>
 #include "rpc/server.h"
 #include "rpc/protocol.h"
+#include "rpc/util.h"
 #include "node/ui_interface.h"
 
 #include <stdexcept>
@@ -102,15 +103,25 @@ public:
 
 UniValue importprivkey(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 3)
-        throw runtime_error(
-        "importprivkey <gridcoinprivkey> [label] [bool:rescan]\n"
+    static const RPCHelpMan help{
+        "importprivkey",
+        "Add a private key (as returned by dumpprivkey) to your wallet.\n"
         "\n"
-        "[label] -------> Optional; Label for imported address\n"
-        "[bool:rescan] -> Optional; Default true\n"
-        "WARNING: if true rescan of blockchain will occur. This could take up to 20 minutes.\n"
-        "\n"
-        "Adds a private key (as returned by dumpprivkey) to your wallet\n");
+        "WARNING: when rescan is true, a full rescan of the blockchain will occur. This can take up to 20 minutes.",
+        {
+            {"gridcoinprivkey", RPCArg::Type::STR, RPCArg::Optional::NO, "Base58 WIF private key."},
+            {"label", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Optional label for the imported address."},
+            {"rescan", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Whether to rescan the blockchain after import. Default: true."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("importprivkey", "\"<wif>\"") +
+            HelpExampleCli("importprivkey", "\"<wif>\" \"label\" false") +
+            HelpExampleRpc("importprivkey", "\"<wif>\", \"label\", false")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     string strSecret = params[0].get_str();
     string strLabel = "";

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -174,14 +174,20 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
 
 UniValue importwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "importwallet <filename>\n"
-            "\n"
-            "<filename> -> filename of the wallet to import\n"
-            "\n"
-            "Imports keys from a wallet dump file (see dumpwallet)\n"
-            "If a path is not specified in the filename, the data directory is used.");
+    static const RPCHelpMan help{
+        "importwallet",
+        "Imports keys from a wallet dump file (see dumpwallet).\n"
+        "If a path is not specified in the filename, the data directory is used.",
+        {
+            {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "Filename of the wallet dump to import."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("importwallet", "\"wallet.dump\"") +
+            HelpExampleRpc("importwallet", "\"wallet.dump\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     fs::path PathForImport = fs::path(params[0].get_str());
     fs::path DefaultPathDataDir = GetDataDir();

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -287,14 +287,25 @@ UniValue importwallet(const UniValue& params, bool fHelp)
 
 UniValue dumpprivkey(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-            "dumpprivkey <gridcoinaddress> [bool:dump hex]\n"
-            "<gridcoinaddress> -> Address of requested key\n"
-            "[bool:dump hex]   -> Optional; default false boolean to dump private and public key\n"
-            "                     as hex strings to JSON in addition to private key base58 encoded"
-            "\n"
-            "Reveals the private key corresponding to <gridcoinaddress>\n");
+    static const RPCHelpMan help{
+        "dumpprivkey",
+        "Reveals the private key corresponding to <gridcoinaddress>.",
+        {
+            {"gridcoinaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "Address of the requested key."},
+            {"dump_hex", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "If true, also include the private and public keys as hex strings in the JSON output. "
+                "Default: false (only the base58 WIF is returned)."},
+        },
+        RPCResult{RPCResult::Type::ANY, "",
+            "When dump_hex is false (default), returns the base58 WIF private key as a string. "
+            "When dump_hex is true, returns a JSON object with base58 and hex representations."},
+        RPCExamples{
+            HelpExampleCli("dumpprivkey", "\"S1Example\"") +
+            HelpExampleCli("dumpprivkey", "\"S1Example\" true") +
+            HelpExampleRpc("dumpprivkey", "\"S1Example\", true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     EnsureWalletIsUnlocked();
 


### PR DESCRIPTION
## Summary

Tier 1 F1 of issue #2922 — packages the legacy help-text-as-`runtime_error` pattern into `RPCHelpMan` for 4 commands in `src/wallet/rpcdump.cpp`. Pure packaging change.

One commit per command + one test commit.

## Stacked on #2923 (merged)

Based on current `origin/development`. Companion to #2954/#2956/#2958 (Tier 1a/1b/1c), #2961 (D1), #2962 (D2), #2963 (D3), #2964 (E1), #2965 (E2), #2966 (E3).

## Commands converted

`importprivkey`, `importwallet`, `dumpprivkey`, `dumpwallet`

Notes:
- These are wallet-encryption-sensitive commands; the `HelpRequiringPassphrase` static-note convention is applied (`"Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted."`).

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly.
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes.

## Tests

`src/test/rpchelpman_tests.cpp` gains `BOOST_AUTO_TEST_CASE(tier1_f1_rpcdump_help_renders)` that iterates all 4 commands, calls each with empty `params` and `fHelp=true`, and asserts the thrown `runtime_error` message contains the RPC name and the `Examples:` marker.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 4 — full help renders, examples present
  - Confirm `importprivkey`/`dumpprivkey` still throw the expected wallet-locked error when applicable
  - Confirm `dumpwallet`/`importwallet` round-trip a wallet file unchanged vs pre-conversion

Refs: #2922