### PR TITLE
test: add Python functional-test framework + rpc_help.py

### DIFF
--- a/test/functional/feature_hello.py
+++ b/test/functional/feature_hello.py
@@ -5,9 +5,16 @@
 """Phase 1 smoke test for the functional-test framework.
 
 Starts gridcoinresearchd in -testnet mode with no outbound peers, calls
-getblockchaininfo over RPC, and asserts the daemon reports chain=="test".
-The point is to prove the Python framework can start the binary, authenticate,
-issue an RPC, parse the response, and shut the binary down cleanly.
+getblockchaininfo over RPC, and asserts the daemon reports it's running on
+testnet. The point is to prove the Python framework can start the binary,
+authenticate, issue an RPC, parse the response, and shut the binary down
+cleanly.
+
+Note on schema: Gridcoin's getblockchaininfo result intentionally diverges
+from Bitcoin Core's. It exposes `testnet: bool` (driven by the fTestNet
+global) instead of `chain: str`, and omits Bitcoin Core fields like
+bestblockhash and softforks. See src/rpc/blockchain.cpp:getblockchaininfo
+for the canonical schema.
 
 Phase 2A introduces CRegTestParams; after that lands, additional tests can run
 against -regtest and exercise generate/staking/contract code paths. For Phase
@@ -37,9 +44,9 @@ class FeatureHelloTest(GridcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
         info = node.getblockchaininfo()
-        assert_equal(info["chain"], "test")
-        self.log.info("feature_hello: getblockchaininfo OK (chain=%s, blocks=%d)",
-                      info["chain"], info["blocks"])
+        assert_equal(info["testnet"], True)
+        self.log.info("feature_hello: getblockchaininfo OK (testnet=%s, blocks=%d)",
+                      info["testnet"], info["blocks"])
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_hello.py
+++ b/test/functional/feature_hello.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Phase 1 smoke test for the functional-test framework.
+
+Starts gridcoinresearchd in -testnet mode with no outbound peers, calls
+getblockchaininfo over RPC, and asserts the daemon reports chain=="test".
+The point is to prove the Python framework can start the binary, authenticate,
+issue an RPC, parse the response, and shut the binary down cleanly.
+
+Phase 2A introduces CRegTestParams; after that lands, additional tests can run
+against -regtest and exercise generate/staking/contract code paths. For Phase
+1, testnet is the only available chain, so this test deliberately avoids any
+RPC that requires the node to be in sync, have peers, or have mined blocks.
+"""
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class FeatureHelloTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "test"
+        self.setup_clean_chain = True
+        # -connect=0 prevents the daemon from reaching out to testnet seed
+        # nodes; the test only needs the RPC interface to come up.
+        # -listen=0 stops the daemon from binding an inbound listener.
+        self.extra_args = [["-connect=0", "-listen=0"]]
+
+    def setup_network(self):
+        # Single node; nothing to connect or sync. Skip the base class's
+        # connect_nodes/sync_all loop.
+        self.setup_nodes()
+
+    def run_test(self):
+        node = self.nodes[0]
+        info = node.getblockchaininfo()
+        assert_equal(info["chain"], "test")
+        self.log.info("feature_hello: getblockchaininfo OK (chain=%s, blocks=%d)",
+                      info["chain"], info["blocks"])
+
+
+if __name__ == "__main__":
+    FeatureHelloTest().main()

--- a/test/functional/feature_hello.py
+++ b/test/functional/feature_hello.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2014-2026 The Gridcoin developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/mit-license.php.
 """Phase 1 smoke test for the functional-test framework.
 
 Starts gridcoinresearchd in -testnet mode with no outbound peers, calls

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -16,10 +16,20 @@ Discovery model
 Rather than maintaining a hand-curated list of converted commands (which
 goes stale the moment a new conversion PR merges), the test walks the help
 RPC's categories to enumerate every command the daemon advertises, then
-classifies each as RPCHelpMan-converted or legacy by inspecting its
-`help <name>` output. Converted commands -- the ones whose help contains
-both `Result:` and `Examples:` sections -- get the full pattern check.
-Legacy commands are logged and skipped.
+classifies each as RPCHelpMan-converted, legacy, or category-alias by
+inspecting its `help <name>` output. Converted commands -- the ones whose
+help contains both `Result:` and `Examples:` sections -- get the full
+pattern check. Legacy commands are logged and skipped.
+
+Category-alias commands cover an awkward Gridcoin-specific case: the help
+RPC routes <name> lookups through a category check first, so calling
+`help <name>` for a command whose name collides with a category name (e.g.
+`network`, which is both a real RPC and the network category) returns the
+category listing instead of the command's own help. classify_command()
+detects this (first non-blank line of the help text doesn't start with
+the command name) and short-circuits to 'category_alias', skipping the
+per-command pattern check. The command itself may still be converted --
+it just can't be validated through the help RPC alone.
 
 That means a reviewer validating a pending RPCHelpMan PR (#2958-#2975 as
 of this writing, plus future ones) needs only:
@@ -173,15 +183,40 @@ class RpcHelpTest(GridcoinTestFramework):
                     names.add(cand)
         return sorted(names)
 
-    def is_converted(self, node, name):
-        """Return (True, help_text) if `help <name>` looks RPCHelpMan-formatted."""
+    def classify_command(self, node, name):
+        """Classify `name` as 'converted', 'legacy', or 'category_alias'.
+
+        Returns a (status, help_text) tuple. Per-command pattern checks only
+        run for 'converted'. 'category_alias' covers the case where Gridcoin's
+        help RPC returns a category listing instead of the command's own help
+        because `name` collides with one of the category names -- the only
+        current collision is `network`, which is both a real RPCHelpMan-
+        converted command AND the name of the network category. Without
+        special handling, our format inspection would misclassify it as
+        legacy.
+
+        Detection heuristic: a real command's help (whether RPCHelpMan or
+        legacy throw-runtime_error) always starts with the command name in
+        the synopsis line ("name [arg1] [arg2]\\n..."). A category listing
+        starts with whichever command sorts first in that category, never
+        with `name` itself.
+        """
         try:
             text = node.help(name)
         except Exception:
-            return False, ""
+            return "legacy", ""
         if not isinstance(text, str):
-            return False, ""
-        return all(marker in text for marker in HELPMAN_MARKERS), text
+            return "legacy", ""
+        first_line = next((ln for ln in text.splitlines() if ln.strip()), "")
+        if not first_line.startswith(name):
+            # help returned a category listing, not the command's own help.
+            # Skip per-command checks for this name -- the command may still
+            # be RPCHelpMan-converted (network is), but we can't inspect its
+            # format through the help RPC alone.
+            return "category_alias", text
+        if all(marker in text for marker in HELPMAN_MARKERS):
+            return "converted", text
+        return "legacy", text
 
     # --- Per-command pattern check -----------------------------------------
 
@@ -237,26 +272,35 @@ class RpcHelpTest(GridcoinTestFramework):
 
         converted = []
         legacy = []
+        category_aliases = []
         for name in all_names:
-            ok, text = self.is_converted(node, name)
-            if ok:
+            status, text = self.classify_command(node, name)
+            if status == "converted":
                 converted.append((name, text))
-            else:
+            elif status == "legacy":
                 legacy.append(name)
+            else:  # category_alias
+                category_aliases.append(name)
 
         self.log.info(
-            "Discovered %d total RPCs: %d RPCHelpMan-converted, %d legacy",
+            "Discovered %d total RPCs: %d RPCHelpMan-converted, %d legacy, "
+            "%d category-alias (skipped: %s)",
             len(all_names), len(converted), len(legacy),
+            len(category_aliases),
+            ", ".join(category_aliases) if category_aliases else "(none)",
         )
 
         # Regression guard: fail loudly if we lost coverage on previously-
         # converted commands (catches accidental reverts to legacy or a
-        # discovery walk that broke).
+        # discovery walk that broke). category-alias commands are excluded
+        # from this count because we can't introspect their help text from
+        # the help RPC alone (see classify_command).
         assert len(converted) >= MIN_CONVERTED_COMMANDS, (
             f"Only {len(converted)} converted commands discovered; "
             f"expected at least {MIN_CONVERTED_COMMANDS}. "
             f"Either a conversion was reverted or discovery is broken.\n"
-            f"Legacy commands seen: {legacy}"
+            f"Legacy commands seen: {legacy}\n"
+            f"Category-alias commands seen: {category_aliases}"
         )
 
         # Pattern check every converted command.

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -119,6 +119,12 @@ HELPMAN_MARKERS = ("Result", "Examples")
 #     of `chain: str`, no bestblockhash, no softforks. The fields below are
 #     all unconditional pushKVs in src/rpc/blockchain.cpp:getblockchaininfo
 #     -- stable enough to assert on without flapping.
+#
+# Note: the PR description's "spot-check {chain, blocks, bestblockhash}"
+# wording was inherited from upstream Bitcoin Core's schema and predates
+# the audit above; the actual assertion set is the divergent-Gridcoin one
+# below. Update the PR description (or this comment, if the divergence is
+# narrowed later) to match before merging.
 OBJ_SHAPE_CHECKS = {
     "getblockchaininfo": {
         "blocks", "in_sync", "moneysupply", "difficulty", "testnet", "errors",

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""Exercise the help RPC and RPCHelpMan arity validation across every
+converted RPC the running daemon advertises.
+
+This test is the motivating use-case for the functional-test framework: the
+RPCHelpMan rollout tracked at #2922 changes RPC help rendering and moves
+argument-count validation from ad-hoc params.size() checks into
+`RPCHelpMan::IsValidNumArgs()`. Per-command conversion PRs need automated
+coverage so a regression is caught before merge.
+
+Discovery model
+---------------
+Rather than maintaining a hand-curated list of converted commands (which
+goes stale the moment a new conversion PR merges), the test walks the help
+RPC's categories to enumerate every command the daemon advertises, then
+classifies each as RPCHelpMan-converted or legacy by inspecting its
+`help <name>` output. Converted commands -- the ones whose help contains
+both `Result:` and `Examples:` sections -- get the full pattern check.
+Legacy commands are logged and skipped.
+
+That means a reviewer validating a pending RPCHelpMan PR (#2958-#2975 as
+of this writing, plus future ones) needs only:
+
+  git checkout <the-pr-branch>
+  cmake --build build
+  python3 test/functional/test_runner.py rpc_help.py
+
+The newly-converted commands are auto-discovered as `RPCHelpMan` and the
+pattern check runs against them. No edits to this file are required.
+
+Regression guard
+----------------
+`MIN_CONVERTED_COMMANDS` is a floor on how many converted commands the
+test expects to find. If it ever drops below that, a previously-converted
+command has reverted to legacy (or discovery itself is broken). Bump the
+floor whenever a new tier merges.
+
+What it catches per converted command
+-------------------------------------
+  - `help <cmd>` includes Result:/Examples: sections (format regression).
+  - Wrong-arity call surfaces as RPC_MISC_ERROR (-1) with help.ToString()
+    in the message (proves IsValidNumArgs is wired through the dispatcher).
+
+What it does NOT catch (deferred to richer tests once regtest lands)
+-------------------------------------------------------------------
+  - Per-field return-shape drift on OBJ-returning RPCs (only the
+    representative getblockchaininfo spot-check is asserted here).
+  - Happy-path return values for commands that require wallet/chain/peer
+    state -- those need Phase 2A regtest to set up deterministically.
+"""
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+# JSON-RPC error code emitted by the dispatcher when an RPC handler throws
+# std::runtime_error -- which is exactly what
+# `throw runtime_error(help.ToString())` does on an arity violation.
+# Defined as RPC_MISC_ERROR in src/rpc/protocol.h.
+RPC_MISC_ERROR = -1
+
+# Categories advertised by the help RPC (see src/rpc/server.cpp). The help
+# RPC accepts each of these as a single-word category filter and returns a
+# listing of commands in that category.
+HELP_CATEGORIES = ("wallet", "staking", "developer", "network", "voting")
+
+# Universal arity-violation argument list. RPCHelpMan::IsValidNumArgs
+# rejects calls where params.size() > m_args.size(); passing far more args
+# than any sensible RPC declares is the simplest way to trip it without
+# knowing each command's signature.
+ARITY_VIOLATION_ARGS = ["x"] * 100
+
+# Floor for the converted-command count. Bump when a new tier merges. If
+# discovery ever returns fewer than this, a previously-converted command
+# has reverted to legacy (regression) or the discovery walk itself broke.
+# Tier 1a (#2954, 21 commands) and Tier 1b (#2956, 17 commands) are merged
+# as of 2026-05-25 along with a handful of earlier conversions; 30 is a
+# conservative lower bound that still catches significant regressions.
+MIN_CONVERTED_COMMANDS = 30
+
+# RPCHelpMan output markers. Both must appear in `help <cmd>` for the
+# command to be considered converted -- RPCHelpMan::ToString always emits
+# both sections, while legacy throw-runtime_error help strings do not.
+HELPMAN_MARKERS = ("Result", "Examples")
+
+# Representative OBJ-returning commands worth spot-checking for top-level
+# field drift. Each entry maps command name -> set of top-level fields
+# that must be present in the result. Restricted to commands that work
+# against a fresh -testnet datadir (genesis-only, no peers, no wallet
+# activity).
+OBJ_SHAPE_CHECKS = {
+    "getblockchaininfo": {"chain", "blocks", "bestblockhash"},
+}
+
+
+class RpcHelpTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "test"
+        self.setup_clean_chain = True
+        self.extra_args = [["-connect=0", "-listen=0"]]
+
+    def setup_network(self):
+        # Single isolated node is enough for help RPCs; no P2P, no sync.
+        self.setup_nodes()
+
+    # --- System-level checks (not per command) ------------------------------
+
+    def check_help_overview(self, node):
+        """`help` with no args returns the help-on-help category overview."""
+        text = node.help()
+        assert isinstance(text, str)
+        for token in ("help", "Categories", "wallet", "staking", "network"):
+            assert token in text, f"help() output missing '{token}'\n---\n{text}"
+
+    def check_help_unknown(self, node):
+        """`help <unknown cmd>` responds sanely rather than crashing."""
+        text = node.help("zzz_definitely_not_a_real_rpc")
+        assert isinstance(text, str)
+        # CRPCTable::help returns "help: unknown command: <name>" when no
+        # command matches; assert tolerantly so wording tweaks don't break us.
+        assert "unknown command" in text.lower() or text.strip() == "", (
+            f"help(unknown) didn't report unknown-command sanely: {text!r}"
+        )
+
+    # --- Discovery ----------------------------------------------------------
+
+    def discover_commands(self, node):
+        """Enumerate every RPC the daemon advertises across all help categories."""
+        names = set()
+        for category in HELP_CATEGORIES:
+            try:
+                text = node.help(category)
+            except Exception as e:  # noqa: BLE001 - help on category should not fail
+                self.log.warning("help(%s) failed: %s", category, e)
+                continue
+            for line in text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                tokens = line.split()
+                if not tokens:
+                    continue
+                cand = tokens[0]
+                # RPC command names are lowercase identifiers (a-z, 0-9, _).
+                # Filter out section headers, blank lines, prose, etc.
+                if cand and cand[0].islower() and all(
+                    c.isalnum() or c == "_" for c in cand
+                ):
+                    names.add(cand)
+        return sorted(names)
+
+    def is_converted(self, node, name):
+        """Return (True, help_text) if `help <name>` looks RPCHelpMan-formatted."""
+        try:
+            text = node.help(name)
+        except Exception:
+            return False, ""
+        if not isinstance(text, str):
+            return False, ""
+        return all(marker in text for marker in HELPMAN_MARKERS), text
+
+    # --- Per-command pattern check -----------------------------------------
+
+    def check_helpman_pattern(self, node, name, help_text):
+        """Validate one RPCHelpMan-converted command end-to-end.
+
+        Asserts the help text carries the RPCHelpMan structure and that
+        IsValidNumArgs() rejects a clearly-too-many call.
+        """
+        # 1. Help format: command name + RPCHelpMan section markers must
+        #    all be present. Already implicit in discovery, but assert
+        #    here so the failure points at the specific command.
+        for marker in (name,) + HELPMAN_MARKERS:
+            assert marker in help_text, (
+                f"help({name!r}) missing marker '{marker}'\n---\n{help_text}"
+            )
+
+        # 2. Wrong-arity call: passing 100 dummy positional args exceeds
+        #    every realistic m_args.size(), so IsValidNumArgs rejects and
+        #    the dispatcher re-throws runtime_error as RPC_MISC_ERROR.
+        #    Pass an empty message substring -- we only assert the error
+        #    code here. (Asserting message content would require knowing
+        #    each command's description; the per-command shape spot-checks
+        #    below cover that for the representative cases.)
+        method = getattr(node, name)
+        assert_raises_rpc_error(
+            RPC_MISC_ERROR, None, method, *ARITY_VIOLATION_ARGS,
+        )
+
+    # --- Test driver -------------------------------------------------------
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("help (no args) returns the category overview")
+        self.check_help_overview(node)
+
+        self.log.info("help (unknown command) responds gracefully")
+        self.check_help_unknown(node)
+
+        self.log.info("Discovering all advertised RPCs across categories")
+        all_names = self.discover_commands(node)
+        assert all_names, "Discovery returned no commands; help categories broken?"
+
+        converted = []
+        legacy = []
+        for name in all_names:
+            ok, text = self.is_converted(node, name)
+            if ok:
+                converted.append((name, text))
+            else:
+                legacy.append(name)
+
+        self.log.info(
+            "Discovered %d total RPCs: %d RPCHelpMan-converted, %d legacy",
+            len(all_names), len(converted), len(legacy),
+        )
+
+        # Regression guard: fail loudly if we lost coverage on previously-
+        # converted commands (catches accidental reverts to legacy or a
+        # discovery walk that broke).
+        assert len(converted) >= MIN_CONVERTED_COMMANDS, (
+            f"Only {len(converted)} converted commands discovered; "
+            f"expected at least {MIN_CONVERTED_COMMANDS}. "
+            f"Either a conversion was reverted or discovery is broken.\n"
+            f"Legacy commands seen: {legacy}"
+        )
+
+        # Pattern check every converted command.
+        self.log.info("Validating RPCHelpMan pattern on %d converted commands",
+                      len(converted))
+        for name, help_text in converted:
+            self.log.info("  -> %s", name)
+            self.check_helpman_pattern(node, name, help_text)
+
+        # Spot-check representative OBJ-returning commands for field drift.
+        self.log.info("Spot-checking OBJ result shapes")
+        for name, expected_fields in OBJ_SHAPE_CHECKS.items():
+            self.log.info("  -> %s expects fields %s", name, sorted(expected_fields))
+            result = getattr(node, name)()
+            assert isinstance(result, dict), (
+                f"{name} returned non-dict: {type(result).__name__}"
+            )
+            missing = expected_fields - set(result.keys())
+            assert not missing, (
+                f"{name} result missing expected fields: {sorted(missing)}\n"
+                f"got: {sorted(result.keys())}"
+            )
+
+        # Final genesis-only sanity: prove the dispatcher answers real data,
+        # not just error paths. getblockcount and getbestblockhash are
+        # converted and don't need any chain state beyond genesis.
+        assert_equal(node.getblockcount(), 0)
+        assert_equal(node.getbestblockhash(), node.getblockhash(0))
+
+
+if __name__ == "__main__":
+    RpcHelpTest().main()

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -41,8 +41,12 @@ floor whenever a new tier merges.
 What it catches per converted command
 -------------------------------------
   - `help <cmd>` includes Result:/Examples: sections (format regression).
-  - Wrong-arity call surfaces as RPC_MISC_ERROR (-1) with help.ToString()
-    in the message (proves IsValidNumArgs is wired through the dispatcher).
+  - Wrong-arity call is rejected. Most converted commands fail IsValidNumArgs
+    and surface RPC_MISC_ERROR (-1) with help.ToString() in the message.
+    Variadic commands accept the 100 args and fall through to per-argument
+    validation, raising RPC_INVALID_PARAMETER (-8) from the function body.
+    Either constitutes "the command rejected the call", which is enough to
+    verify dispatcher + arity-or-arg-validation behavior end-to-end.
 
 What it does NOT catch (deferred to richer tests once regtest lands)
 -------------------------------------------------------------------
