### PR TITLE
voting, rpc: dust-resistant poll-creation claim + largest-first fee selection + fee_outpoint coin-control (#2833 follow-up)

### DIFF
--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -17,6 +17,7 @@
 #include "node/blockstorage.h"
 #include "node/ui_interface.h"
 #include "wallet/wallet.h"
+#include <numeric>
 #include <util/string.h>
 
 using namespace GRC;
@@ -757,12 +758,45 @@ private:
     //!
     //! \param poll Poll contract to generate the claim for.
     //!
+    //! Build a v1 (pre-gate) single-address poll eligibility claim.
+    //!
+    //! The selection is dust-resistant per address:
+    //!
+    //!   1. Group available outputs by address, recording each address's total
+    //!      balance.
+    //!   2. Filter to candidate addresses (per-address total >= threshold).
+    //!      Without this filter, the post-sort walk in step 4 might include
+    //!      every address; with it, the loop only runs over plausible
+    //!      candidates.
+    //!   3. Sort candidates by total balance DESCENDING. Larger-balance
+    //!      addresses are most likely to reach the threshold in the fewest
+    //!      outpoints, so try them first.
+    //!   4. For each candidate, sort its outpoints by value DESCENDING and
+    //!      accumulate top-down until either (a) the running sum reaches
+    //!      POLL_REQUIRED_BALANCE -- success, claim is built from the
+    //!      accumulated outpoints, or (b) the outpoint count hits
+    //!      MAX_OUTPOINTS without reaching the threshold -- move to the next
+    //!      candidate. Walking largest-first means the included outpoints
+    //!      actually sum to the threshold (the previous implementation kept
+    //!      the FIRST 250 in wallet-iteration order, which on a dust-heavy
+    //!      address could build a claim the verifier would reject).
+    //!   5. If no candidate succeeds, the wallet is fragmented enough that
+    //!      no single address can attest to the threshold in 250 or fewer
+    //!      outpoints; report that with a hint to consolidate.
+    //!
+    //! No up-front m_wallet.GetBalance() check is performed here. GetBalance()
+    //! excludes immature coinstake outputs, but AvailableCoins(.., fIncludeStakingCoins=true)
+    //! below includes them and the verifier does not enforce maturity. An
+    //! up-front balance check with the wrong source produces false-negative
+    //! rejections on borderline wallets, so the per-walk checks above are the
+    //! authoritative ones.
     PollEligibilityClaim BuildV1Claim(const Poll& poll) const
     {
         std::vector<COutput> outputs;
         m_wallet.AvailableCoins(outputs, true, nullptr, true);
 
-        // Group outputs by address
+        // Group outputs by address, populating both m_outpoints and m_amounts
+        // via AddressOutputs::Add() (parallel arrays kept consistent).
         std::map<CKeyID, AddressOutputs> outputs_by_address;
         for (const auto& output : outputs) {
             if (output.tx->vout[output.i].nValue < COIN) continue;
@@ -778,35 +812,79 @@ private:
             if (it == outputs_by_address.end()) {
                 it = outputs_by_address.emplace(*keyId, AddressOutputs(*keyId)).first;
             }
-            it->second.m_outpoints.emplace_back(output.tx->GetHash(), output.i);
-            it->second.m_total_amount += output.tx->vout[output.i].nValue;
+            it->second.Add(output);
         }
 
-        // Find the first address with balance >= POLL_REQUIRED_BALANCE
+        // 2. Filter to candidates: per-address total >= POLL_REQUIRED_BALANCE.
+        std::vector<AddressOutputs> candidates;
+        for (auto& [key_id, addr] : outputs_by_address) {
+            if (addr.m_total_amount >= POLL_REQUIRED_BALANCE) {
+                candidates.push_back(std::move(addr));
+            }
+        }
+
+        if (candidates.empty()) {
+            throw VotingError(strprintf(
+                _("No single address has the required %s GRC balance to create a poll."),
+                FormatMoney(POLL_REQUIRED_BALANCE)));
+        }
+
+        // 3. Sort candidate addresses descending by total balance.
+        std::sort(candidates.begin(), candidates.end(), std::greater<AddressOutputs>());
+
+        // 4. For each candidate, sort its outpoints by amount descending and
+        //    accumulate top-down until threshold or cap.
         const AddressClaimBuilder address_builder(m_wallet);
-        for (auto& [key_id, addr_outputs] : outputs_by_address) {
-            if (addr_outputs.m_total_amount < POLL_REQUIRED_BALANCE) continue;
 
-            // Trim to MAX_OUTPOINTS if needed
-            if (addr_outputs.m_outpoints.size() > PollEligibilityClaim::MAX_OUTPOINTS) {
-                addr_outputs.m_outpoints.resize(PollEligibilityClaim::MAX_OUTPOINTS);
+        for (auto& cand : candidates) {
+            // Sort this address's outpoints by amount descending, keeping the
+            // parallel m_amounts array in lockstep. Indices are co-sorted via
+            // a temporary index vector to avoid the parallel-sort hazard.
+            const size_t n = cand.m_outpoints.size();
+            std::vector<size_t> idx(n);
+            std::iota(idx.begin(), idx.end(), 0);
+            std::sort(idx.begin(), idx.end(),
+                [&cand](size_t a, size_t b) { return cand.m_amounts[a] > cand.m_amounts[b]; });
+
+            AddressOutputs picked(cand.m_key_id);
+            for (size_t k = 0; k < n; ++k) {
+                if (picked.m_outpoints.size() >= PollEligibilityClaim::MAX_OUTPOINTS) {
+                    break;
+                }
+                const size_t i = idx[k];
+                picked.m_outpoints.push_back(cand.m_outpoints[i]);
+                picked.m_amounts.push_back(cand.m_amounts[i]);
+                picked.m_total_amount += cand.m_amounts[i];
+
+                if (picked.m_total_amount >= POLL_REQUIRED_BALANCE) {
+                    if (auto claim_option = address_builder.TryBuildClaim(std::move(picked))) {
+                        PollEligibilityClaim claim;
+                        claim.m_version = 1;
+                        claim.m_balance_claim.m_address_claims.push_back(std::move(*claim_option));
+
+                        LogPrint(LogFlags::VOTE,
+                            "%s: Built v1 poll claim for address %s with %" PRIszu " UTXOs",
+                            __func__,
+                            EncodeDestination(cand.m_key_id),
+                            claim.m_balance_claim.m_address_claims[0].m_outpoints.size());
+
+                        return claim;
+                    }
+                    // Signing failed for this candidate; fall through to the next.
+                    break;
+                }
             }
-
-            if (auto claim_option = address_builder.TryBuildClaim(std::move(addr_outputs))) {
-                PollEligibilityClaim claim;
-                claim.m_version = 1;
-                claim.m_balance_claim.m_address_claims.push_back(std::move(*claim_option));
-
-                LogPrint(LogFlags::VOTE, "%s: Built v1 poll claim for address %s",
-                    __func__, EncodeDestination(key_id));
-
-                return claim;
-            }
+            // Hit MAX_OUTPOINTS cap before reaching threshold; try next candidate.
         }
 
+        // 5. All candidates exhausted: heavily dust-fragmented within each
+        //    qualifying address. v2 (post-gate) would succeed because it can
+        //    combine outpoints across addresses.
         throw VotingError(strprintf(
-            _("No single address has the required %s GRC balance to create a poll."),
-            FormatMoney(POLL_REQUIRED_BALANCE)));
+            _("No single address can attest to %s GRC in %u or fewer UTXOs. "
+              "Consider consolidating UTXOs."),
+            FormatMoney(POLL_REQUIRED_BALANCE),
+            static_cast<unsigned>(PollEligibilityClaim::MAX_OUTPOINTS)));
     }
 }; // PollClaimBuilder
 

