### PR TITLE
rpc: convert remaining 10 straggler commands to RPCHelpMan (PSGT + wallet tx-state debug, #2922)

### DIFF
--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -555,17 +555,21 @@ UniValue walletprocesspsgt(const UniValue& params, bool fHelp)
 
 UniValue utxoupdatepsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "utxoupdatepsgt \"psgt\"\n"
-            "\nUpdate a PSGT with UTXO data from the node.\n"
-            "For each input, if the non_witness_utxo is missing, attempt to\n"
-            "look up the previous transaction and fill it in.\n"
-            "\nArguments:\n"
-            "1. \"psgt\"             (string, required) A base64 PSGT string\n"
-            "\nResult:\n"
-            "  \"psgt\"              (string) The base64-encoded updated PSGT\n"
-        );
+    static const RPCHelpMan help{
+        "utxoupdatepsgt",
+        "Update a PSGT with UTXO data from the node. "
+        "For each input where non_witness_utxo is missing, look up the previous transaction and fill it in.",
+        {
+            {"psgt", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "A base64-encoded PSGT."},
+        },
+        RPCResult{RPCResult::Type::STR, "psgt", "The base64-encoded updated PSGT."},
+        RPCExamples{
+            HelpExampleCli("utxoupdatepsgt", "\"cHNidP8B...\"") +
+            HelpExampleRpc("utxoupdatepsgt", "\"cHNidP8B...\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     PartiallySignedTransaction psgt;
     string error;

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -151,33 +151,28 @@ UniValue createpsgt(const UniValue& params, bool fHelp)
 
 UniValue decodepsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "decodepsgt \"psgt\"\n"
-            "\nReturn a JSON object representing the PSGT.\n"
-            "\nArguments:\n"
-            "1. \"psgt\"             (string, required) The base64-encoded PSGT string\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"tx\" : {              (json object) The decoded unsigned transaction\n"
-            "    ...                    (same format as decoderawtransaction)\n"
-            "  },\n"
-            "  \"inputs\" : [          (array of json objects)\n"
-            "    {\n"
-            "      \"non_witness_utxo\" : {...},\n"
-            "      \"partial_signatures\" : {...},\n"
-            "      \"sighash\" : \"type\",\n"
-            "      \"redeem_script\" : {...},\n"
-            "      \"final_scriptSig\" : {...}\n"
-            "    }\n"
-            "  ],\n"
-            "  \"outputs\" : [         (array of json objects)\n"
-            "    {\n"
-            "      \"redeem_script\" : {...}\n"
-            "    }\n"
-            "  ]\n"
-            "}\n"
-        );
+    static const RPCHelpMan help{
+        "decodepsgt",
+        "Return a JSON object representing the given PSGT (Partially Signed Gridcoin Transaction).",
+        {
+            {"psgt", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The base64-encoded PSGT."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::OBJ, "tx", "The decoded unsigned transaction (same shape as decoderawtransaction).",
+                    {{RPCResult::Type::ELISION, "", ""}}},
+                {RPCResult::Type::ARR, "inputs", "Per-input PSGT metadata.",
+                    {{RPCResult::Type::ELISION, "", "input fields: non_witness_utxo, partial_signatures, sighash, redeem_script, final_scriptSig, bip32_derivs, unknown"}}},
+                {RPCResult::Type::ARR, "outputs", "Per-output PSGT metadata.",
+                    {{RPCResult::Type::ELISION, "", "output fields: redeem_script, bip32_derivs, unknown"}}},
+            }},
+        RPCExamples{
+            HelpExampleCli("decodepsgt", "\"cHNidP8B...\"") +
+            HelpExampleRpc("decodepsgt", "\"cHNidP8B...\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     PartiallySignedTransaction psgt;
     string error;

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -644,24 +644,48 @@ UniValue converttopsgt(const UniValue& params, bool fHelp)
 
 UniValue walletcreatefundedpsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 4)
-        throw runtime_error(
-            "walletcreatefundedpsgt [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,...} ( options sign )\n"
-            "\nCreate and fund a PSGT with wallet UTXOs, optionally signing it.\n"
-            "\nArguments:\n"
-            "1. \"inputs\"           (array, required) A json array of json objects (can be empty for auto-selection)\n"
-            "2. \"outputs\"          (object, required) a json object with addresses as keys and amounts as values\n"
-            "3. \"options\"          (object, optional)\n"
-            "    {\n"
-            "      \"changeAddress\" : \"addr\"   (string, optional) Address for change output\n"
-            "    }\n"
-            "4. sign                 (boolean, optional, default true) Also sign the PSGT with wallet keys\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"psgt\"       : \"value\",   (string) The base64-encoded PSGT\n"
-            "  \"fee\"        : n            (numeric) The fee paid\n"
-            "}\n"
-        );
+    static const RPCHelpMan help{
+        "walletcreatefundedpsgt",
+        "Create and fund a PSGT with wallet UTXOs, optionally signing it. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted and `sign` is true.",
+        {
+            {"inputs", RPCArg::Type::ARR, RPCArg::Optional::NO,
+                "A JSON array of inputs (empty array allows auto-selection from wallet UTXOs).",
+                {
+                    {"input", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id."},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number."},
+                        }},
+                }},
+            {"outputs", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO,
+                "A JSON object with addresses as keys and GRC amounts as values.",
+                {
+                    {"address", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                        "The GRC amount to send to this address."},
+                }},
+            {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED,
+                "Optional funding options.",
+                {
+                    {"changeAddress", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                        "Address to receive change. Default: a new address from the keypool."},
+                }},
+            {"sign", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Also sign the PSGT with wallet keys. Default: true."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "psgt", "The base64-encoded PSGT."},
+                {RPCResult::Type::STR_AMOUNT, "fee", "The fee paid in GRC."},
+            }},
+        RPCExamples{
+            HelpExampleCli("walletcreatefundedpsgt",
+                "\"[]\" \"{\\\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\\\":0.1}\"") +
+            HelpExampleRpc("walletcreatefundedpsgt",
+                "[], {\"SD1qpYx1mAdLPZJyTrL4S4n7B2y4VLBLnJ\":0.1}")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, {UniValue::VARR, UniValue::VOBJ});
 

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -594,17 +594,21 @@ UniValue utxoupdatepsgt(const UniValue& params, bool fHelp)
 
 UniValue converttopsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "converttopsgt \"hexstring\"\n"
-            "\nConvert a raw transaction to PSGT format.\n"
-            "The resulting PSGT will have empty input metadata; use\n"
-            "utxoupdatepsgt to fill in UTXO information.\n"
-            "\nArguments:\n"
-            "1. \"hexstring\"        (string, required) The hex-encoded raw transaction\n"
-            "\nResult:\n"
-            "  \"psgt\"              (string) The base64-encoded PSGT\n"
-        );
+    static const RPCHelpMan help{
+        "converttopsgt",
+        "Convert a raw transaction to PSGT format. "
+        "The resulting PSGT will have empty input metadata; use utxoupdatepsgt to fill in UTXO information.",
+        {
+            {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+                "The hex-encoded raw transaction."},
+        },
+        RPCResult{RPCResult::Type::STR, "psgt", "The base64-encoded PSGT."},
+        RPCExamples{
+            HelpExampleCli("converttopsgt", "\"0200000001...\"") +
+            HelpExampleRpc("converttopsgt", "\"0200000001...\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     vector<unsigned char> txData(ParseHex(params[0].get_str()));
     CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -8,6 +8,7 @@
 #include <main.h>
 #include <rpc/server.h>
 #include <rpc/protocol.h>
+#include <rpc/util.h>
 #include <script/sign.h>
 #include <script/standard.h>
 #include <streams.h>
@@ -67,30 +68,37 @@ static void FillHDKeypaths(const CWallet& wallet,
 
 UniValue createpsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 3)
-        throw runtime_error(
-            "createpsgt [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,...} ( ntime )\n"
-            "\nCreates an unsigned PSGT (Partially Signed Gridcoin Transaction).\n"
-            "\nArguments:\n"
-            "1. \"inputs\"           (array, required) A json array of json objects\n"
-            "     [\n"
-            "       {\n"
-            "         \"txid\":\"id\",    (string, required) The transaction id\n"
-            "         \"vout\":n          (numeric, required) The output number\n"
-            "       }\n"
-            "       ,...\n"
-            "     ]\n"
-            "2. \"outputs\"          (object, required) a json object with addresses as keys and amounts as values\n"
-            "    {\n"
-            "      \"address\": x.xxx    (numeric, required) The key is the Gridcoin address, the value is the GRC amount\n"
-            "      ,...\n"
-            "    }\n"
-            "3. ntime                (numeric, optional) Transaction timestamp (default: current adjusted time)\n"
-            "\nResult:\n"
-            "  \"psgt\"               (string) The base64-encoded unsigned PSGT\n"
-            "\nExamples:\n"
-            "createpsgt \"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"address\\\":0.01}\"\n"
-        );
+    static const RPCHelpMan help{
+        "createpsgt",
+        "Creates an unsigned Partially Signed Gridcoin Transaction (PSGT).",
+        {
+            {"inputs", RPCArg::Type::ARR, RPCArg::Optional::NO,
+                "A JSON array of inputs.",
+                {
+                    {"input", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED, "",
+                        {
+                            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id."},
+                            {"vout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The output number."},
+                        }},
+                }},
+            {"outputs", RPCArg::Type::OBJ_USER_KEYS, RPCArg::Optional::NO,
+                "A JSON object with addresses as keys and GRC amounts as values.",
+                {
+                    {"address", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED,
+                        "The GRC amount to send to this address."},
+                }},
+            {"ntime", RPCArg::Type::NUM, RPCArg::Optional::OMITTED,
+                "Transaction timestamp (default: current adjusted time)."},
+        },
+        RPCResult{RPCResult::Type::STR, "psgt", "The base64-encoded unsigned PSGT."},
+        RPCExamples{
+            HelpExampleCli("createpsgt",
+                "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"address\\\":0.01}\"") +
+            HelpExampleRpc("createpsgt",
+                "[{\"txid\":\"myid\",\"vout\":0}], {\"address\":0.01}")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, {UniValue::VARR, UniValue::VOBJ});
 

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -432,19 +432,28 @@ UniValue finalizepsgt(const UniValue& params, bool fHelp)
 
 UniValue walletprocesspsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-            "walletprocesspsgt \"psgt\" ( sighashtype )\n"
-            "\nSign a PSGT with keys from the wallet.\n"
-            "\nArguments:\n"
-            "1. \"psgt\"             (string, required) A base64 PSGT string\n"
-            "2. \"sighashtype\"      (string, optional, default=ALL) The signature hash type to sign with\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"psgt\"     : \"value\",   (string) The base64-encoded partially signed transaction\n"
-            "  \"complete\" : true|false   (boolean) If the transaction has a complete set of signatures\n"
-            "}\n"
-        );
+    static const RPCHelpMan help{
+        "walletprocesspsgt",
+        "Sign a PSGT with keys from the wallet. "
+        "Requires wallet passphrase to be set with walletpassphrase first if wallet is encrypted.",
+        {
+            {"psgt", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "A base64-encoded PSGT."},
+            {"sighashtype", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
+                "The signature hash type to sign with (default: ALL). "
+                "Valid: \"ALL\", \"ALL|ANYONECANPAY\", \"NONE\", \"NONE|ANYONECANPAY\", \"SINGLE\", \"SINGLE|ANYONECANPAY\"."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "psgt", "The base64-encoded partially-signed transaction."},
+                {RPCResult::Type::BOOL, "complete", "Whether the transaction has a complete set of signatures."},
+            }},
+        RPCExamples{
+            HelpExampleCli("walletprocesspsgt", "\"cHNidP8B...\"") +
+            HelpExampleRpc("walletprocesspsgt", "\"cHNidP8B...\", \"ALL\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     EnsureWalletIsUnlocked();
 

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -388,19 +388,26 @@ UniValue combinepsgt(const UniValue& params, bool fHelp)
 
 UniValue finalizepsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "finalizepsgt \"psgt\"\n"
-            "\nFinalize a PSGT. If all inputs have been signed, extract the\n"
-            "complete transaction and return it as hex.\n"
-            "\nArguments:\n"
-            "1. \"psgt\"             (string, required) A base64 PSGT string\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"hex\"   : \"value\",   (string) The hex-encoded raw transaction (if complete)\n"
-            "  \"complete\" : true|false (boolean) If the transaction is fully signed and ready to broadcast\n"
-            "}\n"
-        );
+    static const RPCHelpMan help{
+        "finalizepsgt",
+        "Finalize a PSGT. If all inputs have been signed, extract the complete transaction and return it as hex.",
+        {
+            {"psgt", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "A base64-encoded PSGT."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR_HEX, "hex", /*optional=*/true,
+                    "The hex-encoded raw transaction (only present when complete)."},
+                {RPCResult::Type::BOOL, "complete",
+                    "Whether the transaction is fully signed and ready to broadcast."},
+            }},
+        RPCExamples{
+            HelpExampleCli("finalizepsgt", "\"cHNidP8B...\"") +
+            HelpExampleRpc("finalizepsgt", "\"cHNidP8B...\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     PartiallySignedTransaction psgt;
     string error;

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -347,15 +347,23 @@ UniValue decodepsgt(const UniValue& params, bool fHelp)
 
 UniValue combinepsgt(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-            "combinepsgt [\"psgt\",...]\n"
-            "\nCombine multiple PSGTs for the same transaction into one.\n"
-            "\nArguments:\n"
-            "1. \"psgts\"            (array, required) A json array of base64 PSGT strings\n"
-            "\nResult:\n"
-            "  \"psgt\"              (string) The base64-encoded combined PSGT\n"
-        );
+    static const RPCHelpMan help{
+        "combinepsgt",
+        "Combine multiple PSGTs for the same transaction into one merged PSGT.",
+        {
+            {"psgts", RPCArg::Type::ARR, RPCArg::Optional::NO,
+                "A JSON array of base64-encoded PSGT strings to combine.",
+                {
+                    {"psgt", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "A base64-encoded PSGT."},
+                }},
+        },
+        RPCResult{RPCResult::Type::STR, "psgt", "The base64-encoded combined PSGT."},
+        RPCExamples{
+            HelpExampleCli("combinepsgt", "\"[\\\"cHNidP8B...\\\", \\\"cHNidP8B...\\\"]\"") +
+            HelpExampleRpc("combinepsgt", "[\"cHNidP8B...\", \"cHNidP8B...\"]")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     RPCTypeCheck(params, {UniValue::VARR});
     UniValue psgtArr = params[0].get_array();

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -72,6 +72,20 @@ UniValue addnode(const UniValue& params, bool fHelp);
 UniValue setban(const UniValue& params, bool fHelp);
 UniValue listsinceblock(const UniValue& params, bool fHelp);
 
+// Forward declarations of the wallet transaction-state debug commands under test.
+UniValue abandontransaction(const UniValue& params, bool fHelp);
+UniValue inspectwalletstate(const UniValue& params, bool fHelp);
+
+// Forward declarations of the PSGT (Partially Signed Gridcoin Transaction) commands under test.
+UniValue createpsgt(const UniValue& params, bool fHelp);
+UniValue decodepsgt(const UniValue& params, bool fHelp);
+UniValue combinepsgt(const UniValue& params, bool fHelp);
+UniValue finalizepsgt(const UniValue& params, bool fHelp);
+UniValue walletprocesspsgt(const UniValue& params, bool fHelp);
+UniValue utxoupdatepsgt(const UniValue& params, bool fHelp);
+UniValue converttopsgt(const UniValue& params, bool fHelp);
+UniValue walletcreatefundedpsgt(const UniValue& params, bool fHelp);
+
 // Tier 1c forward declarations (snapshots, registries, generic-data, dumpcontracts).
 // Same global-namespace placement requirement as the Tier 2 block above.
 UniValue superblocks(const UniValue& params, bool fHelp);
@@ -1164,6 +1178,55 @@ BOOST_AUTO_TEST_CASE(tier1_f4_wallet_mgmt_send_help_renders)
                                 std::string{"help text missing Examples marker: "} + name);
         }
     }
+}
+
+// Helper for the straggler-batch help-rendering tests below. Each converted
+// command throws runtime_error(help.ToString()) on fHelp=true before any
+// wallet/state access, so iterating fixture-free is safe.
+static void check_straggler_help_renders(
+    const std::vector<std::pair<const char*, UniValue (*)(const UniValue&, bool)>>& cases)
+{
+    const UniValue empty(UniValue::VARR);
+    for (const auto& [rpc_name, fn] : cases) {
+        BOOST_TEST_CONTEXT(rpc_name) {
+            bool threw = false;
+            try {
+                fn(empty, /*fHelp=*/true);
+            } catch (const std::runtime_error& e) {
+                threw = true;
+                const std::string what{e.what()};
+                BOOST_CHECK_MESSAGE(what.find(rpc_name) != std::string::npos,
+                    rpc_name << ": help text missing command name; got: " << what);
+                BOOST_CHECK_MESSAGE(what.find("Examples:") != std::string::npos,
+                    rpc_name << ": help text missing 'Examples:' section");
+            }
+            BOOST_CHECK_MESSAGE(threw, rpc_name << ": expected runtime_error for fHelp=true");
+        }
+    }
+}
+
+// Wallet transaction-state debug commands (introduced in #2839 issue-1157-2).
+BOOST_AUTO_TEST_CASE(wallet_tx_state_debug_help_renders)
+{
+    check_straggler_help_renders({
+        {"abandontransaction", &abandontransaction},
+        {"inspectwalletstate", &inspectwalletstate},
+    });
+}
+
+// PSGT commands (Partially Signed Gridcoin Transaction, introduced in #2877 G).
+BOOST_AUTO_TEST_CASE(psgt_commands_help_renders)
+{
+    check_straggler_help_renders({
+        {"createpsgt",             &createpsgt},
+        {"decodepsgt",             &decodepsgt},
+        {"combinepsgt",            &combinepsgt},
+        {"finalizepsgt",           &finalizepsgt},
+        {"walletprocesspsgt",      &walletprocesspsgt},
+        {"utxoupdatepsgt",         &utxoupdatepsgt},
+        {"converttopsgt",          &converttopsgt},
+        {"walletcreatefundedpsgt", &walletcreatefundedpsgt},
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2796,24 +2796,46 @@ static const char* ClassifyWalletTxState(const CWalletTx& wtx)
  */
 UniValue inspectwalletstate(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() > 1)
-        throw runtime_error(
-                "inspectwalletstate ( verbose )\n"
-                "\n"
-                "Diagnostic command to inspect transaction states in the wallet.\n"
-                "Shows how many transactions are in each state and identifies issues.\n"
-                "\nArguments:\n"
-                "1. verbose (boolean, optional, default=false) Show per-transaction details\n"
-                "   including inactive/unrecognized transaction data.\n"
-                "\nResult:\n"
-                "{\n"
-                "  \"total_transactions\": n,\n"
-                "  \"state_counts\": { \"mempool\": n, \"confirmed\": n, \"inactive\": n, \"unrecognized\": n },\n"
-                "  \"balance_calculation\": { ... },\n"
-                "  \"inactive_transactions\": [...],    (verbose only)\n"
-                "  \"unrecognized_transactions\": [...], (verbose only)\n"
-                "  \"all_transactions\": [...]           (verbose only)\n"
-                "}\n");
+    static const RPCHelpMan help{
+        "inspectwalletstate",
+        "Diagnostic command to inspect transaction states in the wallet. "
+        "Shows how many transactions are in each state and identifies issues. "
+        "Useful for debugging the transaction state machine introduced in Issue #1157.",
+        {
+            {"verbose", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+                "Show per-transaction details including inactive/unrecognized transaction data. Default: false."},
+        },
+        RPCResult{RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM, "total_transactions", "Total number of transactions in the wallet."},
+                {RPCResult::Type::OBJ, "state_counts", "",
+                    {
+                        {RPCResult::Type::NUM, "mempool",      "Transactions currently in the mempool."},
+                        {RPCResult::Type::NUM, "confirmed",    "Transactions confirmed in a block."},
+                        {RPCResult::Type::NUM, "inactive",     "Transactions in the inactive state (abandoned or conflicted)."},
+                        {RPCResult::Type::NUM, "unrecognized", "Transactions whose state could not be classified."},
+                    }},
+                {RPCResult::Type::OBJ, "balance_calculation", "Diagnostic balance breakdown.",
+                    {
+                        {RPCResult::Type::ELISION, "", "trusted/confirmed counts and sums"},
+                    }},
+                {RPCResult::Type::ARR, "inactive_transactions", /*optional=*/true,
+                    "Per-transaction inactive details (verbose only).",
+                    {{RPCResult::Type::ELISION, "", ""}}},
+                {RPCResult::Type::ARR, "unrecognized_transactions", /*optional=*/true,
+                    "Per-transaction unrecognized details (verbose only).",
+                    {{RPCResult::Type::ELISION, "", ""}}},
+                {RPCResult::Type::ARR, "all_transactions", /*optional=*/true,
+                    "Every wallet transaction with state breakdown (verbose only).",
+                    {{RPCResult::Type::ELISION, "", ""}}},
+            }},
+        RPCExamples{
+            HelpExampleCli("inspectwalletstate", "") +
+            HelpExampleCli("inspectwalletstate", "true") +
+            HelpExampleRpc("inspectwalletstate", "true")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     bool fVerbose = false;
     if (params.size() > 0)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2322,24 +2322,24 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
 
 UniValue abandontransaction(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
-        throw runtime_error(
-                "abandontransaction \"txid\"\n"
-                "\nMark in-wallet transaction <txid> as abandoned.\n"
-                "This will mark this transaction and all its in-wallet descendants as abandoned\n"
-                "which will allow their inputs to be respent. It can be used to replace \"stuck\"\n"
-                "or evicted transactions.\n"
-                "It only works on transactions which are not included in a block and are not\n"
-                "currently in the mempool.\n"
-                "It has no effect on transactions which are already conflicted or abandoned.\n"
-                "\nArguments:\n"
-                "1. \"txid\"    (string, required) The transaction id\n"
-                "\nResult:\n"
-                "null\n"
-                "\nExamples:\n"
-                "\nabandon a transaction\n"
-                "\n> gridcoinresearchd abandontransaction \"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"\n"
-        );
+    static const RPCHelpMan help{
+        "abandontransaction",
+        "Mark in-wallet transaction <txid> as abandoned. "
+        "This will mark this transaction and all its in-wallet descendants as abandoned, "
+        "which will allow their inputs to be respent. It can be used to replace stuck or evicted transactions. "
+        "It only works on transactions which are not included in a block and are not currently in the mempool. "
+        "It has no effect on transactions which are already conflicted or abandoned.",
+        {
+            {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+                "The transaction id (must be in the wallet)."},
+        },
+        RPCResult{RPCResult::Type::NONE, "", ""},
+        RPCExamples{
+            HelpExampleCli("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"") +
+            HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")},
+    };
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 


### PR DESCRIPTION
## Summary

Final batch of straight-conversion work under issue #2922: converts the 10 RPC commands that remained on the legacy `if (fHelp) throw runtime_error("text")` pattern after #2954-#2971 + #2973 landed:

- **PSGT (8 cmds)** in `src/rpc/psgt.cpp` — originally landed in #2877 G; never got the RPCHelpMan upgrade.
- **Wallet tx-state debug (2 cmds)** in `src/wallet/rpcwallet.cpp` — `abandontransaction` and `inspectwalletstate`, added in #2839 issue-1157-2 *after* the wallet F2/F3/F4 conversion PRs were branched.

After this PR + the in-flight conversion stack lands, every command in the dispatch table will use the `RPCHelpMan` declaration style. That is the precondition for the optional PR M3 (drop `bool fHelp` from `rpcfn_type` and every signature).

## Commands converted

**PSGT (8):** `createpsgt`, `decodepsgt`, `combinepsgt`, `finalizepsgt`, `walletprocesspsgt`, `utxoupdatepsgt`, `converttopsgt`, `walletcreatefundedpsgt`

**Wallet tx-state debug (2):** `abandontransaction`, `inspectwalletstate`

Notes:
- `walletprocesspsgt` and `walletcreatefundedpsgt` get the `HelpRequiringPassphrase` static-note convention applied (matches the convention from #2966/#2967/#2969 — the `+ HelpRequiringPassphrase()` runtime concatenation is replaced with literal text since `RPCHelpMan` description strings must be compile-time literals).
- `createpsgt` and `walletcreatefundedpsgt` use `RPCArg::Type::OBJ_USER_KEYS` for the address→amount map (mirrors `sendmany` from #2971).
- `inspectwalletstate` has a richly-structured result schema (state_counts sub-object + several optional verbose-only arrays); flagged here for the schema reviewer.
- `psgt.cpp` gains `#include <rpc/util.h>` (previously missing — only needed once these commands started referencing `RPCHelpMan`/`RPCArg`/`RPCResult`).

## Behavior

**No behavior changes.** Per command:
- `help <cmd>` renders structured `RPCHelpMan` output instead of free-form text.
- `params.size()` checks moved to `help.IsValidNumArgs(...)`; arity bounds preserved exactly per command.
- All function bodies below the help/arity check are untouched. No locking changes, no return-value changes.

## Tests

`src/test/rpchelpman_tests.cpp` gains two new `BOOST_AUTO_TEST_CASE`s:
- `wallet_tx_state_debug_help_renders` — iterates `abandontransaction` + `inspectwalletstate`.
- `psgt_commands_help_renders` — iterates all 8 PSGT commands.

Both share a `check_straggler_help_renders` helper that asserts each command's `fHelp=true` throw contains the command name and the `Examples:` marker.

## Test plan

- [x] CMake Quality Gate passes on the fork
- [x] CMake Compatibility Builds passes on the fork
- [x] CMake Distribution Native Builds passes on the fork
- [x] CMake Production Builds passes on the fork
- [x] Manual RPC smoke (per command) — before marking ready:
  - `gridcoinresearch help <cmd>` for each of the 10 — full help renders, examples present
  - Confirm `abandontransaction` still throws "Invalid or non-wallet transaction id" for unknown txids (unchanged)
  - Confirm `inspectwalletstate` returns the same state_counts shape vs pre-conversion
  - Confirm PSGT round-trips: `createpsgt` → `decodepsgt`, `walletprocesspsgt`, `finalizepsgt`

Refs: #2922