@@ -52,15 +56,23 @@ What it does NOT catch (deferred to richer tests once regtest lands)
     state -- those need Phase 2A regtest to set up deterministically.
 """
 
+from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import GridcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import assert_equal
 
 
-# JSON-RPC error code emitted by the dispatcher when an RPC handler throws
-# std::runtime_error -- which is exactly what
-# `throw runtime_error(help.ToString())` does on an arity violation.
-# Defined as RPC_MISC_ERROR in src/rpc/protocol.h.
+# JSON-RPC error codes (src/rpc/protocol.h).
+#
+# RPC_MISC_ERROR (-1) is emitted by the dispatcher when an RPC handler throws
+# std::runtime_error -- exactly what `throw runtime_error(help.ToString())`
+# does on an arity violation. RPC_INVALID_PARAMETER (-8) is what *some*
+# RPCs throw when they reach the function body with the wrong shape (e.g.,
+# variadic commands that accept the 100 args and then fail on individual
+# argument validation). Either constitutes "the command rejected the bad
+# call", which is the per-command invariant we want to assert.
 RPC_MISC_ERROR = -1
+RPC_INVALID_PARAMETER = -8
+RPC_ARITY_REJECTION_CODES = (RPC_MISC_ERROR, RPC_INVALID_PARAMETER)
 
 # Categories advertised by the help RPC (see src/rpc/server.cpp). The help
 # RPC accepts each of these as a single-word category filter and returns a
@@ -180,16 +192,25 @@ class RpcHelpTest(GridcoinTestFramework):
             )
 
         # 2. Wrong-arity call: passing 100 dummy positional args exceeds
-        #    every realistic m_args.size(), so IsValidNumArgs rejects and
-        #    the dispatcher re-throws runtime_error as RPC_MISC_ERROR.
-        #    Pass an empty message substring -- we only assert the error
-        #    code here. (Asserting message content would require knowing
-        #    each command's description; the per-command shape spot-checks
-        #    below cover that for the representative cases.)
+        #    every realistic m_args.size(). Most converted commands reject
+        #    this via IsValidNumArgs -> runtime_error -> RPC_MISC_ERROR (-1).
+        #    Variadic commands (e.g. changesettings) accept the args and
+        #    fail downstream with RPC_INVALID_PARAMETER (-8) on individual
+        #    arg validation. Either outcome satisfies "the command rejected
+        #    the bad call", which is the per-command invariant we want.
         method = getattr(node, name)
-        assert_raises_rpc_error(
-            RPC_MISC_ERROR, None, method, *ARITY_VIOLATION_ARGS,
-        )
+        try:
+            method(*ARITY_VIOLATION_ARGS)
+        except JSONRPCException as e:
+            assert e.error['code'] in RPC_ARITY_REJECTION_CODES, (
+                f"{name}: unexpected JSONRPC error code {e.error['code']} "
+                f"on 100-arg call (expected one of {RPC_ARITY_REJECTION_CODES})"
+            )
+        else:
+            raise AssertionError(
+                f"{name}: 100-arg call did not raise -- the command "
+                f"accepted clearly-bogus args without rejection"
+            )
 
     # --- Test driver -------------------------------------------------------
 

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -51,12 +51,15 @@ floor whenever a new tier merges.
 What it catches per converted command
 -------------------------------------
   - `help <cmd>` includes Result:/Examples: sections (format regression).
-  - Wrong-arity call is rejected. Most converted commands fail IsValidNumArgs
-    and surface RPC_MISC_ERROR (-1) with help.ToString() in the message.
-    Variadic commands accept the 100 args and fall through to per-argument
+  - Wrong-arity call is rejected. Most converted commands fail the
+    dispatcher's IsValidNumArgs pre-check, which throws help.ToString() as
+    a std::runtime_error before CRPCTable::execute's try-block and surfaces
+    as RPC_PARSE_ERROR (-32700) via the connection handler. Commands whose
+    bodies reject instead surface RPC_MISC_ERROR (-1), and variadic
+    commands accept the 100 args and fall through to per-argument
     validation, raising RPC_INVALID_PARAMETER (-8) from the function body.
-    Either constitutes "the command rejected the call", which is enough to
-    verify dispatcher + arity-or-arg-validation behavior end-to-end.
+    Any of these constitutes "the command rejected the call", which is
+    enough to verify dispatcher + arity-or-arg-validation end-to-end.
 
 What it does NOT catch (deferred to richer tests once regtest lands)
 -------------------------------------------------------------------
@@ -73,16 +76,21 @@ from test_framework.util import assert_equal
 
 # JSON-RPC error codes (src/rpc/protocol.h).
 #
-# RPC_MISC_ERROR (-1) is emitted by the dispatcher when an RPC handler throws
-# std::runtime_error -- exactly what `throw runtime_error(help.ToString())`
-# does on an arity violation. RPC_INVALID_PARAMETER (-8) is what *some*
-# RPCs throw when they reach the function body with the wrong shape (e.g.,
-# variadic commands that accept the 100 args and then fail on individual
-# argument validation). Either constitutes "the command rejected the bad
-# call", which is the per-command invariant we want to assert.
+# RPC_PARSE_ERROR (-32700) is what the dispatcher's arity pre-check surfaces
+# since #2922 PR M3: CRPCTable::execute throws help.ToString() as a
+# std::runtime_error *before* its try-block, so the throw escapes to the
+# connection handler, whose generic std::exception catch maps it to
+# RPC_PARSE_ERROR. RPC_MISC_ERROR (-1) is emitted when an RPC handler body
+# throws std::runtime_error inside execute's try-block. RPC_INVALID_PARAMETER
+# (-8) is what *some* RPCs throw when they reach the function body with the
+# wrong shape (e.g., variadic commands that accept the 100 args and then fail
+# on individual argument validation). Any of these constitutes "the command
+# rejected the bad call", which is the per-command invariant we want to
+# assert.
+RPC_PARSE_ERROR = -32700
 RPC_MISC_ERROR = -1
 RPC_INVALID_PARAMETER = -8
-RPC_ARITY_REJECTION_CODES = (RPC_MISC_ERROR, RPC_INVALID_PARAMETER)
+RPC_ARITY_REJECTION_CODES = (RPC_PARSE_ERROR, RPC_MISC_ERROR, RPC_INVALID_PARAMETER)
 
 # Categories advertised by the help RPC (see src/rpc/server.cpp). The help
 # RPC accepts each of these as a single-word category filter and returns a
@@ -94,6 +102,17 @@ HELP_CATEGORIES = ("wallet", "staking", "developer", "network", "voting")
 # than any sensible RPC declares is the simplest way to trip it without
 # knowing each command's signature.
 ARITY_VIOLATION_ARGS = ["x"] * 100
+
+# Commands marked MarkVariadic() in C++ whose bodies deliberately accept
+# and silently ignore extra trailing positional args (legacy lenience kept
+# by #2922). For these, a non-raising 100-arg call is the documented
+# behavior, not an arity-enforcement regression. Every other converted
+# command must reject the probe. If a future conversion legitimately adds
+# such lenience, list it here with a pointer to the C++ MarkVariadic()
+# site; an unexpected name in this situation is a real failure.
+VARIADIC_ACCEPTS_EXTRA_ARGS = {
+    "parselegacysb",  # src/rpc/blockchain.cpp: body uses params[0] only
+}
 
 # Floor for the converted-command count. Bump when a new tier merges. If
 # discovery ever returns fewer than this, a previously-converted command
@@ -242,12 +261,19 @@ class RpcHelpTest(GridcoinTestFramework):
 
         # 2. Wrong-arity call: passing 100 dummy positional args exceeds
         #    every realistic m_args.size(). Most converted commands reject
-        #    this via IsValidNumArgs -> runtime_error -> RPC_MISC_ERROR (-1).
-        #    Variadic commands (e.g. changesettings) accept the args and
-        #    fail downstream with RPC_INVALID_PARAMETER (-8) on individual
-        #    arg validation. Either outcome satisfies "the command rejected
-        #    the bad call", which is the per-command invariant we want.
-        method = getattr(node, name)
+        #    this via the dispatcher's IsValidNumArgs pre-check
+        #    (RPC_PARSE_ERROR); commands whose bodies reject instead raise
+        #    RPC_MISC_ERROR. Variadic commands (e.g. changesettings) accept
+        #    the args and fail downstream with RPC_INVALID_PARAMETER (-8)
+        #    on individual arg validation. Any outcome in the accepted set
+        #    satisfies "the command rejected the bad call", which is the
+        #    per-command invariant we want.
+        #
+        #    Probe through the raw RPC proxy, not TestNode attribute
+        #    access: TestNode defines Python convenience wrappers (e.g.
+        #    TestNode.generate) that shadow same-named RPCs and would
+        #    raise TypeError on the 100-arg call before any RPC is made.
+        method = getattr(node.rpc, name)
         try:
             method(*ARITY_VIOLATION_ARGS)
         except JSONRPCException as e:
@@ -256,10 +282,12 @@ class RpcHelpTest(GridcoinTestFramework):
                 f"on 100-arg call (expected one of {RPC_ARITY_REJECTION_CODES})"
             )
         else:
-            raise AssertionError(
-                f"{name}: 100-arg call did not raise -- the command "
-                f"accepted clearly-bogus args without rejection"
-            )
+            if name not in VARIADIC_ACCEPTS_EXTRA_ARGS:
+                raise AssertionError(
+                    f"{name}: 100-arg call did not raise -- the command "
+                    f"accepted clearly-bogus args without rejection"
+                )
+            self.log.info("  (variadic-lenient: accepted extra args by design)")
 
     # --- Test driver -------------------------------------------------------
 

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -103,8 +103,16 @@ HELPMAN_MARKERS = ("Result", "Examples")
 # that must be present in the result. Restricted to commands that work
 # against a fresh -testnet datadir (genesis-only, no peers, no wallet
 # activity).
+#
+# Schema notes (Gridcoin diverges from Bitcoin Core intentionally):
+#   - getblockchaininfo emits `testnet: bool` (driven by fTestNet) instead
+#     of `chain: str`, no bestblockhash, no softforks. The fields below are
+#     all unconditional pushKVs in src/rpc/blockchain.cpp:getblockchaininfo
+#     -- stable enough to assert on without flapping.
 OBJ_SHAPE_CHECKS = {
-    "getblockchaininfo": {"chain", "blocks", "bestblockhash"},
+    "getblockchaininfo": {
+        "blocks", "in_sync", "moneysupply", "difficulty", "testnet", "errors",
+    },
 }
 
 

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2011 Jeff Garzik
+#
+# Previous copyright, from python-jsonrpc/jsonrpc/proxy.py:
+#
+# Copyright (c) 2007 Jan-Klaas Kollhof
+#
+# This file is part of jsonrpc.
+#
+# jsonrpc is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this software; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+"""HTTP proxy for opening RPC connection to bitcoind.
+
+AuthServiceProxy has the following improvements over python-jsonrpc's
+ServiceProxy class:
+
+- HTTP connections persist for the life of the AuthServiceProxy object
+  (if server supports HTTP/1.1)
+- sends protocol 'version', per JSON-RPC 1.1
+- sends proper, incrementing 'id'
+- sends Basic HTTP authentication headers
+- parses all JSON numbers that look like floats as Decimal
+- uses standard Python json lib
+"""
+
+import base64
+import decimal
+from http import HTTPStatus
+import http.client
+import json
+import logging
+import os
+import socket
+import time
+import urllib.parse
+
+HTTP_TIMEOUT = 30
+USER_AGENT = "AuthServiceProxy/0.1"
+
+log = logging.getLogger("BitcoinRPC")
+
+class JSONRPCException(Exception):
+    def __init__(self, rpc_error, http_status=None):
+        try:
+            errmsg = '%(message)s (%(code)i)' % rpc_error
+        except (KeyError, TypeError):
+            errmsg = ''
+        super().__init__(errmsg)
+        self.error = rpc_error
+        self.http_status = http_status
+
+
+def EncodeDecimal(o):
+    if isinstance(o, decimal.Decimal):
+        return str(o)
+    raise TypeError(repr(o) + " is not JSON serializable")
+
+class AuthServiceProxy():
+    __id_count = 0
+
+    # ensure_ascii: escape unicode as \uXXXX, passed to json.dumps
+    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, ensure_ascii=True):
+        self.__service_url = service_url
+        self._service_name = service_name
+        self.ensure_ascii = ensure_ascii  # can be toggled on the fly by tests
+        self.__url = urllib.parse.urlparse(service_url)
+        user = None if self.__url.username is None else self.__url.username.encode('utf8')
+        passwd = None if self.__url.password is None else self.__url.password.encode('utf8')
+        authpair = user + b':' + passwd
+        self.__auth_header = b'Basic ' + base64.b64encode(authpair)
+        self.timeout = timeout
+        self._set_conn(connection)
+
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            # Python internal stuff
+            raise AttributeError
+        if self._service_name is not None:
+            name = "%s.%s" % (self._service_name, name)
+        return AuthServiceProxy(self.__service_url, name, connection=self.__conn)
+
+    def _request(self, method, path, postdata):
+        '''
+        Do a HTTP request, with retry if we get disconnected (e.g. due to a timeout).
+        This is a workaround for https://bugs.python.org/issue3566 which is fixed in Python 3.5.
+        '''
+        headers = {'Host': self.__url.hostname,
+                   'User-Agent': USER_AGENT,
+                   'Authorization': self.__auth_header,
+                   'Content-type': 'application/json'}
+        if os.name == 'nt':
+            # Windows somehow does not like to re-use connections
+            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
+            # Avoid "ConnectionAbortedError: [WinError 10053] An established connection was aborted by the software in your host machine"
+            self._set_conn()
+        try:
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
+        except (BrokenPipeError, ConnectionResetError):
+            # Python 3.5+ raises BrokenPipeError when the connection was reset
+            # ConnectionResetError happens on FreeBSD
+            self.__conn.close()
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
+        except OSError as e:
+            retry = (
+                '[WinError 10053] An established connection was aborted by the software in your host machine' in str(e))
+            # Workaround for a bug on macOS. See https://bugs.python.org/issue33450
+            retry = retry or ('[Errno 41] Protocol wrong type for socket' in str(e))
+            if retry:
+                self.__conn.close()
+                self.__conn.request(method, path, postdata, headers)
+                return self._get_response()
+            else:
+                raise
+
+    def get_request(self, *args, **argsn):
+        AuthServiceProxy.__id_count += 1
+
+        log.debug("-{}-> {} {}".format(
+            AuthServiceProxy.__id_count,
+            self._service_name,
+            json.dumps(args or argsn, default=EncodeDecimal, ensure_ascii=self.ensure_ascii),
+        ))
+        if args and argsn:
+            raise ValueError('Cannot handle both named and positional arguments')
+        return {'version': '1.1',
+                'method': self._service_name,
+                'params': args or argsn,
+                'id': AuthServiceProxy.__id_count}
+
+    def __call__(self, *args, **argsn):
+        postdata = json.dumps(self.get_request(*args, **argsn), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
+        response, status = self._request('POST', self.__url.path, postdata.encode('utf-8'))
+        if response['error'] is not None:
+            raise JSONRPCException(response['error'], status)
+        elif 'result' not in response:
+            raise JSONRPCException({
+                'code': -343, 'message': 'missing JSON-RPC result'}, status)
+        elif status != HTTPStatus.OK:
+            raise JSONRPCException({
+                'code': -342, 'message': 'non-200 HTTP status code but no JSON-RPC error'}, status)
+        else:
+            return response['result']
+
+    def batch(self, rpc_call_list):
+        postdata = json.dumps(list(rpc_call_list), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
+        log.debug("--> " + postdata)
+        response, status = self._request('POST', self.__url.path, postdata.encode('utf-8'))
+        if status != HTTPStatus.OK:
+            raise JSONRPCException({
+                'code': -342, 'message': 'non-200 HTTP status code but no JSON-RPC error'}, status)
+        return response
+
+    def _get_response(self):
+        req_start_time = time.time()
+        try:
+            http_response = self.__conn.getresponse()
+        except socket.timeout:
+            raise JSONRPCException({
+                'code': -344,
+                'message': '%r RPC took longer than %f seconds. Consider '
+                           'using larger timeout for calls that take '
+                           'longer to return.' % (self._service_name,
+                                                  self.__conn.timeout)})
+        if http_response is None:
+            raise JSONRPCException({
+                'code': -342, 'message': 'missing HTTP response from server'})
+
+        content_type = http_response.getheader('Content-Type')
+        if content_type != 'application/json':
+            raise JSONRPCException(
+                {'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)},
+                http_response.status)
+
+        responsedata = http_response.read().decode('utf8')
+        response = json.loads(responsedata, parse_float=decimal.Decimal)
+        elapsed = time.time() - req_start_time
+        if "error" in response and response["error"] is None:
+            log.debug("<-%s- [%.6f] %s" % (response["id"], elapsed, json.dumps(response["result"], default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
+        else:
+            log.debug("<-- [%.6f] %s" % (elapsed, responsedata))
+        return response, http_response.status
+
+    def __truediv__(self, relative_uri):
+        return AuthServiceProxy("{}/{}".format(self.__service_url, relative_uri), self._service_name, connection=self.__conn)
+
+    def _set_conn(self, connection=None):
+        port = 80 if self.__url.port is None else self.__url.port
+        if connection:
+            self.__conn = connection
+            self.timeout = connection.timeout
+        elif self.__url.scheme == 'https':
+            self.__conn = http.client.HTTPSConnection(self.__url.hostname, port, timeout=self.timeout)
+        else:
+            self.__conn = http.client.HTTPConnection(self.__url.hostname, port, timeout=self.timeout)

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -218,3 +218,16 @@ class AuthServiceProxy():
             self.__conn = http.client.HTTPSConnection(self.__url.hostname, port, timeout=self.timeout)
         else:
             self.__conn = http.client.HTTPConnection(self.__url.hostname, port, timeout=self.timeout)
+
+    def _close_conn(self):
+        """Close the underlying persistent HTTP connection.
+
+        Gridcoin's boost::asio JSON-RPC server blocks shutdown -- its
+        StopRPCThreads() does rpc_io_service->stop() then
+        rpc_worker_group->join_all(), and a worker bound to a still-open
+        keep-alive client socket never returns, so the daemon hangs after
+        "Stop RPC IO service" and never reaches "Gridcoin exited". After
+        issuing `stop` the framework must close this socket (curl exits
+        cleanly for exactly this reason). Best-effort; safe to call twice."""
+        if self.__conn is not None:
+            self.__conn.close()

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -127,16 +127,30 @@ class AuthServiceProxy():
     def get_request(self, *args, **argsn):
         AuthServiceProxy.__id_count += 1
 
+        if args and argsn:
+            raise ValueError('Cannot handle both named and positional arguments')
+        # Gridcoin's RPC parser strictly requires `params` to be a JSON array
+        # (or null) -- see src/rpc/server.cpp JSONRequest::parse, which throws
+        # "Params must be an array" otherwise. The Bitcoin Core v0.21.2
+        # expression `args or argsn` returns `{}` when BOTH are empty (Python
+        # short-circuits on the first non-empty operand, and an empty tuple
+        # `or` an empty dict yields the empty dict), which serializes to a
+        # JSON object and is rejected. Coerce the empty case to a real list,
+        # and convert the positional case to a list (was a tuple).
+        if args:
+            params = list(args)
+        elif argsn:
+            params = argsn
+        else:
+            params = []
         log.debug("-{}-> {} {}".format(
             AuthServiceProxy.__id_count,
             self._service_name,
-            json.dumps(args or argsn, default=EncodeDecimal, ensure_ascii=self.ensure_ascii),
+            json.dumps(params, default=EncodeDecimal, ensure_ascii=self.ensure_ascii),
         ))
-        if args and argsn:
-            raise ValueError('Cannot handle both named and positional arguments')
         return {'version': '1.1',
                 'method': self._service_name,
-                'params': args or argsn,
+                'params': params,
                 'id': AuthServiceProxy.__id_count}
 
     def __call__(self, *args, **argsn):

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this software; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-"""HTTP proxy for opening RPC connection to bitcoind.
+"""HTTP proxy for opening RPC connection to gridcoinresearchd.
 
 AuthServiceProxy has the following improvements over python-jsonrpc's
 ServiceProxy class:
@@ -47,7 +47,7 @@ import urllib.parse
 HTTP_TIMEOUT = 30
 USER_AGENT = "AuthServiceProxy/0.1"
 
-log = logging.getLogger("BitcoinRPC")
+log = logging.getLogger("GridcoinRPC")
 
 class JSONRPCException(Exception):
     def __init__(self, rpc_error, http_status=None):

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Utilities for doing coverage analysis on the RPC interface.
+
+Provides a way to track which RPC commands are exercised during
+testing.
+"""
+
+import os
+
+
+REFERENCE_FILENAME = 'rpc_interface.txt'
+
+
+class AuthServiceProxyWrapper():
+    """
+    An object that wraps AuthServiceProxy to record specific RPC calls.
+
+    """
+    def __init__(self, auth_service_proxy_instance, coverage_logfile=None):
+        """
+        Kwargs:
+            auth_service_proxy_instance (AuthServiceProxy): the instance
+                being wrapped.
+            coverage_logfile (str): if specified, write each service_name
+                out to a file when called.
+
+        """
+        self.auth_service_proxy_instance = auth_service_proxy_instance
+        self.coverage_logfile = coverage_logfile
+
+    def __getattr__(self, name):
+        return_val = getattr(self.auth_service_proxy_instance, name)
+        if not isinstance(return_val, type(self.auth_service_proxy_instance)):
+            # If proxy getattr returned an unwrapped value, do the same here.
+            return return_val
+        return AuthServiceProxyWrapper(return_val, self.coverage_logfile)
+
+    def __call__(self, *args, **kwargs):
+        """
+        Delegates to AuthServiceProxy, then writes the particular RPC method
+        called to a file.
+
+        """
+        return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
+        self._log_call()
+        return return_val
+
+    def _log_call(self):
+        rpc_method = self.auth_service_proxy_instance._service_name
+
+        if self.coverage_logfile:
+            with open(self.coverage_logfile, 'a+', encoding='utf8') as f:
+                f.write("%s\n" % rpc_method)
+
+    def __truediv__(self, relative_uri):
+        return AuthServiceProxyWrapper(self.auth_service_proxy_instance / relative_uri,
+                                       self.coverage_logfile)
+
+    def get_request(self, *args, **kwargs):
+        self._log_call()
+        return self.auth_service_proxy_instance.get_request(*args, **kwargs)
+
+def get_filename(dirname, n_node):
+    """
+    Get a filename unique to the test process ID and node.
+
+    This file will contain a list of RPC commands covered.
+    """
+    pid = str(os.getpid())
+    return os.path.join(
+        dirname, "coverage.pid%s.node%s.txt" % (pid, str(n_node)))
+
+
+def write_all_rpc_commands(dirname, node):
+    """
+    Write out a list of all RPC functions available in `bitcoin-cli` for
+    coverage comparison. This will only happen once per coverage
+    directory.
+
+    Args:
+        dirname (str): temporary test dir
+        node (AuthServiceProxy): client
+
+    Returns:
+        bool. if the RPC interface file was written.
+
+    """
+    filename = os.path.join(dirname, REFERENCE_FILENAME)
+
+    if os.path.isfile(filename):
+        return False
+
+    help_output = node.help().split('\n')
+    commands = set()
+
+    for line in help_output:
+        line = line.strip()
+
+        # Ignore blanks and headers
+        if line and not line.startswith('='):
+            commands.add("%s\n" % line.split()[0])
+
+    with open(filename, 'w', encoding='utf8') as f:
+        f.writelines(list(commands))
+
+    return True

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2015-2018 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/mit-license.php.
 """Utilities for doing coverage analysis on the RPC interface.
 
 Provides a way to track which RPC commands are exercised during

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -76,7 +76,7 @@ def get_filename(dirname, n_node):
 
 def write_all_rpc_commands(dirname, node):
     """
-    Write out a list of all RPC functions available in `bitcoin-cli` for
+    Write out a list of all RPC functions available in `gridcoin-cli` for
     coverage comparison. This will only happen once per coverage
     directory.
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -223,12 +223,12 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         self.config = config
         fname_gridcoind = os.path.join(
             config["environment"]["BUILDDIR"],
-            "src",
+            "bin",
             "gridcoinresearchd" + config["environment"]["EXEEXT"],
         )
         fname_gridcoincli = os.path.join(
             config["environment"]["BUILDDIR"],
-            "src",
+            "bin",
             "gridcoin-cli" + config["environment"]["EXEEXT"],
         )
         self.options.gridcoind = os.getenv("GRIDCOIND", default=fname_gridcoind)
@@ -600,13 +600,15 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         def connect_nodes_helper(from_connection, node_num):
             ip_port = "127.0.0.1:" + str(p2p_port(node_num))
             from_connection.addnode(ip_port, "onetry")