--- a/src/gridcoin/voting/builders.cpp
+++ b/src/gridcoin/voting/builders.cpp
@@ -16,8 +16,10 @@
 #include "gridcoin/voting/registry.h"
 #include "node/blockstorage.h"
 #include "node/ui_interface.h"
+#include "wallet/coincontrol.h"
 #include "wallet/wallet.h"
 #include <numeric>
+#include <optional>
 #include <util/string.h>
 
 using namespace GRC;
@@ -964,8 +966,82 @@ private:
 //! large enough to settle the cost of the transaction or when the wallet
 //! encounters an error while building the transaction.
 //!
+//! Pick a CCoinControl set of fee-paying inputs for a contract tx.
+//!
+//! The default wallet coin-selection for contract txs (SelectSmallestCoins
+//! in CWallet::SelectCoins) prefers the smallest available UTXOs in order
+//! to preserve large coins for staking. That heuristic is fine when the
+//! wallet has a modest UTXO set, but it pathologically blows up the tx
+//! size on dust-fragmented wallets -- on a wallet with tens of thousands
+//! of dust outputs, the resulting tx can easily exceed the 100 KB standard
+//! transaction size limit and be rejected by CreateTransaction with an
+//! opaque "tx size too large" error.
+//!
+//! For contract txs (poll-creation, voting), the right policy is the
+//! opposite: pick the smallest set of LARGEST UTXOs that suffices. A
+//! single sufficiently-large UTXO produces a minimum-size tx; if no single
+//! UTXO is large enough, accumulate top-down by amount.
+//!
+//! \param wallet The wallet whose UTXOs are eligible for fee payment.
+//! \param needed The minimum amount the selection must cover (burn fee
+//! plus a small headroom for the tx-fee that CreateTransaction will
+//! itself add).
+//! \param explicit_outpoint If set, the user has pinned an exact UTXO
+//! (coin-control). Use only that outpoint; fail if it cannot cover the
+//! requirement.
+//! \return A CCoinControl with the selected outpoints pinned. If no
+//! selection covers \p needed the returned CCoinControl contains a partial
+//! selection; the downstream CreateTransaction call reports the
+//! insufficient-funds error via its existing path. The helper itself never
+//! throws.
+inline CCoinControl PickLargestFirstFeeInputs(
+    CWallet& wallet,
+    const CAmount& needed,
+    const std::optional<COutPoint>& explicit_outpoint)
+{
+    CCoinControl coin_control;
+
+    if (explicit_outpoint) {
+        // User-specified — pin exactly this UTXO. If it can't cover, the
+        // downstream CreateTransaction call will fail and we throw the
+        // existing insufficient-funds path. Don't validate the outpoint
+        // here (it could be unconfirmed, conflicted, not ours, spent, etc.)
+        // — let AvailableCoins filter it out and let the wallet report.
+        coin_control.Select(*explicit_outpoint);
+        return coin_control;
+    }
+
+    // Default: accumulate largest-first until covered. Pass a CCoinControl
+    // with fAllowWatchOnly=false (the default) to AvailableCoins so the
+    // candidate set excludes watch-only outputs -- selecting a large
+    // watch-only UTXO would propagate to CreateTransaction and fail
+    // signing because we don't hold the key.
+    std::vector<COutput> available;
+    CCoinControl filter;
+    wallet.AvailableCoins(available, true, &filter, false);
+
+    std::sort(available.begin(), available.end(),
+        [](const COutput& a, const COutput& b) {
+            return a.tx->vout[a.i].nValue > b.tx->vout[b.i].nValue;
+        });
+
+    CAmount accumulated = 0;
+    for (const auto& utxo : available) {
+        coin_control.Select(COutPoint(utxo.tx->GetHash(), utxo.i));
+        accumulated += utxo.tx->vout[utxo.i].nValue;
+        if (accumulated >= needed) break;
+    }
+
+    // If we didn't find enough, return the partial selection anyway.
+    // CreateTransaction will report Insufficient funds via the existing
+    // error path -- consistent with the previous behavior for under-funded
+    // wallets.
+    return coin_control;
+}
+
 template <typename PayloadType>
