### PR TITLE
rpc: convert 13 wallet mgmt+send commands to RPCHelpMan (Tier 1 F4, #2922)

### DIFF
--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -219,6 +219,21 @@ UniValue liststakes(const UniValue& params, bool fHelp);
 UniValue gettransaction(const UniValue& params, bool fHelp);
 UniValue getrawwallettransaction(const UniValue& params, bool fHelp);
 
+// Forward declarations of the Tier 1 F4 wallet management/send commands under test.
+UniValue sendtoaddress(const UniValue& params, bool fHelp);
+UniValue sendfrom(const UniValue& params, bool fHelp);
+UniValue sendmany(const UniValue& params, bool fHelp);
+UniValue backupwallet(const UniValue& params, bool fHelp);
+UniValue keypoolrefill(const UniValue& params, bool fHelp);
+UniValue walletdiagnose(const UniValue& params, bool fHelp);
+UniValue encryptwallet(const UniValue& params, bool fHelp);
+UniValue reservebalance(const UniValue& params, bool fHelp);
+UniValue checkwallet(const UniValue& params, bool fHelp);
+UniValue repairwallet(const UniValue& params, bool fHelp);
+UniValue resendtx(const UniValue& params, bool fHelp);
+UniValue burn(const UniValue& params, bool fHelp);
+UniValue upgradewallet(const UniValue& params, bool fHelp);
+
 BOOST_AUTO_TEST_SUITE(rpchelpman_tests)
 
 // Helper: build a minimal RPCHelpMan with one required string arg and one result.
@@ -1097,6 +1112,43 @@ BOOST_AUTO_TEST_CASE(tier1_f3_wallet_queries_help_renders)
         {"liststakes",              &liststakes},
         {"gettransaction",          &gettransaction},
         {"getrawwallettransaction", &getrawwallettransaction},
+    };
+
+    const UniValue params(UniValue::VARR);
+    for (const auto& [name, fn] : commands) {
+        try {
+            fn(params, /*fHelp=*/true);
+            BOOST_FAIL(std::string{"expected runtime_error for "} + name);
+        } catch (const std::runtime_error& e) {
+            const std::string what{e.what()};
+            BOOST_CHECK_MESSAGE(what.find(name) != std::string::npos,
+                                std::string{"help text missing command name: "} + name);
+            BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                                std::string{"help text missing Examples marker: "} + name);
+        }
+    }
+}
+
+// Tier 1 F4: each of the wallet-mgmt/send commands renders help text on
+// fHelp=true before touching pwalletMain / cs_main / cs_wallet. Same
+// fixture-free pattern as the F2/F3 tests above.
+BOOST_AUTO_TEST_CASE(tier1_f4_wallet_mgmt_send_help_renders)
+{
+    using HelpFn = UniValue(*)(const UniValue&, bool);
+    const std::vector<std::pair<const char*, HelpFn>> commands{
+        {"sendtoaddress",   &sendtoaddress},
+        {"sendfrom",        &sendfrom},
+        {"sendmany",        &sendmany},
+        {"backupwallet",    &backupwallet},
+        {"keypoolrefill",   &keypoolrefill},
+        {"walletdiagnose", &walletdiagnose},
+        {"encryptwallet",   &encryptwallet},
+        {"reservebalance",  &reservebalance},
+        {"checkwallet",     &checkwallet},
+        {"repairwallet",    &repairwallet},
+        {"resendtx",        &resendtx},
+        {"burn",            &burn},
+        {"upgradewallet",   &upgradewallet},
     };
 
     const UniValue params(UniValue::VARR);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2392,11 +2392,28 @@ UniValue getrawwallettransaction(const UniValue& params, bool fHelp)
 
 UniValue backupwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-        throw runtime_error(
-                "backupwallet\n"
-                "\n"
-                "Backup your wallet, config, and settings files.\n");
+    static const RPCHelpMan help{
+        "backupwallet",
+        "Backup the wallet, config, and settings files. Old retained backups are pruned.",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::BOOL, "Backup wallet success", "Whether wallet.dat was backed up successfully."},
+                {RPCResult::Type::BOOL, "Backup config success", "Whether gridcoinresearch.conf was backed up successfully."},
+                {RPCResult::Type::BOOL, "Backup settings success", "Whether gridcoinsettings.json was backed up successfully."},
+                {RPCResult::Type::BOOL, "Maintain backup file retention success", "Whether retention pruning succeeded."},
+                {RPCResult::Type::NUM, "Number of files removed", "Number of old backup files pruned."},
+                {RPCResult::Type::ARR, "Files removed", "Names of pruned backup files.",
+                    {
+                        {RPCResult::Type::STR, "", "Name of a removed backup file."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("backupwallet", "") +
+            HelpExampleRpc("backupwallet", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3271,15 +3271,30 @@ UniValue validatepubkey(const UniValue& params, bool fHelp)
 // ppcoin: reserve balance from being staked for network protection
 UniValue reservebalance(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 2)
-        throw runtime_error(
-                "reservebalance [<reserve> [amount]]\n"
-                "\n"
-                "<reserve> is true or false to turn balance reserve on or off.\n"
-                "<amount> is a real and rounded to cent.\n"
-                "Reserved amount secures a balance in wallet that can be spendable at anytime.\n"
-                "However reserve will secure utxo(s) of any size to respect this setting.\n"
-                "If no parameters provided current setting is printed.\n");
+    static const RPCHelpMan help{
+        "reservebalance",
+        "Reserve a balance in the wallet that will not be used for staking, leaving it "
+        "spendable at any time. The reserve will protect UTXOs of any size to honor this "
+        "setting. If no parameters are provided, the current setting is printed.",
+        {
+            {"reserve", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "true to turn balance reserve on, false to turn it off."},
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                "The amount in GRC to reserve (rounded to cent). Required when reserve=true; forbidden when reserve=false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::BOOL, "reserve", "Whether a reserve amount is currently set."},
+                {RPCResult::Type::STR_AMOUNT, "amount", "The current reserve amount in GRC."},
+            }},
+        RPCExamples{
+            HelpExampleCli("reservebalance", "") +
+            HelpExampleCli("reservebalance", "true 1000") +
+            HelpExampleCli("reservebalance", "false") +
+            HelpExampleRpc("reservebalance", "true, 1000")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     if (params.size() > 0)
     {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3365,11 +3365,25 @@ UniValue checkwallet(const UniValue& params, bool fHelp)
 // ppcoin: repair wallet
 UniValue repairwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-        throw runtime_error(
-                "repairwallet\n"
-                "\n"
-                "Repair wallet if checkwallet reports any problem.\n");
+    static const RPCHelpMan help{
+        "repairwallet",
+        "Repair the wallet if checkwallet reports any problem (fixes mismatched spent coins).",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::BOOL, "wallet check passed", /*optional=*/true,
+                    "Present and true when no mismatches were found."},
+                {RPCResult::Type::NUM, "mismatched spent coins", /*optional=*/true,
+                    "Number of mismatches that were corrected (only present when nonzero)."},
+                {RPCResult::Type::STR_AMOUNT, "amount affected by repair", /*optional=*/true,
+                    "Total balance involved in the corrections (only present when nonzero)."},
+            }},
+        RPCExamples{
+            HelpExampleCli("repairwallet", "") +
+            HelpExampleRpc("repairwallet", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     int nMismatchSpent;
     int64_t nBalanceInQuestion;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3402,12 +3402,17 @@ UniValue repairwallet(const UniValue& params, bool fHelp)
 // NovaCoin: resend unconfirmed wallet transactions
 UniValue resendtx(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "resendtx\n"
-                "\n"
-                "Re-send unconfirmed transactions.\n"
-                );
+    static const RPCHelpMan help{
+        "resendtx",
+        "Re-send unconfirmed transactions in the wallet.",
+        {},
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("resendtx", "") +
+            HelpExampleRpc("resendtx", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     {
         LOCK2(cs_main, cs_setpwalletRegistered);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2543,11 +2543,22 @@ UniValue maintainbackups(const UniValue& params, bool fHelp)
 
 UniValue keypoolrefill(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "keypoolrefill [new-size]\n"
-                "Fills the keypool.\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "keypoolrefill",
+        "Fills the keypool. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"newsize", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "The new keypool size (default: from -keypool option)."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("keypoolrefill", "") +
+            HelpExampleCli("keypoolrefill", "1000") +
+            HelpExampleRpc("keypoolrefill", "1000")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -502,18 +502,30 @@ UniValue getaddressesbyaccount(const UniValue& params, bool fHelp)
 
 UniValue sendtoaddress(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 5)
-        throw runtime_error(
-                "sendtoaddress <gridcoinaddress> <amount> [comment] [comment-to] [message]\n"
-                "\n"
-                "<amount> is a real and is rounded to the nearest 0.000001\n"
-                "[comment] a comment used to store what the transaction is for.\n"
-                "         This is not part of the transaction, just kept in your wallet.\n"
-                "[comment_to] a comment to store the name of the person or organization\n"
-                "             to which you're sending the transaction. This is not part of the \n"
-                "             transaction, just kept in your wallet.\n"
-                "[message] Optional message to add to the receiver.\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "sendtoaddress",
+        "Send an amount of GRC to the given Gridcoin address. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The Gridcoin address to send to."},
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO,
+                "The amount in GRC to send (rounded to the nearest 0.000001)."},
+            {"comment", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Comment used to store what the transaction is for. Not part of the transaction, just kept in your wallet."},
+            {"comment_to", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Comment to store the name of the person or organization to which you're sending the transaction. Not part of the transaction."},
+            {"message", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Optional message to add to the receiver (TxMessage contract)."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+        RPCExamples{
+            HelpExampleCli("sendtoaddress", "\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\" 100") +
+            HelpExampleCli("sendtoaddress", "\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\" 100 \"donation\" \"charity\"") +
+            HelpExampleRpc("sendtoaddress", "\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\", 100, \"donation\", \"charity\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2943,11 +2943,21 @@ UniValue inspectwalletstate(const UniValue& params, bool fHelp)
  */
 UniValue walletdiagnose(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-                "walletdiagnose\n"
-                "\n"
-                "Runs several tests to diagnose issues in the wallet.");
+    static const RPCHelpMan help{
+        "walletdiagnose",
+        "Runs several diagnostic tests on the wallet (connection counts, sync state, "
+        "client version, BOINC path, CPID, clock, TCP port, difficulty, ETTS).",
+        {},
+        RPCResult{RPCResult::Type::OBJ_DYN, "", "",
+            {
+                {RPCResult::Type::ELISION, "", "diagnostic key/result entry"},
+            }},
+        RPCExamples{
+            HelpExampleCli("walletdiagnose", "") +
+            HelpExampleRpc("walletdiagnose", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     std::set<std::pair<std::string , unique_ptr<DiagnoseLib::Diagnose>>> testSet;
     //Construct the tests needed.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3573,16 +3573,24 @@ UniValue sethdseed(const UniValue& params, bool fHelp)
 
 UniValue upgradewallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1) {
-        throw std::runtime_error(
-                "upgradewallet [version]\n"
-                "\n"
-                "Upgrade the wallet. Upgrades to the latest version if no version number is specified\n"
-                "New keys may be generated and a new wallet backup will need to be made.\n"
-                "\n"
-                "[version] - The version number to upgrade to. Default is the latest wallet version."
-        );
-    }
+    static const RPCHelpMan help{
+        "upgradewallet",
+        "Upgrade the wallet to a newer version. Upgrades to the latest version if no version "
+        "number is specified. New keys may be generated and a new wallet backup may be required. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"version", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "The version number to upgrade to. Default is the latest wallet version."},
+        },
+        RPCResult{RPCResult::Type::STR, "error",
+            "Empty string on success; otherwise an error message describing why the upgrade failed."},
+        RPCExamples{
+            HelpExampleCli("upgradewallet", "") +
+            HelpExampleCli("upgradewallet", "169900") +
+            HelpExampleRpc("upgradewallet", "169900")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     EnsureWalletIsUnlocked();
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1259,14 +1259,34 @@ UniValue sendfrom(const UniValue& params, bool fHelp)
 
 UniValue sendmany(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 4)
-        throw runtime_error(
-                "sendmany <fromaccount> {address:amount,...} [minconf=1] [comment]\n"
-                "\n"
-                "<fromaccount> Specify account name to use or use '' to use all addresses in wallet\n"
-                "\n"
-                "amounts are double-precision floating point numbers\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "sendmany",
+        "Send GRC to multiple addresses in a single transaction. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"fromaccount", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Specify account name to use; use \"\" to use all addresses in the wallet. "
+                "Accounts subsystem is deprecated and may be removed in a future release."},
+            {"amounts", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO,
+                "A JSON object with addresses as keys and GRC amounts as values.",
+                {
+                    {"address", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                        "GRC amount to send to this address (rounded to the nearest 0.000001)."},
+                }},
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Only use balance confirmed at least this many times (default: 1)."},
+            {"comment", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Wallet-local comment describing what the transaction is for."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+        RPCExamples{
+            HelpExampleCli("sendmany",
+                "\"\" \"{\\\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\\\":1.5,\\\"SkNNd1234567890abcdefghijklmnopqr\\\":0.5}\"") +
+            HelpExampleRpc("sendmany",
+                "\"\", {\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\":1.5,\"SkNNd1234567890abcdefghijklmnopqr\":0.5}")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     string strAccount = AccountFromValue(params[0]);
     bool bFromAccount = false;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1187,21 +1187,34 @@ UniValue movecmd(const UniValue& params, bool fHelp)
 
 UniValue sendfrom(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 3 || params.size() > 7)
-        throw runtime_error(
-                "sendfrom <account> <gridcoinaddress> <amount> [minconf=1] [comment] [comment-to] [message]\n"
-                "\n"
-                "<account> account to send from.\n"
-                "<gridcoinaddress> address to send to.\n"
-                "<amount> is a real and is rounded to the nearest 0.000001\n"
-                "[minconf] only use the balance confirmed at least this many times."
-                "[comment] a comment used to store what the transaction is for.\n"
-                "         This is not part of the transaction, just kept in your wallet.\n"
-                "[comment_to] a comment to store the name of the person or organization\n"
-                "             to which you're sending the transaction. This is not part of the \n"
-                "             transaction, just kept in your wallet.\n"
-                "[message] Optional message to add to the receiver.\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "sendfrom",
+        "Send GRC from an account to a Gridcoin address. "
+        "Accounts subsystem is deprecated and may be removed in a future release. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"account", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "Account to send from."},
+            {"address", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The Gridcoin address to send to."},
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO,
+                "The amount in GRC (rounded to the nearest 0.000001)."},
+            {"minconf", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Only use the balance confirmed at least this many times (default: 1)."},
+            {"comment", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Wallet-local comment describing what the transaction is for."},
+            {"comment_to", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Wallet-local comment naming the recipient."},
+            {"message", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "Optional message to add to the receiver (TxMessage contract)."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+        RPCExamples{
+            HelpExampleCli("sendfrom", "\"tabby\" \"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\" 100 6") +
+            HelpExampleRpc("sendfrom", "\"tabby\", \"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\", 100, 6")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     string strAccount = AccountFromValue(params[0]);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3067,11 +3067,22 @@ UniValue walletlock(const UniValue& params, bool fHelp)
 
 UniValue encryptwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "encryptwallet <passphrase>\n"
-                "\n"
-                "Encrypts the wallet with <passphrase>.\n");
+    static const RPCHelpMan help{
+        "encryptwallet",
+        "Encrypts the wallet with the given passphrase. "
+        "After encryption, the node will shut down and must be restarted.",
+        {
+            {"passphrase", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The passphrase used to encrypt the wallet. Must be non-empty."},
+        },
+        RPCResult{RPCResult::Type::STR, "message",
+            "Confirmation message; the daemon stops after returning."},
+        RPCExamples{
+            HelpExampleCli("encryptwallet", "\"mypassphrase\"") +
+            HelpExampleRpc("encryptwallet", "\"mypassphrase\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     if (pwalletMain->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an encrypted wallet, but encryptwallet was called.");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3327,11 +3327,25 @@ UniValue reservebalance(const UniValue& params, bool fHelp)
 // ppcoin: check wallet integrity
 UniValue checkwallet(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 0)
-        throw runtime_error(
-                "checkwallet\n"
-                "\n"
-                "Check wallet for integrity.\n");
+    static const RPCHelpMan help{
+        "checkwallet",
+        "Check the wallet for integrity (mismatched spent coins).",
+        {},
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::BOOL, "wallet check passed", /*optional=*/true,
+                    "Present and true when no mismatches were found."},
+                {RPCResult::Type::NUM, "mismatched spent coins", /*optional=*/true,
+                    "Number of mismatched spent coins detected (only present when nonzero)."},
+                {RPCResult::Type::STR_AMOUNT, "amount in question", /*optional=*/true,
+                    "Total balance involved in the mismatches (only present when nonzero)."},
+            }},
+        RPCExamples{
+            HelpExampleCli("checkwallet", "") +
+            HelpExampleRpc("checkwallet", "")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     int nMismatchSpent;
     int64_t nBalanceInQuestion;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3459,12 +3459,24 @@ UniValue makekeypair(const UniValue& params, bool fHelp)
 
 UniValue burn(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-                "burn <amount> [hex string]\n"
-                "\n"
-                "<amount> is a real and is rounded to the nearest 0.00000001\n"
-                + HelpRequiringPassphrase());
+    static const RPCHelpMan help{
+        "burn",
+        "Send an amount to an unspendable OP_RETURN output, optionally with a hex data payload. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"amount", RPCArg::Type::AMOUNT, RPCArg::Optional::NO,
+                "Amount to burn in GRC (rounded to the nearest 0.00000001)."},
+            {"data", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED,
+                "Optional hex-encoded payload to attach to the OP_RETURN output."},
+        },
+        RPCResult{RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+        RPCExamples{
+            HelpExampleCli("burn", "1.0") +
+            HelpExampleCli("burn", "1.0 \"deadbeef\"") +
+            HelpExampleRpc("burn", "1.0, \"deadbeef\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");


### PR DESCRIPTION
## Summary

Tier 1 F4 of issue #2922 — packages the legacy help-text-as-`runtime_error` pattern into `RPCHelpMan` for 13 wallet management and send commands in `src/wallet/rpcwallet.cpp`. Pure packaging change.

One commit per command + one test commit.

## Stacked on F3 (#2970)

This branch is stacked on `rpc/rpchelpman-wallet-queries` (#2970), which is itself stacked on F2 (#2969). All three touch `rpcwallet.cpp` and must merge in order. Will rebase to `origin/development` once F2 + F3 merge.

Companion to #2954/#2956/#2958 (Tier 1a/1b/1c), #2961-2968 (D1, D2, D3, E1, E2, E3, F1, deprecated batch), #2969 (F2), #2970 (F3).

## Commands converted

**Send (4):** `sendtoaddress`, `sendfrom`, `sendmany`, `burn`

**Wallet mgmt (9):** `backupwallet`, `keypoolrefill`, `walletdiagnose`, `encryptwallet`, `reservebalance`, `checkwallet`, `repairwallet`, `resendtx`, `upgradewallet`

Notes:
- `HelpRequiringPassphrase` static-note convention applied to `sendtoaddress`, `sendfrom`, `sendmany`, `burn`, `keypoolrefill`, `sethdseed` (matches the convention in #2966 / #2967 / #2969).
- `sendmany` uses `RPCArg::Type::OBJ_USER_KEYS` for the variable-key address→amount map (mirrors the Bitcoin Core idiom for this argument shape).
- `resendtx` arity tightened from "0 or 1" to 0 (legacy `params.size() > 1` accepted a single ignored argument; the body uses no params).
- `reservebalance`: schema has cross-arg semantics (amount required iff reserve=true) that `IsValidNumArgs` can't express; the manual sub-checks inside the body preserve the legacy errors verbatim.
- `walletdiagnose` result is variable-keyed (each diagnostic test is a key); uses `OBJ_DYN + ELISION`.
- `encryptwallet` returns a `STR` confirmation message and immediately schedules shutdown — the schema documents both behaviors.

## Behavior

**No behavior changes** for in-spec usage. Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly, except `resendtx`'s intentional 0-arg tightening.
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes.
- The `HelpRequiringPassphrase` note text matches the current `HelpRequiringPassphrase()` output verbatim.

## Tests

`src/test/rpchelpman_tests.cpp` gains `BOOST_AUTO_TEST_CASE(tier1_f4_wallet_mgmt_send_help_renders)` that iterates all 13 commands, calls each with empty `params` and `fHelp=true`, and asserts the thrown `runtime_error` message contains the RPC name and the `Examples:` marker.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 13 — full help renders, examples present
  - Confirm `sendtoaddress`/`sendfrom`/`sendmany` still throw the expected wallet-locked error when applicable
  - Confirm `reservebalance` cross-arg validation (no amount when reserve=true; no amount allowed when reserve=false) still throws the legacy text
  - Review the `resendtx` arity tightening — revert if undesired
  - Confirm `encryptwallet` still triggers shutdown after a successful encryption

Refs: #2922