-            # poll until version handshake complete to avoid race conditions
-            # with transaction relaying
-            # See comments in net_processing:
-            # * Must have a version message before anything else
-            # * Must have a verack message before anything else
-            wait_until_helper(lambda: all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
-            wait_until_helper(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()))
+            # Poll until the version handshake has produced a peer with a
+            # negotiated protocol version. Gridcoin's getpeerinfo does not
+            # expose Bitcoin Core's per-message byte counters (bytesrecv_per_msg),
+            # so we cannot key on the verack byte count; requiring a non-empty
+            # peer list with version != 0 avoids the vacuous-true on an empty
+            # list and is sufficient before sync_blocks (which polls with its
+            # own timeout).
+            wait_until_helper(lambda: len(from_connection.getpeerinfo()) > 0
+                              and all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
 
         connect_nodes_helper(self.nodes[a], b)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2019 The Bitcoin Core developers
 # Copyright (c) 2014-2026 The Gridcoin developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/mit-license.php.
 """Base class for RPC testing."""
 
 import configparser
@@ -21,19 +21,6 @@ import time
 
 from .authproxy import JSONRPCException
 from . import coverage
-
-
-class NetworkThread:
-    """Placeholder until Phase 3 ports test_framework/p2p.py. No-op start()/close()
-    so tests that don't use P2P (the entire Phase 1 + Phase 2 set) work unchanged."""
-
-    def start(self):
-        pass
-
-    def close(self, timeout=10):
-        pass
-
-
 from .test_node import TestNode
 from .util import (
     MAX_NODES,
@@ -45,6 +32,17 @@ from .util import (
     p2p_port,
     wait_until_helper,
 )
+
+
+class NetworkThread:
+    """Placeholder until Phase 3 ports test_framework/p2p.py. No-op start()/close()
+    so tests that don't use P2P (the entire Phase 1 + Phase 2 set) work unchanged."""
+
+    def start(self):
+        pass
+
+    def close(self, timeout=10):
+        pass
 
 
 class TestStatus(Enum):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -26,6 +26,7 @@ from .util import (
     MAX_NODES,
     PortSeed,
     assert_equal,
+    chain_subdir,
     check_json_precision,
     get_datadir_path,
     initialize_datadir,
@@ -284,7 +285,18 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
             pdb.set_trace()
 
         self.log.debug('Closing down network thread')
-        self.network_thread.close()
+        # Guard against early-setup failures: setup() initializes
+        # network_thread on the success path only. If setup raised before
+        # the assignment (e.g. log-init failure), the attribute is still
+        # None and the unconditional .close() would AttributeError, masking
+        # the original failure.
+        if self.network_thread is not None:
+            try:
+                self.network_thread.close()
+            except Exception:
+                # Best-effort: log the cleanup failure but don't mask the
+                # original error that led us here.
+                self.log.exception("network_thread.close() failed during shutdown")
         if not self.options.noshutdown:
             self.log.info("Stopping nodes")
             if self.nodes:
@@ -319,7 +331,14 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         else:
             self.log.error("Test failed. Test logging available at %s/test_framework.log", self.options.tmpdir)
             self.log.error("")
-            self.log.error("Hint: Call {} '{}' to consolidate all logs".format(os.path.normpath(os.path.dirname(os.path.realpath(__file__)) + "/../combine_logs.py"), self.options.tmpdir))
+            combine_logs_path = os.path.normpath(os.path.dirname(os.path.realpath(__file__)) + "/../combine_logs.py")
+            if os.path.isfile(combine_logs_path):
+                self.log.error("Hint: Call {} '{}' to consolidate all logs".format(combine_logs_path, self.options.tmpdir))
+            else:
+                # combine_logs.py hasn't been ported to this PR. Point users
+                # at the per-node log directory until Phase 3 lands the
+                # script.
+                self.log.error("Hint: Per-node logs are under '{}/node*/<chain>/debug.log' (combine_logs.py not present in this build).".format(self.options.tmpdir))
             self.log.error("")
             self.log.error("If this failure happened unexpectedly or intermittently, please file a bug and provide a link or upload of the combined log.")
             self.log.error(self.config['environment']['PACKAGE_BUGREPORT'])
@@ -537,14 +556,37 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         self.nodes[i].wait_until_stopped()
 
     def stop_nodes(self, wait=0):
-        """Stop multiple gridcoinresearchd test nodes"""
+        """Stop multiple gridcoinresearchd test nodes.
+
+        A failure on one node's stop RPC or wait_until_stopped() must not
+        abort the loop — the remaining nodes would be left running and
+        their resources would leak. Per-node try/except guards each call;
+        the first error is recorded and re-raised after the sweep so
+        callers still see a failure indication.
+        """
+        first_exc = None
         for node in self.nodes:
-            # Issue RPC to stop nodes
-            node.stop_node(wait=wait)
+            try:
+                # Issue RPC to stop nodes
+                node.stop_node(wait=wait)
+            except Exception as e:
+                self.log.exception("stop_node raised for node %s: %s",
+                                   getattr(node, 'index', '?'), e)
+                if first_exc is None:
+                    first_exc = e
 
         for node in self.nodes:
-            # Wait for nodes to stop
-            node.wait_until_stopped()
+            try:
+                # Wait for nodes to stop
+                node.wait_until_stopped()
+            except Exception as e:
+                self.log.exception("wait_until_stopped raised for node %s: %s",
+                                   getattr(node, 'index', '?'), e)
+                if first_exc is None:
+                    first_exc = e
+
+        if first_exc is not None:
+            raise first_exc
 
     def restart_node(self, i, extra_args=None):
         """Stop and start a test node"""
@@ -753,7 +795,7 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
             self.nodes = []
 
             def cache_path(*paths):
-                return os.path.join(cache_node_dir, self.chain, *paths)
+                return os.path.join(cache_node_dir, chain_subdir(self.chain), *paths)
 
             os.rmdir(cache_path('wallets'))  # Remove empty wallets dir
             for entry in os.listdir(cache_path()):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1,0 +1,824 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Base class for RPC testing."""
+
+import configparser
+from enum import Enum
+import argparse
+import logging
+import os
+import pdb
+import random
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+from .authproxy import JSONRPCException
+from . import coverage
+
+
+class NetworkThread:
+    """Placeholder until Phase 3 ports test_framework/p2p.py. No-op start()/close()
+    so tests that don't use P2P (the entire Phase 1 + Phase 2 set) work unchanged."""
+
+    def start(self):
+        pass
+
+    def close(self, timeout=10):
+        pass
+
+
+from .test_node import TestNode
+from .util import (
+    MAX_NODES,
+    PortSeed,
+    assert_equal,
+    check_json_precision,
+    get_datadir_path,
+    initialize_datadir,
+    p2p_port,
+    wait_until_helper,
+)
+
+
+class TestStatus(Enum):
+    PASSED = 1
+    FAILED = 2
+    SKIPPED = 3
+
+TEST_EXIT_PASSED = 0
+TEST_EXIT_FAILED = 1
+TEST_EXIT_SKIPPED = 77
+
+TMPDIR_PREFIX = "gridcoin_func_test_"
+
+
+class SkipTest(Exception):
+    """This exception is raised to skip a test"""
+
+    def __init__(self, message):
+        self.message = message
+
+
+class GridcoinTestMetaClass(type):
+    """Metaclass for GridcoinTestFramework.
+
+    Ensures that any attempt to register a subclass of `GridcoinTestFramework`
+    adheres to a standard whereby the subclass overrides `set_test_params` and
+    `run_test` but DOES NOT override either `__init__` or `main`. If any of
+    those standards are violated, a ``TypeError`` is raised."""
+
+    def __new__(cls, clsname, bases, dct):
+        if not clsname == 'GridcoinTestFramework':
+            if not ('run_test' in dct and 'set_test_params' in dct):
+                raise TypeError("GridcoinTestFramework subclasses must override "
+                                "'run_test' and 'set_test_params'")
+            if '__init__' in dct or 'main' in dct:
+                raise TypeError("GridcoinTestFramework subclasses may not override "
+                                "'__init__' or 'main'")
+
+        return super().__new__(cls, clsname, bases, dct)
+
+
+class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
+    """Base class for a Gridcoin test script.
+
+    Individual Gridcoin test scripts should subclass this class and override the set_test_params() and run_test() methods.
+
+    Individual tests can also override the following methods to customize the test setup:
+
+    - add_options()
+    - setup_chain()
+    - setup_network()
+    - setup_nodes()
+
+    The __init__() and main() methods should not be overridden.
+
+    This class also contains various public and private helper methods."""
+
+    chain = None  # type: str
+    setup_clean_chain = None  # type: bool
+
+    def __init__(self):
+        """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
+        # Phase 1 default: "test" (gridcoinresearchd's NetworkIDString for -testnet).
+        # Phase 2A will let subclasses switch to "regtest" once CRegTestParams lands.
+        self.chain = 'test'
+        self.setup_clean_chain = False
+        self.nodes = []
+        self.network_thread = None
+        self.rpc_timeout = 60  # Wait for up to 60 seconds for the RPC server to respond
+        self.supports_cli = True
+        self.bind_to_localhost_only = True
+        self.parse_args()
+        # Gridcoin uses BDB wallets (no descriptors). Default wallet name is empty
+        # (selects the daemon's default wallet.dat).
+        self.default_wallet_name = ""
+        self.wallet_data_filename = "wallet.dat"
+        # Optional list of wallet names that can be set in set_test_params to
+        # create and import keys to. If unset, default is len(nodes) *
+        # [default_wallet_name]. If wallet names are None, wallet creation is
+        # skipped. If list is truncated, wallet creation is skipped and keys
+        # are not imported.
+        self.wallet_names = None
+        self.set_test_params()
+        assert self.wallet_names is None or len(self.wallet_names) <= self.num_nodes
+        if self.options.timeout_factor == 0 :
+            self.options.timeout_factor = 99999
+        self.rpc_timeout = int(self.rpc_timeout * self.options.timeout_factor) # optionally, increase timeout by a factor
+
+    def main(self):
+        """Main function. This should not be overridden by the subclass test scripts."""
+
+        assert hasattr(self, "num_nodes"), "Test must set self.num_nodes in set_test_params()"
+
+        try:
+            self.setup()
+            self.run_test()
+        except JSONRPCException:
+            self.log.exception("JSONRPC error")
+            self.success = TestStatus.FAILED
+        except SkipTest as e:
+            self.log.warning("Test Skipped: %s" % e.message)
+            self.success = TestStatus.SKIPPED
+        except AssertionError:
+            self.log.exception("Assertion failed")
+            self.success = TestStatus.FAILED
+        except KeyError:
+            self.log.exception("Key error")
+            self.success = TestStatus.FAILED
+        except subprocess.CalledProcessError as e:
+            self.log.exception("Called Process failed with '{}'".format(e.output))
+            self.success = TestStatus.FAILED
+        except Exception:
+            self.log.exception("Unexpected exception caught during testing")
+            self.success = TestStatus.FAILED
+        except KeyboardInterrupt:
+            self.log.warning("Exiting after keyboard interrupt")
+            self.success = TestStatus.FAILED
+        finally:
+            exit_code = self.shutdown()
+            sys.exit(exit_code)
+
+    def parse_args(self):
+        previous_releases_path = os.getenv("PREVIOUS_RELEASES_DIR") or os.getcwd() + "/releases"
+        parser = argparse.ArgumentParser(usage="%(prog)s [options]")
+        parser.add_argument("--nocleanup", dest="nocleanup", default=False, action="store_true",
+                            help="Leave gridcoinresearchds and test.* datadir on exit or error")
+        parser.add_argument("--noshutdown", dest="noshutdown", default=False, action="store_true",
+                            help="Don't stop gridcoinresearchds after the test execution")
+        parser.add_argument("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../cache"),
+                            help="Directory for caching pregenerated datadirs (default: %(default)s)")
+        parser.add_argument("--tmpdir", dest="tmpdir", help="Root directory for datadirs")
+        parser.add_argument("-l", "--loglevel", dest="loglevel", default="INFO",
+                            help="log events at this level and higher to the console. Can be set to DEBUG, INFO, WARNING, ERROR or CRITICAL. Passing --loglevel DEBUG will output all logs to console. Note that logs at all levels are always written to the test_framework.log file in the temporary test directory.")
+        parser.add_argument("--tracerpc", dest="trace_rpc", default=False, action="store_true",
+                            help="Print out all RPC calls as they are made")
+        parser.add_argument("--portseed", dest="port_seed", default=os.getpid(), type=int,
+                            help="The seed to use for assigning port numbers (default: current process id)")
+        parser.add_argument("--previous-releases", dest="prev_releases", action="store_true",
+                            default=os.path.isdir(previous_releases_path) and bool(os.listdir(previous_releases_path)),
+                            help="Force test of previous releases (default: %(default)s)")
+        parser.add_argument("--coveragedir", dest="coveragedir",
+                            help="Write tested RPC commands into this directory")
+        parser.add_argument("--configfile", dest="configfile",
+                            default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../config.ini"),
+                            help="Location of the test framework config file (default: %(default)s)")
+        parser.add_argument("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
+                            help="Attach a python debugger if test fails")
+        parser.add_argument("--usecli", dest="usecli", default=False, action="store_true",
+                            help="use gridcoin-cli instead of RPC for all commands")
+        parser.add_argument("--perf", dest="perf", default=False, action="store_true",
+                            help="profile running nodes with perf for the duration of the test")
+        parser.add_argument("--valgrind", dest="valgrind", default=False, action="store_true",
+                            help="run nodes under the valgrind memory error detector: expect at least a ~10x slowdown, valgrind 3.14 or later required")
+        parser.add_argument("--randomseed", type=int,
+                            help="set a random seed for deterministically reproducing a previous test run")
+        parser.add_argument('--timeout-factor', dest="timeout_factor", type=float, default=1.0, help='adjust test timeouts by a factor. Setting it to 0 disables all timeouts')
+
+        # Gridcoin: no --descriptors / --legacy-wallet flags. Gridcoin's wallet is
+        # always BDB-backed. The Phase 1 framework drops Bitcoin Core's
+        # descriptor/legacy wallet selector entirely.
+
+        self.add_options(parser)
+        self.options = parser.parse_args()
+        self.options.previous_releases_path = previous_releases_path
+
+    def setup(self):
+        """Call this method to start up the test framework object with options set."""
+
+        PortSeed.n = self.options.port_seed
+
+        check_json_precision()
+
+        self.options.cachedir = os.path.abspath(self.options.cachedir)
+
+        config = configparser.ConfigParser()
+        config.read_file(open(self.options.configfile))
+        self.config = config
+        fname_gridcoind = os.path.join(
+            config["environment"]["BUILDDIR"],
+            "src",
+            "gridcoinresearchd" + config["environment"]["EXEEXT"],
+        )
+        fname_gridcoincli = os.path.join(
+            config["environment"]["BUILDDIR"],
+            "src",
+            "gridcoin-cli" + config["environment"]["EXEEXT"],
+        )
+        self.options.gridcoind = os.getenv("GRIDCOIND", default=fname_gridcoind)
+        self.options.gridcoincli = os.getenv("GRIDCOINCLI", default=fname_gridcoincli)
+
+        os.environ['PATH'] = os.pathsep.join([
+            os.path.join(config['environment']['BUILDDIR'], 'src'),
+            os.path.join(config['environment']['BUILDDIR'], 'src', 'qt'), os.environ['PATH']
+        ])
+
+        # Set up temp directory and start logging
+        if self.options.tmpdir:
+            self.options.tmpdir = os.path.abspath(self.options.tmpdir)
+            os.makedirs(self.options.tmpdir, exist_ok=False)
+        else:
+            self.options.tmpdir = tempfile.mkdtemp(prefix=TMPDIR_PREFIX)
+        self._start_logging()
+
+        # Seed the PRNG. Note that test runs are reproducible if and only if
+        # a single thread accesses the PRNG. For more information, see
+        # https://docs.python.org/3/library/random.html#notes-on-reproducibility.
+        # The network thread shouldn't access random. If we need to change the
+        # network thread to access randomness, it should instantiate its own
+        # random.Random object.
+        seed = self.options.randomseed
+
+        if seed is None:
+            seed = random.randrange(sys.maxsize)
+        else:
+            self.log.debug("User supplied random seed {}".format(seed))
+
+        random.seed(seed)
+        self.log.debug("PRNG seed is: {}".format(seed))
+
+        self.log.debug('Setting up network thread')
+        self.network_thread = NetworkThread()
+        self.network_thread.start()
+
+        if self.options.usecli:
+            if not self.supports_cli:
+                raise SkipTest("--usecli specified but test does not support using CLI")
+            self.skip_if_no_cli()
+        self.skip_test_if_missing_module()
+        self.setup_chain()
+        self.setup_network()
+
+        self.success = TestStatus.PASSED
+
+    def shutdown(self):
+        """Call this method to shut down the test framework object."""
+
+        if self.success == TestStatus.FAILED and self.options.pdbonfailure:
+            print("Testcase failed. Attaching python debugger. Enter ? for help")
+            pdb.set_trace()
+
+        self.log.debug('Closing down network thread')
+        self.network_thread.close()
+        if not self.options.noshutdown:
+            self.log.info("Stopping nodes")
+            if self.nodes:
+                self.stop_nodes()
+        else:
+            for node in self.nodes:
+                node.cleanup_on_exit = False
+            self.log.info("Note: gridcoinresearchds were not stopped and may still be running")
+
+        should_clean_up = (
+            not self.options.nocleanup and
+            not self.options.noshutdown and
+            self.success != TestStatus.FAILED and
+            not self.options.perf
+        )
+        if should_clean_up:
+            self.log.info("Cleaning up {} on exit".format(self.options.tmpdir))
+            cleanup_tree_on_exit = True
+        elif self.options.perf:
+            self.log.warning("Not cleaning up dir {} due to perf data".format(self.options.tmpdir))
+            cleanup_tree_on_exit = False
+        else:
+            self.log.warning("Not cleaning up dir {}".format(self.options.tmpdir))
+            cleanup_tree_on_exit = False
+
+        if self.success == TestStatus.PASSED:
+            self.log.info("Tests successful")
+            exit_code = TEST_EXIT_PASSED
+        elif self.success == TestStatus.SKIPPED:
+            self.log.info("Test skipped")
+            exit_code = TEST_EXIT_SKIPPED
+        else:
+            self.log.error("Test failed. Test logging available at %s/test_framework.log", self.options.tmpdir)
+            self.log.error("")
+            self.log.error("Hint: Call {} '{}' to consolidate all logs".format(os.path.normpath(os.path.dirname(os.path.realpath(__file__)) + "/../combine_logs.py"), self.options.tmpdir))
+            self.log.error("")
+            self.log.error("If this failure happened unexpectedly or intermittently, please file a bug and provide a link or upload of the combined log.")
+            self.log.error(self.config['environment']['PACKAGE_BUGREPORT'])
+            self.log.error("")
+            exit_code = TEST_EXIT_FAILED
+        # Logging.shutdown will not remove stream- and filehandlers, so we must
+        # do it explicitly. Handlers are removed so the next test run can apply
+        # different log handler settings.
+        # See: https://docs.python.org/3/library/logging.html#logging.shutdown
+        for h in list(self.log.handlers):
+            h.flush()
+            h.close()
+            self.log.removeHandler(h)
+        rpc_logger = logging.getLogger("GridcoinRPC")
+        for h in list(rpc_logger.handlers):
+            h.flush()
+            rpc_logger.removeHandler(h)
+        if cleanup_tree_on_exit:
+            shutil.rmtree(self.options.tmpdir)
+
+        self.nodes.clear()
+        return exit_code
+
+    # Methods to override in subclass test scripts.
+    def set_test_params(self):
+        """Tests must this method to change default values for number of nodes, topology, etc"""
+        raise NotImplementedError
+
+    def add_options(self, parser):
+        """Override this method to add command-line options to the test"""
+        pass
+
+    def skip_test_if_missing_module(self):
+        """Override this method to skip a test if a module is not compiled"""
+        pass
+
+    def setup_chain(self):
+        """Override this method to customize blockchain setup"""
+        self.log.info("Initializing test directory " + self.options.tmpdir)
+        if self.setup_clean_chain:
+            self._initialize_chain_clean()
+        else:
+            self._initialize_chain()
+
+    def setup_network(self):
+        """Override this method to customize test network topology"""
+        self.setup_nodes()
+
+        # Connect the nodes as a "chain".  This allows us
+        # to split the network between nodes 1 and 2 to get
+        # two halves that can work on competing chains.
+        #
+        # Topology looks like this:
+        # node0 <-- node1 <-- node2 <-- node3
+        #
+        # If all nodes are in IBD (clean chain from genesis), node0 is assumed to be the source of blocks (miner). To
+        # ensure block propagation, all nodes will establish outgoing connections toward node0.
+        # See fPreferredDownload in net_processing.
+        #
+        # If further outbound connections are needed, they can be added at the beginning of the test with e.g.
+        # self.connect_nodes(1, 2)
+        for i in range(self.num_nodes - 1):
+            self.connect_nodes(i + 1, i)
+        self.sync_all()
+
+    def setup_nodes(self):
+        """Override this method to customize test node setup.
+
+        Gridcoin Phase 1 note: the Bitcoin Core 199-block-cache assertion and
+        per-node coinbase import only make sense under regtest. Until Phase 2A
+        introduces CRegTestParams, this method skips both of those steps when
+        the chain is not 'regtest'."""
+        extra_args = [[]] * self.num_nodes
+        if hasattr(self, "extra_args"):
+            extra_args = self.extra_args
+        self.add_nodes(self.num_nodes, extra_args)
+        self.start_nodes()
+        if self.chain == 'regtest' and self.is_wallet_compiled():
+            self.import_deterministic_coinbase_privkeys()
+        if self.chain == 'regtest' and not self.setup_clean_chain:
+            for n in self.nodes:
+                assert_equal(n.getblockchaininfo()["blocks"], 199)
+            # To ensure that all nodes are out of IBD, the most recent block
+            # must have a timestamp not too old (see IsInitialBlockDownload()).
+            self.log.debug('Generate a block with current time')
+            block_hash = self.nodes[0].generate(1)[0]
+            block = self.nodes[0].getblock(blockhash=block_hash, verbosity=0)
+            for n in self.nodes:
+                n.submitblock(block)
+                chain_info = n.getblockchaininfo()
+                assert_equal(chain_info["blocks"], 200)
+                assert_equal(chain_info["initialblockdownload"], False)
+
+    def import_deterministic_coinbase_privkeys(self):
+        for i in range(self.num_nodes):
+            self.init_wallet(i)
+
+    def init_wallet(self, i):
+        wallet_name = self.default_wallet_name if self.wallet_names is None else self.wallet_names[i] if i < len(self.wallet_names) else False
+        if wallet_name is not False:
+            n = self.nodes[i]
+            if wallet_name is not None:
+                n.createwallet(wallet_name=wallet_name, load_on_startup=True)
+            n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
+
+    def run_test(self):
+        """Tests must override this method to define test logic"""
+        raise NotImplementedError
+
+    # Public helper methods. These can be accessed by the subclass test scripts.
+
+    def add_nodes(self, num_nodes: int, extra_args=None, *, rpchost=None, binary=None, binary_cli=None, versions=None):
+        """Instantiate TestNode objects.
+
+        Should only be called once after the nodes have been specified in
+        set_test_params()."""
+        def get_bin_from_version(version, bin_name, bin_default):
+            if not version:
+                return bin_default
+            return os.path.join(
+                self.options.previous_releases_path,
+                re.sub(
+                    r'\.0$',
+                    '',  # remove trailing .0 for point releases
+                    'v{}.{}.{}.{}'.format(
+                        (version % 100000000) // 1000000,
+                        (version % 1000000) // 10000,
+                        (version % 10000) // 100,
+                        (version % 100) // 1,
+                    ),
+                ),
+                'bin',
+                bin_name,
+            )
+
+        if self.bind_to_localhost_only:
+            extra_confs = [["bind=127.0.0.1"]] * num_nodes
+        else:
+            extra_confs = [[]] * num_nodes
+        if extra_args is None:
+            extra_args = [[]] * num_nodes
+        if versions is None:
+            versions = [None] * num_nodes
+        if binary is None:
+            binary = [get_bin_from_version(v, 'gridcoinresearchd', self.options.gridcoind) for v in versions]
+        if binary_cli is None:
+            binary_cli = [get_bin_from_version(v, 'gridcoin-cli', self.options.gridcoincli) for v in versions]
+        assert_equal(len(extra_confs), num_nodes)
+        assert_equal(len(extra_args), num_nodes)
+        assert_equal(len(versions), num_nodes)
+        assert_equal(len(binary), num_nodes)
+        assert_equal(len(binary_cli), num_nodes)
+        for i in range(num_nodes):
+            test_node_i = TestNode(
+                i,
+                get_datadir_path(self.options.tmpdir, i),
+                chain=self.chain,
+                rpchost=rpchost,
+                timewait=self.rpc_timeout,
+                timeout_factor=self.options.timeout_factor,
+                gridcoind=binary[i],
+                gridcoin_cli=binary_cli[i],
+                version=versions[i],
+                coverage_dir=self.options.coveragedir,
+                cwd=self.options.tmpdir,
+                extra_conf=extra_confs[i],
+                extra_args=extra_args[i],
+                use_cli=self.options.usecli,
+                start_perf=self.options.perf,
+                use_valgrind=self.options.valgrind,
+            )
+            self.nodes.append(test_node_i)
+            if not test_node_i.version_is_at_least(170000):
+                # adjust conf for pre 17
+                conf_file = test_node_i.gridcoinconf
+                with open(conf_file, 'r', encoding='utf8') as conf:
+                    conf_data = conf.read()
+                with open(conf_file, 'w', encoding='utf8') as conf:
+                    conf.write(conf_data.replace('[regtest]', ''))
+
+    def start_node(self, i, *args, **kwargs):
+        """Start a gridcoinresearchd"""
+
+        node = self.nodes[i]
+
+        node.start(*args, **kwargs)
+        node.wait_for_rpc_connection()
+
+        if self.options.coveragedir is not None:
+            coverage.write_all_rpc_commands(self.options.coveragedir, node.rpc)
+
+    def start_nodes(self, extra_args=None, *args, **kwargs):
+        """Start multiple gridcoinresearchds"""
+
+        if extra_args is None:
+            extra_args = [None] * self.num_nodes
+        assert_equal(len(extra_args), self.num_nodes)
+        try:
+            for i, node in enumerate(self.nodes):
+                node.start(extra_args[i], *args, **kwargs)
+            for node in self.nodes:
+                node.wait_for_rpc_connection()
+        except:
+            # If one node failed to start, stop the others
+            self.stop_nodes()
+            raise
+
+        if self.options.coveragedir is not None:
+            for node in self.nodes:
+                coverage.write_all_rpc_commands(self.options.coveragedir, node.rpc)
+
+    def stop_node(self, i, expected_stderr='', wait=0):
+        """Stop a gridcoinresearchd test node"""
+        self.nodes[i].stop_node(expected_stderr, wait=wait)
+        self.nodes[i].wait_until_stopped()
+
+    def stop_nodes(self, wait=0):
+        """Stop multiple gridcoinresearchd test nodes"""
+        for node in self.nodes:
+            # Issue RPC to stop nodes
+            node.stop_node(wait=wait)
+
+        for node in self.nodes:
+            # Wait for nodes to stop
+            node.wait_until_stopped()
+
+    def restart_node(self, i, extra_args=None):
+        """Stop and start a test node"""
+        self.stop_node(i)
+        self.start_node(i, extra_args)
+
+    def wait_for_node_exit(self, i, timeout):
+        self.nodes[i].process.wait(timeout)
+
+    def connect_nodes(self, a, b):
+        def connect_nodes_helper(from_connection, node_num):
+            ip_port = "127.0.0.1:" + str(p2p_port(node_num))
+            from_connection.addnode(ip_port, "onetry")
+            # poll until version handshake complete to avoid race conditions
+            # with transaction relaying
+            # See comments in net_processing:
+            # * Must have a version message before anything else
+            # * Must have a verack message before anything else
+            wait_until_helper(lambda: all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
+            wait_until_helper(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()))
+
+        connect_nodes_helper(self.nodes[a], b)
+
+    def disconnect_nodes(self, a, b):
+        def disconnect_nodes_helper(from_connection, node_num):
+            def get_peer_ids():
+                result = []
+                for peer in from_connection.getpeerinfo():
+                    if "testnode{}".format(node_num) in peer['subver']:
+                        result.append(peer['id'])
+                return result
+
+            peer_ids = get_peer_ids()
+            if not peer_ids:
+                self.log.warning("disconnect_nodes: {} and {} were not connected".format(
+                    from_connection.index,
+                    node_num,
+                ))
+                return
+            for peer_id in peer_ids:
+                try:
+                    from_connection.disconnectnode(nodeid=peer_id)
+                except JSONRPCException as e:
+                    # If this node is disconnected between calculating the peer id
+                    # and issuing the disconnect, don't worry about it.
+                    # This avoids a race condition if we're mass-disconnecting peers.
+                    if e.error['code'] != -29:  # RPC_CLIENT_NODE_NOT_CONNECTED
+                        raise
+
+            # wait to disconnect
+            wait_until_helper(lambda: not get_peer_ids(), timeout=5)
+
+        disconnect_nodes_helper(self.nodes[a], b)
+
+    def split_network(self):
+        """
+        Split the network of four nodes into nodes 0/1 and 2/3.
+        """
+        self.disconnect_nodes(1, 2)
+        self.sync_all(self.nodes[:2])
+        self.sync_all(self.nodes[2:])
+
+    def join_network(self):
+        """
+        Join the (previously split) network halves together.
+        """
+        self.connect_nodes(1, 2)
+        self.sync_all()
+
+    def sync_blocks(self, nodes=None, wait=1, timeout=60):
+        """
+        Wait until everybody has the same tip.
+        sync_blocks needs to be called with an rpc_connections set that has least
+        one node already synced to the latest, stable tip, otherwise there's a
+        chance it might return before all nodes are stably synced.
+        """
+        rpc_connections = nodes or self.nodes
+        timeout = int(timeout * self.options.timeout_factor)
+        stop_time = time.time() + timeout
+        while time.time() <= stop_time:
+            best_hash = [x.getbestblockhash() for x in rpc_connections]
+            if best_hash.count(best_hash[0]) == len(rpc_connections):
+                return
+            # Check that each peer has at least one connection
+            assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
+            time.sleep(wait)
+        raise AssertionError("Block sync timed out after {}s:{}".format(
+            timeout,
+            "".join("\n  {!r}".format(b) for b in best_hash),
+        ))
+
+    def sync_mempools(self, nodes=None, wait=1, timeout=60, flush_scheduler=True):
+        """
+        Wait until everybody has the same transactions in their memory
+        pools
+        """
+        rpc_connections = nodes or self.nodes
+        timeout = int(timeout * self.options.timeout_factor)
+        stop_time = time.time() + timeout
+        while time.time() <= stop_time:
+            pool = [set(r.getrawmempool()) for r in rpc_connections]
+            if pool.count(pool[0]) == len(rpc_connections):
+                if flush_scheduler:
+                    for r in rpc_connections:
+                        r.syncwithvalidationinterfacequeue()
+                return
+            # Check that each peer has at least one connection
+            assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
+            time.sleep(wait)
+        raise AssertionError("Mempool sync timed out after {}s:{}".format(
+            timeout,
+            "".join("\n  {!r}".format(m) for m in pool),
+        ))
+
+    def sync_all(self, nodes=None):
+        self.sync_blocks(nodes)
+        self.sync_mempools(nodes)
+
+    def wait_until(self, test_function, timeout=60):
+        return wait_until_helper(test_function, timeout=timeout, timeout_factor=self.options.timeout_factor)
+
+    # Private helper methods. These should not be accessed by the subclass test scripts.
+
+    def _start_logging(self):
+        # Add logger and logging handlers
+        self.log = logging.getLogger('TestFramework')
+        self.log.setLevel(logging.DEBUG)
+        # Create file handler to log all messages
+        fh = logging.FileHandler(self.options.tmpdir + '/test_framework.log', encoding='utf-8')
+        fh.setLevel(logging.DEBUG)
+        # Create console handler to log messages to stderr. By default this logs only error messages, but can be configured with --loglevel.
+        ch = logging.StreamHandler(sys.stdout)
+        # User can provide log level as a number or string (eg DEBUG). loglevel was caught as a string, so try to convert it to an int
+        ll = int(self.options.loglevel) if self.options.loglevel.isdigit() else self.options.loglevel.upper()
+        ch.setLevel(ll)
+        # Format logs the same as gridcoinresearchd's debug.log with microprecision (so log files can be concatenated and sorted)
+        formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)03d000Z %(name)s (%(levelname)s): %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
+        formatter.converter = time.gmtime
+        fh.setFormatter(formatter)
+        ch.setFormatter(formatter)
+        # add the handlers to the logger
+        self.log.addHandler(fh)
+        self.log.addHandler(ch)
+
+        if self.options.trace_rpc:
+            rpc_logger = logging.getLogger("GridcoinRPC")
+            rpc_logger.setLevel(logging.DEBUG)
+            rpc_handler = logging.StreamHandler(sys.stdout)
+            rpc_handler.setLevel(logging.DEBUG)
+            rpc_logger.addHandler(rpc_handler)
+
+    def _initialize_chain(self):
+        """Initialize a pre-mined blockchain for use by the test.
+
+        Create a cache of a 199-block-long chain
+        Afterward, create num_nodes copies from the cache."""
+
+        CACHE_NODE_ID = 0  # Use node 0 to create the cache for all other nodes
+        cache_node_dir = get_datadir_path(self.options.cachedir, CACHE_NODE_ID)
+        assert self.num_nodes <= MAX_NODES
+
+        if not os.path.isdir(cache_node_dir):
+            self.log.debug("Creating cache directory {}".format(cache_node_dir))
+
+            initialize_datadir(self.options.cachedir, CACHE_NODE_ID, self.chain)
+            self.nodes.append(
+                TestNode(
+                    CACHE_NODE_ID,
+                    cache_node_dir,
+                    chain=self.chain,
+                    extra_conf=["bind=127.0.0.1"],
+                    extra_args=['-disablewallet'],
+                    rpchost=None,
+                    timewait=self.rpc_timeout,
+                    timeout_factor=self.options.timeout_factor,
+                    gridcoind=self.options.gridcoind,
+                    gridcoin_cli=self.options.gridcoincli,
+                    coverage_dir=None,
+                    cwd=self.options.tmpdir,
+                ))
+            self.start_node(CACHE_NODE_ID)
+            cache_node = self.nodes[CACHE_NODE_ID]
+
+            # Wait for RPC connections to be ready
+            cache_node.wait_for_rpc_connection()
+
+            # Set a time in the past, so that blocks don't end up in the future
+            cache_node.setmocktime(cache_node.getblockheader(cache_node.getbestblockhash())['time'])
+
+            # Create a 199-block-long chain; each of the 4 first nodes
+            # gets 25 mature blocks and 25 immature.
+            # The 4th node gets only 24 immature blocks so that the very last
+            # block in the cache does not age too much (have an old tip age).
+            # This is needed so that we are out of IBD when the test starts,
+            # see the tip age check in IsInitialBlockDownload().
+            for i in range(8):
+                cache_node.generatetoaddress(
+                    nblocks=25 if i != 7 else 24,
+                    address=TestNode.PRIV_KEYS[i % 4].address,
+                )
+
+            assert_equal(cache_node.getblockchaininfo()["blocks"], 199)
+
+            # Shut it down, and clean up cache directories:
+            self.stop_nodes()
+            self.nodes = []
+
+            def cache_path(*paths):
+                return os.path.join(cache_node_dir, self.chain, *paths)
+
+            os.rmdir(cache_path('wallets'))  # Remove empty wallets dir
+            for entry in os.listdir(cache_path()):
+                if entry not in ['chainstate', 'blocks']:  # Only keep chainstate and blocks folder
+                    os.remove(cache_path(entry))
+
+        for i in range(self.num_nodes):
+            self.log.debug("Copy cache directory {} to node {}".format(cache_node_dir, i))
+            to_dir = get_datadir_path(self.options.tmpdir, i)
+            shutil.copytree(cache_node_dir, to_dir)
+            initialize_datadir(self.options.tmpdir, i, self.chain)  # Overwrite port/rpcport in gridcoinresearch.conf
+
+    def _initialize_chain_clean(self):
+        """Initialize empty blockchain for use by the test.
+
+        Create an empty blockchain and num_nodes wallets.
+        Useful if a test case wants complete control over initialization."""
+        for i in range(self.num_nodes):
+            initialize_datadir(self.options.tmpdir, i, self.chain)
+
+    def skip_if_no_py3_zmq(self):
+        """Attempt to import the zmq package and skip the test if the import fails."""
+        try:
+            import zmq  # noqa
+        except ImportError:
+            raise SkipTest("python3-zmq module not available.")
+
+    def skip_if_no_gridcoinresearchd_zmq(self):
+        """Skip the running test if gridcoinresearchd has not been compiled with zmq support."""
+        if not self.is_zmq_compiled():
+            raise SkipTest("gridcoinresearchd has not been built with zmq enabled.")
+
+    def skip_if_no_wallet(self):
+        """Skip the running test if wallet has not been compiled."""
+        if not self.is_wallet_compiled():
+            raise SkipTest("wallet has not been compiled.")
+
+    def skip_if_no_cli(self):
+        """Skip the running test if gridcoin-cli has not been compiled."""
+        if not self.is_cli_compiled():
+            raise SkipTest("gridcoin-cli has not been compiled.")
+
+    def skip_if_no_previous_releases(self):
+        """Skip the running test if previous releases are not available."""
+        if not self.has_previous_releases():
+            raise SkipTest("previous releases not available or disabled")
+
+    def has_previous_releases(self):
+        """Checks whether previous releases are present and enabled."""
+        if not os.path.isdir(self.options.previous_releases_path):
+            if self.options.prev_releases:
+                raise AssertionError("Force test of previous releases but releases missing: {}".format(
+                    self.options.previous_releases_path))
+        return self.options.prev_releases
+
+    def is_cli_compiled(self):
+        """Checks whether gridcoin-cli was compiled."""
+        return self.config["components"].getboolean("ENABLE_CLI")
+
+    def is_wallet_compiled(self):
+        """Checks whether the wallet module was compiled."""
+        return self.config["components"].getboolean("ENABLE_WALLET")
+
+    def is_zmq_compiled(self):
+        """Checks whether the zmq module was compiled."""
+        return self.config["components"].getboolean("ENABLE_ZMQ")

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017-2020 The Bitcoin Core developers
 # Copyright (c) 2014-2026 The Gridcoin developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/mit-license.php.
 """Class for gridcoinresearchd node under test"""
 
 import contextlib

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -337,6 +337,16 @@ class TestNode():
                 self.log.exception("Unable to stop node cleanly: %s", e)
                 stop_exc = e
 
+            # Close the persistent RPC connection. Gridcoin's boost::asio RPC
+            # server blocks shutdown (StopRPCThreads -> join_all) on an open
+            # keep-alive client socket, so without this the daemon never exits
+            # and wait_until_stopped() times out. See AuthServiceProxy._close_conn.
+            if self.rpc is not None:
+                try:
+                    self.rpc._close_conn()
+                except Exception:
+                    pass
+
             # If there are any running perf processes, stop them. Per-process
             # try/except so one perf failure doesn't strand the rest.
             for profile_name in tuple(self.perf_subprocesses.keys()):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2020 The Bitcoin Core developers
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Class for gridcoinresearchd node under test"""
+
+import contextlib
+import decimal
+import errno
+from enum import Enum
+import http.client
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import time
+import urllib.parse
+import collections
+import shlex
+import sys
+
+from .authproxy import JSONRPCException
+# Phase 3 will restore `from .messages import MY_SUBVERSION` once messages.py
+# lands. Until then, the constant is defined locally below.
+from .util import (
+    MAX_NODES,
+    append_config,
+    delete_cookie_file,
+    get_auth_cookie,
+    get_rpc_proxy,
+    rpc_url,
+    wait_until_helper,
+    p2p_port,
+    EncodeDecimal,
+)
+
+MY_SUBVERSION = "/python-mininode-tester:0.0.3/"
+
+GRIDCOIND_PROC_WAIT_TIMEOUT = 60
+
+
+class FailedToStartError(Exception):
+    """Raised when a node fails to start correctly."""
+
+
+class ErrorMatch(Enum):
+    FULL_TEXT = 1
+    FULL_REGEX = 2
+    PARTIAL_REGEX = 3
+
+
+class TestNode():
+    """A class for representing a gridcoinresearchd node under test.
+
+    This class contains:
+
+    - state about the node (whether it's running, etc)
+    - a Python subprocess.Popen object representing the running process
+    - an RPC connection to the node
+    - one or more P2P connections to the node
+
+
+    To make things easier for the test writer, any unrecognised messages will
+    be dispatched to the RPC connection."""
+
+    def __init__(self, i, datadir, *, chain, rpchost, timewait, timeout_factor, gridcoind, gridcoin_cli, coverage_dir, cwd, extra_conf=None, extra_args=None, use_cli=False, start_perf=False, use_valgrind=False, version=None):
+        """
+        Kwargs:
+            start_perf (bool): If True, begin profiling the node with `perf` as soon as
+                the node starts.
+        """
+
+        self.index = i
+        self.datadir = datadir
+        self.gridcoinconf = os.path.join(self.datadir, "gridcoinresearch.conf")
+        self.stdout_dir = os.path.join(self.datadir, "stdout")
+        self.stderr_dir = os.path.join(self.datadir, "stderr")
+        self.chain = chain
+        self.rpchost = rpchost
+        self.rpc_timeout = timewait
+        self.binary = gridcoind
+        self.coverage_dir = coverage_dir
+        self.cwd = cwd
+        if extra_conf is not None:
+            append_config(datadir, extra_conf)
+        # Most callers will just need to add extra args to the standard list below.
+        # For those callers that need more flexibility, they can just set the args property directly.
+        # Note that common args are set in the config file (see initialize_datadir)
+        self.extra_args = extra_args
+        self.version = version
+        # Configuration for logging is set as command-line args rather than in the gridcoinresearch.conf file.
+        # This means that starting a gridcoinresearchd using the temp dir to debug a failed test won't
+        # spam debug.log.
+        self.args = [
+            self.binary,
+            "-datadir=" + self.datadir,
+            "-logtimemicros",
+            "-debug",
+            "-debugexclude=libevent",
+            "-debugexclude=leveldb",
+            "-uacomment=testnode%d" % i,
+        ]
+        if use_valgrind:
+            default_suppressions_file = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "..", "..", "..", "contrib", "valgrind.supp")
+            suppressions_file = os.getenv("VALGRIND_SUPPRESSIONS_FILE",
+                                          default_suppressions_file)
+            self.args = ["valgrind", "--suppressions={}".format(suppressions_file),
+                         "--gen-suppressions=all", "--exit-on-first-error=yes",
+                         "--error-exitcode=1", "--quiet"] + self.args
+
+        if self.version_is_at_least(190000):
+            self.args.append("-logthreadnames")
+
+        self.cli = TestNodeCLI(gridcoin_cli, self.datadir)
+        self.use_cli = use_cli
+        self.start_perf = start_perf
+
+        self.running = False
+        self.process = None
+        self.rpc_connected = False
+        self.rpc = None
+        self.url = None
+        self.log = logging.getLogger('TestFramework.node%d' % i)
+        self.cleanup_on_exit = True # Whether to kill the node when this object goes away
+        # Cache perf subprocesses here by their data output filename.
+        self.perf_subprocesses = {}
+
+        self.p2ps = []
+        self.timeout_factor = timeout_factor
+
+    AddressKeyPair = collections.namedtuple('AddressKeyPair', ['address', 'key'])
+    PRIV_KEYS = [
+            # address , privkey
+            AddressKeyPair('mjTkW3DjgyZck4KbiRusZsqTgaYTxdSz6z', 'cVpF924EspNh8KjYsfhgY96mmxvT6DgdWiTYMtMjuM74hJaU5psW'),
+            AddressKeyPair('msX6jQXvxiNhx3Q62PKeLPrhrqZQdSimTg', 'cUxsWyKyZ9MAQTaAhUQWJmBbSvHMwSmuv59KgxQV7oZQU3PXN3KE'),
+            AddressKeyPair('mnonCMyH9TmAsSj3M59DsbH8H63U3RKoFP', 'cTrh7dkEAeJd6b3MRX9bZK8eRmNqVCMH3LSUkE3dSFDyzjU38QxK'),
+            AddressKeyPair('mqJupas8Dt2uestQDvV2NH3RU8uZh2dqQR', 'cVuKKa7gbehEQvVq717hYcbE9Dqmq7KEBKqWgWrYBa2CKKrhtRim'),
+            AddressKeyPair('msYac7Rvd5ywm6pEmkjyxhbCDKqWsVeYws', 'cQDCBuKcjanpXDpCqacNSjYfxeQj8G6CAtH1Dsk3cXyqLNC4RPuh'),
+            AddressKeyPair('n2rnuUnwLgXqf9kk2kjvVm8R5BZK1yxQBi', 'cQakmfPSLSqKHyMFGwAqKHgWUiofJCagVGhiB4KCainaeCSxeyYq'),
+            AddressKeyPair('myzuPxRwsf3vvGzEuzPfK9Nf2RfwauwYe6', 'cQMpDLJwA8DBe9NcQbdoSb1BhmFxVjWD5gRyrLZCtpuF9Zi3a9RK'),
+            AddressKeyPair('mumwTaMtbxEPUswmLBBN3vM9oGRtGBrys8', 'cSXmRKXVcoouhNNVpcNKFfxsTsToY5pvB9DVsFksF1ENunTzRKsy'),
+            AddressKeyPair('mpV7aGShMkJCZgbW7F6iZgrvuPHjZjH9qg', 'cSoXt6tm3pqy43UMabY6eUTmR3eSUYFtB2iNQDGgb3VUnRsQys2k'),
+            AddressKeyPair('mq4fBNdckGtvY2mijd9am7DRsbRB4KjUkf', 'cN55daf1HotwBAgAKWVgDcoppmUNDtQSfb7XLutTLeAgVc3u8hik'),
+            AddressKeyPair('mpFAHDjX7KregM3rVotdXzQmkbwtbQEnZ6', 'cT7qK7g1wkYEMvKowd2ZrX1E5f6JQ7TM246UfqbCiyF7kZhorpX3'),
+            AddressKeyPair('mzRe8QZMfGi58KyWCse2exxEFry2sfF2Y7', 'cPiRWE8KMjTRxH1MWkPerhfoHFn5iHPWVK5aPqjW8NxmdwenFinJ'),
+    ]
+
+    def get_deterministic_priv_key(self):
+        """Return a deterministic priv key in base58, that only depends on the node's index"""
+        assert len(self.PRIV_KEYS) == MAX_NODES
+        return self.PRIV_KEYS[self.index]
+
+    def _node_msg(self, msg: str) -> str:
+        """Return a modified msg that identifies this node by its index as a debugging aid."""
+        return "[node %d] %s" % (self.index, msg)
+
+    def _raise_assertion_error(self, msg: str):
+        """Raise an AssertionError with msg modified to identify this node."""
+        raise AssertionError(self._node_msg(msg))
+
+    def __del__(self):
+        # Ensure that we don't leave any gridcoinresearchd processes lying around after
+        # the test ends
+        if self.process and self.cleanup_on_exit:
+            # Should only happen on test failure
+            # Avoid using logger, as that may have already been shutdown when
+            # this destructor is called.
+            print(self._node_msg("Cleaning up leftover process"))
+            self.process.kill()
+
+    def __getattr__(self, name):
+        """Dispatches any unrecognised messages to the RPC connection or a CLI instance."""
+        if self.use_cli:
+            return getattr(self.cli, name)
+        else:
+            assert self.rpc_connected and self.rpc is not None, self._node_msg("Error: no RPC connection")
+            return getattr(self.rpc, name)
+
+    def start(self, extra_args=None, *, cwd=None, stdout=None, stderr=None, **kwargs):
+        """Start the node."""
+        if extra_args is None:
+            extra_args = self.extra_args
+
+        # Add a new stdout and stderr file each time gridcoinresearchd is started
+        if stderr is None:
+            stderr = tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False)
+        if stdout is None:
+            stdout = tempfile.NamedTemporaryFile(dir=self.stdout_dir, delete=False)
+        self.stderr = stderr
+        self.stdout = stdout
+
+        if cwd is None:
+            cwd = self.cwd
+
+        # Delete any existing cookie file -- if such a file exists (eg due to
+        # unclean shutdown), it will get overwritten anyway by gridcoinresearchd, and
+        # potentially interfere with our attempt to authenticate
+        delete_cookie_file(self.datadir, self.chain)
+
+        # add environment variable LIBC_FATAL_STDERR_=1 so that libc errors are written to stderr and not the terminal
+        subp_env = dict(os.environ, LIBC_FATAL_STDERR_="1")
+
+        self.process = subprocess.Popen(self.args + extra_args, env=subp_env, stdout=stdout, stderr=stderr, cwd=cwd, **kwargs)
+
+        self.running = True
+        self.log.debug("gridcoinresearchd started, waiting for RPC to come up")
+
+        if self.start_perf:
+            self._start_perf()
+
+    def wait_for_rpc_connection(self):
+        """Sets up an RPC connection to the gridcoinresearchd process. Returns False if unable to connect."""
+        # Poll at a rate of four times per second
+        poll_per_s = 4
+        for _ in range(poll_per_s * self.rpc_timeout):
+            if self.process.poll() is not None:
+                raise FailedToStartError(self._node_msg(
+                    'gridcoinresearchd exited with status {} during initialization'.format(self.process.returncode)))
+            try:
+                rpc = get_rpc_proxy(
+                    rpc_url(self.datadir, self.index, self.chain, self.rpchost),
+                    self.index,
+                    timeout=self.rpc_timeout // 2,  # Shorter timeout to allow for one retry in case of ETIMEDOUT
+                    coveragedir=self.coverage_dir,
+                )
+                rpc.getblockcount()
+                # If the call to getblockcount() succeeds then the RPC connection is up
+                if self.version_is_at_least(190000):
+                    # getmempoolinfo.loaded is available since commit
+                    # bb8ae2c (version 0.19.0)
+                    wait_until_helper(lambda: rpc.getmempoolinfo()['loaded'], timeout_factor=self.timeout_factor)
+                    # Wait for the node to finish reindex, block import, and
+                    # loading the mempool. Usually importing happens fast or
+                    # even "immediate" when the node is started. However, there
+                    # is no guarantee and sometimes ThreadImport might finish
+                    # later. This is going to cause intermittent test failures,
+                    # because generally the tests assume the node is fully
+                    # ready after being started.
+                    #
+                    # For example, the node will reject block messages from p2p
+                    # when it is still importing with the error "Unexpected
+                    # block message received"
+                    #
+                    # The wait is done here to make tests as robust as possible
+                    # and prevent racy tests and intermittent failures as much
+                    # as possible. Some tests might not need this, but the
+                    # overhead is trivial, and the added guarantees are worth
+                    # the minimal performance cost.
+                self.log.debug("RPC successfully started")
+                if self.use_cli:
+                    return
+                self.rpc = rpc
+                self.rpc_connected = True
+                self.url = self.rpc.url
+                return
+            except JSONRPCException as e:  # Initialization phase
+                # -28 RPC in warmup
+                # -342 Service unavailable, RPC server started but is shutting down due to error
+                if e.error['code'] != -28 and e.error['code'] != -342:
+                    raise  # unknown JSON RPC exception
+            except ConnectionResetError:
+                # This might happen when the RPC server is in warmup, but shut down before the call to getblockcount
+                # succeeds. Try again to properly raise the FailedToStartError
+                pass
+            except OSError as e:
+                if e.errno == errno.ETIMEDOUT:
+                    pass  # Treat identical to ConnectionResetError
+                elif e.errno == errno.ECONNREFUSED:
+                    pass  # Port not yet open?
+                else:
+                    raise  # unknown OS error
+            except ValueError as e:  # cookie file not found and no rpcuser or rpcpassword; gridcoinresearchd is still starting
+                if "No RPC credentials" not in str(e):
+                    raise
+            time.sleep(1.0 / poll_per_s)
+        self._raise_assertion_error("Unable to connect to gridcoinresearchd after {}s".format(self.rpc_timeout))
+
+    def wait_for_cookie_credentials(self):
+        """Ensures auth cookie credentials can be read, e.g. for testing CLI with -rpcwait before RPC connection is up."""
+        self.log.debug("Waiting for cookie credentials")
+        # Poll at a rate of four times per second.
+        poll_per_s = 4
+        for _ in range(poll_per_s * self.rpc_timeout):
+            try:
+                get_auth_cookie(self.datadir, self.chain)
+                self.log.debug("Cookie credentials successfully retrieved")
+                return
+            except ValueError:  # cookie file not found and no rpcuser or rpcpassword; gridcoinresearchd is still starting
+                pass            # so we continue polling until RPC credentials are retrieved
+            time.sleep(1.0 / poll_per_s)
+        self._raise_assertion_error("Unable to retrieve cookie credentials after {}s".format(self.rpc_timeout))
+
+    def generate(self, nblocks, maxtries=1000000):
+        self.log.debug("TestNode.generate() dispatches `generate` call to `generatetoaddress`")
+        return self.generatetoaddress(nblocks=nblocks, address=self.get_deterministic_priv_key().address, maxtries=maxtries)
+
+    def get_wallet_rpc(self, wallet_name):
+        if self.use_cli:
+            return self.cli("-rpcwallet={}".format(wallet_name))
+        else:
+            assert self.rpc_connected and self.rpc, self._node_msg("RPC not connected")
+            wallet_path = "wallet/{}".format(urllib.parse.quote(wallet_name))
+            return self.rpc / wallet_path
+
+    def version_is_at_least(self, ver):
+        return self.version is None or self.version >= ver
+
+    def stop_node(self, expected_stderr='', wait=0):
+        """Stop the node."""
+        if not self.running:
+            return
+        self.log.debug("Stopping node")
+        try:
+            # Do not use wait argument when testing older nodes, e.g. in feature_backwards_compatibility.py
+            if self.version_is_at_least(180000):
+                self.stop(wait=wait)
+            else:
+                self.stop()
+        except http.client.CannotSendRequest:
+            self.log.exception("Unable to stop node.")
+
+        # If there are any running perf processes, stop them.
+        for profile_name in tuple(self.perf_subprocesses.keys()):
+            self._stop_perf(profile_name)
+
+        # Check that stderr is as expected
+        self.stderr.seek(0)
+        stderr = self.stderr.read().decode('utf-8').strip()
+        if stderr != expected_stderr:
+            raise AssertionError("Unexpected stderr {} != {}".format(stderr, expected_stderr))
+
+        self.stdout.close()
+        self.stderr.close()
+
+        del self.p2ps[:]
+
+    def is_node_stopped(self):
+        """Checks whether the node has stopped.
+
+        Returns True if the node has stopped. False otherwise.
+        This method is responsible for freeing resources (self.process)."""
+        if not self.running:
+            return True
+        return_code = self.process.poll()
+        if return_code is None:
+            return False
+
+        # process has stopped. Assert that it didn't return an error code.
+        assert return_code == 0, self._node_msg(
+            "Node returned non-zero exit code (%d) when stopping" % return_code)
+        self.running = False
+        self.process = None
+        self.rpc_connected = False
+        self.rpc = None
+        self.log.debug("Node stopped")
+        return True
+
+    def wait_until_stopped(self, timeout=GRIDCOIND_PROC_WAIT_TIMEOUT):
+        wait_until_helper(self.is_node_stopped, timeout=timeout, timeout_factor=self.timeout_factor)
+
+    @contextlib.contextmanager
+    def assert_debug_log(self, expected_msgs, unexpected_msgs=None, timeout=2):
+        if unexpected_msgs is None:
+            unexpected_msgs = []
+        time_end = time.time() + timeout * self.timeout_factor
+        debug_log = os.path.join(self.datadir, self.chain, 'debug.log')
+        with open(debug_log, encoding='utf-8') as dl:
+            dl.seek(0, 2)
+            prev_size = dl.tell()
+
+        yield
+
+        while True:
+            found = True
+            with open(debug_log, encoding='utf-8') as dl:
+                dl.seek(prev_size)
+                log = dl.read()
+            print_log = " - " + "\n - ".join(log.splitlines())
+            for unexpected_msg in unexpected_msgs:
+                if re.search(re.escape(unexpected_msg), log, flags=re.MULTILINE):
+                    self._raise_assertion_error('Unexpected message "{}" partially matches log:\n\n{}\n\n'.format(unexpected_msg, print_log))
+            for expected_msg in expected_msgs:
+                if re.search(re.escape(expected_msg), log, flags=re.MULTILINE) is None:
+                    found = False
+            if found:
+                return
+            if time.time() >= time_end:
+                break
+            time.sleep(0.05)
+        self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
+
+    @contextlib.contextmanager
+    def profile_with_perf(self, profile_name):
+        """
+        Context manager that allows easy profiling of node activity using `perf`.
+
+        See `test/functional/README.md` for details on perf usage.
+
+        Args:
+            profile_name (str): This string will be appended to the
+                profile data filename generated by perf.
+        """
+        subp = self._start_perf(profile_name)
+
+        yield
+
+        if subp:
+            self._stop_perf(profile_name)
+
+    def _start_perf(self, profile_name=None):
+        """Start a perf process to profile this node.
+
+        Returns the subprocess running perf."""
+        subp = None
+
+        def test_success(cmd):
+            return subprocess.call(
+                # shell=True required for pipe use below
+                cmd, shell=True,
+                stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL) == 0
+
+        if not sys.platform.startswith('linux'):
+            self.log.warning("Can't profile with perf; only available on Linux platforms")
+            return None
+
+        if not test_success('which perf'):
+            self.log.warning("Can't profile with perf; must install perf-tools")
+            return None
+
+        if not test_success('readelf -S {} | grep .debug_str'.format(shlex.quote(self.binary))):
+            self.log.warning(
+                "perf output won't be very useful without debug symbols compiled into gridcoinresearchd")
+
+        output_path = tempfile.NamedTemporaryFile(
+            dir=self.datadir,
+            prefix="{}.perf.data.".format(profile_name or 'test'),
+            delete=False,
+        ).name
+
+        cmd = [
+            'perf', 'record',
+            '-g',                     # Record the callgraph.
+            '--call-graph', 'dwarf',  # Compatibility for gcc's --fomit-frame-pointer.
+            '-F', '101',              # Sampling frequency in Hz.
+            '-p', str(self.process.pid),
+            '-o', output_path,
+        ]
+        subp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.perf_subprocesses[profile_name] = subp
+
+        return subp
+
+    def _stop_perf(self, profile_name):
+        """Stop (and pop) a perf subprocess."""
+        subp = self.perf_subprocesses.pop(profile_name)
+        output_path = subp.args[subp.args.index('-o') + 1]
+
+        subp.terminate()
+        subp.wait(timeout=10)
+
+        stderr = subp.stderr.read().decode()
+        if 'Consider tweaking /proc/sys/kernel/perf_event_paranoid' in stderr:
+            self.log.warning(
+                "perf couldn't collect data! Try "
+                "'sudo sysctl -w kernel.perf_event_paranoid=-1'")
+        else:
+            report_cmd = "perf report -i {}".format(output_path)
+            self.log.info("See perf output by running '{}'".format(report_cmd))
+
+    def assert_start_raises_init_error(self, extra_args=None, expected_msg=None, match=ErrorMatch.FULL_TEXT, *args, **kwargs):
+        """Attempt to start the node and expect it to raise an error.
+
+        extra_args: extra arguments to pass through to gridcoinresearchd
+        expected_msg: regex that stderr should match when gridcoinresearchd fails
+
+        Will throw if gridcoinresearchd starts without an error.
+        Will throw if an expected_msg is provided and it does not match gridcoinresearchd's stdout."""
+        with tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False) as log_stderr, \
+             tempfile.NamedTemporaryFile(dir=self.stdout_dir, delete=False) as log_stdout:
+            try:
+                self.start(extra_args, stdout=log_stdout, stderr=log_stderr, *args, **kwargs)
+                self.wait_for_rpc_connection()
+                self.stop_node()
+                self.wait_until_stopped()
+            except FailedToStartError as e:
+                self.log.debug('gridcoinresearchd failed to start: %s', e)
+                self.running = False
+                self.process = None
+                # Check stderr for expected message
+                if expected_msg is not None:
+                    log_stderr.seek(0)
+                    stderr = log_stderr.read().decode('utf-8').strip()
+                    if match == ErrorMatch.PARTIAL_REGEX:
+                        if re.search(expected_msg, stderr, flags=re.MULTILINE) is None:
+                            self._raise_assertion_error(
+                                'Expected message "{}" does not partially match stderr:\n"{}"'.format(expected_msg, stderr))
+                    elif match == ErrorMatch.FULL_REGEX:
+                        if re.fullmatch(expected_msg, stderr) is None:
+                            self._raise_assertion_error(
+                                'Expected message "{}" does not fully match stderr:\n"{}"'.format(expected_msg, stderr))
+                    elif match == ErrorMatch.FULL_TEXT:
+                        if expected_msg != stderr:
+                            self._raise_assertion_error(
+                                'Expected message "{}" does not fully match stderr:\n"{}"'.format(expected_msg, stderr))
+            else:
+                if expected_msg is None:
+                    assert_msg = "gridcoinresearchd should have exited with an error"
+                else:
+                    assert_msg = "gridcoinresearchd should have exited with expected error " + expected_msg
+                self._raise_assertion_error(assert_msg)
+
+    def add_p2p_connection(self, p2p_conn, *, wait_for_verack=True, **kwargs):
+        """Add a p2p connection to the node.
+
+        This method adds the p2p connection to the self.p2ps list and also
+        returns the connection to the caller."""
+        if 'dstport' not in kwargs:
+            kwargs['dstport'] = p2p_port(self.index)
+        if 'dstaddr' not in kwargs:
+            kwargs['dstaddr'] = '127.0.0.1'
+
+        p2p_conn.peer_connect(**kwargs, net=self.chain, timeout_factor=self.timeout_factor)()
+        self.p2ps.append(p2p_conn)
+        p2p_conn.wait_until(lambda: p2p_conn.is_connected, check_connected=False)
+        if wait_for_verack:
+            # Wait for the node to send us the version and verack
+            p2p_conn.wait_for_verack()
+            # At this point we have sent our version message and received the version and verack, however the full node
+            # has not yet received the verack from us (in reply to their version). So, the connection is not yet fully
+            # established (fSuccessfullyConnected).
+            #
+            # This shouldn't lead to any issues when sending messages, since the verack will be in-flight before the
+            # message we send. However, it might lead to races where we are expecting to receive a message. E.g. a
+            # transaction that will be added to the mempool as soon as we return here.
+            #
+            # So syncing here is redundant when we only want to send a message, but the cost is low (a few milliseconds)
+            # in comparison to the upside of making tests less fragile and unexpected intermittent errors less likely.
+            p2p_conn.sync_with_ping()
+
+        return p2p_conn
+
+    def num_test_p2p_connections(self):
+        """Return number of test framework p2p connections to the node."""
+        return len([peer for peer in self.getpeerinfo() if peer['subver'] == MY_SUBVERSION])
+
+    def disconnect_p2ps(self):
+        """Close all p2p connections to the node."""
+        for p in self.p2ps:
+            p.peer_disconnect()
+        del self.p2ps[:]
+        wait_until_helper(lambda: self.num_test_p2p_connections() == 0, timeout_factor=self.timeout_factor)
+
+
+class TestNodeCLIAttr:
+    def __init__(self, cli, command):
+        self.cli = cli
+        self.command = command
+
+    def __call__(self, *args, **kwargs):
+        return self.cli.send_cli(self.command, *args, **kwargs)
+
+    def get_request(self, *args, **kwargs):
+        return lambda: self(*args, **kwargs)
+
+
+def arg_to_cli(arg):
+    if isinstance(arg, bool):
+        return str(arg).lower()
+    elif arg is None:
+        return 'null'
+    elif isinstance(arg, dict) or isinstance(arg, list):
+        return json.dumps(arg, default=EncodeDecimal)
+    else:
+        return str(arg)
+
+
+class TestNodeCLI():
+    """Interface to gridcoin-cli for an individual node"""
+    def __init__(self, binary, datadir):
+        self.options = []
+        self.binary = binary
+        self.datadir = datadir
+        self.input = None
+        self.log = logging.getLogger('TestFramework.gridcoincli')
+
+    def __call__(self, *options, input=None):
+        # TestNodeCLI is callable with gridcoin-cli command-line options
+        cli = TestNodeCLI(self.binary, self.datadir)
+        cli.options = [str(o) for o in options]
+        cli.input = input
+        return cli
+
+    def __getattr__(self, command):
+        return TestNodeCLIAttr(self, command)
+
+    def batch(self, requests):
+        results = []
+        for request in requests:
+            try:
+                results.append(dict(result=request()))
+            except JSONRPCException as e:
+                results.append(dict(error=e))
+        return results
+
+    def send_cli(self, command=None, *args, **kwargs):
+        """Run gridcoin-cli command. Deserializes returned string as python object."""
+        pos_args = [arg_to_cli(arg) for arg in args]
+        named_args = [str(key) + "=" + arg_to_cli(value) for (key, value) in kwargs.items()]
+        assert not (pos_args and named_args), "Cannot use positional arguments and named arguments in the same gridcoin-cli call"
+        p_args = [self.binary, "-datadir=" + self.datadir] + self.options
+        if named_args:
+            p_args += ["-named"]
+        if command is not None:
+            p_args += [command]
+        p_args += pos_args + named_args
+        self.log.debug("Running gridcoin-cli {}".format(p_args[2:]))
+        process = subprocess.Popen(p_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        cli_stdout, cli_stderr = process.communicate(input=self.input)
+        returncode = process.poll()
+        if returncode:
+            match = re.match(r'error code: ([-0-9]+)\nerror message:\n(.*)', cli_stderr)
+            if match:
+                code, message = match.groups()
+                raise JSONRPCException(dict(code=int(code), message=message))
+            # Ignore cli_stdout, raise with cli_stderr
+            raise subprocess.CalledProcessError(returncode, self.binary, output=cli_stderr)
+        try:
+            return json.loads(cli_stdout, parse_float=decimal.Decimal)
+        except (json.JSONDecodeError, decimal.InvalidOperation):
+            return cli_stdout.rstrip("\n")

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -101,8 +101,18 @@ class TestNode():
             "-debug",
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
-            "-uacomment=testnode%d" % i,
         ]