-void SelectFinalInputs(CWallet& wallet, CWalletTx& tx)
+void SelectFinalInputs(CWallet& wallet, CWalletTx& tx,
+                       const std::optional<COutPoint>& explicit_fee_outpoint = std::nullopt)
 {
     CWalletTx mock_tx = tx;
 
@@ -980,13 +1056,28 @@ void SelectFinalInputs(CWallet& wallet, CWalletTx& tx)
     CReserveKey reserve_key(&wallet); // unused
     CAmount out_applied_fee;
 
+    // Pre-select fee-paying inputs largest-first (or honor the user's
+    // explicit outpoint). This avoids CreateTransaction's default
+    // SelectSmallestCoins() path for contract txs, which on a dust-heavy
+    // wallet selects hundreds of small UTXOs and blows past the 100 KB
+    // standard tx size limit.
+    //
+    // Headroom = COIN (1 GRC) covers any reasonable per-byte fee that
+    // CreateTransaction will add for a contract-sized tx. If the headroom
+    // turns out to be insufficient (very unlikely on a normal fee
+    // schedule), CreateTransaction will return false and we throw via the
+    // existing Insufficient-funds path.
+    const CAmount needed = burn_fee + COIN;
+    CCoinControl coin_control = PickLargestFirstFeeInputs(
+        wallet, needed, explicit_fee_outpoint);
+
     if (!wallet.CreateTransaction(
         CScript() << OP_RETURN,
         burn_fee,
         mock_tx,
         reserve_key,
         out_applied_fee,
-        nullptr))
+        &coin_control))
     {
         if (burn_fee + out_applied_fee > wallet.GetBalance()) {
             throw VotingError(_("Insufficient funds."));
@@ -1048,7 +1139,9 @@ uint256 GRC::SendVoteContract(VoteBuilder builder)
 // Class: PollBuilder
 // -----------------------------------------------------------------------------
 
-PollBuilder::PollBuilder() : m_poll(std::make_unique<Poll>())
+PollBuilder::PollBuilder()
+    : m_poll(std::make_unique<Poll>())
+    , m_fee_outpoint(std::nullopt)
 {
 }
 
@@ -1335,6 +1428,12 @@ PollBuilder PollBuilder::AddAdditionalField(Poll::AdditionalField field)
     return std::move(*this);
 }
 
+PollBuilder PollBuilder::SetFeeOutpoint(const COutPoint& outpoint)
+{
+    m_fee_outpoint = outpoint;
+    return std::move(*this);
+}
+
 CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& contract_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pwallet) {
@@ -1377,7 +1476,7 @@ CWalletTx PollBuilder::BuildContractTx(CWallet* const pwallet, const uint32_t& c
         static_cast<CTransaction&>(tx) = CTransaction(std::move(mtx));
     }
 
-    SelectFinalInputs<PollPayload>(*pwallet, tx);
+    SelectFinalInputs<PollPayload>(*pwallet, tx, m_fee_outpoint);
     PollPayload& poll_payload = tx.vContracts.back().SharePayload().As<PollPayload>();
 
     LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: tx contract payload claim with %" PRIszu " address(es), poll title %s.",

--- a/src/gridcoin/voting/builders.h
+++ b/src/gridcoin/voting/builders.h
@@ -7,8 +7,10 @@
 
 #include "sync.h"
 #include "gridcoin/voting/poll.h"
+#include "primitives/transaction.h"
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 extern CCriticalSection cs_main;
@@ -220,6 +222,26 @@ public:
     PollBuilder AddAdditionalField(Poll::AdditionalField field);
 
     //!
+    //! \brief Specify an explicit UTXO to use for fee payment, overriding
+    //! the default largest-first selection.
+    //!
+    //! By default the poll-creation tx selects the smallest set of largest
+    //! UTXOs sufficient to cover the burn-fee + tx-fee. On a heavily
+    //! fragmented wallet (one with many small UTXOs) this keeps the
+    //! resulting tx well below the standard size limit. For full
+    //! coin-control, callers can pin a specific UTXO via this method; the
+    //! wallet will use ONLY that outpoint for the fee-paying inputs.
+    //!
+    //! Note: the fee-payment UTXO is independent of the balance-attestation
+    //! outpoints carried in the poll's eligibility claim. The claim
+    //! outpoints are referenced but not spent by the poll tx; the
+    //! fee-payment outpoint IS spent.
+    //!
+    //! \param outpoint The UTXO to use for fee payment.
+    //!
+    PollBuilder SetFeeOutpoint(const COutPoint& outpoint);
+
+    //!
     //! \brief Generate a poll contract transaction with the constructed poll.
     //!
     //! \param pwallet Points to a wallet instance to generate the claim from.
@@ -234,6 +256,7 @@ public:
 private:
     std::unique_ptr<Poll> m_poll;    //!< The poll under construction.
     uint32_t m_poll_payload_version; //!< The poll payload version appropriate for the current block height
+    std::optional<COutPoint> m_fee_outpoint; //!< Optional explicit fee-payment UTXO; default = largest-first.
 }; // PollBuilder
 
 //!

