### PR TITLE
rpc: convert 9 deprecated commands (wallet accounts + vote) to RPCHelpMan (Tier 1 Deprecated, #2922)

### DIFF
--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -744,17 +744,25 @@ UniValue getvotingclaim(const UniValue& params, bool fHelp)
 
 UniValue vote(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 2)
-        throw std::runtime_error(
-            "DEPRECATED: vote <title> <answer1;answer2...>\n"
-            "\n"
-            "<title> ---> Title of the poll to vote for.\n"
-            "<answers> -> Labels of the choices to vote for separated by semicolons (;).\n"
-            "\n"
-            "Cast a vote for a poll.\n"
-            "\n"
-            "This RPC function is deprecated and may be removed in the future. "
-            "Use \"votebyid\" instead.");
+    static const RPCHelpMan help{
+        "vote",
+        "DEPRECATED. Use votebyid instead. This RPC may be removed in the future.\n"
+        "\n"
+        "Cast a vote for a poll, identified by title.",
+        {
+            {"title", RPCArg::Type::STR, RPCArg::Optional::NO, "Title of the poll to vote for."},
+            {"answers", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Labels of the choices to vote for, separated by semicolons (;)."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {{RPCResult::Type::ELISION, "",
+                "Vote submission detail; see source (SubmitVote) — includes poll, vote_txid, and responses."}}},
+        RPCExamples{
+            HelpExampleCli("vote", "\"Example Poll\" \"yes\"") +
+            HelpExampleRpc("vote", "\"Example Poll\", \"yes\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw std::runtime_error(help.ToString());
 
     if (OutOfSyncByAge()) {
         throw JSONRPCError(RPC_MISC_ERROR, "The wallet must be in sync to vote.");

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -755,8 +755,19 @@ UniValue vote(const UniValue& params, bool fHelp)
                 "Labels of the choices to vote for, separated by semicolons (;)."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "",
-            {{RPCResult::Type::ELISION, "",
-                "Vote submission detail; see source (SubmitVote) — includes poll, vote_txid, and responses."}}},
+            {
+                {RPCResult::Type::STR, "poll", "Poll title."},
+                {RPCResult::Type::STR_HEX, "vote_txid", "Transaction id of the vote contract submission."},
+                {RPCResult::Type::ARR, "responses", "Vote responses submitted (one entry per choice voted).",
+                    {
+                        {RPCResult::Type::OBJ, "", "",
+                            {
+                                {RPCResult::Type::STR, "choice", "Choice label that was selected."},
+                                {RPCResult::Type::NUM, "id", "Choice index."},
+                                {RPCResult::Type::STR_AMOUNT, "weight", "Weight of this vote response."},
+                            }},
+                    }},
+            }},
         RPCExamples{
             HelpExampleCli("vote", "\"Example Poll\" \"yes\"") +
             HelpExampleRpc("vote", "\"Example Poll\", \"yes\"")},

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -180,6 +180,19 @@ UniValue importwallet(const UniValue& params, bool fHelp);
 UniValue dumpprivkey(const UniValue& params, bool fHelp);
 UniValue dumpwallet(const UniValue& params, bool fHelp);
 
+// Tier 1 deprecated batch: the deprecated-accounts wallet RPCs plus the
+// deprecated `vote` RPC. Each function's converted body throws via
+// help.ToString() before touching pwalletMain or the poll registry.
+UniValue getaccountaddress(const UniValue& params, bool fHelp);
+UniValue setaccount(const UniValue& params, bool fHelp);
+UniValue getaccount(const UniValue& params, bool fHelp);
+UniValue getaddressesbyaccount(const UniValue& params, bool fHelp);
+UniValue getreceivedbyaccount(const UniValue& params, bool fHelp);
+UniValue listreceivedbyaccount(const UniValue& params, bool fHelp);
+UniValue listaccounts(const UniValue& params, bool fHelp);
+UniValue movecmd(const UniValue& params, bool fHelp);  // dispatched as "move"
+UniValue vote(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -922,6 +935,43 @@ BOOST_AUTO_TEST_CASE(tier1_f1_rpcdump_help_renders)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(tier1_deprecated_batch_help_renders)
+{
+    const UniValue empty(UniValue::VARR);
+    using HelpFn = UniValue (*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> cases{
+        {"getaccountaddress", &getaccountaddress},
+        {"setaccount", &setaccount},
+        {"getaccount", &getaccount},
+        {"getaddressesbyaccount", &getaddressesbyaccount},
+        {"getreceivedbyaccount", &getreceivedbyaccount},
+        {"listreceivedbyaccount", &listreceivedbyaccount},
+        {"listaccounts", &listaccounts},
+        // dispatched RPC name is "move", but the C++ function symbol is movecmd.
+        {"move", &movecmd},
+        {"vote", &vote},
+    };
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                                    "help text missing command name: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                                    "help text missing Examples section: " << what);
+                BOOST_CHECK_MESSAGE(what.find("DEPRECATED") != std::string::npos,
+                                    "help text missing DEPRECATED marker: " << what);
+            }
+            BOOST_CHECK_MESSAGE(threw, "expected runtime_error from " << rpc_name);
+        }
+    }
+}
+
 
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -321,11 +321,21 @@ UniValue getaccountaddress(const UniValue& params, bool fHelp)
 
 UniValue setaccount(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-                "setaccount <gridcoinaddress> <account>\n"
-                "\n"
-                "Sets the account associated with the given address.\n");
+    static const RPCHelpMan help{
+        "setaccount",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Sets the account associated with the given address.",
+        {
+            {"gridcoinaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The address."},
+            {"account", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The account name. Default: empty string."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("setaccount", "\"S1Example\" \"myaccount\"") +
+            HelpExampleRpc("setaccount", "\"S1Example\", \"myaccount\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -646,11 +646,26 @@ void GetAccountAddresses(string strAccount, set<CTxDestination>& setAddress) EXC
 
 UniValue getreceivedbyaccount(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-                "getreceivedbyaccount <account> [minconf=1]\n"
-                "\n"
-                "Returns the total amount received by addresses with <account> in transactions with at least [minconf] confirmations.\n");
+    static const RPCHelpMan help{
+        "getreceivedbyaccount",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Use getreceivedbyaddress instead.\n"
+        "\n"
+        "Returns the total amount received by addresses with <account> in transactions with at least\n"
+        "[minconf] confirmations.",
+        {
+            {"account", RPCArg::Type::STR, RPCArg::Optional::NO, "The account name."},
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Minimum confirmations. Default: 1."},
+        },
+        RPCResult{RPCResult::Type::STR_AMOUNT, "", "Total amount received by addresses in the account."},
+        RPCExamples{
+            HelpExampleCli("getreceivedbyaccount", "\"myaccount\"") +
+            HelpExampleCli("getreceivedbyaccount", "\"myaccount\" 6") +
+            HelpExampleRpc("getreceivedbyaccount", "\"myaccount\", 6")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     accountingDeprecationCheck();
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -363,11 +363,20 @@ UniValue setaccount(const UniValue& params, bool fHelp)
 
 UniValue getaccount(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "getaccount <gridcoinaddress>\n"
-                "\n"
-                "Returns the account associated with the given address.\n");
+    static const RPCHelpMan help{
+        "getaccount",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Returns the account associated with the given address.",
+        {
+            {"gridcoinaddress", RPCArg::Type::STR, RPCArg::Optional::NO, "The address."},
+        },
+        RPCResult{RPCResult::Type::STR, "", "The account name (empty string for the default account)."},
+        RPCExamples{
+            HelpExampleCli("getaccount", "\"S1Example\"") +
+            HelpExampleRpc("getaccount", "\"S1Example\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1857,17 +1857,24 @@ UniValue liststakes(const UniValue& params, bool fHelp)
 
 UniValue listaccounts(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 2)
-        throw runtime_error(
-                "listaccounts ( minconf includeWatchonly)\n"
-                "\n"
-                "Returns UniValue that has account names as keys, account balances as values."
-                "1. minconf          (numeric, optional, default=1) Only include transactions with at least this many confirmations\n"
-                "2. includeWatchonly (bool, optional, default=false) Include balances in watchonly addresses (see 'importaddress')\n"
-                "\nResult:\n"
-                "{                      (json object where keys are account names, and values are numeric balances\n"
-                "  \"account\": x.xxx,  (numeric) The property name is the account name, and the value is the total balance for the account.\n"
-                );
+    static const RPCHelpMan help{
+        "listaccounts",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Returns a JSON object where keys are account names and values are account balances.",
+        {
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Only include transactions with at least this many confirmations. Default: 1."},
+            {"includeWatchonly", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Include balances in watch-only addresses (see importaddress). Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ_DYN, "", "Mapping of account name to balance",
+            {{RPCResult::Type::STR_AMOUNT, "account", "Total balance for the account."}}},
+        RPCExamples{
+            HelpExampleCli("listaccounts", "") +
+            HelpExampleRpc("listaccounts", "6, true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     accountingDeprecationCheck();
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -952,11 +952,28 @@ UniValue getunconfirmedbalance(const UniValue& params, bool fHelp)
 
 UniValue movecmd(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 3 || params.size() > 5)
-        throw runtime_error(
-                "move <fromaccount> <toaccount> <amount> [minconf=1] [comment]\n"
-                "\n"
-                "Move from one account in your wallet to another.\n");
+    static const RPCHelpMan help{
+        "move",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Move funds from one account in your wallet to another.\n"
+        "\n"
+        "Note: the C++ function name is `movecmd` (because `move` is a C++ keyword); the dispatch entry\n"
+        "registers it as `move`.",
+        {
+            {"fromaccount", RPCArg::Type::STR, RPCArg::Optional::NO, "Source account name."},
+            {"toaccount", RPCArg::Type::STR, RPCArg::Optional::NO, "Destination account name."},
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO, "Amount in GRC to move."},
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Unused parameter retained for backwards compatibility. Default: 1."},
+            {"comment", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Optional comment string."},
+        },
+        RPCResult{RPCResult::Type::BOOL, "", "True on success."},
+        RPCExamples{
+            HelpExampleCli("move", "\"acct1\" \"acct2\" 0.01") +
+            HelpExampleRpc("move", "\"acct1\", \"acct2\", 0.01")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     accountingDeprecationCheck();
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -292,11 +292,20 @@ CTxDestination GetAccountAddress(string strAccount, bool bForceNew=false) EXCLUS
 
 UniValue getaccountaddress(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "getaccountaddress <account>\n"
-                "\n"
-                "Returns the current Gridcoin address for receiving payments to this account.\n");
+    static const RPCHelpMan help{
+        "getaccountaddress",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Returns the current Gridcoin address for receiving payments to this account.",
+        {
+            {"account", RPCArg::Type::STR, RPCArg::Optional::NO, "The account name (use \"\" for the default account)."},
+        },
+        RPCResult{RPCResult::Type::STR, "", "The address associated with this account."},
+        RPCExamples{
+            HelpExampleCli("getaccountaddress", "\"\"") +
+            HelpExampleRpc("getaccountaddress", "\"myaccount\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     // Parse the account first so we don't generate a key if there's an error
     string strAccount = AccountFromValue(params[0]);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -396,11 +396,21 @@ UniValue getaccount(const UniValue& params, bool fHelp)
 
 UniValue getaddressesbyaccount(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "getaddressesbyaccount <account>\n"
-                "\n"
-                "Returns the list of addresses for the given account.\n");
+    static const RPCHelpMan help{
+        "getaddressesbyaccount",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Returns the list of addresses for the given account.",
+        {
+            {"account", RPCArg::Type::STR, RPCArg::Optional::NO, "The account name."},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {{RPCResult::Type::STR, "address", "An address in the account."}}},
+        RPCExamples{
+            HelpExampleCli("getaddressesbyaccount", "\"myaccount\"") +
+            HelpExampleRpc("getaddressesbyaccount", "\"myaccount\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     string strAccount = AccountFromValue(params[0]);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -403,8 +403,8 @@ UniValue getaddressesbyaccount(const UniValue& params, bool fHelp)
         {
             {"account", RPCArg::Type::STR, RPCArg::Optional::NO, "The account name."},
         },
-        RPCResult{RPCResult::Type::ARR, "", "",
-            {{RPCResult::Type::STR, "address", "An address in the account."}}},
+        RPCResult{RPCResult::Type::ARR, "", "Addresses associated with the given account.",
+            {{RPCResult::Type::STR, "", "An address in the account."}}},
         RPCExamples{
             HelpExampleCli("getaddressesbyaccount", "\"myaccount\"") +
             HelpExampleRpc("getaddressesbyaccount", "\"myaccount\"")},

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1463,22 +1463,37 @@ UniValue listreceivedbyaddress(const UniValue& params, bool fHelp)
 
 UniValue listreceivedbyaccount(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 3)
-        throw runtime_error(
-                "listreceivedbyaccount ( minconf includeempty includeWatchonly)\n"
-                "\nList balances by account.\n"
-                "\nArguments:\n"
-                "1. minconf      (numeric, optional, default=1) The minimum number of confirmations before payments are included.\n"
-                "2. includeempty (bool, optional, default=false) Whether to include accounts that haven't received any payments.\n"
-                "3. includeWatchonly (bool, optional, default=false) Whether to include watchonly addresses (see 'importaddress').\n"
-                "\nResult:\n"
-                "[\n"
-                "  {\n"
-                "    \"involvesWatchonly\" : \"true\",    (bool) Only returned if imported addresses were involved in transaction\n"
-                "    \"account\" : \"accountname\",  (string) The account name of the receiving account\n"
-                "    \"amount\" : x.xxx,             (numeric) The total amount received by addresses with this account\n"
-                "    \"confirmations\" : n           (numeric) The number of confirmations of the most recent transaction included\n"
-                );
+    static const RPCHelpMan help{
+        "listreceivedbyaccount",
+        "DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release.\n"
+        "Use listreceivedbyaddress instead.\n"
+        "\n"
+        "List balances by account.",
+        {
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Minimum confirmations before payments are included. Default: 1."},
+            {"includeempty", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Include accounts that haven't received any payments. Default: false."},
+            {"includeWatchonly", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Include watch-only addresses (see importaddress). Default: false."},
+        },
+        RPCResult{RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::BOOL, "involvesWatchonly", /*optional=*/true,
+                            "Only returned if imported addresses were involved in transactions."},
+                        {RPCResult::Type::STR, "account", "Account name of the receiving account."},
+                        {RPCResult::Type::STR_AMOUNT, "amount", "Total amount received by addresses in this account."},
+                        {RPCResult::Type::NUM, "confirmations", "Confirmations of the most recent transaction."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("listreceivedbyaccount", "") +
+            HelpExampleRpc("listreceivedbyaccount", "6, true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 


### PR DESCRIPTION
## Summary

Tier 1 Deprecated batch of issue #2922 — packages the legacy help-text-as-`runtime_error` pattern into `RPCHelpMan` for 9 deprecated commands: 8 wallet account-system commands in `src/wallet/rpcwallet.cpp` and 1 voting wrapper (`vote` → `votebyid`) in `src/rpc/voting.cpp`. Pure packaging change.

Every command's description starts with `"DEPRECATED. The accounts subsystem is deprecated and may be removed in a future release."` (for the wallet commands) or `"DEPRECATED. This command delegates to votebyid."` (for `vote`). The test asserts that marker is present.

One commit per command + one test commit.

## Stacked on #2923 (merged)

Based on current `origin/development`. Companion to #2954/#2956/#2958 (Tier 1a/1b/1c), #2961 (D1), #2962 (D2), #2963 (D3), #2964 (E1), #2965 (E2), #2966 (E3), #2967 (F1).

## Commands converted

**rpcwallet.cpp account system (8):** `getaccountaddress`, `setaccount`, `getaccount`, `getaddressesbyaccount`, `getreceivedbyaccount`, `listreceivedbyaccount`, `listaccounts`, `move` (dispatched from `movecmd`)

**voting.cpp (1):** `vote` (deprecated wrapper that delegates to `votebyid`, converted in #2963)

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text; descriptions lead with the explicit DEPRECATED marker.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly.
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes, no account-system semantics changes.

## Tests

`src/test/rpchelpman_tests.cpp` gains `BOOST_AUTO_TEST_CASE(tier1_deprecated_batch_help_renders)` that iterates all 9 commands, calls each with empty `params` and `fHelp=true`, and asserts the thrown `runtime_error` message contains:
1. The RPC name,
2. The `Examples:` marker, and
3. The literal substring `"DEPRECATED"` (to confirm the deprecation banner is present in help output).

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 9 — full help renders, DEPRECATED banner present, examples present
  - Confirm `vote` still delegates to `votebyid` and returns the same JSON
  - Confirm account-system commands return identical results vs pre-conversion

Refs: #2922