+        # Gridcoin's daemon doesn't recognize -uacomment (Bitcoin Core only),
+        # so it's omitted from the defaults above.
+        #
+        # Chain selection must be on the command line: putting `testnet=1` in
+        # the .conf is read but does NOT set the fTestNet global (see
+        # src/init.cpp's `fTestNet = gArgs.GetBoolArg("-testnet")`), which
+        # gates many code paths including genesis-block construction.
+        if self.chain == 'test':
+            self.args.append('-testnet=1')
+        elif self.chain == 'regtest':
+            self.args.append('-regtest=1')
         if use_valgrind:
             default_suppressions_file = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
@@ -229,28 +239,13 @@ class TestNode():
                     coveragedir=self.coverage_dir,
                 )
                 rpc.getblockcount()
-                # If the call to getblockcount() succeeds then the RPC connection is up
-                if self.version_is_at_least(190000):
-                    # getmempoolinfo.loaded is available since commit
-                    # bb8ae2c (version 0.19.0)
-                    wait_until_helper(lambda: rpc.getmempoolinfo()['loaded'], timeout_factor=self.timeout_factor)
-                    # Wait for the node to finish reindex, block import, and
-                    # loading the mempool. Usually importing happens fast or
-                    # even "immediate" when the node is started. However, there
-                    # is no guarantee and sometimes ThreadImport might finish
-                    # later. This is going to cause intermittent test failures,
-                    # because generally the tests assume the node is fully
-                    # ready after being started.
-                    #
-                    # For example, the node will reject block messages from p2p
-                    # when it is still importing with the error "Unexpected
-                    # block message received"
-                    #
-                    # The wait is done here to make tests as robust as possible
-                    # and prevent racy tests and intermittent failures as much
-                    # as possible. Some tests might not need this, but the
-                    # overhead is trivial, and the added guarantees are worth
-                    # the minimal performance cost.
+                # If the call to getblockcount() succeeds then the RPC connection is up.
+                # Bitcoin Core polled getmempoolinfo()['loaded'] here to wait for the
+                # node to finish loading the mempool from disk after restart. Gridcoin
+                # has no getmempoolinfo RPC (RPC_METHOD_NOT_FOUND) and no equivalent
+                # mempool-loading concept, so the poll is omitted. Phase 2A regtest
+                # will revisit whether any node-readiness gate is needed before tests
+                # start issuing further RPCs.
                 self.log.debug("RPC successfully started")
                 if self.use_cli:
                     return