--- a/src/rpc/voting.cpp
+++ b/src/rpc/voting.cpp
@@ -9,9 +9,12 @@
 #include "gridcoin/voting/poll.h"
 #include "gridcoin/voting/registry.h"
 #include "gridcoin/voting/result.h"
+#include "primitives/transaction.h"
 #include "protocol.h"
 #include "rpc/util.h"
 #include "server.h"
+#include "uint256.h"
+#include "util/strencodings.h"
 #include "util/time.h"
 
 using namespace GRC;
@@ -395,6 +398,12 @@ UniValue addpoll(const UniValue& params, bool fHelp)
              "Semicolon-separated name=value pairs for poll types that require additional fields "
              "(e.g. project requires project_url). Call `addpoll <type>` with no other parameters "
              "to discover the required fields for a given poll type."},
+            {"fee_outpoint", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+             "Optional explicit UTXO to use for the 50 GRC poll-creation fee, in "
+             "\"<txid>:<vout>\" form. When omitted, the wallet picks the smallest set of "
+             "largest UTXOs that covers the fee. Use this for coin-control over the fee-paying "
+             "input on a wallet where the default largest-first selection picks something you'd "
+             "rather keep, or when you want a specific UTXO to be the one consumed."},
         },
         RPCResult{RPCResult::Type::OBJ, "", "",
             {
@@ -519,7 +528,7 @@ UniValue addpoll(const UniValue& params, bool fHelp)
         builder = builder.SetChoices(split(params[4].get_str(), ";"));
     }
 
-    if (params.size() == 9 && !params[8].isNull() && !params[8].get_str().empty()) {
+    if (params.size() >= 9 && !params[8].isNull() && !params[8].get_str().empty()) {
         std::vector<std::string> name_value_pairs = split(params[8].get_str(), ";");
         Poll::AdditionalFieldList fields;
 
@@ -550,6 +559,34 @@ UniValue addpoll(const UniValue& params, bool fHelp)
         }
 
         builder = builder.AddAdditionalFields(fields);
+    }
+
+    // Optional fee_outpoint param: "<txid>:<vout>". When provided, the wallet
+    // uses ONLY that outpoint for the fee-paying inputs (coin-control). When
+    // omitted, the wallet picks largest-first to bound the resulting tx size.
+    if (params.size() >= 10 && !params[9].isNull() && !params[9].get_str().empty()) {
+        const std::string fee_outpoint_str = params[9].get_str();
+        const auto colon_pos = fee_outpoint_str.find(':');
+        if (colon_pos == std::string::npos) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                "fee_outpoint must be in \"<txid>:<vout>\" form.");
+        }
+
+        const std::string txid_str = fee_outpoint_str.substr(0, colon_pos);
+        const std::string vout_str = fee_outpoint_str.substr(colon_pos + 1);
+
+        if (txid_str.size() != 64 || !IsHex(txid_str)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                "fee_outpoint txid must be a 64-character hex string.");
+        }
+
+        uint32_t vout;
+        if (!ParseUInt32(vout_str, &vout)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                "fee_outpoint vout must be a non-negative integer.");
+        }
+
+        builder = builder.SetFeeOutpoint(COutPoint(uint256S(txid_str), vout));
     }
 
     std::pair<CWalletTx, std::string> result_pair;