@@ -316,11 +311,12 @@ class TestNode():
             return
         self.log.debug("Stopping node")
         try:
-            # Do not use wait argument when testing older nodes, e.g. in feature_backwards_compatibility.py
-            if self.version_is_at_least(180000):
-                self.stop(wait=wait)
-            else:
-                self.stop()
+            # Gridcoin's stop RPC takes no arguments. Bitcoin Core accepted
+            # an optional `wait` parameter, but Gridcoin's RPC parser rejects
+            # named-arg dicts ({"wait": 0}) with "Params must be an array".
+            # The `wait` kwarg is preserved on stop_node()'s signature for
+            # caller compatibility but not forwarded to the RPC.
+            self.stop()
         except http.client.CannotSendRequest:
             self.log.exception("Unable to stop node.")
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -28,6 +28,7 @@ from .authproxy import JSONRPCException
 from .util import (
     MAX_NODES,
     append_config,
+    chain_subdir,
     delete_cookie_file,
     get_auth_cookie,
     get_rpc_proxy,
@@ -306,34 +307,66 @@ class TestNode():
         return self.version is None or self.version >= ver
 
     def stop_node(self, expected_stderr='', wait=0):
-        """Stop the node."""
+        """Stop the node.
+
+        Cleanup is performed in a finally block so a failure on the stop RPC,
+        an unexpected stderr, or perf-subprocess shutdown does not leak open
+        file descriptors / temp files. The `stop()` call is wrapped in a
+        broader except than the legacy `http.client.CannotSendRequest`-only
+        catch, since the RPC layer can raise `JSONRPCException`,
+        `ConnectionError`, `socket.timeout`, etc., when the daemon is mid-
+        shutdown. The original error is logged and re-raised at the end so
+        the caller still sees the failure.
+        """
         if not self.running:
             return
         self.log.debug("Stopping node")
+        stop_exc = None
         try:
-            # Gridcoin's stop RPC takes no arguments. Bitcoin Core accepted
-            # an optional `wait` parameter, but Gridcoin's RPC parser rejects
-            # named-arg dicts ({"wait": 0}) with "Params must be an array".
-            # The `wait` kwarg is preserved on stop_node()'s signature for
-            # caller compatibility but not forwarded to the RPC.
-            self.stop()
-        except http.client.CannotSendRequest:
-            self.log.exception("Unable to stop node.")
+            try:
+                # Gridcoin's stop RPC takes no arguments. Bitcoin Core accepted
+                # an optional `wait` parameter, but Gridcoin's RPC parser rejects
+                # named-arg dicts ({"wait": 0}) with "Params must be an array".
+                # The `wait` kwarg is preserved on stop_node()'s signature for
+                # caller compatibility but not forwarded to the RPC.
+                self.stop()
+            except (http.client.CannotSendRequest,
+                    JSONRPCException,
+                    ConnectionError,
+                    OSError) as e:
+                self.log.exception("Unable to stop node cleanly: %s", e)
+                stop_exc = e
 
-        # If there are any running perf processes, stop them.
-        for profile_name in tuple(self.perf_subprocesses.keys()):
-            self._stop_perf(profile_name)
+            # If there are any running perf processes, stop them. Per-process
+            # try/except so one perf failure doesn't strand the rest.
+            for profile_name in tuple(self.perf_subprocesses.keys()):
+                try:
+                    self._stop_perf(profile_name)
+                except Exception as e:
+                    self.log.exception("Failed to stop perf process %s: %s",
+                                       profile_name, e)
 
-        # Check that stderr is as expected
-        self.stderr.seek(0)
-        stderr = self.stderr.read().decode('utf-8').strip()
-        if stderr != expected_stderr:
-            raise AssertionError("Unexpected stderr {} != {}".format(stderr, expected_stderr))
+            # Check that stderr is as expected. This can raise; the file
+            # closes below still run.
+            self.stderr.seek(0)
+            stderr = self.stderr.read().decode('utf-8').strip()
+            if stderr != expected_stderr:
+                raise AssertionError("Unexpected stderr {} != {}".format(stderr, expected_stderr))
+        finally:
+            # Guarantee tempfiles close even when the stderr check above
+            # raises. Each close is itself best-effort so a closed/broken
+            # handle doesn't mask the original failure.
+            for fh in (self.stdout, self.stderr):
+                try:
+                    fh.close()
+                except Exception:
+                    pass
+            del self.p2ps[:]
 
-        self.stdout.close()
-        self.stderr.close()
-
-        del self.p2ps[:]
+        if stop_exc is not None:
+            # Re-raise the original RPC failure once cleanup is complete so
+            # callers don't silently believe the node stopped cleanly.
+            raise stop_exc
 
     def is_node_stopped(self):
         """Checks whether the node has stopped.
@@ -364,7 +397,7 @@ class TestNode():
         if unexpected_msgs is None:
             unexpected_msgs = []
         time_end = time.time() + timeout * self.timeout_factor
-        debug_log = os.path.join(self.datadir, self.chain, 'debug.log')
+        debug_log = os.path.join(self.datadir, chain_subdir(self.chain), 'debug.log')
         with open(debug_log, encoding='utf-8') as dl:
             dl.seek(0, 2)
             prev_size = dl.tell()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2014-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/mit-license.php.
 """Helpful routines for regression testing."""
 
 from base64 import b64encode

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import time
 import unittest
 
@@ -350,11 +351,42 @@ def initialize_datadir(dirname, n, chain):
     if chain == 'test':
         chain_name_conf_arg = 'testnet'
         chain_name_conf_section = 'test'
+        chain_subdir = 'testnet'
+    elif chain == 'regtest':
+        chain_name_conf_arg = chain
+        chain_name_conf_section = chain
+        chain_subdir = 'regtest'
     else:
         chain_name_conf_arg = chain
         chain_name_conf_section = chain
+        chain_subdir = ''
+    # Gridcoin requires explicit rpcuser/rpcpassword in the chain-specific
+    # conf when -server is set -- there's no cookie-auth fallback like
+    # Bitcoin Core's, and Gridcoin loads chain-specific settings from
+    # <datadir>/<chain>/gridcoinresearch.conf rather than honoring Bitcoin
+    # Core's [test] section in the top-level conf. Pre-create the chain
+    # subdir and write the auth + port settings there directly; the global
+    # conf below still gets a copy of rpcuser/rpcpassword so get_auth_cookie
+    # can read them from a single known path.
+    rpc_user = "gctest_" + secrets.token_hex(8)
+    rpc_pass = secrets.token_hex(32)
+    if chain_subdir:
+        os.makedirs(os.path.join(datadir, chain_subdir), exist_ok=True)
+        with open(os.path.join(datadir, chain_subdir, "gridcoinresearch.conf"), 'w', encoding='utf8') as f:
+            f.write("rpcuser=" + rpc_user + "\n")
+            f.write("rpcpassword=" + rpc_pass + "\n")
+            f.write("port=" + str(p2p_port(n)) + "\n")
+            f.write("rpcport=" + str(rpc_port(n)) + "\n")
+            f.write("server=1\n")
+            f.write("listen=0\n")
+            f.write("discover=0\n")
+            f.write("dnsseed=0\n")
+            f.write("listenonion=0\n")
+            f.write("upnp=0\n")
     with open(os.path.join(datadir, "gridcoinresearch.conf"), 'w', encoding='utf8') as f:
         f.write("{}=1\n".format(chain_name_conf_arg))
+        f.write("rpcuser=" + rpc_user + "\n")
+        f.write("rpcpassword=" + rpc_pass + "\n")
         f.write("[{}]\n".format(chain_name_conf_section))
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -400,7 +400,11 @@ def initialize_datadir(dirname, n, chain):
             f.write("port=" + str(p2p_port(n)) + "\n")
             f.write("rpcport=" + str(rpc_port(n)) + "\n")
             f.write("server=1\n")
-            f.write("listen=0\n")
+            # listen=1 so the node accepts inbound P2P connections from the
+            # framework (add_p2p_connection / connect_nodes). Tests that want an
+            # isolated node pass -listen=0 / -connect=0 on the command line,
+            # which overrides this conf value.
+            f.write("listen=1\n")
             f.write("discover=0\n")
             f.write("dnsseed=0\n")
             f.write("listenonion=0\n")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Helpful routines for regression testing."""
+
+from base64 import b64encode
+from binascii import unhexlify
+from decimal import Decimal, ROUND_DOWN
+from subprocess import CalledProcessError
+import hashlib
+import inspect
+import json
+import logging
+import os
+import re
+import time
+import unittest
+
+from . import coverage
+from .authproxy import AuthServiceProxy, JSONRPCException
+from io import BytesIO
+
+logger = logging.getLogger("TestFramework.utils")
+
+# Assert functions
+##################
+
+
+def assert_approx(v, vexp, vspan=0.00001):
+    """Assert that `v` is within `vspan` of `vexp`"""
+    if v < vexp - vspan:
+        raise AssertionError("%s < [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
+    if v > vexp + vspan:
+        raise AssertionError("%s > [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
+
+
+def assert_fee_amount(fee, tx_size, fee_per_kB):
+    """Assert the fee was in range"""
+    target_fee = round(tx_size * fee_per_kB / 1000, 8)
+    if fee < target_fee:
+        raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
+    # allow the wallet's estimation to be at most 2 bytes off
+    if fee > (tx_size + 2) * fee_per_kB / 1000:
+        raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
+
+
+def assert_equal(thing1, thing2, *args):
+    if thing1 != thing2 or any(thing1 != arg for arg in args):
+        raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
+
+
+def assert_greater_than(thing1, thing2):
+    if thing1 <= thing2:
+        raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))
+
+
+def assert_greater_than_or_equal(thing1, thing2):
+    if thing1 < thing2:
+        raise AssertionError("%s < %s" % (str(thing1), str(thing2)))
+
+
+def assert_raises(exc, fun, *args, **kwds):
+    assert_raises_message(exc, None, fun, *args, **kwds)
+
+
+def assert_raises_message(exc, message, fun, *args, **kwds):
+    try:
+        fun(*args, **kwds)
+    except JSONRPCException:
+        raise AssertionError("Use assert_raises_rpc_error() to test RPC failures")
+    except exc as e:
+        if message is not None and message not in e.error['message']:
+            raise AssertionError(
+                "Expected substring not found in error message:\nsubstring: '{}'\nerror message: '{}'.".format(
+                    message, e.error['message']))
+    except Exception as e:
+        raise AssertionError("Unexpected exception raised: " + type(e).__name__)
+    else:
+        raise AssertionError("No exception raised")
+
+
+def assert_raises_process_error(returncode, output, fun, *args, **kwds):
+    """Execute a process and asserts the process return code and output.
+
+    Calls function `fun` with arguments `args` and `kwds`. Catches a CalledProcessError
+    and verifies that the return code and output are as expected. Throws AssertionError if
+    no CalledProcessError was raised or if the return code and output are not as expected.
+
+    Args:
+        returncode (int): the process return code.
+        output (string): [a substring of] the process output.
+        fun (function): the function to call. This should execute a process.
+        args*: positional arguments for the function.
+        kwds**: named arguments for the function.
+    """
+    try:
+        fun(*args, **kwds)
+    except CalledProcessError as e:
+        if returncode != e.returncode:
+            raise AssertionError("Unexpected returncode %i" % e.returncode)
+        if output not in e.output:
+            raise AssertionError("Expected substring not found:" + e.output)
+    else:
+        raise AssertionError("No exception raised")
+
+
+def assert_raises_rpc_error(code, message, fun, *args, **kwds):
+    """Run an RPC and verify that a specific JSONRPC exception code and message is raised.
+
+    Calls function `fun` with arguments `args` and `kwds`. Catches a JSONRPCException
+    and verifies that the error code and message are as expected. Throws AssertionError if
+    no JSONRPCException was raised or if the error code/message are not as expected.
+
+    Args:
+        code (int), optional: the error code returned by the RPC call (defined
+            in src/rpc/protocol.h). Set to None if checking the error code is not required.
+        message (string), optional: [a substring of] the error string returned by the
+            RPC call. Set to None if checking the error string is not required.
+        fun (function): the function to call. This should be the name of an RPC.
+        args*: positional arguments for the function.
+        kwds**: named arguments for the function.
+    """
+    assert try_rpc(code, message, fun, *args, **kwds), "No exception raised"
+
+
+def try_rpc(code, message, fun, *args, **kwds):
+    """Tries to run an rpc command.
+
+    Test against error code and message if the rpc fails.
+    Returns whether a JSONRPCException was raised."""
+    try:
+        fun(*args, **kwds)
+    except JSONRPCException as e:
+        # JSONRPCException was thrown as expected. Check the code and message values are correct.
+        if (code is not None) and (code != e.error["code"]):
+            raise AssertionError("Unexpected JSONRPC error code %i" % e.error["code"])
+        if (message is not None) and (message not in e.error['message']):
+            raise AssertionError(
+                "Expected substring not found in error message:\nsubstring: '{}'\nerror message: '{}'.".format(
+                    message, e.error['message']))
+        return True
+    except Exception as e:
+        raise AssertionError("Unexpected exception raised: " + type(e).__name__)
+    else:
+        return False
+
+
+def assert_is_hex_string(string):
+    try:
+        int(string, 16)
+    except Exception as e:
+        raise AssertionError("Couldn't interpret %r as hexadecimal; raised: %s" % (string, e))
+
+
+def assert_is_hash_string(string, length=64):
+    if not isinstance(string, str):
+        raise AssertionError("Expected a string, got type %r" % type(string))
+    elif length and len(string) != length:
+        raise AssertionError("String of length %d expected; got %d" % (length, len(string)))
+    elif not re.match('[abcdef0-9]+$', string):
+        raise AssertionError("String %r contains invalid characters for a hash." % string)
+
+
+def assert_array_result(object_array, to_match, expected, should_not_find=False):
+    """
+        Pass in array of JSON objects, a dictionary with key/value pairs
+        to match against, and another dictionary with expected key/value
+        pairs.
+        If the should_not_find flag is true, to_match should not be found
+        in object_array
+        """
+    if should_not_find:
+        assert_equal(expected, {})
+    num_matched = 0
+    for item in object_array:
+        all_match = True
+        for key, value in to_match.items():
+            if item[key] != value:
+                all_match = False
+        if not all_match:
+            continue
+        elif should_not_find:
+            num_matched = num_matched + 1
+        for key, value in expected.items():
+            if item[key] != value:
+                raise AssertionError("%s : expected %s=%s" % (str(item), str(key), str(value)))
+            num_matched = num_matched + 1
+    if num_matched == 0 and not should_not_find:
+        raise AssertionError("No objects matched %s" % (str(to_match)))
+    if num_matched > 0 and should_not_find:
+        raise AssertionError("Objects were found %s" % (str(to_match)))
+
+
+# Utility functions
+###################
+
+
+def check_json_precision():
+    """Make sure json library being used does not lose precision converting BTC values"""
+    n = Decimal("20000000.00000003")
+    satoshis = int(json.loads(json.dumps(float(n))) * 1.0e8)
+    if satoshis != 2000000000000003:
+        raise RuntimeError("JSON encode/decode loses precision")
+
+
+def EncodeDecimal(o):
+    if isinstance(o, Decimal):
+        return str(o)
+    raise TypeError(repr(o) + " is not JSON serializable")
+
+
+def count_bytes(hex_string):
+    return len(bytearray.fromhex(hex_string))
+
+
+def hex_str_to_bytes(hex_str):
+    return unhexlify(hex_str.encode('ascii'))
+
+
+def str_to_b64str(string):
+    return b64encode(string.encode('utf-8')).decode('ascii')
+
+
+def satoshi_round(amount):
+    return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
+
+
+def wait_until_helper(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None, timeout_factor=1.0):
+    """Sleep until the predicate resolves to be True.
+
+    Warning: Note that this method is not recommended to be used in tests as it is
+    not aware of the context of the test framework. Using the `wait_until()` members
+    from `GridcoinTestFramework` or `P2PInterface` class ensures the timeout is
+    properly scaled. Furthermore, `wait_until()` from `P2PInterface` class in
+    `p2p.py` has a preset lock.
+    """
+    if attempts == float('inf') and timeout == float('inf'):
+        timeout = 60
+    timeout = timeout * timeout_factor
+    attempt = 0
+    time_end = time.time() + timeout
+
+    while attempt < attempts and time.time() < time_end:
+        if lock:
+            with lock:
+                if predicate():
+                    return
+        else:
+            if predicate():
+                return
+        attempt += 1
+        time.sleep(0.05)
+
+    # Print the cause of the timeout
+    predicate_source = "''''\n" + inspect.getsource(predicate) + "'''"
+    logger.error("wait_until() failed. Predicate: {}".format(predicate_source))
+    if attempt >= attempts:
+        raise AssertionError("Predicate {} not true after {} attempts".format(predicate_source, attempts))
+    elif time.time() >= time_end:
+        raise AssertionError("Predicate {} not true after {} seconds".format(predicate_source, timeout))
+    raise RuntimeError('Unreachable')
+
+def sha256sum_file(filename):
+    h = hashlib.sha256()
+    with open(filename, 'rb') as f:
+        d = f.read(4096)
+        while len(d) > 0:
+            h.update(d)
+            d = f.read(4096)
+    return h.digest()
+
+# RPC/P2P connection constants and functions
+############################################
+
+# The maximum number of nodes a single test can spawn
+MAX_NODES = 12
+# Don't assign rpc or p2p ports lower than this.
+# Gridcoin reserves: main P2P 32749 / RPC 15715, testnet P2P 32748 / RPC 25715,
+# regtest P2P 32747 / RPC 35715. Test ports occupy [PORT_MIN, PORT_MIN + 2*PORT_RANGE),
+# so we start at 41000 to stay clear of all reserved ranges.
+PORT_MIN = int(os.getenv('TEST_RUNNER_PORT_MIN', default=41000))
+# The number of ports to "reserve" for p2p and rpc, each
+PORT_RANGE = 5000
+
+
+class PortSeed:
+    # Must be initialized with a unique integer for each process
+    n = None
+
+
+def get_rpc_proxy(url, node_number, *, timeout=None, coveragedir=None):
+    """
+    Args:
+        url (str): URL of the RPC server to call
+        node_number (int): the node number (or id) that this calls to
+
+    Kwargs:
+        timeout (int): HTTP timeout in seconds
+        coveragedir (str): Directory
+
+    Returns:
+        AuthServiceProxy. convenience object for making RPC calls.
+
+    """
+    proxy_kwargs = {}
+    if timeout is not None:
+        proxy_kwargs['timeout'] = int(timeout)
+
+    proxy = AuthServiceProxy(url, **proxy_kwargs)
+    proxy.url = url  # store URL on proxy for info
+
+    coverage_logfile = coverage.get_filename(coveragedir, node_number) if coveragedir else None
+
+    return coverage.AuthServiceProxyWrapper(proxy, coverage_logfile)
+
+
+def p2p_port(n):
+    assert n <= MAX_NODES
+    return PORT_MIN + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
+
+
+def rpc_port(n):
+    return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
+
+
+def rpc_url(datadir, i, chain, rpchost):
+    rpc_u, rpc_p = get_auth_cookie(datadir, chain)
+    host = '127.0.0.1'
+    port = rpc_port(i)
+    if rpchost:
+        parts = rpchost.split(':')
+        if len(parts) == 2:
+            host, port = parts
+        else:
+            host = rpchost
+    return "http://%s:%s@%s:%d" % (rpc_u, rpc_p, host, int(port))
+
+
+# Node functions
+################
+
+
+def initialize_datadir(dirname, n, chain):
+    datadir = get_datadir_path(dirname, n)
+    if not os.path.isdir(datadir):
+        os.makedirs(datadir)
+    # Translate chain name to config name.
+    # Gridcoin: chain string "test" -> arg "-testnet" -> section "[test]".
+    if chain == 'test':
+        chain_name_conf_arg = 'testnet'
+        chain_name_conf_section = 'test'
+    else:
+        chain_name_conf_arg = chain
+        chain_name_conf_section = chain
+    with open(os.path.join(datadir, "gridcoinresearch.conf"), 'w', encoding='utf8') as f:
+        f.write("{}=1\n".format(chain_name_conf_arg))
+        f.write("[{}]\n".format(chain_name_conf_section))
+        f.write("port=" + str(p2p_port(n)) + "\n")
+        f.write("rpcport=" + str(rpc_port(n)) + "\n")
+        f.write("fallbackfee=0.0002\n")
+        f.write("server=1\n")
+        f.write("keypool=1\n")
+        f.write("discover=0\n")
+        f.write("dnsseed=0\n")
+        f.write("listenonion=0\n")
+        f.write("printtoconsole=0\n")
+        f.write("upnp=0\n")
+        f.write("shrinkdebugfile=0\n")
+        os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
+        os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
+    return datadir
+
+
+def get_datadir_path(dirname, n):
+    return os.path.join(dirname, "node" + str(n))
+
+
+def append_config(datadir, options):
+    with open(os.path.join(datadir, "gridcoinresearch.conf"), 'a', encoding='utf8') as f:
+        for option in options:
+            f.write(option + "\n")
+
+
+def get_auth_cookie(datadir, chain):
+    user = None
+    password = None
+    if os.path.isfile(os.path.join(datadir, "gridcoinresearch.conf")):
+        with open(os.path.join(datadir, "gridcoinresearch.conf"), 'r', encoding='utf8') as f:
+            for line in f:
+                if line.startswith("rpcuser="):
+                    assert user is None  # Ensure that there is only one rpcuser line
+                    user = line.split("=")[1].strip("\n")
+                if line.startswith("rpcpassword="):
+                    assert password is None  # Ensure that there is only one rpcpassword line
+                    password = line.split("=")[1].strip("\n")
+    try:
+        with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
+            userpass = f.read()
+            split_userpass = userpass.split(':')
+            user = split_userpass[0]
+            password = split_userpass[1]
+    except OSError:
+        pass
+    if user is None or password is None:
+        raise ValueError("No RPC credentials")
+    return user, password
+
+
+# If a cookie file exists in the given datadir, delete it.
+def delete_cookie_file(datadir, chain):
+    if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
+        logger.debug("Deleting leftover cookie file")
+        os.remove(os.path.join(datadir, chain, ".cookie"))
+
+
+def softfork_active(node, key):
+    """Return whether a softfork is active."""
+    return node.getblockchaininfo()['softforks'][key]['active']
+
+
+def set_node_times(nodes, t):
+    for node in nodes:
+        node.setmocktime(t)
+
+
+# Transaction/Block functions
+#############################
+
+
+def find_output(node, txid, amount, *, blockhash=None):
+    """
+    Return index to output of txid with value amount
+    Raises exception if there is none.
+    """
+    txdata = node.getrawtransaction(txid, 1, blockhash)
+    for i in range(len(txdata["vout"])):
+        if txdata["vout"][i]["value"] == amount:
+            return i
+    raise RuntimeError("find_output txid %s : %s not found" % (txid, str(amount)))
+
+
+# Helper to create at least "count" utxos
+# Pass in a fee that is sufficient for relay and mining new transactions.
+def create_confirmed_utxos(fee, node, count):
+    to_generate = int(0.5 * count) + 101
+    while to_generate > 0:
+        node.generate(min(25, to_generate))
+        to_generate -= 25
+    utxos = node.listunspent()
+    iterations = count - len(utxos)
+    addr1 = node.getnewaddress()
+    addr2 = node.getnewaddress()
+    if iterations <= 0:
+        return utxos
+    for _ in range(iterations):
+        t = utxos.pop()
+        inputs = []
+        inputs.append({"txid": t["txid"], "vout": t["vout"]})
+        outputs = {}
+        send_value = t['amount'] - fee
+        outputs[addr1] = satoshi_round(send_value / 2)
+        outputs[addr2] = satoshi_round(send_value / 2)
+        raw_tx = node.createrawtransaction(inputs, outputs)
+        signed_tx = node.signrawtransactionwithwallet(raw_tx)["hex"]
+        node.sendrawtransaction(signed_tx)
+
+    while (node.getmempoolinfo()['size'] > 0):
+        node.generate(1)
+
+    utxos = node.listunspent()
+    assert len(utxos) >= count
+    return utxos
+
+
+# Create large OP_RETURN txouts that can be appended to a transaction
+# to make it large (helper for constructing large transactions).
+def gen_return_txouts():
+    # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
+    # So we have big transactions (and therefore can't fit very many into each block)
+    # create one script_pubkey
+    script_pubkey = "6a4d0200"  # OP_RETURN OP_PUSH2 512 bytes
+    for _ in range(512):
+        script_pubkey = script_pubkey + "01"
+    # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
+    txouts = []
+    from .messages import CTxOut
+    txout = CTxOut()
+    txout.nValue = 0
+    txout.scriptPubKey = hex_str_to_bytes(script_pubkey)
+    for _ in range(128):
+        txouts.append(txout)
+    return txouts
+
+
+# Create a spend of each passed-in utxo, splicing in "txouts" to each raw
+# transaction to make it large.  See gen_return_txouts() above.
+def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
+    addr = node.getnewaddress()
+    txids = []
+    from .messages import CTransaction
+    for _ in range(num):
+        t = utxos.pop()
+        inputs = [{"txid": t["txid"], "vout": t["vout"]}]
+        outputs = {}
+        change = t['amount'] - fee
+        outputs[addr] = satoshi_round(change)
+        rawtx = node.createrawtransaction(inputs, outputs)
+        tx = CTransaction()
+        tx.deserialize(BytesIO(hex_str_to_bytes(rawtx)))
+        for txout in txouts:
+            tx.vout.append(txout)
+        newtx = tx.serialize().hex()
+        signresult = node.signrawtransactionwithwallet(newtx, None, "NONE")
+        txid = node.sendrawtransaction(signresult["hex"], 0)
+        txids.append(txid)
+    return txids
+
+
+def mine_large_block(node, utxos=None):
+    # generate a 66k transaction,
+    # and 14 of them is close to the 1MB block limit
+    num = 14
+    txouts = gen_return_txouts()
+    utxos = utxos if utxos is not None else []
+    if len(utxos) < num:
+        utxos.clear()
+        utxos.extend(node.listunspent())
+    fee = 100 * node.getnetworkinfo()["relayfee"]
+    create_lots_of_big_transactions(node, txouts, utxos, num, fee=fee)
+    node.generate(1)
+
+
+def find_vout_for_address(node, txid, addr):
+    """
+    Locate the vout index of the given transaction sending to the
+    given address. Raises runtime error exception if not found.
+    """
+    tx = node.getrawtransaction(txid, True)
+    for i in range(len(tx["vout"])):
+        if any([addr == a for a in tx["vout"][i]["scriptPubKey"]["addresses"]]):
+            return i
+    raise RuntimeError("Vout not found for address: txid=%s, addr=%s" % (txid, addr))
+
+def modinv(a, n):
+    """Compute the modular inverse of a modulo n using the extended Euclidean
+    Algorithm. See https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm#Modular_integers.
+    """
+    # TODO: Change to pow(a, -1, n) available in Python 3.8
+    t1, t2 = 0, 1
+    r1, r2 = n, a
+    while r2 != 0:
+        q = r1 // r2
+        t1, t2 = t2, t1 - q * t2
+        r1, r2 = r2, r1 - q * r2
+    if r1 > 1:
+        return None
+    if t1 < 0:
+        t1 += n
+    return t1
+
+class TestFrameworkUtil(unittest.TestCase):
+    def test_modinv(self):
+        test_vectors = [
+            [7, 11],
+            [11, 29],
+            [90, 13],
+            [1891, 3797],
+            [6003722857, 77695236973],
+        ]
+
+        for a, n in test_vectors:
+            self.assertEqual(modinv(a, n), pow(a, n-2, n))

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -71,10 +71,17 @@ def assert_raises_message(exc, message, fun, *args, **kwds):
     except JSONRPCException:
         raise AssertionError("Use assert_raises_rpc_error() to test RPC failures")
     except exc as e:
-        if message is not None and message not in e.error['message']:
+        # The caller passed `exc` as the expected exception type. The matching
+        # branch needs to inspect the actual exception's message, but only
+        # JSONRPCException has the `e.error['message']` shape — other
+        # exceptions (RuntimeError, ValueError, etc.) carry their text on
+        # str(e). The JSONRPCException case is handled by the earlier branch
+        # (above), so if we land here `e` is a non-JSONRPC exception and the
+        # message lives on str(e).
+        if message is not None and message not in str(e):
             raise AssertionError(
                 "Expected substring not found in error message:\nsubstring: '{}'\nerror message: '{}'.".format(
-                    message, e.error['message']))
+                    message, str(e)))
     except Exception as e:
         raise AssertionError("Unexpected exception raised: " + type(e).__name__)
     else:
@@ -342,6 +349,23 @@ def rpc_url(datadir, i, chain, rpchost):
 ################
 
 
+def chain_subdir(chain):
+    """Map a Bitcoin-style chain name ('main', 'test', 'regtest') to Gridcoin's
+    datadir subdirectory layout.
+
+    Bitcoin Core uses `chain='test'` for testnet and the subdirectory matches
+    the chain name. Gridcoin's testnet datadir subdirectory is `testnet`, not
+    `test`, so any code that builds `<datadir>/<chain>/...` paths needs to
+    translate `'test'` -> `'testnet'`. Mainnet has no subdirectory
+    (everything lives directly under datadir); regtest matches the chain name.
+    """
+    if chain == 'test':
+        return 'testnet'
+    if chain == 'regtest':
+        return 'regtest'
+    return ''
+
+
 def initialize_datadir(dirname, n, chain):
     datadir = get_datadir_path(dirname, n)
     if not os.path.isdir(datadir):
@@ -351,15 +375,13 @@ def initialize_datadir(dirname, n, chain):
     if chain == 'test':
         chain_name_conf_arg = 'testnet'
         chain_name_conf_section = 'test'
-        chain_subdir = 'testnet'
     elif chain == 'regtest':
         chain_name_conf_arg = chain
         chain_name_conf_section = chain