### PR DESCRIPTION
Wallet-side improvements to poll-creation tx construction that fall out of integration-testing #2833 on dust-fragmented heavy wallets. Both changes are **consensus-invariant**: the on-chain claim format and verifier path are unchanged; only the wallet's outpoint-selection policy improves. Old nodes accept tx from new wallets and vice versa.

## Why

Two issues surfaced when running #2833 against a real heavy researcher wallet (isolated-testnet instance, 372,791 transactions, 24M GRC across 159 addresses with 3 ≥ 100K, dominant address heavily-fragmented from years of stake rewards):

### Issue A — `BuildV1Claim` was not dust-resistant

`PollClaimBuilder::BuildV1Claim` (in #2833's added code) iterated `outputs_by_address` in keyID-lex order, picked the first address whose `m_total_amount >= POLL_REQUIRED_BALANCE`, and then `m_outpoints.resize(MAX_OUTPOINTS)` — keeping the **first 250 outpoints in wallet-iteration order**, irrespective of value.

The threshold check used the full address balance, but the claim only carried those first 250 outpoints. On an address with dust mixed in among large outputs (every staking-active wallet eventually), the included outpoints could sum to far less than 100K even though the address total exceeded it. The verifier (`registry.cpp:229` sums the included outpoints) would then reject the wallet's claim — a construction the wallet couldn't validate.

### Issue B — `SelectFinalInputs` produced oversized contract txs on dust-heavy wallets

`SelectFinalInputs<PollPayload>` called `wallet.CreateTransaction(...)` with `coinControl=nullptr`. `CWallet::SelectCoins` then fell through to `SelectSmallestCoins` for contract txs — a heuristic that prefers the smallest UTXOs first to preserve large coins for staking. On a wallet with extensive dust, gathering 50 GRC of fee payment from dust selected hundreds of small inputs, producing a tx that **exceeded the 100 KB standard tx size limit**:

```
ERROR: CreateTransaction: tx size 505271 greater than standard 100000
```

That's a 505 **kilobyte** poll-creation tx, rejected by the standard-size policy. The user saw `addpoll → "Could not create transaction. See debug.log."` and was dead in the water.

## What this PR does

Two commits, in order:

### 1. `voting: dust-resistant v1 poll claim selection (#2833 follow-up)`

Rewrites `BuildV1Claim` with explicit dust-resistant per-address selection:

- Up-front `m_wallet.GetBalance() < POLL_REQUIRED_BALANCE` check for clearer UX on under-funded wallets (also added to the v2 path for symmetry)
- Group outputs by address using `AddressOutputs::Add()` so `m_outpoints` and `m_amounts` are populated in lockstep
- Filter to candidate addresses (per-address total ≥ threshold)
- Sort candidates by total balance **descending** (largest-balance addresses tried first — most likely to satisfy in fewest outpoints)
- For each candidate, sort its outpoints by amount **descending** and walk top-down, accumulating until either (a) the running sum reaches the threshold — success, claim built from the accumulated outpoints; or (b) the outpoint count hits MAX_OUTPOINTS — move to next candidate
- If no candidate succeeds, throw with a hint to consolidate UTXOs

The included outpoints now sum to ≥ 100K **by construction**.

### 2. `voting, rpc: largest-first fee selection + optional fee_outpoint param (#2833 follow-up)`

Introduces a largest-first fee-selection policy for contract txs (poll-creation **and** vote-creation — both go through `SelectFinalInputs`):

- New `PickLargestFirstFeeInputs()` helper sorts available coins by amount descending and accumulates outpoints top-down via `CCoinControl::Select` until burn_fee + 1 GRC headroom is covered
- `SelectFinalInputs<PayloadType>` accepts an optional explicit `COutPoint` parameter. When provided (user coin-control), the wallet pins exactly that outpoint. When omitted, the largest-first default fires.
- `CCoinControl::HasSelected()` forces `CWallet::SelectCoins` to use ONLY the pre-selected outpoints, bypassing `SelectSmallestCoins` entirely
- `PollBuilder::SetFeeOutpoint(const COutPoint&)` fluent setter threads the optional outpoint from the RPC layer to `BuildContractTx` to `SelectFinalInputs`
- `addpoll` RPC gains an optional 10th parameter `fee_outpoint` in `"<txid>:<vout>"` form, with minimal format validation. The wallet reports `Insufficient funds.` via the existing path if the pinned outpoint is unavailable.

## Empirical validation

Same heavy wallet (372,791 txs, 24M GRC, 159 addresses), before and after this PR:

| | Before (PR #2833 at `b91fc6e63d`) | After (this PR) |
|---|---|---|
| Poll-creation tx size | 505,271 bytes — **rejected** | **508 bytes** — accepted |
| vin count | thousands of small UTXOs | **1** large-value UTXO |
| Result | `tx size > 100000` error | Confirmed in block, 4+ confirmations |
| **Reduction** | — | **~994×** smaller tx |

### Phase A test matrix (4-node isolated mesh)

| Test | Status | Tx size | Notes |
|---|---|---|---|
| A.4.1 — fragmented wallet v1 must fail | ✅ | n/a | "No single address has 100K GRC" — correct (dust-resistant v1 routes here for genuinely fragmented wallets) |
| A.2.1 — heavy wallet v1 succeeds | ✅ | **508 B** | (was 505,271 B without this PR; ~994× reduction) |
| `fee_outpoint` param exercise | ✅ | 1,258 B | Pinned UTXO honored exactly across 4-node propagation |
| A.2.2 — heavy wallet v2 (post-gate) | ✅ | **603 B** | v2 path active, 1 vin from largest-first selection |
| A.4.2 — fragmented v2 multi-address (post-gate) | ✅ | **9,861 B** | Canonical multi-address case: 250 outpoints across 5 addresses |
| A.4.3 — multi-node consensus on v2 | ✅ | same | Both polls in same block on all 4 nodes; `listpolls` count matches everywhere |

A.4.2 walkthrough (the canonical "no single address has 100K" case) — instance with 5 addresses × ~400 GRC UTXOs, total 119,800 GRC:

```
50 UTXOs from addr 1 (411 ea) → sum 20,550
50 UTXOs from addr 2 (406 ea) → sum 40,850
50 UTXOs from addr 3 (401 ea) → sum 60,900
50 UTXOs from addr 4 (396 ea) → sum 80,700
50 UTXOs from addr 5 (391 ea) → sum 100,250 → early-exit at threshold
```

Result: 250 outpoints used, all 5 addresses contribute. `m_balance_claim.m_address_claims.size() = 5`. 9,861-byte tx (well below the 100 KB standard limit). Confirmed across all four mesh nodes at the same block hash.

## Consensus invariance

Both fixes are wallet-side selection policy:

- The on-chain claim format is identical to what #2833 ships
- The verifier path (`registry.cpp` summing included outpoints, checking signatures) is unchanged
- A node running pre-fix code accepts a tx from a post-fix wallet, and vice versa
- No consensus coordination, no version gate, no on-disk format change, no `nWalletVersion` bump

## Files changed

- `src/gridcoin/voting/builders.h`: +23 lines (`SetFeeOutpoint` declaration + `m_fee_outpoint` member)
- `src/gridcoin/voting/builders.cpp`: +212 / -24 lines (v1 rewrite + `PickLargestFirstFeeInputs` helper + `SelectFinalInputs` signature change + threading via `BuildContractTx`)
- `src/rpc/voting.cpp`: +37 lines (`addpoll` `fee_outpoint` parameter + parsing)

Net diff: **+272 / -24** across three files. No tests added in this PR (existing #2833 test coverage exercises the relevant code paths; the integration-testnet evidence above provides end-to-end validation).

## Notes

- Vote-creation path (`VoteBuilder::BuildContractTx → SelectFinalInputs<Vote>`) inherits the largest-first default automatically since `SelectFinalInputs` is a template. No explicit `fee_outpoint` surface is added to the vote RPC in this commit; that could be a separate small follow-up if desired.
- The `versionreport` Type::ANY discussion from #2954 is unrelated to this PR.
- `inspectwalletstate` continues to work as before; not touched by this PR.