-        chain_subdir = 'regtest'
     else:
         chain_name_conf_arg = chain
         chain_name_conf_section = chain
-        chain_subdir = ''
+    chain_subdir_name = chain_subdir(chain)
     # Gridcoin requires explicit rpcuser/rpcpassword in the chain-specific
     # conf when -server is set -- there's no cookie-auth fallback like
     # Bitcoin Core's, and Gridcoin loads chain-specific settings from
@@ -370,9 +392,9 @@ def initialize_datadir(dirname, n, chain):
     # can read them from a single known path.
     rpc_user = "gctest_" + secrets.token_hex(8)
     rpc_pass = secrets.token_hex(32)
-    if chain_subdir:
-        os.makedirs(os.path.join(datadir, chain_subdir), exist_ok=True)
-        with open(os.path.join(datadir, chain_subdir, "gridcoinresearch.conf"), 'w', encoding='utf8') as f:
+    if chain_subdir_name:
+        os.makedirs(os.path.join(datadir, chain_subdir_name), exist_ok=True)
+        with open(os.path.join(datadir, chain_subdir_name, "gridcoinresearch.conf"), 'w', encoding='utf8') as f:
             f.write("rpcuser=" + rpc_user + "\n")
             f.write("rpcpassword=" + rpc_pass + "\n")
             f.write("port=" + str(p2p_port(n)) + "\n")
@@ -427,7 +449,7 @@ def get_auth_cookie(datadir, chain):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
     try:
-        with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
+        with open(os.path.join(datadir, chain_subdir(chain), ".cookie"), 'r', encoding="ascii") as f:
             userpass = f.read()
             split_userpass = userpass.split(':')
             user = split_userpass[0]
@@ -441,9 +463,10 @@ def get_auth_cookie(datadir, chain):
 
 # If a cookie file exists in the given datadir, delete it.
 def delete_cookie_file(datadir, chain):
-    if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
+    cookie_path = os.path.join(datadir, chain_subdir(chain), ".cookie")
+    if os.path.isfile(cookie_path):
         logger.debug("Deleting leftover cookie file")
-        os.remove(os.path.join(datadir, chain, ".cookie"))
+        os.remove(cookie_path)
 
 
 def softfork_active(node, key):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2020 The Bitcoin Core developers
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Run regression test suite.
+
+This module calls down into individual test cases via subprocess. It will
+forward all unrecognized arguments onto the individual test scripts.
+
+For a description of arguments recognized by test scripts, see
+`test/functional/test_framework/test_framework.py:GridcoinTestFramework.main`.
+
+"""
+
+import argparse
+from collections import deque
+import configparser
+import datetime
+import os
+import time
+import shutil
+import subprocess
+import sys
+import tempfile
+import re
+import logging
+import unittest
+
+# Formatting. Default colors to empty strings.
+BOLD, GREEN, RED, GREY = ("", ""), ("", ""), ("", ""), ("", "")
+try:
+    # Make sure python thinks it can write unicode to its stdout
+    "\u2713".encode("utf_8").decode(sys.stdout.encoding)
+    TICK = "✓ "
+    CROSS = "✖ "
+    CIRCLE = "○ "
+except UnicodeDecodeError:
+    TICK = "P "
+    CROSS = "x "
+    CIRCLE = "o "
+
+if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
+    if os.name == 'nt':
+        import ctypes
+        kernel32 = ctypes.windll.kernel32  # type: ignore
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+        STD_OUTPUT_HANDLE = -11
+        STD_ERROR_HANDLE = -12
+        # Enable ascii color control to stdout
+        stdout = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+        stdout_mode = ctypes.c_int32()
+        kernel32.GetConsoleMode(stdout, ctypes.byref(stdout_mode))
+        kernel32.SetConsoleMode(stdout, stdout_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+        # Enable ascii color control to stderr
+        stderr = kernel32.GetStdHandle(STD_ERROR_HANDLE)
+        stderr_mode = ctypes.c_int32()
+        kernel32.GetConsoleMode(stderr, ctypes.byref(stderr_mode))
+        kernel32.SetConsoleMode(stderr, stderr_mode.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+    # primitive formatting on supported
+    # terminal via ANSI escape sequences:
+    BOLD = ('\033[0m', '\033[1m')
+    GREEN = ('\033[0m', '\033[0;32m')
+    RED = ('\033[0m', '\033[0;31m')
+    GREY = ('\033[0m', '\033[1;30m')
+
+TEST_EXIT_PASSED = 0
+TEST_EXIT_SKIPPED = 77
+
+TEST_FRAMEWORK_MODULES = [
+    # Phase 1 only has util.py. Phase 3 will add address / blocktools / key /
+    # script / messages once messages.py and p2p.py land.
+    "util",
+]
+
+EXTENDED_SCRIPTS = [
+    # These tests are not run by default.
+    # Longest test should go first, to favor running tests in parallel.
+    # Phase 1 has no extended tests.
+]
+
+BASE_SCRIPTS = [
+    # Scripts that are run by default.
+    # Phase 1 ships a single smoke test that exercises the framework against
+    # gridcoinresearchd -testnet. Phase 4 expands the suite.
+    'feature_hello.py',
+]
+
+# Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled
+# earlier when parallelism is available.
+ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS
+
+NON_SCRIPTS = [
+    # These are python files that live in the functional tests directory, but are not test scripts.
+    "combine_logs.py",
+    "create_cache.py",
+    "test_runner.py",
+]
+
+def main():
+    # Parse arguments and pass through unrecognised args
+    parser = argparse.ArgumentParser(add_help=False,
+                                     usage='%(prog)s [test_runner.py options] [script options] [scripts]',
+                                     description=__doc__,
+                                     epilog='''
+    Help text and arguments for individual test script:''',
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--ansi', action='store_true', default=sys.stdout.isatty(), help="Use ANSI colors and dots in output (enabled by default when standard output is a TTY)")
+    parser.add_argument('--combinedlogslen', '-c', type=int, default=0, metavar='n', help='On failure, print a log (of length n lines) to the console, combined from the test framework and all test nodes.')
+    parser.add_argument('--coverage', action='store_true', help='generate a basic coverage report for the RPC interface')
+    parser.add_argument('--ci', action='store_true', help='Run checks and code that are usually only enabled in a continuous integration environment')
+    parser.add_argument('--exclude', '-x', help='specify a comma-separated-list of scripts to exclude.')
+    parser.add_argument('--extended', action='store_true', help='run the extended test suite in addition to the basic tests')
+    parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
+    parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
+    parser.add_argument('--quiet', '-q', action='store_true', help='only print dots, results summary and failure logs')
+    parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
+    parser.add_argument('--failfast', action='store_true', help='stop execution after the first test failure')
+    parser.add_argument('--filter', help='filter scripts to run by regular expression')
+
+    args, unknown_args = parser.parse_known_args()
+    if not args.ansi:
+        global BOLD, GREEN, RED, GREY
+        BOLD = ("", "")
+        GREEN = ("", "")
+        RED = ("", "")
+        GREY = ("", "")
+
+    # args to be passed on always start with two dashes; tests are the remaining unknown args
+    tests = [arg for arg in unknown_args if arg[:2] != "--"]
+    passon_args = [arg for arg in unknown_args if arg[:2] == "--"]
+
+    # Read config generated by configure.
+    config = configparser.ConfigParser()
+    configfile = os.path.abspath(os.path.dirname(__file__)) + "/../config.ini"
+    config.read_file(open(configfile, encoding="utf8"))
+
+    passon_args.append("--configfile=%s" % configfile)
+
+    # Set up logging
+    logging_level = logging.INFO if args.quiet else logging.DEBUG
+    logging.basicConfig(format='%(message)s', level=logging_level)
+
+    # Create base test directory
+    tmpdir = "%s/test_runner_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+
+    os.makedirs(tmpdir)
+
+    logging.debug("Temporary test directory at %s" % tmpdir)
+
+    enable_gridcoind = config["components"].getboolean("ENABLE_GRIDCOIND")
+
+    if not enable_gridcoind:
+        print("No functional tests to run.")
+        print("Rerun cmake with -DENABLE_GRIDCOIND=ON and rebuild")
+        sys.exit(0)
+
+    # Build list of tests
+    test_list = []
+    if tests:
+        # Individual tests have been specified. Run specified tests that exist
+        # in the ALL_SCRIPTS list. Accept names with or without a .py extension.
+        # Specified tests can contain wildcards, but in that case the supplied
+        # paths should be coherent, e.g. the same path as that provided to call
+        # test_runner.py. Examples:
+        #   `test/functional/test_runner.py test/functional/wallet*`
+        #   `test/functional/test_runner.py ./test/functional/wallet*`
+        #   `test_runner.py wallet*`
+        #   but not:
+        #   `test/functional/test_runner.py wallet*`
+        # Multiple wildcards can be passed:
+        #   `test_runner.py tool* mempool*`
+        for test in tests:
+            script = test.split("/")[-1]
+            script = script + ".py" if ".py" not in script else script
+            if script in ALL_SCRIPTS:
+                test_list.append(script)
+            else:
+                print("{}WARNING!{} Test '{}' not found in full test list.".format(BOLD[1], BOLD[0], test))
+    elif args.extended:
+        # Include extended tests
+        test_list += ALL_SCRIPTS
+    else:
+        # Run base tests only
+        test_list += BASE_SCRIPTS
+
+    # Remove the test cases that the user has explicitly asked to exclude.
+    if args.exclude:
+        exclude_tests = [test.split('.py')[0] for test in args.exclude.split(',')]
+        for exclude_test in exclude_tests:
+            # Remove <test_name>.py and <test_name>.py --arg from the test list
+            exclude_list = [test for test in test_list if test.split('.py')[0] == exclude_test]
+            for exclude_item in exclude_list:
+                test_list.remove(exclude_item)
+            if not exclude_list:
+                print("{}WARNING!{} Test '{}' not found in current test list.".format(BOLD[1], BOLD[0], exclude_test))
+
+    if args.filter:
+        test_list = list(filter(re.compile(args.filter).search, test_list))
+
+    if not test_list:
+        print("No valid test scripts specified. Check that your test is in one "
+              "of the test lists in test_runner.py, or run test_runner.py with no arguments to run all tests")
+        sys.exit(0)
+
+    if args.help:
+        # Print help for test_runner.py, then print help of the first script (with args removed) and exit.
+        parser.print_help()
+        subprocess.check_call([sys.executable, os.path.join(config["environment"]["SRCDIR"], 'test', 'functional', test_list[0].split()[0]), '-h'])
+        sys.exit(0)
+
+    check_script_list(src_dir=config["environment"]["SRCDIR"], fail_on_warn=args.ci)
+    check_script_prefixes()
+
+    if not args.keepcache:
+        shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
+
+    run_tests(
+        test_list=test_list,
+        src_dir=config["environment"]["SRCDIR"],
+        build_dir=config["environment"]["BUILDDIR"],
+        tmpdir=tmpdir,
+        jobs=args.jobs,
+        enable_coverage=args.coverage,
+        args=passon_args,
+        combined_logs_len=args.combinedlogslen,
+        failfast=args.failfast,
+        use_term_control=args.ansi,
+    )
+
+def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, use_term_control):
+    args = args or []
+
+    # Warn if gridcoinresearchd is already running
+    try:
+        # pgrep exits with code zero when one or more matching processes found
+        if subprocess.run(["pgrep", "-x", "gridcoinresearchd"], stdout=subprocess.DEVNULL).returncode == 0:
+            print("%sWARNING!%s There is already a gridcoinresearchd process running on this system. Tests may fail unexpectedly due to resource contention!" % (BOLD[1], BOLD[0]))
+    except OSError:
+        # pgrep not supported
+        pass
+
+    # Warn if there is a cache directory
+    cache_dir = "%s/test/cache" % build_dir
+    if os.path.isdir(cache_dir):
+        print("%sWARNING!%s There is a cache directory here: %s. If tests fail unexpectedly, try deleting the cache directory." % (BOLD[1], BOLD[0], cache_dir))
+
+    # Test Framework Tests
+    print("Running Unit Tests for Test Framework Modules")
+    test_framework_tests = unittest.TestSuite()
+    for module in TEST_FRAMEWORK_MODULES:
+        test_framework_tests.addTest(unittest.TestLoader().loadTestsFromName("test_framework.{}".format(module)))
+    result = unittest.TextTestRunner(verbosity=1, failfast=True).run(test_framework_tests)
+    if not result.wasSuccessful():
+        logging.debug("Early exiting after failure in TestFramework unit tests")
+        sys.exit(False)
+
+    tests_dir = src_dir + '/test/functional/'
+
+    flags = ['--cachedir={}'.format(cache_dir)] + args
+
+    if enable_coverage:
+        coverage = RPCCoverage()
+        flags.append(coverage.flag)
+        logging.debug("Initializing coverage directory at %s" % coverage.dir)
+    else:
+        coverage = None
+
+    if len(test_list) > 1 and jobs > 1:
+        # Populate cache
+        try:
+            subprocess.check_output([sys.executable, tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
+        except subprocess.CalledProcessError as e:
+            sys.stdout.buffer.write(e.output)
+            raise
+
+    #Run Tests
+    job_queue = TestHandler(
+        num_tests_parallel=jobs,
+        tests_dir=tests_dir,
+        tmpdir=tmpdir,
+        test_list=test_list,
+        flags=flags,
+        use_term_control=use_term_control,
+    )
+    start_time = time.time()
+    test_results = []
+
+    max_len_name = len(max(test_list, key=len))
+    test_count = len(test_list)
+    for i in range(test_count):
+        test_result, testdir, stdout, stderr = job_queue.get_next()
+        test_results.append(test_result)
+        done_str = "{}/{} - {}{}{}".format(i + 1, test_count, BOLD[1], test_result.name, BOLD[0])
+        if test_result.status == "Passed":
+            logging.debug("%s passed, Duration: %s s" % (done_str, test_result.time))
+        elif test_result.status == "Skipped":
+            logging.debug("%s skipped" % (done_str))
+        else:
+            print("%s failed, Duration: %s s\n" % (done_str, test_result.time))
+            print(BOLD[1] + 'stdout:\n' + BOLD[0] + stdout + '\n')
+            print(BOLD[1] + 'stderr:\n' + BOLD[0] + stderr + '\n')
+            if combined_logs_len and os.path.isdir(testdir):
+                # Print the final `combinedlogslen` lines of the combined logs
+                print('{}Combine the logs and print the last {} lines ...{}'.format(BOLD[1], combined_logs_len, BOLD[0]))
+                print('\n============')
+                print('{}Combined log for {}:{}'.format(BOLD[1], testdir, BOLD[0]))
+                print('============\n')
+                combined_logs_args = [sys.executable, os.path.join(tests_dir, 'combine_logs.py'), testdir]
+                if BOLD[0]:
+                    combined_logs_args += ['--color']
+                combined_logs, _ = subprocess.Popen(combined_logs_args, universal_newlines=True, stdout=subprocess.PIPE).communicate()
+                print("\n".join(deque(combined_logs.splitlines(), combined_logs_len)))
+
+            if failfast:
+                logging.debug("Early exiting after test failure")
+                break
+
+    print_results(test_results, max_len_name, (int(time.time() - start_time)))
+
+    if coverage:
+        coverage_passed = coverage.report_rpc_coverage()
+
+        logging.debug("Cleaning up coverage data")
+        coverage.cleanup()
+    else:
+        coverage_passed = True
+
+    # Clear up the temp directory if all subdirectories are gone
+    if not os.listdir(tmpdir):
+        os.rmdir(tmpdir)
+
+    all_passed = all(map(lambda test_result: test_result.was_successful, test_results)) and coverage_passed
+
+    # This will be a no-op unless failfast is True in which case there may be dangling
+    # processes which need to be killed.
+    job_queue.kill_and_join()
+
+    sys.exit(not all_passed)
+
+def print_results(test_results, max_len_name, runtime):
+    results = "\n" + BOLD[1] + "%s | %s | %s\n\n" % ("TEST".ljust(max_len_name), "STATUS   ", "DURATION") + BOLD[0]
+
+    test_results.sort(key=TestResult.sort_key)
+    all_passed = True
+    time_sum = 0
+
+    for test_result in test_results:
+        all_passed = all_passed and test_result.was_successful
+        time_sum += test_result.time
+        test_result.padding = max_len_name
+        results += str(test_result)
+
+    status = TICK + "Passed" if all_passed else CROSS + "Failed"
+    if not all_passed:
+        results += RED[1]
+    results += BOLD[1] + "\n%s | %s | %s s (accumulated) \n" % ("ALL".ljust(max_len_name), status.ljust(9), time_sum) + BOLD[0]
+    if not all_passed:
+        results += RED[0]
+    results += "Runtime: %s s\n" % (runtime)
+    print(results)
+
+class TestHandler:
+    """
+    Trigger the test scripts passed in via the list.
+    """
+
+    def __init__(self, *, num_tests_parallel, tests_dir, tmpdir, test_list, flags, use_term_control):
+        assert num_tests_parallel >= 1
+        self.num_jobs = num_tests_parallel
+        self.tests_dir = tests_dir
+        self.tmpdir = tmpdir
+        self.test_list = test_list
+        self.flags = flags
+        self.num_running = 0
+        self.jobs = []
+        self.use_term_control = use_term_control
+
+    def get_next(self):
+        while self.num_running < self.num_jobs and self.test_list:
+            # Add tests
+            self.num_running += 1
+            test = self.test_list.pop(0)
+            portseed = len(self.test_list)
+            portseed_arg = ["--portseed={}".format(portseed)]
+            log_stdout = tempfile.SpooledTemporaryFile(max_size=2**16)
+            log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
+            test_argv = test.split()
+            testdir = "{}/{}_{}".format(self.tmpdir, re.sub(".py$", "", test_argv[0]), portseed)
+            tmpdir_arg = ["--tmpdir={}".format(testdir)]
+            self.jobs.append((test,
+                              time.time(),
+                              subprocess.Popen([sys.executable, self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + portseed_arg + tmpdir_arg,
+                                               universal_newlines=True,
+                                               stdout=log_stdout,
+                                               stderr=log_stderr),
+                              testdir,
+                              log_stdout,
+                              log_stderr))
+        if not self.jobs:
+            raise IndexError('pop from empty list')
+
+        # Print remaining running jobs when all jobs have been started.
+        if not self.test_list:
+            print("Remaining jobs: [{}]".format(", ".join(j[0] for j in self.jobs)))
+
+        dot_count = 0
+        while True:
+            # Return first proc that finishes
+            time.sleep(.5)
+            for job in self.jobs:
+                (name, start_time, proc, testdir, log_out, log_err) = job
+                if proc.poll() is not None:
+                    log_out.seek(0), log_err.seek(0)
+                    [stdout, stderr] = [log_file.read().decode('utf-8') for log_file in (log_out, log_err)]
+                    log_out.close(), log_err.close()
+                    if proc.returncode == TEST_EXIT_PASSED and stderr == "":
+                        status = "Passed"
+                    elif proc.returncode == TEST_EXIT_SKIPPED:
+                        status = "Skipped"
+                    else:
+                        status = "Failed"
+                    self.num_running -= 1
+                    self.jobs.remove(job)
+                    if self.use_term_control:
+                        clearline = '\r' + (' ' * dot_count) + '\r'
+                        print(clearline, end='', flush=True)
+                    dot_count = 0
+                    return TestResult(name, status, int(time.time() - start_time)), testdir, stdout, stderr
+            if self.use_term_control:
+                print('.', end='', flush=True)
+            dot_count += 1
+
+    def kill_and_join(self):
+        """Send SIGKILL to all jobs and block until all have ended."""
+        procs = [i[2] for i in self.jobs]
+
+        for proc in procs:
+            proc.kill()
+
+        for proc in procs:
+            proc.wait()
+
+
+class TestResult():
+    def __init__(self, name, status, time):
+        self.name = name
+        self.status = status
+        self.time = time
+        self.padding = 0
+
+    def sort_key(self):
+        if self.status == "Passed":
+            return 0, self.name.lower()
+        elif self.status == "Failed":
+            return 2, self.name.lower()
+        elif self.status == "Skipped":
+            return 1, self.name.lower()
+
+    def __repr__(self):
+        if self.status == "Passed":
+            color = GREEN
+            glyph = TICK
+        elif self.status == "Failed":
+            color = RED
+            glyph = CROSS
+        elif self.status == "Skipped":
+            color = GREY
+            glyph = CIRCLE
+
+        return color[1] + "%s | %s%s | %s s\n" % (self.name.ljust(self.padding), glyph, self.status.ljust(7), self.time) + color[0]
+
+    @property
+    def was_successful(self):
+        return self.status != "Failed"
+
+
+def check_script_prefixes():
+    """Check that test scripts start with one of the allowed name prefixes."""
+
+    good_prefixes_re = re.compile("^(example|feature|interface|mempool|mining|p2p|rpc|wallet|tool)_")
+    bad_script_names = [script for script in ALL_SCRIPTS if good_prefixes_re.match(script) is None]
+
+    if bad_script_names:
+        print("%sERROR:%s %d tests not meeting naming conventions:" % (BOLD[1], BOLD[0], len(bad_script_names)))
+        print("  %s" % ("\n  ".join(sorted(bad_script_names))))
+        raise AssertionError("Some tests are not following naming convention!")
+
+
+def check_script_list(*, src_dir, fail_on_warn):
+    """Check scripts directory.
+
+    Check that there are no scripts in the functional tests directory which are
+    not being run by pull-tester.py."""
+    script_dir = src_dir + '/test/functional/'
+    python_files = set([test_file for test_file in os.listdir(script_dir) if test_file.endswith(".py")])
+    missed_tests = list(python_files - set(map(lambda x: x.split()[0], ALL_SCRIPTS + NON_SCRIPTS)))
+    if len(missed_tests) != 0:
+        print("%sWARNING!%s The following scripts are not being run: %s. Check the test lists in test_runner.py." % (BOLD[1], BOLD[0], str(missed_tests)))
+        if fail_on_warn:
+            # On CI this warning is an error to prevent merging incomplete commits into master
+            sys.exit(1)
+
+
+class RPCCoverage():
+    """
+    Coverage reporting utilities for test_runner.
+
+    Coverage calculation works by having each test script subprocess write
+    coverage files into a particular directory. These files contain the RPC
+    commands invoked during testing, as well as a complete listing of RPC
+    commands per `gridcoin-cli help` (`rpc_interface.txt`).
+
+    After all tests complete, the commands run are combined and diff'd against
+    the complete list to calculate uncovered RPC commands.
+
+    See also: test/functional/test_framework/coverage.py
+
+    """
+    def __init__(self):
+        self.dir = tempfile.mkdtemp(prefix="coverage")
+        self.flag = '--coveragedir=%s' % self.dir
+
+    def report_rpc_coverage(self):
+        """
+        Print out RPC commands that were unexercised by tests.
+
+        """
+        uncovered = self._get_uncovered_rpc_commands()
+
+        if uncovered:
+            print("Uncovered RPC commands:")
+            print("".join(("  - %s\n" % command) for command in sorted(uncovered)))
+            return False
+        else:
+            print("All RPC commands covered.")
+            return True
+
+    def cleanup(self):
+        return shutil.rmtree(self.dir)
+
+    def _get_uncovered_rpc_commands(self):
+        """
+        Return a set of currently untested RPC commands.
+
+        """
+        # This is shared from `test/functional/test_framework/coverage.py`
+        reference_filename = 'rpc_interface.txt'
+        coverage_file_prefix = 'coverage.'
+
+        coverage_ref_filename = os.path.join(self.dir, reference_filename)
+        coverage_filenames = set()
+        all_cmds = set()
+        # Consider RPC generate covered, because it is overloaded in
+        # test_framework/test_node.py and not seen by the coverage check.
+        covered_cmds = set({'generate'})
+
+        if not os.path.isfile(coverage_ref_filename):
+            raise RuntimeError("No coverage reference found")
+
+        with open(coverage_ref_filename, 'r', encoding="utf8") as coverage_ref_file:
+            all_cmds.update([line.strip() for line in coverage_ref_file.readlines()])
+
+        for root, _, files in os.walk(self.dir):
+            for filename in files:
+                if filename.startswith(coverage_file_prefix):
+                    coverage_filenames.add(os.path.join(root, filename))
+
+        for filename in coverage_filenames:
+            with open(filename, 'r', encoding="utf8") as coverage_file:
+                covered_cmds.update([line.strip() for line in coverage_file.readlines()])
+
+        return all_cmds - covered_cmds
+
+
+if __name__ == '__main__':
+    main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -258,7 +258,10 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
     result = unittest.TextTestRunner(verbosity=1, failfast=True).run(test_framework_tests)
     if not result.wasSuccessful():
         logging.debug("Early exiting after failure in TestFramework unit tests")
-        sys.exit(False)
+        # `sys.exit(False)` exits with code 0 (False == 0). Use 1 so CI
+        # actually reports the framework unit-test failure rather than
+        # swallowing it as a success.
+        sys.exit(1)
 
     tests_dir = src_dir + '/test/functional/'
 
@@ -272,12 +275,20 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
         coverage = None
 
     if len(test_list) > 1 and jobs > 1:
-        # Populate cache
-        try:
-            subprocess.check_output([sys.executable, tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
-        except subprocess.CalledProcessError as e:
-            sys.stdout.buffer.write(e.output)
-            raise
+        create_cache_path = tests_dir + 'create_cache.py'
+        if os.path.isfile(create_cache_path):
+            # Populate cache
+            try:
+                subprocess.check_output([sys.executable, create_cache_path] + flags + ["--tmpdir=%s/cache" % tmpdir])
+            except subprocess.CalledProcessError as e:
+                sys.stdout.buffer.write(e.output)
+                raise
+        else:
+            # create_cache.py hasn't been ported to this PR. Force
+            # sequential execution so tests don't race on a missing
+            # shared cache.
+            logging.warning("create_cache.py not present; forcing jobs=1 (no shared cache available).")
+            jobs = 1
 
     #Run Tests
     job_queue = TestHandler(
@@ -306,16 +317,23 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
             print(BOLD[1] + 'stdout:\n' + BOLD[0] + stdout + '\n')
             print(BOLD[1] + 'stderr:\n' + BOLD[0] + stderr + '\n')
             if combined_logs_len and os.path.isdir(testdir):
-                # Print the final `combinedlogslen` lines of the combined logs
-                print('{}Combine the logs and print the last {} lines ...{}'.format(BOLD[1], combined_logs_len, BOLD[0]))
-                print('\n============')
-                print('{}Combined log for {}:{}'.format(BOLD[1], testdir, BOLD[0]))
-                print('============\n')
-                combined_logs_args = [sys.executable, os.path.join(tests_dir, 'combine_logs.py'), testdir]
-                if BOLD[0]:
-                    combined_logs_args += ['--color']
-                combined_logs, _ = subprocess.Popen(combined_logs_args, universal_newlines=True, stdout=subprocess.PIPE).communicate()
-                print("\n".join(deque(combined_logs.splitlines(), combined_logs_len)))
+                combine_logs_path = os.path.join(tests_dir, 'combine_logs.py')
+                if os.path.isfile(combine_logs_path):
+                    # Print the final `combinedlogslen` lines of the combined logs
+                    print('{}Combine the logs and print the last {} lines ...{}'.format(BOLD[1], combined_logs_len, BOLD[0]))
+                    print('\n============')
+                    print('{}Combined log for {}:{}'.format(BOLD[1], testdir, BOLD[0]))
+                    print('============\n')
+                    combined_logs_args = [sys.executable, combine_logs_path, testdir]
+                    if BOLD[0]:
+                        combined_logs_args += ['--color']
+                    combined_logs, _ = subprocess.Popen(combined_logs_args, universal_newlines=True, stdout=subprocess.PIPE).communicate()
+                    print("\n".join(deque(combined_logs.splitlines(), combined_logs_len)))
+                else:
+                    # combine_logs.py hasn't been ported. Fall back to the
+                    # captured stdout/stderr already printed above, so the
+                    # caller still sees actionable failure context.
+                    print("(combine_logs.py not present; printing per-process stdout/stderr only)")
 
             if failfast:
                 logging.debug("Early exiting after test failure")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2020 The Bitcoin Core developers
 # Copyright (c) 2014-2026 The Gridcoin developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://opensource.org/licenses/mit-license.php.
 """Run regression test suite.
 
 This module calls down into individual test cases via subprocess. It will
@@ -40,7 +40,7 @@ except UnicodeDecodeError:
     CROSS = "x "
     CIRCLE = "o "
 
-if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
+if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):  # type: ignore[attr-defined]
     if os.name == 'nt':
         import ctypes
         kernel32 = ctypes.windll.kernel32  # type: ignore
@@ -73,7 +73,7 @@ TEST_FRAMEWORK_MODULES = [
     "util",
 ]
 
-EXTENDED_SCRIPTS = [
+EXTENDED_SCRIPTS: list = [
     # These tests are not run by default.
     # Longest test should go first, to favor running tests in parallel.
     # Phase 1 has no extended tests.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -81,9 +81,13 @@ EXTENDED_SCRIPTS: list = [
 
 BASE_SCRIPTS = [
     # Scripts that are run by default.
-    # Phase 1 ships a single smoke test that exercises the framework against
-    # gridcoinresearchd -testnet. Phase 4 expands the suite.
+    # Phase 1 ships:
+    #   - feature_hello.py: framework smoke test (start node, getblockchaininfo)
+    #   - rpc_help.py: RPCHelpMan rollout coverage (the motivating use case
+    #     from #2922 — exercises `help`, structured help format, and
+    #     IsValidNumArgs() arity validation on converted commands)
     'feature_hello.py',
+    'rpc_help.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since longer tests benefit from being scheduled


### PR DESCRIPTION
## Summary

- Ports Bitcoin Core's `test/functional/` Python framework (spine from v0.21.2, commit `831599913d`) to Gridcoin with the minimum surgery required for our PoS+BOINC codebase: class renames, binary/conf renames, `nTime`-aware test conventions, descriptor/SQLite wallet branches stripped (Gridcoin is BDB-only), port allocation moved clear of Gridcoin's reserved ranges.
- Adds `feature_hello.py` — a single smoke test that proves the framework can start `gridcoinresearchd -testnet`, authenticate over RPC, call `getblockchaininfo`, and shut down cleanly.
- Adds `rpc_help.py` — automated coverage for the RPCHelpMan rollout tracked at #2922. **Auto-discovers** every RPCHelpMan-converted command the daemon advertises and validates the format/arity invariants, so per-PR manual smoke testing becomes a single `test_runner.py` invocation.

This is Phase 1 of the plan tracked at #2932. Phases 2A (CRegTestParams + IsMockableChain gates), 2B (PoS staking RPCs + synthetic beacon + RSA trust anchor), 3 (messages.py / p2p.py for the wire protocol), and 4 (starter test suite + CMake + CI workflow + docs) follow as separate PRs.

## Why now

Every RPC, wallet, and consensus change today is validated either by in-process Boost unit tests or by manual smoke checklists in PR descriptions. The motivating use case is the RPCHelpMan rollout (#2922) — each per-command conversion PR carries a *"Manual RPC smoke (per command) — before marking ready for review"* checklist item. `rpc_help.py` is designed to satisfy the format-and-arity portion of that checklist automatically for any converted command.

## Surgery vs. v0.21.2 (documented for future cherry-picks)

- `BitcoinTestFramework` → `GridcoinTestFramework` (plus metaclass rename).
- `bitcoind`/`bitcoin-cli`/`bitcoin.conf` → `gridcoinresearchd`/`gridcoin-cli`/`gridcoinresearch.conf` throughout.
- `PORT_MIN` 11000 → 41000 — clears Gridcoin's reserved ports (main P2P 32749 / RPC 15715, testnet P2P 32748 / RPC 25715, regtest P2P 32747 / RPC 35715 once Phase 2A lands).
- Descriptor-wallet and SQLite branches stripped (Gridcoin's wallet is always BDB-backed).
- `from .p2p import NetworkThread` replaced with a no-op stub; Phase 3 ports `messages.py` / `p2p.py` and restores the real import.
- `199-block cache initialization` in `setup_nodes()` gated to `chain == 'regtest'`. Phase 2A introduces regtest; until then `setup_nodes()` leaves testnet alone.
- `TEST_FRAMEWORK_MODULES` trimmed to `['util']` (the only unit-test-bearing module shipping in Phase 1).
- `BASE_SCRIPTS` is just `feature_hello.py` + `rpc_help.py`. Phase 4 expands it.
- `# type: ignore[attr-defined]` on `sys.getwindowsversion()` — short-circuit at runtime, but `mypy --platform linux` still type-checks the right side.

## Workflow for reviewing RPCHelpMan PRs (#2958–#2975 and successors)

```bash
git checkout <the-rpchelpman-pr-branch>
git merge fork/test/functional-framework-phase1  # test/ files only, no conflicts
cmake -B build -DENABLE_TESTS=ON && cmake --build build -j

# Hand-write test/config.ini (the CMake-generated version lands in Phase 4):
cat > test/config.ini <<INI
[environment]
PACKAGE_NAME=Gridcoin Research
PACKAGE_BUGREPORT=https://github.com/gridcoin-community/Gridcoin-Research/issues
SRCDIR=$(pwd)
BUILDDIR=$(pwd)/build
EXEEXT=
[components]
ENABLE_WALLET=true
USE_BDB=true
ENABLE_CLI=true
ENABLE_GRIDCOIND=true
ENABLE_ZMQ=true
INI

python3 test/functional/test_runner.py rpc_help.py
```

`rpc_help.py` auto-discovers the PR's newly-converted commands and validates the format/arity pattern against them. **No edits to this test file are required per conversion PR.**

## What `rpc_help.py` enforces (per converted command)

- `help <cmd>` includes the command name plus `Result:` and `Examples:` sections (catches a conversion silently reverting to legacy or a `help.ToString()` formatting regression).
- A wrong-arity call (100 dummy positional args) raises `RPC_MISC_ERROR (-1)` — proving the `IsValidNumArgs` → `runtime_error` → dispatcher re-throw chain (`src/rpc/server.cpp` `JSONRPCExecOne`) is wired.
- Regression guard: `MIN_CONVERTED_COMMANDS = 30` — if discovery returns fewer than this, either a previously-converted command was reverted to legacy or the discovery walk broke. Bump as new tiers merge.
- Spot-check: `getblockchaininfo` returns the expected Gridcoin field set `{blocks, in_sync, moneysupply, difficulty, testnet, errors}` (representative "no field drift" check; per-field shape across all OBJ-returners needs regtest, deferred to Phase 4).

## What this PR does NOT deliver (intentionally deferred)

- **Regtest support** — `gridcoinresearchd -regtest` doesn't start yet. Phase 2A.
- **Block-producing RPCs** (`generatetoaddress`, `walletsettings stakelimit`, `generatesuperblock`) — Phase 2B.
- **Synthetic beacon / RSA trust anchor** — Phase 2B (security-sensitive; needs maintainer signoff on trust-anchor injection design).
- **`messages.py` / `p2p.py`** for Gridcoin's PoS wire protocol — Phase 3.
- **CMake `functional` test target and `.github/workflows/cmake_functional.yml`** — Phase 4. Until then, `python3 test/functional/test_runner.py` is the manual entry point.
- **State-dependent tests** (wallet, mempool, p2p, reorg, contract replay, MRC, sidestake) — Phase 4, once regtest and the wire-protocol Python types are available.

## Test plan

- [x] `python3 -c "import test.functional.test_framework.test_framework"` — module import smoke
- [x] `flake8 --select=<CI ruleset>` on all new files — clean
- [x] `mypy --platform linux --ignore-missing-imports test/functional/test_framework/*.py test/functional/*.py` — clean
- [x] `codespell` on all new files — clean
- [x] `test/lint/lint-copyright-https.sh` on the diff — clean
- [x] CMake Quality Gate (Lint Checks + Sanitizers + Thread Safety) green on the branch
- [x] CMake Production Builds green
- [x] CMake Compatibility Builds green
- [x] CMake Distribution Native Builds green
- [x] Reviewer runs `python3 test/functional/test_runner.py rpc_help.py` against this branch (hand-written `test/config.ini` per the workflow above)
- [x] Reviewer runs `python3 test/functional/test_runner.py feature_hello.py` to verify framework smoke

## Commits

```
c9d128406  test: add rpc_help.py with auto-discovered RPCHelpMan coverage (refs #2922, refs #2932)
b4637ab21  test: fix lint findings in functional-test framework port (refs #2932)
89757b32c  test: port Bitcoin Core v0.21.2 functional-test framework (refs #2932)
```

Refs #2922, refs #2932.
