### PR TITLE
refactor: complete thread-safety annotation coverage across the codebase

### DIFF
--- a/src/gridcoin/consensus/block_rewards.cpp
+++ b/src/gridcoin/consensus/block_rewards.cpp
@@ -803,7 +803,7 @@ bool BlockRewardRules::CheckResearchRewardDrift(std::string& error_out) const
     return true;
 }
 
-bool BlockRewardRules::CheckClaimMagnitude(std::string& error_out) const
+bool BlockRewardRules::CheckClaimMagnitude(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const Claim& claim = m_block->GetClaim();
     const double mag = Quorum::GetMagnitude(claim.m_mining_id).Floating();

--- a/src/gridcoin/consensus/block_rewards.h
+++ b/src/gridcoin/consensus/block_rewards.h
@@ -222,7 +222,7 @@ private:
     // Legacy v9-v10 checks
     bool CheckResearchRewardLimit(std::string& error_out) const;
     bool CheckResearchRewardDrift(std::string& error_out) const;
-    bool CheckClaimMagnitude(std::string& error_out) const;
+    bool CheckClaimMagnitude(std::string& error_out) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 } // namespace GRC

--- a/src/gridcoin/contract/contract.cpp
+++ b/src/gridcoin/contract/contract.cpp
@@ -163,7 +163,7 @@ public:
     //! projects), or the objects are independent and unique by key and admit to
     //! simple reversion, such as polls/votes.
     //!
-    void ResetHandlers()
+    void ResetHandlers() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         // Nothing to do.
     }
@@ -174,7 +174,7 @@ public:
     //!
     //! \param ctx References the contract and associated context.
     //!
-    void Apply(const ContractContext& ctx)
+    void Apply(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (ctx->m_action == ContractAction::ADD) {
             ctx.Log("INFO: Add contract");
@@ -200,7 +200,7 @@ public:
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS)
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return GetHandler(contract.m_type.Value()).Validate(contract, tx, DoS);
     }
@@ -214,7 +214,7 @@ public:
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS)
+    bool BlockValidate(const ContractContext& ctx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         if (!GetHandler(ctx.m_contract.m_type.Value()).BlockValidate(ctx, DoS)) {
             error("%s: Contract of type %s failed validation.",
@@ -233,7 +233,7 @@ public:
     //!
     //! \param ctx References the contract and associated context.
     //!
-    void Revert(const ContractContext& ctx)
+    void Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         ctx.Log("INFO: Revert contract");
 
@@ -501,7 +501,7 @@ void GRC::ReplayContracts(CBlockIndex* pindex_end, CBlockIndex* pindex_start) EX
 void GRC::ApplyContracts(
     const CBlock& block,
     const CBlockIndex* const pindex, const RegistryBookmarks& db_heights,
-    bool& out_found_contract)
+    bool& out_found_contract) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     out_found_contract = false;
 
@@ -517,7 +517,7 @@ void GRC::ApplyContracts(
 void GRC::ApplyContracts(
     const CTransaction& tx,
     const CBlockIndex* const pindex, const RegistryBookmarks& db_heights,
-    bool& out_found_contract)
+    bool& out_found_contract) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     for (const auto& contract : tx.GetContracts()) {
         // Do not (re)apply contracts that have already been stored/loaded into
@@ -576,7 +576,7 @@ void GRC::ApplyContracts(
     }
 }
 
-bool GRC::ValidateContracts(const CTransaction& tx, int& DoS)
+bool GRC::ValidateContracts(const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     for (const auto& contract : tx.GetContracts()) {
         if (!g_dispatcher.Validate(contract, tx, DoS)) {
@@ -587,7 +587,7 @@ bool GRC::ValidateContracts(const CTransaction& tx, int& DoS)
     return true;
 }
 
-bool GRC::BlockValidateContracts(const CBlockIndex* const pindex, const CTransaction& tx, int& DoS)
+bool GRC::BlockValidateContracts(const CBlockIndex* const pindex, const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     for (const auto& contract: tx.GetContracts()) {
         if (!g_dispatcher.BlockValidate({ contract, tx, pindex }, DoS)) {
@@ -598,7 +598,7 @@ bool GRC::BlockValidateContracts(const CBlockIndex* const pindex, const CTransac
     return true;
 }
 
-void GRC::RevertContracts(const CTransaction& tx, const CBlockIndex* const pindex)
+void GRC::RevertContracts(const CTransaction& tx, const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Reverse the contracts. Reorganize will load any previous versions:
     for (const auto& contract : tx.GetContracts()) {
@@ -1002,7 +1002,7 @@ void Contract::Body::ResetType(const ContractType type) EXCLUSIVE_LOCKS_REQUIRED
 // Abstract Class: IContractHandler
 // -----------------------------------------------------------------------------
 
-void IContractHandler::Revert(const ContractContext& ctx)
+void IContractHandler::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (ctx->m_action == ContractAction::ADD) {
         Delete(ctx);

--- a/src/gridcoin/contract/contract.h
+++ b/src/gridcoin/contract/contract.h
@@ -240,7 +240,11 @@ public:
         //!
         //! \param type Indicates which IContractHandler type to construct.
         //!
-        void ResetType(const ContractType type);
+        //! THREAD SAFETY: Called from Contract::Unserialize (template,
+        //! header-defined below). Reads nBestHeight for POLL/PROJECT/PROTOCOL/
+        //! SCRAPER payload version selection — requires cs_main.
+        //!
+        void ResetType(const ContractType type) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     }; // Contract::Body
 
     //!
@@ -448,10 +452,14 @@ public:
     //!
     //! For CTransaction::nVersion >= 2.
     //!
+    //! THREAD SAFETY: m_body.ResetType reads nBestHeight for payload version
+    //! selection — requires cs_main. Callers (CTransaction deserialization
+    //! paths invoked from block / mempool / wallet load) must hold cs_main.
+    //!
     //! \param stream The input stream.
     //!
     template<typename Stream>
-    void Unserialize(Stream& s)
+    void Unserialize(Stream& s) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         s >> m_version;
         s >> m_type;
@@ -618,7 +626,7 @@ void ReplayContracts(CBlockIndex *pindex_end, CBlockIndex *pindex_start = nullpt
 //!
 void ApplyContracts(const CBlock& block,
     const CBlockIndex* const pindex, const RegistryBookmarks& db_heights,
-    bool& out_found_contract);
+    bool& out_found_contract) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Apply contracts from transactions by passing them to the appropriate
@@ -630,7 +638,7 @@ void ApplyContracts(const CBlock& block,
 //!
 void ApplyContracts(const CTransaction& tx,
     const CBlockIndex* const pindex, const RegistryBookmarks& db_heights,
-    bool& out_found_contract);
+    bool& out_found_contract) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Perform contextual validation for the contracts in a transaction.
@@ -640,7 +648,7 @@ void ApplyContracts(const CTransaction& tx,
 //!
 //! \return \c false When a contract in the transaction fails validation.
 //!
-bool ValidateContracts(const CTransaction& tx, int& DoS);
+bool ValidateContracts(const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Perform contextual validation for the contracts in a transaction including block context. This is used
@@ -652,7 +660,7 @@ bool ValidateContracts(const CTransaction& tx, int& DoS);
 //!
 //! \return  \c false If the contract fails validation.
 //!
-bool BlockValidateContracts(const CBlockIndex* const pindex, const CTransaction& tx, int& DoS);
+bool BlockValidateContracts(const CBlockIndex* const pindex, const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Revert previously-applied contracts from a transaction by passing
@@ -661,7 +669,7 @@ bool BlockValidateContracts(const CBlockIndex* const pindex, const CTransaction&
 //! \param tx     Transaction that contains contracts to revert.
 //! \param pindex Block index for the block that contains the transaction.
 //!
-void RevertContracts(const CTransaction& tx, const CBlockIndex* const pindex);
+void RevertContracts(const CTransaction& tx, const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 }
 
 #endif // GRIDCOIN_CONTRACT_CONTRACT_H

--- a/src/gridcoin/contract/handler.h
+++ b/src/gridcoin/contract/handler.h
@@ -5,11 +5,14 @@
 #ifndef GRIDCOIN_CONTRACT_HANDLER_H
 #define GRIDCOIN_CONTRACT_HANDLER_H
 
+#include "sync.h"
+
 #include <cstdint>
 #include <string>
 
 class CBlockIndex;
 class CTransaction;
+extern CCriticalSection cs_main;
 
 namespace GRC {
 
@@ -75,6 +78,12 @@ public:
 //! its methods that provide the read-only access to the contract data imported
 //! by this interface.
 //!
+//! THREAD SAFETY: The "applies from only one thread" promise above is realized
+//! by gating all of these mutation/validation entry points on cs_main —
+//! Validate/BlockValidate/Reset/Add/Delete/Revert are all annotated
+//! EXCLUSIVE_LOCKS_REQUIRED(cs_main). Read-only query methods are NOT part of
+//! this interface; subclasses provide their own thread-safe accessors.
+//!
 struct IContractHandler
 {
     //!
@@ -91,7 +100,7 @@ struct IContractHandler
     //!
     //! \return \c false If the contract fails validation.
     //!
-    virtual bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const = 0;
+    virtual bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     //!
     //! \brief Perform contextual validation for the provided contract including block context. This is used
@@ -102,27 +111,27 @@ struct IContractHandler
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    virtual bool BlockValidate(const ContractContext& ctx, int& DoS) const = 0;
+    virtual bool BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     //!
     //! \brief Destroy the contract handler state to prepare for historical
     //! contract replay.
     //!
-    virtual void Reset() = 0;
+    virtual void Reset() EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     //!
     //! \brief Handle an contract addition.
     //!
     //! \param ctx References the contract and associated context.
     //!
-    virtual void Add(const ContractContext& ctx) = 0;
+    virtual void Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     //!
     //! \brief Handle a contract deletion.
     //!
     //! \param ctx References the contract and associated context.
     //!
-    virtual void Delete(const ContractContext& ctx) = 0;
+    virtual void Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main) = 0;
 
     //!
     //! \brief Revert a contract found in a disconnected block.
@@ -134,7 +143,7 @@ struct IContractHandler
     //!
     //! \param ctx References the contract and associated context.
     //!
-    virtual void Revert(const ContractContext& ctx);
+    virtual void Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief This method is implemented for those contract handlers that have a registry (backing) database.

--- a/src/gridcoin/gridcoin.cpp
+++ b/src/gridcoin/gridcoin.cpp
@@ -168,7 +168,7 @@ bool VerifyCheckpoints(const CBlockIndex* const pindexBest) EXCLUSIVE_LOCKS_REQU
 //!
 //! \param pindexBest Block index of the tip of the chain.
 //!
-void InitializeSuperblockQuorum(const CBlockIndex* pindexBest)
+void InitializeSuperblockQuorum(const CBlockIndex* pindexBest) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (IsV9Enabled(pindexBest->nHeight)) {
         LogPrintf("Gridcoin: Loading superblock cache...");

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -745,7 +745,7 @@ WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& fil
     return WhitelistSnapshot(std::make_shared<ProjectList>(projects), filter);
 }
 
-void Whitelist::Reset()
+void Whitelist::Reset() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LOCK(cs_lock);
 
@@ -882,17 +882,17 @@ void Whitelist::AddDelete(const ContractContext& ctx)
 
 }
 
-void Whitelist::Add(const ContractContext& ctx)
+void Whitelist::Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void Whitelist::Delete(const ContractContext& ctx)
+void Whitelist::Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void Whitelist::Revert(const ContractContext& ctx)
+void Whitelist::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const auto payload = ctx->SharePayloadAs<Project>();
 
@@ -967,7 +967,7 @@ void Whitelist::Revert(const ContractContext& ctx)
     }
 }
 
-bool Whitelist::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const
+bool Whitelist::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // No validation is done with contract versions of 2 or less.
     if (contract.m_version <= 2) {
@@ -993,7 +993,7 @@ bool Whitelist::Validate(const Contract& contract, const CTransaction& tx, int &
     return true;
 }
 
-bool Whitelist::BlockValidate(const ContractContext& ctx, int& DoS) const
+bool Whitelist::BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const auto payload = ctx.m_contract.SharePayloadAs<Project>();
 

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -907,7 +907,7 @@ public:
     //! \brief Destroy the contract handler state to prepare for historical
     //! contract replay.
     //!
-    void Reset() override;
+    void Reset() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Perform contextual validation for the provided contract.
@@ -918,7 +918,7 @@ public:
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Perform contextual validation for the provided contract including block context. This is used
@@ -929,21 +929,21 @@ public:
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Add a project to the whitelist from contract data.
     //!
     //! \param ctx References the project contract and associated context.
     //!
-    void Add(const ContractContext& ctx) override;
+    void Add(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Remove the specified project from the whitelist.
     //!
     //! \param ctx References the project contract and associated context.
     //!
-    void Delete(const ContractContext& ctx) override;
+    void Delete(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Revert the registry state for the project entry to the state prior
@@ -952,7 +952,7 @@ public:
     //!
     //! \param ctx References the project entry contract and associated context.
     //!
-    void Revert(const ContractContext& ctx) override;
+    void Revert(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Initialize the Project Whitelist (registry), which now includes restoring the state of the whitelist from

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -335,7 +335,7 @@ ProtocolEntryOption ProtocolRegistry::TryLastBeforeTimestamp(const std::string& 
     }
 }
 
-void ProtocolRegistry::Reset()
+void ProtocolRegistry::Reset() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LOCK(cs_lock);
 
@@ -418,17 +418,17 @@ void ProtocolRegistry::AddDelete(const ContractContext& ctx)
     return;
 }
 
-void ProtocolRegistry::Add(const ContractContext& ctx)
+void ProtocolRegistry::Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void ProtocolRegistry::Delete(const ContractContext& ctx)
+void ProtocolRegistry::Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void ProtocolRegistry::Revert(const ContractContext& ctx)
+void ProtocolRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const auto payload = ctx->SharePayloadAs<ProtocolEntryPayload>();
 
@@ -494,7 +494,7 @@ void ProtocolRegistry::Revert(const ContractContext& ctx)
     }
 }
 
-bool ProtocolRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const
+bool ProtocolRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (contract.m_version < 1) {
         return true;
@@ -517,7 +517,7 @@ bool ProtocolRegistry::Validate(const Contract& contract, const CTransaction& tx
     return true;
 }
 
-bool ProtocolRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+bool ProtocolRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return Validate(ctx.m_contract, ctx.m_tx, DoS);
 }

--- a/src/gridcoin/protocol.h
+++ b/src/gridcoin/protocol.h
@@ -478,7 +478,7 @@ public:
     //! as a startup argument, because contract replay storage and full reversion has
     //! been implemented for protocol entries.
     //!
-    void Reset() override;
+    void Reset() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a protocol entry contract is valid.
@@ -489,7 +489,7 @@ public:
     //!
     //! \return \c true if the contract contains a valid protocol entry.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a protocol entry contract is valid including block context. This is used
@@ -501,7 +501,7 @@ public:
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Add a protocol entry to the registry from contract data. For the protocol registry
@@ -509,7 +509,7 @@ public:
     //! is actually symmetric to both.
     //! \param ctx
     //!
-    void Add(const ContractContext& ctx) override;
+    void Add(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Mark a protocol entry deleted in the registry from contract data. For the protocol registry
@@ -517,7 +517,7 @@ public:
     //! is actually symmetric to both.
     //! \param ctx
     //!
-    void Delete(const ContractContext& ctx) override;
+    void Delete(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Revert the registry state for the protocol entry to the state prior
@@ -526,7 +526,7 @@ public:
     //!
     //! \param ctx References the protocol entry contract and associated context.
     //!
-    void Revert(const ContractContext& ctx) override;
+    void Revert(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Initialize the ProtocolRegistry, which now includes restoring the state of the ProtocolRegistry from

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -1611,12 +1611,21 @@ private: // SuperblockValidator methods
 //!
 //! \brief Stores recent superblock data.
 //!
-SuperblockIndex g_superblock_index;
+//! Touched by Quorum static methods that mutate (PushSuperblock,
+//! PopSuperblock, CommitSuperblock, LoadSuperblockIndex) or read
+//! (CurrentSuperblock, PendingSuperblock, HasPendingSuperblock, GetMagnitude).
+//! Has no internal mutex; cs_main is the external protection per the
+//! Quorum class contract.
+//!
+SuperblockIndex g_superblock_index GUARDED_BY(cs_main);
 
 //!
 //! \brief Orchestrates superblock voting for legacy quorum consensus.
 //!
-LegacyConsensus g_legacy_consensus;
+//! Touched by Quorum's vote-recording methods (FindPopularHash, RecordVote,
+//! ForgetVote). No internal mutex; cs_main is the external protection.
+//!
+LegacyConsensus g_legacy_consensus GUARDED_BY(cs_main);
 
 } // anonymous namespace
 
@@ -1630,7 +1639,7 @@ bool Quorum::Participating(const std::string& grc_address, const int64_t time)
     return LegacyConsensus::Participating(grc_address, time);
 }
 
-QuorumHash Quorum::FindPopularHash(const CBlockIndex* const pindex)
+QuorumHash Quorum::FindPopularHash(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_legacy_consensus.FindPopularHash(pindex);
 }
@@ -1638,12 +1647,12 @@ QuorumHash Quorum::FindPopularHash(const CBlockIndex* const pindex)
 void Quorum::RecordVote(
     const QuorumHash quorum_hash,
     const std::string& grc_address,
-    const CBlockIndex* const pindex)
+    const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     g_legacy_consensus.RecordVote(quorum_hash, grc_address, pindex);
 }
 
-void Quorum::ForgetVote(const CBlockIndex* const pindex)
+void Quorum::ForgetVote(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     g_legacy_consensus.ForgetVote(pindex);
 }
@@ -1743,12 +1752,12 @@ bool Quorum::ValidateSuperblock(
     return result != Result::INVALID;
 }
 
-Magnitude Quorum::GetMagnitude(const Cpid cpid)
+Magnitude Quorum::GetMagnitude(const Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return Quorum::CurrentSuperblock()->m_cpids.MagnitudeOf(cpid);
 }
 
-Magnitude Quorum::GetMagnitude(const MiningId mining_id)
+Magnitude Quorum::GetMagnitude(const MiningId mining_id) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (const auto cpid_option = mining_id.TryCpid()) {
         return GetMagnitude(*cpid_option);
@@ -1806,17 +1815,17 @@ std::vector<ExplainMagnitudeProject> Quorum::ExplainMagnitude(const Cpid cpid)
     return projects;
 }
 
-SuperblockPtr Quorum::CurrentSuperblock()
+SuperblockPtr Quorum::CurrentSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_superblock_index.Current();
 }
 
-SuperblockPtr Quorum::PendingSuperblock()
+SuperblockPtr Quorum::PendingSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_superblock_index.Pending();
 }
 
-bool Quorum::HasPendingSuperblock()
+bool Quorum::HasPendingSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_superblock_index.HasPending();
 }
@@ -1834,7 +1843,7 @@ bool Quorum::SuperblockNeeded(const int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_mai
 
 }
 
-void Quorum::LoadSuperblockIndex(const CBlockIndex* pindexLast)
+void Quorum::LoadSuperblockIndex(const CBlockIndex* pindexLast) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pindexLast) {
         return;
@@ -1848,21 +1857,21 @@ Superblock Quorum::CreateSuperblock()
     return ScraperGetSuperblockContract();
 }
 
-void Quorum::PushSuperblock(SuperblockPtr superblock)
+void Quorum::PushSuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrintf("Quorum::PushSuperblock(%" PRId64 ")", superblock.m_height);
 
     g_superblock_index.PushSuperblock(std::move(superblock));
 }
 
-void Quorum::PopSuperblock(const CBlockIndex* const pindex)
+void Quorum::PopSuperblock(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LogPrintf("Quorum::PopSuperblock(%" PRId64 ")", pindex->nHeight);
 
     g_superblock_index.PopSuperblock();
 }
 
-bool Quorum::CommitSuperblock(const uint32_t height)
+bool Quorum::CommitSuperblock(const uint32_t height) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_superblock_index.Commit(height);
 }

--- a/src/gridcoin/quorum.h
+++ b/src/gridcoin/quorum.h
@@ -63,7 +63,15 @@ public:
 //! update the superblock data for research reward calculations.
 //!
 //! THREAD SAFETY: The quorum system interacts closely with pointers to blocks
-//! in the chain index. Always lock cs_main before calling its methods.
+//! in the chain index, and its in-memory state (g_superblock_index,
+//! g_legacy_consensus) is protected by cs_main. Methods that consult chain
+//! state or mutate that in-memory state are annotated
+//! EXCLUSIVE_LOCKS_REQUIRED(cs_main). The exceptions are:
+//!
+//!   - Participating()       -- pure function over (address, time)
+//!   - ValidateSuperblock()  -- scraper-side; uses cs_ConvergedScraperStatsCache
+//!   - ExplainMagnitude()    -- scraper-side; uses cs_ConvergedScraperStatsCache
+//!   - CreateSuperblock()    -- scraper-side; uses cs_Scraper / cs_mapManifest
 //!
 class Quorum
 {
@@ -90,7 +98,7 @@ public:
     //! \return Quorum hash of the most popular superblock or an invalid hash
     //! when no nodes voted in the current superblock cycle.
     //!
-    static QuorumHash FindPopularHash(const CBlockIndex* const pindex);
+    static QuorumHash FindPopularHash(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Store a node's vote for a pending superblock in the cache.
@@ -102,14 +110,14 @@ public:
     static void RecordVote(
         const QuorumHash quorum_hash,
         const std::string& grc_address,
-        const CBlockIndex* const pindex);
+        const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Remove a node's vote for a pending superblock from the cache.
     //!
     //! \param pindex The block that contains the vote to remove.
     //!
-    static void ForgetVote(const CBlockIndex* const pindex);
+    static void ForgetVote(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Validate a superblock published to the network for the day.
@@ -152,7 +160,7 @@ public:
     //!
     //! \return Magnitude as of the last tallied superblock.
     //!
-    static Magnitude GetMagnitude(const Cpid cpid);
+    static Magnitude GetMagnitude(const Cpid cpid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get the current magnitude for the specified mining ID.
@@ -162,7 +170,7 @@ public:
     //! \return Magnitude as of the last tallied superblock or zero if the
     //! mining ID represents a non-cruncher.
     //!
-    static Magnitude GetMagnitude(const MiningId mining_id);
+    static Magnitude GetMagnitude(const MiningId mining_id) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Generate a report from scraper statistics that contains the
@@ -179,7 +187,7 @@ public:
     //!
     //! \return The most recent superblock applied by the tally.
     //!
-    static SuperblockPtr CurrentSuperblock();
+    static SuperblockPtr CurrentSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get a reference to the upcoming superblock.
@@ -190,7 +198,7 @@ public:
     //! \return A superblock pending activation if one exists. Returns an empty
     //! superblock when the tally already activated the latest superblock.
     //!
-    static SuperblockPtr PendingSuperblock();
+    static SuperblockPtr PendingSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether any superblocks are pending activation.
@@ -198,7 +206,7 @@ public:
     //! \return \c true if the index contains a superblock loaded at a height
     //! above the last tally window.
     //!
-    static bool HasPendingSuperblock();
+    static bool HasPendingSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether the network expects a new superblock.
@@ -215,7 +223,7 @@ public:
     //!
     //! \param pindexLast The most recent block to begin loading backward from.
     //!
-    static void LoadSuperblockIndex(const CBlockIndex* pindexLast);
+    static void LoadSuperblockIndex(const CBlockIndex* pindexLast) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Create a new superblock from scraper convergence data.
@@ -229,14 +237,14 @@ public:
     //!
     //! \param superblock Contains the superblock data to load.
     //!
-    static void PushSuperblock(SuperblockPtr superblock);
+    static void PushSuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Drop the last superblock loaded into the tally.
     //!
     //! \param pindex Represents the block that contains the superblock to drop.
     //!
-    static void PopSuperblock(const CBlockIndex* const pindex);
+    static void PopSuperblock(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Activate the superblock received at or below the specified
@@ -247,7 +255,7 @@ public:
     //! \return \c true if a superblock at or below the specified height was
     //! activated.
     //!
-    static bool CommitSuperblock(const uint32_t height);
+    static bool CommitSuperblock(const uint32_t height) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 }
 

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -31,7 +31,8 @@ using namespace GRC;
 
 extern CCriticalSection cs_main;
 extern CCriticalSection cs_ScraperGlobals;
-extern std::string msMiningErrors;
+extern CCriticalSection cs_msMiningErrors;
+extern std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
 extern unsigned int nActiveBeforeSB;
 
 std::vector<MiningPool> MiningPools::GetMiningPools()
@@ -457,22 +458,26 @@ bool DetectSplitCpid(const MiningProjectMap& projects)
 void StoreResearcher(Researcher context)
 {
     // TODO: this belongs in presentation layer code:
-    switch (context.Status()) {
-        case ResearcherStatus::ACTIVE:
-            msMiningErrors = _("Eligible for Research Rewards");
-            break;
-        case ResearcherStatus::POOL:
-            msMiningErrors = _("Staking Only - Pool Detected");
-            break;
-        case ResearcherStatus::NO_PROJECTS:
-            msMiningErrors = _("Staking Only - No Eligible Research Projects");
-            break;
-        case ResearcherStatus::NO_BEACON:
-            msMiningErrors = _("Staking Only - No active beacon");
-            break;
-        case ResearcherStatus::NONCRUNCHER:
-            msMiningErrors = _("Staking Only - Non-cruncher Mode");
-            break;
+    {
+        LOCK(cs_msMiningErrors);
+
+        switch (context.Status()) {
+            case ResearcherStatus::ACTIVE:
+                msMiningErrors = _("Eligible for Research Rewards");
+                break;
+            case ResearcherStatus::POOL:
+                msMiningErrors = _("Staking Only - Pool Detected");
+                break;
+            case ResearcherStatus::NO_PROJECTS:
+                msMiningErrors = _("Staking Only - No Eligible Research Projects");
+                break;
+            case ResearcherStatus::NO_BEACON:
+                msMiningErrors = _("Staking Only - No active beacon");
+                break;
+            case ResearcherStatus::NONCRUNCHER:
+                msMiningErrors = _("Staking Only - Non-cruncher Mode");
+                break;
+        }
     }
 
     std::atomic_store(

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -38,29 +38,34 @@ extern CCriticalSection cs_VerifiedBeacons;
 * Global Defaults (externs for header file) *
 *********************************************/
 
-extern unsigned int nScraperSleep;
-extern unsigned int nActiveBeforeSB;
+// The definitions in scraper.cpp carry GUARDED_BY(cs_ScraperGlobals);
+// mirror the annotation onto the extern decls so cross-TU readers see
+// the requirement. The atomics (MAG_ROUND / NETWORK_MAGNITUDE /
+// CPID_MAG_LIMIT) are naturally synchronized and intentionally
+// unguarded.
+extern unsigned int nScraperSleep GUARDED_BY(cs_ScraperGlobals);
+extern unsigned int nActiveBeforeSB GUARDED_BY(cs_ScraperGlobals);
 
-extern bool fExplorer;
+extern bool fExplorer GUARDED_BY(cs_ScraperGlobals);
 
-extern bool SCRAPER_RETAIN_NONCURRENT_FILES;
-extern int64_t SCRAPER_FILE_RETENTION_TIME;
-extern int64_t EXPLORER_EXTENDED_FILE_RETENTION_TIME;
-extern bool SCRAPER_CMANIFEST_RETAIN_NONCURRENT;
-extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME;
-extern bool SCRAPER_CMANIFEST_INCLUDE_NONCURRENT_PROJ_FILES;
+extern bool SCRAPER_RETAIN_NONCURRENT_FILES GUARDED_BY(cs_ScraperGlobals);
+extern int64_t SCRAPER_FILE_RETENTION_TIME GUARDED_BY(cs_ScraperGlobals);
+extern int64_t EXPLORER_EXTENDED_FILE_RETENTION_TIME GUARDED_BY(cs_ScraperGlobals);
+extern bool SCRAPER_CMANIFEST_RETAIN_NONCURRENT GUARDED_BY(cs_ScraperGlobals);
+extern int64_t SCRAPER_CMANIFEST_RETENTION_TIME GUARDED_BY(cs_ScraperGlobals);
+extern bool SCRAPER_CMANIFEST_INCLUDE_NONCURRENT_PROJ_FILES GUARDED_BY(cs_ScraperGlobals);
 extern std::atomic<double> MAG_ROUND;
 extern std::atomic<double> NETWORK_MAGNITUDE;
 extern std::atomic<double> CPID_MAG_LIMIT;
-extern unsigned int SCRAPER_CONVERGENCE_MINIMUM;
-extern double SCRAPER_CONVERGENCE_RATIO;
-extern double CONVERGENCE_BY_PROJECT_RATIO;
-extern bool ALLOW_NONSCRAPER_NODE_STATS_DOWNLOAD;
-extern unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE;
-extern bool REQUIRE_TEAM_WHITELIST_MEMBERSHIP;
-extern std::string TEAM_WHITELIST;
-extern std::string EXTERNAL_ADAPTER_PROJECTS;
-extern int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD;
+extern unsigned int SCRAPER_CONVERGENCE_MINIMUM GUARDED_BY(cs_ScraperGlobals);
+extern double SCRAPER_CONVERGENCE_RATIO GUARDED_BY(cs_ScraperGlobals);
+extern double CONVERGENCE_BY_PROJECT_RATIO GUARDED_BY(cs_ScraperGlobals);
+extern bool ALLOW_NONSCRAPER_NODE_STATS_DOWNLOAD GUARDED_BY(cs_ScraperGlobals);
+extern unsigned int SCRAPER_MISBEHAVING_NODE_BANSCORE GUARDED_BY(cs_ScraperGlobals);
+extern bool REQUIRE_TEAM_WHITELIST_MEMBERSHIP GUARDED_BY(cs_ScraperGlobals);
+extern std::string TEAM_WHITELIST GUARDED_BY(cs_ScraperGlobals);
+extern std::string EXTERNAL_ADAPTER_PROJECTS GUARDED_BY(cs_ScraperGlobals);
+extern int64_t SCRAPER_DEAUTHORIZED_BANSCORE_GRACE_PERIOD GUARDED_BY(cs_ScraperGlobals);
 
 /** Enum for scraper log attributes */
 enum class logattribute

--- a/src/gridcoin/scraper/scraper_net.cpp
+++ b/src/gridcoin/scraper/scraper_net.cpp
@@ -44,7 +44,10 @@ bool CSplitBlob::RecvPart(CNode* pfrom, CDataStream& vRecv)
     */
     auto& ss = vRecv;
     uint256 hash(Hash(ss));
-    mapAlreadyAskedFor.erase(CInv(MSG_PART, hash));
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+        mapAlreadyAskedFor.erase(CInv(MSG_PART, hash));
+    }
 
     LOCK(cs_mapParts);
 

--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -325,7 +325,7 @@ ScraperEntryOption ScraperRegistry::TryAuthorized(const CKeyID& key_id) const
     return nullptr;
 }
 
-void ScraperRegistry::Reset()
+void ScraperRegistry::Reset() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LOCK(cs_lock);
 
@@ -411,17 +411,17 @@ void ScraperRegistry::AddDelete(const ContractContext& ctx)
     return;
 }
 
-void ScraperRegistry::Add(const ContractContext& ctx)
+void ScraperRegistry::Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void ScraperRegistry::Delete(const ContractContext& ctx)
+void ScraperRegistry::Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void ScraperRegistry::Revert(const ContractContext& ctx)
+void ScraperRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const auto payload = ctx->SharePayloadAs<ScraperEntryPayload>();
 
@@ -488,7 +488,7 @@ void ScraperRegistry::Revert(const ContractContext& ctx)
     }
 }
 
-bool ScraperRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const
+bool ScraperRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (contract.m_version < 1) {
         return true;
@@ -512,7 +512,7 @@ bool ScraperRegistry::Validate(const Contract& contract, const CTransaction& tx,
     return true;
 }
 
-bool ScraperRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+bool ScraperRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return Validate(ctx.m_contract, ctx.m_tx, DoS);
 }

--- a/src/gridcoin/scraper/scraper_registry.h
+++ b/src/gridcoin/scraper/scraper_registry.h
@@ -502,7 +502,7 @@ public:
     //! as a startup argument, because contract replay storage and full reversion has
     //! been implemented for scraper entries.
     //!
-    void Reset() override;
+    void Reset() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a scraper entry contract is valid.
@@ -513,7 +513,7 @@ public:
     //!
     //! \return \c true if the contract contains a valid scraper entry.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a scraper entry contract is valid including block context. This is used
@@ -525,7 +525,7 @@ public:
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Add a scraper entry to the registry from contract data. For the scraper registry
@@ -533,7 +533,7 @@ public:
     //! is actually symmetric to both.
     //! \param ctx
     //!
-    void Add(const ContractContext& ctx) override;
+    void Add(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Mark a scraper entry deleted in the registry from contract data. For the scraper registry
@@ -541,7 +541,7 @@ public:
     //! is actually symmetric to both.
     //! \param ctx
     //!
-    void Delete(const ContractContext& ctx) override;
+    void Delete(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Revert the registry state for the scraper entry to the state prior
@@ -550,7 +550,7 @@ public:
     //!
     //! \param ctx References the scraper entry contract and associated context.
     //!
-    void Revert(const ContractContext& ctx) override;
+    void Revert(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Initialize the ScraperRegistry, which now includes restoring the state of the ScraperRegistry from

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -670,7 +670,7 @@ std::vector<SideStake_ptr> SideStakeRegistry::TryActive(const CTxDestination& ke
     return result;
 }
 
-void SideStakeRegistry::Reset()
+void SideStakeRegistry::Reset() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LOCK(cs_lock);
 
@@ -753,12 +753,12 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
     return;
 }
 
-void SideStakeRegistry::Add(const ContractContext& ctx)
+void SideStakeRegistry::Add(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
 
-void SideStakeRegistry::Delete(const ContractContext& ctx)
+void SideStakeRegistry::Delete(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AddDelete(ctx);
 }
@@ -790,7 +790,7 @@ void SideStakeRegistry::NonContractDelete(const CTxDestination& destination, con
     }
 }
 
-void SideStakeRegistry::Revert(const ContractContext& ctx)
+void SideStakeRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const auto payload = ctx->SharePayloadAs<SideStakePayload>();
 
@@ -856,7 +856,7 @@ void SideStakeRegistry::Revert(const ContractContext& ctx)
     }
 }
 
-bool SideStakeRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const
+bool SideStakeRegistry::Validate(const Contract& contract, const CTransaction& tx, int &DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const auto payload = contract.SharePayloadAs<SideStakePayload>();
 
@@ -886,7 +886,7 @@ bool SideStakeRegistry::Validate(const Contract& contract, const CTransaction& t
     return true;
 }
 
-bool SideStakeRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+bool SideStakeRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return (IsV13Enabled(ctx.m_pindex->nHeight) && Validate(ctx.m_contract, ctx.m_tx, DoS));
 }

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -719,7 +719,7 @@ public:
     //! as a startup argument, because contract replay storage and full reversion has
     //! been implemented for sidestake entries.
     //!
-    void Reset() override;
+    void Reset() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a sidestake entry contract is valid.
@@ -730,7 +730,7 @@ public:
     //!
     //! \return \c true if the contract contains a valid sidestake entry.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Determine whether a sidestake entry contract is valid including block context. This is used
@@ -742,7 +742,7 @@ public:
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Add a sidestake entry to the registry from contract data. For the sidestake registry
@@ -751,7 +751,7 @@ public:
     //!
     //! \param ctx
     //!
-    void Add(const ContractContext& ctx) override;
+    void Add(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Mark a sidestake entry deleted in the registry from contract data. For the sidestake registry
@@ -759,7 +759,7 @@ public:
     //! is actually symmetric to both.
     //! \param ctx
     //!
-    void Delete(const ContractContext& ctx) override;
+    void Delete(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Allows local (voluntary) sidestakes to be added to the in-memory local map and not persisted to
@@ -786,7 +786,7 @@ public:
     //!
     //! \param ctx References the sidestake entry contract and associated context.
     //!
-    void Revert(const ContractContext& ctx) override;
+    void Revert(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Initialize the sidestakeRegistry, which now includes restoring the state of the sidestakeRegistry from

--- a/src/gridcoin/staking/chain_trust.h
+++ b/src/gridcoin/staking/chain_trust.h
@@ -6,9 +6,12 @@
 #define GRIDCOIN_STAKING_CHAIN_TRUST_H
 
 #include "arith_uint256.h"
+#include "sync.h"
 
 #include <array>
 #include <vector>
+
+extern CCriticalSection cs_main;
 
 namespace GRC {
 //!
@@ -42,7 +45,7 @@ public:
     //! \param genesis Blockchain index for the genesis block.
     //! \param tip     Blockchain index for the highest known block.
     //!
-    void Initialize(const CBlockIndex* genesis, const CBlockIndex* tip)
+    void Initialize(const CBlockIndex* genesis, const CBlockIndex* tip) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         int64_t start_time = GetTimeMillis();
 
@@ -72,7 +75,7 @@ public:
     //!
     //! \return Chain trust value at the current best block.
     //!
-    arith_uint256 Best() const
+    arith_uint256 Best() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return m_best_trust;
     }
@@ -85,7 +88,7 @@ public:
     //!
     //! \return \c true if the specified block exhibits greater chain trust.
     //!
-    bool Favors(const CBlockIndex* pindex) const
+    bool Favors(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return GetTrust(pindex) > Best();
     }
@@ -97,7 +100,7 @@ public:
     //!
     //! \return Chain trust value for the specified block.
     //!
-    arith_uint256 GetTrust(const CBlockIndex* pindex) const
+    arith_uint256 GetTrust(const CBlockIndex* pindex) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         arith_uint256 chain_trust;
 
@@ -140,7 +143,7 @@ public:
     //! \param pindex Points to the block index entry selected as the tip of
     //! the chain.
     //!
-    void SetBest(const CBlockIndex* pindex)
+    void SetBest(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         m_best_trust = pindex->GetBlockTrust() + GetTrust(pindex->pprev);
         m_best_pindex = pindex;

--- a/src/gridcoin/staking/difficulty.h
+++ b/src/gridcoin/staking/difficulty.h
@@ -6,10 +6,14 @@
 #ifndef GRIDCOIN_STAKING_DIFFICULTY_H
 #define GRIDCOIN_STAKING_DIFFICULTY_H
 
+#include "sync.h"
+
 #include <cstdint>
 class CBlockIndex;
 class CWallet;
 #include <cmath>
+
+extern CCriticalSection cs_main;
 
 namespace GRC {
 // Note that dDiff cannot be = 0 normally. This is set as default because you can't specify the output of
@@ -17,16 +21,18 @@ namespace GRC {
 // The default confidence is 1-1/e which is the mean for the geometric distribution for small probabilities.
 const double DEFAULT_ETTS_CONFIDENCE = 1.0 - 1.0 / exp(1.0);
 
-unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast);
-double GetDifficulty(const CBlockIndex* blockindex = nullptr);
+unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+double GetDifficulty(const CBlockIndex* blockindex = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 double GetBlockDifficulty(unsigned int nBits);
-double GetCurrentDifficulty();
-double GetTargetDifficulty();
-double GetAverageDifficulty(unsigned int nPoSInterval = 40);
-double GetSmoothedDifficulty(int64_t nStakeableBalance);
+double GetCurrentDifficulty() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+double GetTargetDifficulty() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+double GetAverageDifficulty(unsigned int nPoSInterval = 40) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+double GetSmoothedDifficulty(int64_t nStakeableBalance) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+//! Self-managed locking: takes LOCK2(cs_main, wallet.cs_wallet) internally.
+//! Safe to call with or without cs_main already held (cs_main is recursive).
 uint64_t GetStakeWeight(const CWallet& wallet);
-double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);
+double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief This returns the precise average network weight in units of Halfords as a 64 bit unsigned integer. This form takes
@@ -42,7 +48,7 @@ double GetEstimatedNetworkWeight(unsigned int nPoSInterval = 40);
 //!
 //! \return uint64_t of the average network weight in Halford units.
 //!
-uint64_t GetAvgNetworkWeight(const unsigned int& block_interval, CBlockIndex* index_start = nullptr);
+uint64_t GetAvgNetworkWeight(const unsigned int& block_interval, CBlockIndex* index_start = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief This returns the precise average network weight in units of Halfords as a 64 bit unsigned integer. The starting index
@@ -60,7 +66,9 @@ uint64_t GetAvgNetworkWeight(const unsigned int& block_interval, CBlockIndex* in
 //!
 //! \return uint64_t of the average network weight in Halford units.
 //!
-uint64_t GetAvgNetworkWeight(CBlockIndex* index_start = nullptr, CBlockIndex* index_end = nullptr);
+uint64_t GetAvgNetworkWeight(CBlockIndex* index_start = nullptr, CBlockIndex* index_end = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+//! Self-managed locking: takes LOCK2(cs_main, pwalletMain->cs_wallet) internally.
+//! Safe to call with or without cs_main already held (cs_main is recursive).
 double GetEstimatedTimetoStake(bool ignore_staking_status = false, double dDiff = 0.0, double dConfidence = DEFAULT_ETTS_CONFIDENCE);
 } // namespace GRC
 

--- a/src/gridcoin/staking/kernel.cpp
+++ b/src/gridcoin/staking/kernel.cpp
@@ -279,7 +279,7 @@ static bool SelectBlockFromCandidates(
 // block. This is to make it difficult for an attacker to gain control of
 // additional bits in the stake modifier, even after generating a chain of
 // blocks.
-bool GRC::ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier)
+bool GRC::ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     nStakeModifier = 0;
     fGeneratedStakeModifier = false;
@@ -388,7 +388,7 @@ bool GRC::ReadStakedInput(
     const uint256 prevout_hash,
     CBlockHeader& out_header,
     CTransaction& out_txprev,
-    CBlockIndex* pindexPrev)
+    CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CTxIndex tx_index;
 
@@ -440,7 +440,7 @@ bool GRC::CalculateLegacyV3HashProof(
     const CBlock& block,
     const double por_nonce,
     CValidationState& state,
-    uint256& out_hash_proof)
+    uint256& out_hash_proof) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const CTransaction& coinstake = block.vtx[1];
     const COutPoint& prevout = coinstake.vin[0].prevout;
@@ -557,7 +557,7 @@ int64_t GRC::CalculateStakeWeightV8(const CAmount& nValueIn)
 
 // Another version of GetKernelStakeModifier (TomasBrod)
 // Todo: security considerations
-bool GRC::FindStakeModifierRev(uint64_t& nStakeModifier, CBlockIndex* pindexPrev, int& nHeight_mod)
+bool GRC::FindStakeModifierRev(uint64_t& nStakeModifier, CBlockIndex* pindexPrev, int& nHeight_mod) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     nStakeModifier = 0;
     CBlockIndex* pindex_mod = pindexPrev;
@@ -585,7 +585,7 @@ bool GRC::CheckProofOfStakeV8(
     CBlock& Block, //block to check
     bool generated_by_me,
     CValidationState& state,
-    uint256& hashProofOfStake) //proof hash out-parameter
+    uint256& hashProofOfStake) EXCLUSIVE_LOCKS_REQUIRED(cs_main) //proof hash out-parameter
 {
     //Block Transaction 0 is coin:base
     //Block Transaction 1 is coin:stake

--- a/src/gridcoin/staking/kernel.h
+++ b/src/gridcoin/staking/kernel.h
@@ -33,7 +33,7 @@ TimeType MaskStakeTime(const TimeType timestamp)
 }
 
 // Compute the hash modifier for proof-of-stake
-bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
+bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 // Get time weight using supplied timestamps
 int64_t GetWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd);
@@ -58,7 +58,7 @@ bool ReadStakedInput(
     const uint256 prevout_hash,
     CBlockHeader& out_header,
     CTransaction& out_txprev,
-    CBlockIndex* pindexPrev = nullptr);
+    CBlockIndex* pindexPrev = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //!
 //! \brief Calculate the provided block's proof hash with the version 3 staking
@@ -92,7 +92,7 @@ bool CalculateLegacyV3HashProof(
     const CBlock& block,
     const double por_nonce,
     CValidationState& state,
-    uint256& out_hash_proof);
+    uint256& out_hash_proof) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 //Block version 8+ Staking
 bool CheckProofOfStakeV8(
@@ -101,9 +101,9 @@ bool CheckProofOfStakeV8(
     CBlock& Block, //block to check
     bool generated_by_me,
     CValidationState& state,
-    uint256& hashProofOfStake); //proof hash out-parameter
+    uint256& hashProofOfStake) EXCLUSIVE_LOCKS_REQUIRED(cs_main); //proof hash out-parameter
 
-bool FindStakeModifierRev(uint64_t& StakeModifier, CBlockIndex* pindexPrev, int &nHeight);
+bool FindStakeModifierRev(uint64_t& StakeModifier, CBlockIndex* pindexPrev, int &nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 // Kernel for V8
 uint256 CalculateStakeHashV8(

--- a/src/gridcoin/staking/spam.h
+++ b/src/gridcoin/staking/spam.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_STAKING_SPAM_H
 
 #include "kernel.h"
+#include "sync.h"
 #include "uint256.h"
 #include "random.h"
 
@@ -13,6 +14,8 @@
 #include <cmath>
 #include <map>
 #include <vector>
+
+extern CCriticalSection cs_main;
 
 namespace GRC {
 //!
@@ -49,7 +52,7 @@ public:
     //!
     //! \param Proof hash of the stake used to generate a block.
     //!
-    void Remember(uint256 hashProof)
+    void Remember(uint256 hashProof) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         m_proofs_seen[GetOffset(hashProof)] = hashProof;
     }
@@ -59,7 +62,7 @@ public:
     //!
     //! \param coinstake Coinstake transaction from the block.
     //!
-    void RememberOrphan(const CTransaction& coinstake)
+    void RememberOrphan(const CTransaction& coinstake) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         const COutPoint& stake_prevout = coinstake.vin[0].prevout;
         const int64_t stake_time = MaskStakeTime(coinstake.nTime);
@@ -75,7 +78,7 @@ public:
     //!
     //! \return \c true if this container holds a matching proof hash.
     //!
-    bool ContainsProof(const uint256& hashProof) const
+    bool ContainsProof(const uint256& hashProof) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return m_proofs_seen[GetOffset(hashProof)] == hashProof;
     }
@@ -88,7 +91,7 @@ public:
     //!
     //! \return \c true if this container holds a matching proof hash.
     //!
-    bool ContainsOrphan(const CTransaction& coinstake) const
+    bool ContainsOrphan(const CTransaction& coinstake) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         const COutPoint& stake_prevout = coinstake.vin[0].prevout;
         const auto iter_pair = m_orphan_proofs_seen.find(stake_prevout);
@@ -109,7 +112,7 @@ public:
     //!
     //! \param coinstake Coinstake transaction from the block.
     //!
-    void ForgetOrphan(const CTransaction& coinstake)
+    void ForgetOrphan(const CTransaction& coinstake) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         const COutPoint& stake_prevout = coinstake.vin[0].prevout;
         auto iter_pair = m_orphan_proofs_seen.find(stake_prevout);
@@ -138,7 +141,7 @@ public:
     //! blocks re-supplied via P2P would be rejected as duplicate
     //! proof-of-stake.
     //!
-    void Clear()
+    void Clear() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         m_proofs_seen = {};
     }
@@ -148,7 +151,7 @@ public:
     //!
     //! \param pindex Points to the block index for the chain tip.
     //!
-    void Refill(const CBlockIndex* pindex)
+    void Refill(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         for (size_t i = 0; pindex && i < m_proofs_seen.size(); ++i) {
             pindex = pindex->pprev;

--- a/src/gridcoin/staking/status.h
+++ b/src/gridcoin/staking/status.h
@@ -264,19 +264,19 @@ private:
     //! \brief The hash of the last coinstake transaction for a block mined
     //! successfully by this node.
     //!
-    uint256 m_last_pos_tx_hash;
+    uint256 m_last_pos_tx_hash GUARDED_BY(m_cs);
 
     //!
     //! \brief Contains the miner status information related to the last kernel
     //! search cycle performed by the miner thread.
     //!
-    SearchReport m_search;
+    SearchReport m_search GUARDED_BY(m_cs);
 
     //!
     //! \brief Contains the miner status information needed to calculate the
     //! efficiency of the miner thread.
     //!
-    EfficiencyReport m_efficiency;
+    EfficiencyReport m_efficiency GUARDED_BY(m_cs);
 }; // MinerStatus
 } // namespace GRC
 

--- a/src/gridcoin/tally.cpp
+++ b/src/gridcoin/tally.cpp
@@ -1124,7 +1124,7 @@ const ResearchAccount& Tally::GetAccount(const Cpid cpid)
 CAmount Tally::GetAccrual(
     const Cpid cpid,
     const int64_t payment_time,
-    const CBlockIndex* const last_block_ptr)
+    const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return GetComputer(cpid, payment_time, last_block_ptr)->Accrual();
 }
@@ -1132,7 +1132,7 @@ CAmount Tally::GetAccrual(
 CAmount Tally::AccrualNearLimit(
         const Cpid cpid,
         const int64_t payment_time,
-        const CBlockIndex* const last_block_ptr)
+        const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return (GetComputer(cpid, payment_time, last_block_ptr)->NearRewardLimit()) ;
 }
@@ -1340,7 +1340,7 @@ CAmount Tally::GetNewbieSuperblockAccrualCorrection(const Cpid& cpid, const Supe
 AccrualComputer Tally::GetComputer(
     const Cpid cpid,
     const int64_t payment_time,
-    const CBlockIndex* const last_block_ptr)
+    const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!last_block_ptr) {
         return std::make_unique<NullAccrualComputer>();
@@ -1358,7 +1358,7 @@ AccrualComputer Tally::GetSnapshotComputer(
     const ResearchAccount& account,
     const int64_t payment_time,
     const CBlockIndex* const last_block_ptr,
-    const SuperblockPtr superblock)
+    const SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return std::make_unique<SnapshotAccrualComputer>(
         cpid,
@@ -1371,7 +1371,7 @@ AccrualComputer Tally::GetSnapshotComputer(
 AccrualComputer Tally::GetSnapshotComputer(
     const Cpid cpid,
     const int64_t payment_time,
-    const CBlockIndex* const last_block_ptr)
+    const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return GetSnapshotComputer(
         cpid,
@@ -1384,7 +1384,7 @@ AccrualComputer Tally::GetSnapshotComputer(
 AccrualComputer Tally::GetLegacyComputer(
     const Cpid cpid,
     const int64_t payment_time,
-    const CBlockIndex* const last_block_ptr)
+    const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const ResearchAccount& account = GetAccount(cpid);
 
@@ -1451,12 +1451,12 @@ bool Tally::ApplySuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(c
     return g_researcher_tally.ApplySuperblock(std::move(superblock));
 }
 
-bool Tally::RevertSuperblock()
+bool Tally::RevertSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_researcher_tally.RevertSuperblock(Quorum::CurrentSuperblock());
 }
 
-void Tally::LegacyRecount(const CBlockIndex* pindex)
+void Tally::LegacyRecount(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!pindex) {
         return;

--- a/src/gridcoin/tally.h
+++ b/src/gridcoin/tally.h
@@ -133,7 +133,7 @@ public:
     static CAmount GetAccrual(
         const Cpid cpid,
         const int64_t payment_time,
-        const CBlockIndex* const last_block_ptr);
+        const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief A value of the accrual that is near the MaxReward for the accrual computer in context based on
@@ -149,7 +149,7 @@ public:
     static CAmount AccrualNearLimit(
             const Cpid cpid,
             const int64_t payment_time,
-            const CBlockIndex* const last_block_ptr);
+            const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Compute "catch-up" accrual to correct for newbie accrual bug.
@@ -170,7 +170,7 @@ public:
     static AccrualComputer GetComputer(
         const Cpid cpid,
         const int64_t payment_time,
-        const CBlockIndex* const last_block_ptr);
+        const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! \brief Get an accrual computer instance that calculates accrual using
     //! delta snapshot rules.
@@ -192,7 +192,7 @@ public:
         const ResearchAccount& account,
         const int64_t payment_time,
         const CBlockIndex* const last_block_ptr,
-        const SuperblockPtr superblock);
+        const SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get an accrual computer instance that calculates accrual using
@@ -211,7 +211,7 @@ public:
     static AccrualComputer GetSnapshotComputer(
         const Cpid cpid,
         const int64_t payment_time,
-        const CBlockIndex* const last_block_ptr);
+        const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Get an accrual computer instance that calculates accrual using
@@ -230,7 +230,7 @@ public:
     static AccrualComputer GetLegacyComputer(
         const Cpid cpid,
         const int64_t payment_time,
-        const CBlockIndex* const last_block_ptr);
+        const CBlockIndex* const last_block_ptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //!
@@ -261,7 +261,7 @@ public:
     //!
     //! \return \c false if an IO error occurred while processing the superblock.
     //!
-    static bool RevertSuperblock();
+    static bool RevertSuperblock() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Recount the two-week network averages.
@@ -273,7 +273,7 @@ public:
     //!
     //! \param pindex Index of the block to start recounting backward from.
     //!
-    static void LegacyRecount(const CBlockIndex* pindex);
+    static void LegacyRecount(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Return the baseline snapshot height for the tally.

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -1032,7 +1032,7 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main, PollRegistry::cs_poll_registry)
     return ref;
 }
 
-void PollRegistry::Reset()
+void PollRegistry::Reset() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LOCK(cs_poll_registry);
 
@@ -1043,7 +1043,7 @@ void PollRegistry::Reset()
     reorg_occurred_during_reg_traversal = false;
 }
 
-bool PollRegistry::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const
+bool PollRegistry::Validate(const Contract& contract, const CTransaction& tx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Vote contract claims do not affect consensus. Vote claim validation
     // occurs on-demand while computing the results of the poll:
@@ -1073,7 +1073,7 @@ bool PollRegistry::Validate(const Contract& contract, const CTransaction& tx, in
     return true;
 }
 
-bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const
+bool PollRegistry::BlockValidate(const ContractContext& ctx, int& DoS) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Vote contract claims do not affect consensus. Vote claim validation
     // occurs on-demand while computing the results of the poll:

--- a/src/gridcoin/voting/registry.h
+++ b/src/gridcoin/voting/registry.h
@@ -426,7 +426,7 @@ public:
     //! \brief Destroy the contract handler state to prepare for historical
     //! contract replay.
     //!
-    void Reset() override;
+    void Reset() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Perform contextual validation for the provided contract.
@@ -437,7 +437,7 @@ public:
     //!
     //! \return \c false If the contract fails validation.
     //!
-    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override;
+    bool Validate(const Contract& contract, const CTransaction& tx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Perform contextual validation for the provided contract including block context. This is used
@@ -448,21 +448,21 @@ public:
     //!
     //! \return  \c false If the contract fails validation.
     //!
-    bool BlockValidate(const ContractContext& ctx, int& DoS) const override;
+    bool BlockValidate(const ContractContext& ctx, int& DoS) const override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Register a poll or vote from contract data.
     //!
     //! \param ctx References the poll or vote contract and associated context.
     //!
-    void Add(const ContractContext& ctx) override;
+    void Add(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Deregister the poll or vote specified by contract data.
     //!
     //! \param ctx References the poll or vote contract and associated context.
     //!
-    void Delete(const ContractContext& ctx) override;
+    void Delete(const ContractContext& ctx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Detect reorganizations that would affect registry traversal.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1323,7 +1323,10 @@ bool AppInit2(ThreadHandlerPtr threads)
             LOCK(cs_main);
             txdb.LoadBlockIndex();
         }
-        PrintBlockTree();
+        {
+            LOCK(cs_main);
+            PrintBlockTree();
+        }
         return false;
     }
 
@@ -1359,6 +1362,7 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     if (gArgs.GetBoolArg("-printblockindex") || gArgs.GetBoolArg("-printblocktree"))
     {
+        LOCK(cs_main);
         PrintBlockTree();
         return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,15 +95,17 @@ CBlockIndex* pindexBest = nullptr;
 std::atomic<int64_t> g_previous_block_time;
 std::atomic<int64_t> g_nTimeBestReceived;
 std::atomic<bool> g_reorg_in_progress = false;
-CMedianFilter<int> cPeerBlockCounts(5, 0); // Amount of blocks that other nodes claim to have
+CMedianFilter<int> cPeerBlockCounts GUARDED_BY(cs_main) {5, 0}; // Amount of blocks that other nodes claim to have
 
 
 
 
 // Orphan block storage managed by g_orphan_blocks (node/orphan_blocks.h)
 
-map<uint256, CTransaction> mapOrphanTransactions;
-map<uint256, set<uint256> > mapOrphanTransactionsByPrev;
+// Orphan transaction storage. All accesses occur under cs_main from
+// ProcessMessage / AddOrphanTx / EraseOrphanTx / LimitOrphanTxSize.
+map<uint256, CTransaction> mapOrphanTransactions GUARDED_BY(cs_main);
+map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
 
 // Constant stuff for coinbase transactions we create:
 CScript COINBASE_FLAGS;
@@ -245,7 +247,7 @@ double CoinToDouble(double surrogate)
 // mapOrphanTransactions
 //
 
-bool AddOrphanTx(const CTransaction& tx)
+bool AddOrphanTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     uint256 hash = tx.GetHash();
     if (mapOrphanTransactions.count(hash))
@@ -275,7 +277,7 @@ bool AddOrphanTx(const CTransaction& tx)
     return true;
 }
 
-void static EraseOrphanTx(uint256 hash)
+void static EraseOrphanTx(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!mapOrphanTransactions.count(hash))
         return;
@@ -289,7 +291,7 @@ void static EraseOrphanTx(uint256 hash)
     mapOrphanTransactions.erase(hash);
 }
 
-unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
+unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     unsigned int nEvicted = 0;
     while (mapOrphanTransactions.size() > nMaxOrphans)
@@ -2387,6 +2389,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 pfrom->PushGetBlocks(pindexBest, uint256());
                 LogPrint(BCLog::LogFlags::NET, "Asked For blocks.");
             }
+            // cPeerBlockCounts is read by GetNumBlocksOfPeers / IsInitialBlockDownload
+            // under cs_main, so the input also belongs under cs_main.
+            cPeerBlockCounts.input(pfrom->nStartingHeight);
         }
 
         // Relay alerts
@@ -2405,8 +2410,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LogPrint(BCLog::LogFlags::NOISY, "receive version message: version %d, blocks=%d, us=%s, them=%s, peer=%s", pfrom->nVersion,
             pfrom->nStartingHeight, addrMe.ToString(), addrFrom.ToString(), pfrom->addr.ToString());
-
-        cPeerBlockCounts.input(pfrom->nStartingHeight);
     }
     else if (pfrom->nVersion == 0)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,11 +87,11 @@ unsigned int nStakeMaxAge = -1; // unlimited
 
 // Gridcoin:
 int nCoinbaseMaturity = 100;
-CBlockIndex* pindexGenesisBlock = nullptr;
-int nBestHeight = -1;
+CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main) = nullptr;
+int nBestHeight GUARDED_BY(cs_main) = -1;
 
-uint256 hashBestChain;
-CBlockIndex* pindexBest = nullptr;
+uint256 hashBestChain GUARDED_BY(cs_main);
+CBlockIndex* pindexBest GUARDED_BY(cs_main) = nullptr;
 std::atomic<int64_t> g_previous_block_time;
 std::atomic<int64_t> g_nTimeBestReceived;
 std::atomic<bool> g_reorg_in_progress = false;
@@ -2383,11 +2383,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         // Ask the first connected node for block updates
         static int nAskedForBlocks = 0;
+        size_t numNodes;
+        {
+            LOCK(cs_vNodes);
+            numNodes = vNodes.size();
+        }
         {
             LOCK(cs_main);
             if (!pfrom->fClient && !pfrom->fOneShot &&
                 (pfrom->nStartingHeight > (nBestHeight - 144)) &&
-                 (nAskedForBlocks < 1 || (vNodes.size() <= 1 && nAskedForBlocks < 1)))
+                 (nAskedForBlocks < 1 || (numNodes <= 1 && nAskedForBlocks < 1)))
             {
                 nAskedForBlocks++;
                 pfrom->PushGetBlocks(pindexBest, uint256());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2344,8 +2344,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         // record my external IP reported by peer
-        if (addrMe.IsRoutable())
+        if (addrMe.IsRoutable()) {
+            LOCK(cs_addrSeenByPeer);
             addrSeenByPeer = addrMe;
+        }
 
         // Be shy and don't send version until we hear
         if (pfrom->fInbound)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3405,9 +3405,19 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 vGetData.clear();
             }
 
+            // Re-check presence under the lock before refreshing the
+            // timestamp. Another thread may have removed the entry
+            // between the initial presence check above and here
+            // (e.g. the inventory arrived and was processed via the
+            // TX / BLOCK handlers in ProcessMessage, which erase under
+            // cs_mapAlreadyAskedFor). If the entry is gone, the
+            // request is satisfied and we should not reinsert it.
             {
                 LOCK(cs_mapAlreadyAskedFor);
-                mapAlreadyAskedFor[inv] = nNow;
+                auto it = mapAlreadyAskedFor.find(inv);
+                if (it != mapAlreadyAskedFor.end()) {
+                    it->second = nNow;
+                }
             }
         }
         pto->mapAskFor.erase(pto->mapAskFor.begin());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1606,7 +1606,11 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me, CValidatio
 
     // Recursively process any orphan blocks that depended on this one.
     // ProcessQueue handles BFS traversal and SeenStakes cleanup internally.
-    g_orphan_blocks.ProcessQueue(hash, [&](CBlock& orphan) -> bool {
+    // ProcessQueue is EXCLUSIVE_LOCKS_REQUIRED(cs_main) so the lambda runs
+    // with cs_main held, but TSA cannot propagate that into the lambda
+    // body — suppress the analyzer here rather than tag every chain-state
+    // access AcceptBlock makes downstream.
+    g_orphan_blocks.ProcessQueue(hash, [&](CBlock& orphan) NO_THREAD_SAFETY_ANALYSIS -> bool {
         CValidationState orphan_state;
         return AcceptBlock(orphan, orphan_state, generated_by_me);
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1593,7 +1593,10 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool generated_by_me, CValidatio
                 // request time first to guarantee that the node does not postpone
                 // the message:
                 //
-                mapAlreadyAskedFor[ancestor_request] = 0;
+                {
+                    LOCK(cs_mapAlreadyAskedFor);
+                    mapAlreadyAskedFor[ancestor_request] = 0;
+                }
                 pfrom->AskFor(ancestor_request);
             }
         }
@@ -2807,7 +2810,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (AcceptToMemoryPool(mempool, tx, state, &fMissingInputs))
         {
             RelayTransaction(tx, inv.hash);
-            mapAlreadyAskedFor.erase(inv);
+            {
+                LOCK(cs_mapAlreadyAskedFor);
+                mapAlreadyAskedFor.erase(inv);
+            }
             vWorkQueue.push_back(inv.hash);
             vEraseQueue.push_back(inv.hash);
 
@@ -2828,7 +2834,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     {
                         LogPrintf("   accepted orphan tx %s", orphanTxHash.ToString().substr(0,10));
                         RelayTransaction(orphanTx, orphanTxHash);
-                        mapAlreadyAskedFor.erase(CInv(MSG_TX, orphanTxHash));
+                        {
+                            LOCK(cs_mapAlreadyAskedFor);
+                            mapAlreadyAskedFor.erase(CInv(MSG_TX, orphanTxHash));
+                        }
                         vWorkQueue.push_back(orphanTxHash);
                         vEraseQueue.push_back(orphanTxHash);
                         pfrom->nTrust++;
@@ -2880,7 +2889,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CValidationState state;
         if (ProcessBlock(pfrom, &block, false, state))
         {
-            mapAlreadyAskedFor.erase(inv);
+            {
+                LOCK(cs_mapAlreadyAskedFor);
+                mapAlreadyAskedFor.erase(inv);
+            }
             pfrom->nTrust++;
         }
         int nDoS = 0;
@@ -3354,7 +3366,12 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         // receives the object. If the request does not exist in this map, we
         // don't need to ask for the object again:
         //
-        if (mapAlreadyAskedFor.find(inv) == mapAlreadyAskedFor.end())
+        bool already_asked_present;
+        {
+            LOCK(cs_mapAlreadyAskedFor);
+            already_asked_present = mapAlreadyAskedFor.find(inv) != mapAlreadyAskedFor.end();
+        }
+        if (!already_asked_present)
         {
             pto->mapAskFor.erase(pto->mapAskFor.begin());
             continue;
@@ -3388,7 +3405,10 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
                 vGetData.clear();
             }
 
-            mapAlreadyAskedFor[inv] = nNow;
+            {
+                LOCK(cs_mapAlreadyAskedFor);
+                mapAlreadyAskedFor[inv] = nNow;
+            }
         }
         pto->mapAskFor.erase(pto->mapAskFor.begin());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,13 +137,13 @@ int64_t g_v11_timestamp = 0;
 
 // End of Gridcoin Global vars
 
-GRC::SeenStakes g_seen_stakes;
-GRC::ChainTrustCache g_chain_trust;
+GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
+GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
 
 //!
 //! \brief Re-exports chain trust values for reporting.
 //!
-arith_uint256 GetChainTrust(const CBlockIndex* pindex)
+arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return g_chain_trust.GetTrust(pindex);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,8 @@ bool fQtActive = false;
 std::atomic<bool> bGridcoinCoreInitComplete{false};
 
 // Mining status variables
-std::string    msMiningErrors;
+CCriticalSection cs_msMiningErrors;
+std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
 
 //When syncing, we grandfather block rejection rules up to this block, as rules became stricter over time and fields changed
 int nGrandfather = 1034700;

--- a/src/main.h
+++ b/src/main.h
@@ -126,7 +126,7 @@ enum class MemPoolRemovalReason {
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
 void UpdatedTransaction(const uint256& hashTx) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
-bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state);
+bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool CheckDiskSpace(uint64_t nAdditionalBytes=0);
 FILE* OpenBlockFile(unsigned int nFile, unsigned int nBlockPos, const char* pszMode="rb");
 FILE* AppendBlockFile(unsigned int& nFileRet);
@@ -134,10 +134,15 @@ FILE* AppendBlockFile(unsigned int& nFileRet);
 // (the internal LOCK would deadlock under non-recursive locking; cs_main
 // is currently recursive but the annotation contract documents the intent).
 bool LoadBlockIndex(bool fAllowNew=true);
-void PrintBlockTree();
+void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 double CoinToDouble(double surrogate);
 
 bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRecvMsg);
+// Self-managed locking: called from ThreadMessageHandler2 in net.cpp with
+// cs_main and pto->cs_vSend held by TRY_LOCK, but the function body acquires
+// cs_main again internally for each section it needs. The current pattern
+// is recursive-safe but TSA cannot model the recursive-acquire correctly,
+// so the function intentionally has no EXCLUSIVE_LOCKS_REQUIRED annotation.
 bool SendMessages(CNode* pto, bool fSendTrickle);
 bool LoadExternalBlockFile(FILE* fileIn, size_t file_size = 0,
                            unsigned int percent_start = 0, unsigned int percent_end = 100);
@@ -197,8 +202,8 @@ bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx,
-                        CValidationState& state, bool* pfMissingInputs);
-bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew);
+                        CValidationState& state, bool* pfMissingInputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 
 /** A transaction with a merkle branch linking it to the block chain. */

--- a/src/main.h
+++ b/src/main.h
@@ -102,7 +102,14 @@ extern bool fEnforceCanonical;
 // Minimum disk space required - used in CheckDiskSpace()
 static const uint64_t nMinDiskSpace = 52428800;
 
-extern std::string  msMiningErrors;
+//! \brief Guards \ref msMiningErrors. Written by Researcher::StoreResearcher
+//! on the GUI / timer thread, read by getmininginfo RPC and the Qt researcher
+//! model on their respective threads. std::string assignment / copy is not
+//! atomic, so the writer's release of internal buffer storage can race with a
+//! reader's traversal of the same buffer — undefined behaviour without
+//! serialization.
+extern CCriticalSection cs_msMiningErrors;
+extern std::string msMiningErrors GUARDED_BY(cs_msMiningErrors);
 
 extern int nGrandfather;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1180,7 +1180,7 @@ void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, i
     // MRC output 1 is always to the foundation (it is essentially a sidestake) and represents a cut of the MRC fees.
 }
 
-unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency)
+unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     int64_t nDesiredStakeOutputValue = 0;
     unsigned int nStakeOutputs = 1;
@@ -1403,7 +1403,7 @@ bool IsMiningAllowed(CWallet *pwallet)
 
 // This function parses the config file for the directives for stake splitting. It is used
 // in StakeMiner for the miner loop and also called by rpc getstakinginfo.
-bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue)
+bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Parse StakeSplit and SideStaking flags.
     bool fEnableStakeSplit = gArgs.GetBoolArg("-enablestakesplit");
@@ -1462,7 +1462,13 @@ void StakeMiner(CWallet *pwallet)
     while (!fShutdown)
     {
         // nMinStakeSplitValue and dEfficiency are out parameters.
-        bool fEnableStakeSplit = GetStakeSplitStatusAndParams(nMinStakeSplitValue, dEfficiency, nDesiredStakeOutputValue);
+        // cs_main is required for the GetAverageDifficulty(160) lookup inside;
+        // scope it tightly so the MilliSleep below doesn't hold the lock.
+        bool fEnableStakeSplit;
+        {
+            LOCK(cs_main);
+            fEnableStakeSplit = GetStakeSplitStatusAndParams(nMinStakeSplitValue, dEfficiency, nDesiredStakeOutputValue);
+        }
 
         // If the vSideStakeAlloc is not empty, then set fEnableSideStaking to true. Note that vSideStakeAlloc will not be empty
         // if non-zero allocation mandatory sidestakes are set OR local sidestaking is turned on by the -enablesidestaking config

--- a/src/miner.h
+++ b/src/miner.h
@@ -27,8 +27,8 @@ static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, int64_t &nReward,
                           bool &fEnableStakeSplit, bool &fEnableSideStaking,
                           int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency);
-bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue);
+unsigned int GetNumberOfStakeOutputs(int64_t &nValue, int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool GetStakeSplitStatusAndParams(int64_t& nMinStakeSplitValue, double& dEfficiency, int64_t& nDesiredStakeOutputValue) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 bool CreateMRCRewards(CMutableTransaction& mtxCoinbase, CMutableTransaction& mtxCoinstake,
                       CBlock &blocknew,

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -87,7 +87,8 @@ vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
 CCriticalSection cs_mapRelay;
 map<CInv, CDataStream> mapRelay GUARDED_BY(cs_mapRelay);
 deque<pair<int64_t, CInv> > vRelayExpiration GUARDED_BY(cs_mapRelay);
-map<CInv, int64_t> mapAlreadyAskedFor;
+CCriticalSection cs_mapAlreadyAskedFor;
+map<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor);
 
 CCriticalSection cs_vOneShots;
 static deque<string> vOneShots GUARDED_BY(cs_vOneShots);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -64,7 +64,8 @@ CCriticalSection cs_mapLocalHost;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(cs_mapLocalHost);
 static bool vfLimited[NET_MAX] GUARDED_BY(cs_mapLocalHost) = {};
 static CNode* pnodeLocalHost = nullptr;
-CAddress addrSeenByPeer(LookupNumeric("0.0.0.0", 0), nLocalServices);
+CCriticalSection cs_addrSeenByPeer;
+CAddress addrSeenByPeer GUARDED_BY(cs_addrSeenByPeer)(LookupNumeric("0.0.0.0", 0), nLocalServices);
 std::atomic<uint64_t> nLocalHostNonce{0};
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -78,14 +78,14 @@ CAddrMan addrman;
 // Initialization of static class variable.
 std::atomic<NodeId> CNode::nLastNodeId {-1};
 
-vector<CNode*> vNodes;
 CCriticalSection cs_vNodes;
+vector<CNode*> vNodes GUARDED_BY(cs_vNodes);
 CCriticalSection cs_vAddedNodes;
 vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
 
-map<CInv, CDataStream> mapRelay;
-deque<pair<int64_t, CInv> > vRelayExpiration;
 CCriticalSection cs_mapRelay;
+map<CInv, CDataStream> mapRelay GUARDED_BY(cs_mapRelay);
+deque<pair<int64_t, CInv> > vRelayExpiration GUARDED_BY(cs_mapRelay);
 map<CInv, int64_t> mapAlreadyAskedFor;
 
 CCriticalSection cs_vOneShots;
@@ -1174,10 +1174,14 @@ void ThreadSocketHandler2(void* parg)
             // Inactivity checking
             //
             // Consider this for future removal as this really is not beneficial nor harmful.
-            if ((GetAdjustedTime() - pnode->nTimeConnected) > (60*60*2) && (vNodes.size() > (MAX_OUTBOUND_CONNECTIONS*.75)))
+            // Read vNodesCopy.size() (the snapshot taken under cs_vNodes above
+            // at line 1100) rather than vNodes.size() — vNodes is GUARDED_BY
+            // (cs_vNodes) and the size at iteration time is what this check
+            // wants anyway.
+            if ((GetAdjustedTime() - pnode->nTimeConnected) > (60*60*2) && (vNodesCopy.size() > (MAX_OUTBOUND_CONNECTIONS*.75)))
             {
                     LogPrint(BCLog::LogFlags::NET, "Node %s connected longer than 2 hours with connection count of %zd, disconnecting. ",
-                             pnode->addr.ToString(), vNodes.size());
+                             pnode->addr.ToString(), vNodesCopy.size());
 
                     pnode->fDisconnect = true;
 

--- a/src/net.h
+++ b/src/net.h
@@ -113,7 +113,12 @@ extern ServiceFlags nLocalServices;
 // so the per-connection nonce identity is lost), but that is a separate
 // follow-up; atomicising here just closes the data race.
 extern std::atomic<uint64_t> nLocalHostNonce;
-extern CAddress addrSeenByPeer;
+//! \brief Guards \ref addrSeenByPeer. Written by ProcessMessage's version
+//! handler when a peer reports the address it sees us at, read by RPC
+//! handlers (getinfo in rpc/net.cpp + wallet/rpcwallet.cpp). CAddress
+//! assignment/copy is not atomic.
+extern CCriticalSection cs_addrSeenByPeer;
+extern CAddress addrSeenByPeer GUARDED_BY(cs_addrSeenByPeer);
 extern CAddrMan addrman;
 extern CCriticalSection cs_mapRelay;
 extern std::map<CInv, CDataStream> mapRelay GUARDED_BY(cs_mapRelay);

--- a/src/net.h
+++ b/src/net.h
@@ -474,9 +474,16 @@ public:
         // the key is the earliest time the request can be sent
         if (mapAskFor.size() > 50000) return;
 
-        LOCK(cs_mapAlreadyAskedFor);
+        // Snapshot the current request time under the mutex. The
+        // logging / time-formatting / static-counter arithmetic below
+        // does not touch mapAlreadyAskedFor and should not hold the
+        // global mutex.
+        int64_t nRequestTime;
+        {
+            LOCK(cs_mapAlreadyAskedFor);
+            nRequestTime = mapAlreadyAskedFor[inv];
+        }
 
-        int64_t& nRequestTime = mapAlreadyAskedFor[inv];
         LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));
 
         // Make sure not to reuse time indexes to keep things in the same order
@@ -487,8 +494,12 @@ public:
         nLastTime = nNow;
 
         // Each retry is 2 minutes after the last
-        nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
-        mapAskFor.insert(std::make_pair(nRequestTime, inv));
+        const int64_t nNewRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
+        {
+            LOCK(cs_mapAlreadyAskedFor);
+            mapAlreadyAskedFor[inv] = nNewRequestTime;
+        }
+        mapAskFor.insert(std::make_pair(nNewRequestTime, inv));
     }
 
     void BeginMessage(const char* pszCommand) EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)

--- a/src/net.h
+++ b/src/net.h
@@ -123,7 +123,14 @@ extern CAddrMan addrman;
 extern CCriticalSection cs_mapRelay;
 extern std::map<CInv, CDataStream> mapRelay GUARDED_BY(cs_mapRelay);
 extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration GUARDED_BY(cs_mapRelay);
-extern std::map<CInv, int64_t> mapAlreadyAskedFor;
+//! \brief Guards \ref mapAlreadyAskedFor. Written and read from
+//! ProcessMessage handlers (under cs_main) for the TX / BLOCK paths,
+//! from ProcessBlock, from SendMessages' getdata loop, and from
+//! CSplitBlob::RecvPart on the scraper PART path which does NOT hold
+//! cs_main. A dedicated leaf-level mutex avoids hoisting cs_main into
+//! the PART path and keeps the lock as narrow as possible.
+extern CCriticalSection cs_mapAlreadyAskedFor;
+extern std::map<CInv, int64_t> mapAlreadyAskedFor GUARDED_BY(cs_mapAlreadyAskedFor);
 extern ThreadHandler* netThreads;
 
 
@@ -466,6 +473,8 @@ public:
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
         if (mapAskFor.size() > 50000) return;
+
+        LOCK(cs_mapAlreadyAskedFor);
 
         int64_t& nRequestTime = mapAlreadyAskedFor[inv];
         LogPrint(BCLog::LogFlags::NET, "askfor %s   %" PRId64 " (%s)", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime/1000000));

--- a/src/net.h
+++ b/src/net.h
@@ -22,7 +22,10 @@
 
 class CNode;
 class CBlockIndex;
-extern int nBestHeight;
+extern CCriticalSection cs_main;
+// Duplicate extern of the main.h:82 declaration; both must carry the
+// GUARDED_BY annotation so cross-TU readers via net.h see the contract.
+extern int nBestHeight GUARDED_BY(cs_main);
 
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
@@ -52,8 +55,8 @@ bool StopNode();
 // Declared below CNode (the EXCLUSIVE_LOCKS_REQUIRED annotation references
 // pnode->cs_vSend and needs the complete CNode type).
 void SocketSendData(CNode *pnode);
-extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;
+extern std::vector<CNode*> vNodes GUARDED_BY(cs_vNodes);
 
 struct LocalServiceInfo {
     int nScore;
@@ -112,9 +115,9 @@ extern ServiceFlags nLocalServices;
 extern std::atomic<uint64_t> nLocalHostNonce;
 extern CAddress addrSeenByPeer;
 extern CAddrMan addrman;
-extern std::map<CInv, CDataStream> mapRelay;
-extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
+extern std::map<CInv, CDataStream> mapRelay GUARDED_BY(cs_mapRelay);
+extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration GUARDED_BY(cs_mapRelay);
 extern std::map<CInv, int64_t> mapAlreadyAskedFor;
 extern ThreadHandler* netThreads;
 

--- a/src/node/coherence.cpp
+++ b/src/node/coherence.cpp
@@ -15,7 +15,7 @@
 
 #include <limits>
 
-extern GRC::SeenStakes g_seen_stakes;
+extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
 
 namespace GRC {
 

--- a/src/node/orphan_blocks.cpp
+++ b/src/node/orphan_blocks.cpp
@@ -9,11 +9,11 @@
 #include "gridcoin/staking/spam.h"
 #include "util.h"
 
-extern GRC::SeenStakes g_seen_stakes;
+extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
 
-OrphanBlockManager g_orphan_blocks;
+OrphanBlockManager g_orphan_blocks GUARDED_BY(cs_main);
 
-bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t now)
+bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Reject duplicates.
     if (m_orphans.count(hash)) {
@@ -44,7 +44,7 @@ bool OrphanBlockManager::Add(const uint256& hash, const CBlock& block, int64_t n
 
 size_t OrphanBlockManager::ProcessQueue(
     const uint256& accepted_hash,
-    std::function<bool(CBlock&)> accept_fn)
+    std::function<bool(CBlock&)> accept_fn) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     std::vector<uint256> work_queue;
     work_queue.push_back(accepted_hash);
@@ -89,22 +89,22 @@ size_t OrphanBlockManager::ProcessQueue(
     return accepted_count;
 }
 
-const CBlock* OrphanBlockManager::GetRootBlock(const uint256& hash) const
+const CBlock* OrphanBlockManager::GetRootBlock(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return FindRootBlock(hash);
 }
 
-bool OrphanBlockManager::Contains(const uint256& hash) const
+bool OrphanBlockManager::Contains(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return m_orphans.count(hash) > 0;
 }
 
-bool OrphanBlockManager::HasChildrenOf(const uint256& prev_hash) const
+bool OrphanBlockManager::HasChildrenOf(const uint256& prev_hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return m_by_prev.count(prev_hash) > 0;
 }
 
-size_t OrphanBlockManager::EraseExpired(int64_t now)
+size_t OrphanBlockManager::EraseExpired(int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     size_t count = 0;
 
@@ -138,12 +138,12 @@ size_t OrphanBlockManager::EraseExpired(int64_t now)
     return count;
 }
 
-size_t OrphanBlockManager::Size() const
+size_t OrphanBlockManager::Size() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return m_orphans.size();
 }
 
-void OrphanBlockManager::Clear()
+void OrphanBlockManager::Clear() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     for (auto& [hash, entry] : m_orphans) {
         if (entry.block->IsProofOfStake()) {
@@ -179,7 +179,7 @@ std::unique_ptr<CBlock> OrphanBlockManager::EraseInternal(const uint256& hash)
     return block;
 }
 
-void OrphanBlockManager::EvictRandom()
+void OrphanBlockManager::EvictRandom() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (m_orphans.empty()) {
         return;

--- a/src/node/orphan_blocks.h
+++ b/src/node/orphan_blocks.h
@@ -33,7 +33,7 @@ public:
 
     //! Add an orphan block. Returns false if the block is a duplicate.
     //! The caller must hold cs_main.
-    bool Add(const uint256& hash, const CBlock& block, int64_t now);
+    bool Add(const uint256& hash, const CBlock& block, int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Process the orphan chain rooted at \p accepted_hash using breadth-first
     //! traversal. For each orphan whose parent has been accepted, calls
@@ -42,27 +42,27 @@ public:
     //! Returns the count of orphans for which accept_fn returned true.
     size_t ProcessQueue(
         const uint256& accepted_hash,
-        std::function<bool(CBlock&)> accept_fn);
+        std::function<bool(CBlock&)> accept_fn) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Get the root block of the orphan chain containing \p hash.
     //! Returns nullptr if \p hash is not a known orphan.
-    const CBlock* GetRootBlock(const uint256& hash) const;
+    const CBlock* GetRootBlock(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Returns true if \p hash is a known orphan.
-    bool Contains(const uint256& hash) const;
+    bool Contains(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Returns true if any orphan claims \p prev_hash as its parent.
-    bool HasChildrenOf(const uint256& prev_hash) const;
+    bool HasChildrenOf(const uint256& prev_hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Evict orphans older than MAX_ORPHAN_AGE_SECONDS relative to \p now.
     //! Returns the number evicted.
-    size_t EraseExpired(int64_t now);
+    size_t EraseExpired(int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Current number of stored orphans.
-    size_t Size() const;
+    size_t Size() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Remove all orphans and clean up associated SeenStakes entries.
-    void Clear();
+    void Clear() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 private:
     struct OrphanEntry
@@ -92,6 +92,6 @@ private:
 };
 
 //! Global orphan block manager instance. Requires cs_main for all access.
-extern OrphanBlockManager g_orphan_blocks;
+extern OrphanBlockManager g_orphan_blocks GUARDED_BY(cs_main);
 
 #endif // GRIDCOIN_NODE_ORPHAN_BLOCKS_H

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -445,7 +445,12 @@ QString ResearcherModel::formatStatus() const
     }
 
     // TODO: The getstakinginfo RPC shares this global. Refactor to remove it:
-    return QString::fromStdString(msMiningErrors);
+    std::string status;
+    {
+        LOCK(cs_msMiningErrors);
+        status = msMiningErrors;
+    }
+    return QString::fromStdString(status);
 }
 
 QString ResearcherModel::formatBoincPath() const

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2675,12 +2675,21 @@ UniValue superblockage(const UniValue& params, bool fHelp)
 
     UniValue res(UniValue::VOBJ);
 
-    const GRC::SuperblockPtr superblock = GRC::Quorum::CurrentSuperblock();
+    // Hold cs_main only long enough to read the current and pending
+    // superblocks. SuperblockPtr is a refcounted handle to immutable data;
+    // copying it out lets the formatting / pushKV calls run lock-free.
+    GRC::SuperblockPtr superblock;
+    int64_t pending_height = 0;
+    {
+        LOCK(cs_main);
+        superblock = GRC::Quorum::CurrentSuperblock();
+        pending_height = GRC::Quorum::PendingSuperblock().m_height;
+    }
 
     res.pushKV("Superblock Age", superblock.Age(GetAdjustedTime()));
     res.pushKV("Superblock Timestamp", TimestampToHRDate(superblock.m_timestamp));
     res.pushKV("Superblock Block Number", superblock.m_height);
-    res.pushKV("Pending Superblock Height", GRC::Quorum::PendingSuperblock().m_height);
+    res.pushKV("Pending Superblock Height", pending_height);
 
     return res;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -35,7 +35,7 @@ extern GRC::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = 
 extern ScraperPendingBeaconMap GetPendingBeaconsForReport();
 extern ScraperPendingBeaconMap GetVerifiedBeaconsForReport(bool from_global = false);
 extern UniValue GetJSONVersionReport(const int64_t lookback, const bool full_version) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-arith_uint256 GetChainTrust(const CBlockIndex* pindex);
+arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 double CoinToDouble(double surrogate);
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 UniValue ContractToJson(const GRC::Contract& contract);

--- a/src/rpc/dataacq.cpp
+++ b/src/rpc/dataacq.cpp
@@ -159,7 +159,7 @@ UniValue rpc_getblockstats(const UniValue& params, bool fHelp)
             if (block.vtx[1].IsCoinStake())
             {
                 poscount++;
-                double diff = GRC::GetDifficulty(cur);
+                double diff = GRC::GetBlockDifficulty(cur->nBits);
                 diff_sum += diff;
                 diff_max = std::max(diff_max, diff);
                 diff_min = std::min(diff_min, diff);
@@ -405,7 +405,7 @@ UniValue rpc_exportstats(const UniValue& params, bool fHelp)
         if(cur->nHeight>endblock)
             continue;
 
-        double i_diff = GRC::GetDifficulty(cur);
+        double i_diff = GRC::GetBlockDifficulty(cur->nBits);
         sum_diff= sum_diff + i_diff;
         min_diff=std::min(min_diff,i_diff);
         max_diff=std::max(max_diff,i_diff);
@@ -559,7 +559,7 @@ UniValue rpc_getrecentblocks(const UniValue& params, bool fHelp)
             100 json
         */
 
-        double diff = GRC::GetDifficulty(cur);
+        double diff = GRC::GetBlockDifficulty(cur->nBits);
         signed int delta = 0;
         if(cur->pprev)
             delta = (cur->nTime - cur->pprev->nTime);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -574,7 +574,16 @@ UniValue auditsnapshotaccruals(const UniValue& params, bool fHelp)
 
     UniValue result(UniValue::VOBJ);
 
-    SuperblockPtr superblock = GRC::Quorum::CurrentSuperblock();
+    // Hold cs_main only long enough to copy the SuperblockPtr (a refcounted
+    // handle to immutable data). The per-CPID iteration below calls
+    // auditsnapshotaccrual, which takes its own LOCK(cs_main) for each call.
+    // Holding cs_main across the whole loop would freeze the node for minutes
+    // on a full network (one full audit can take that long).
+    SuperblockPtr superblock;
+    {
+        LOCK(cs_main);
+        superblock = GRC::Quorum::CurrentSuperblock();
+    }
 
     UniValue entries(UniValue::VARR);
     int number_of_cpids = 0;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -150,7 +150,13 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
 
     std::string current_poll;
 
-    obj.pushKV("researcher_status", msMiningErrors);
+    std::string researcher_status;
+    {
+        LOCK(cs_msMiningErrors);
+        researcher_status = msMiningErrors;
+    }
+
+    obj.pushKV("researcher_status", researcher_status);
     obj.pushKV("current_poll", GRC::GetCurrentPollTitle());
 
     return obj;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -671,6 +671,12 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
         connections = (int)vNodes.size();
     }
 
+    std::string addr_seen_by_peer_ip;
+    {
+        LOCK(cs_addrSeenByPeer);
+        addr_seen_by_peer_ip = addrSeenByPeer.ToStringIP();
+    }
+
     LOCK(cs_main);
 
     res.pushKV("version",         FormatFullVersion());
@@ -681,7 +687,7 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     res.pushKV("paytxfee",        ValueFromAmount(nTransactionFee));
     res.pushKV("mininput",        ValueFromAmount(nMinimumInputValue));
     res.pushKV("proxy",           (proxy.IsValid() ? proxy.ToStringIPPort() : string()));
-    res.pushKV("ip",              addrSeenByPeer.ToStringIP());
+    res.pushKV("ip",              addr_seen_by_peer_ip);
 
     UniValue localAddresses(UniValue::VARR);
     {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -665,13 +665,19 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     proxyType proxy;
     GetProxy(NET_IPV4, proxy);
 
+    int connections;
+    {
+        LOCK(cs_vNodes);
+        connections = (int)vNodes.size();
+    }
+
     LOCK(cs_main);
 
     res.pushKV("version",         FormatFullVersion());
     res.pushKV("minor_version",   CLIENT_VERSION_MINOR);
     res.pushKV("protocolversion", PROTOCOL_VERSION);
     res.pushKV("timeoffset",      GetTimeOffset());
-    res.pushKV("connections",     (int)vNodes.size());
+    res.pushKV("connections",     connections);
     res.pushKV("paytxfee",        ValueFromAmount(nTransactionFee));
     res.pushKV("mininput",        ValueFromAmount(nMinimumInputValue));
     res.pushKV("proxy",           (proxy.IsValid() ? proxy.ToStringIPPort() : string()));

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -750,7 +750,14 @@ inline void Serialize(Stream& os, const T& a)
 template<typename Stream, typename T>
 inline void Unserialize(Stream& is, T&& a)
 {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     a.Unserialize(is);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 

--- a/src/test/dos_tests.cpp
+++ b/src/test/dos_tests.cpp
@@ -18,10 +18,20 @@
 #include <stdint.h>
 
 // Tests this internal-to-main.cpp method:
-extern bool AddOrphanTx(const CTransaction& tx);
-extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans);
-extern std::map<uint256, CTransaction> mapOrphanTransactions;
-extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev;
+extern bool AddOrphanTx(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+extern std::map<uint256, CTransaction> mapOrphanTransactions GUARDED_BY(cs_main);
+extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);
+
+// The orphan-tx tests below are single-threaded and drive
+// AddOrphanTx / LimitOrphanTxSize / mapOrphanTransactions directly. All
+// three are GUARDED_BY / EXCLUSIVE_LOCKS_REQUIRED(cs_main) in main.cpp;
+// suppress the analyzer for this file rather than take a lock the tests
+// do not need.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 
 CService ip(uint32_t i)
 {
@@ -124,7 +134,7 @@ BOOST_AUTO_TEST_CASE(DoS_misbehavior_decay)
     BOOST_CHECK(nodestats.nMisbehavior == 0); // nMisbehavior should be 0.
 }
 
-CTransaction RandomOrphan()
+CTransaction RandomOrphan() NO_THREAD_SAFETY_ANALYSIS
 {
     auto it = mapOrphanTransactions.lower_bound(InsecureRand256());
     if (it == mapOrphanTransactions.end())
@@ -442,3 +452,7 @@ BOOST_AUTO_TEST_CASE(DoS_checkblock_validation_state)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -9,6 +9,16 @@
 
 #include <boost/test/unit_test.hpp>
 
+// Tests are single-threaded and drive the Whitelist contract handler
+// directly (not via ApplyContracts). The handler is
+// EXCLUSIVE_LOCKS_REQUIRED(cs_main) under the thread-safety annotation
+// rollout; suppress the analyzer for this file rather than take a lock
+// the tests do not need.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+
 namespace {
 void AddProjectEntry(const uint32_t& payload_version, const std::string& name, const std::string& url,
                      const bool& gdpr_status, const int& height, const uint64_t time, const bool& reset_registry = false)
@@ -1535,3 +1545,7 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/test/gridcoin/protocol_tests.cpp
+++ b/src/test/gridcoin/protocol_tests.cpp
@@ -7,6 +7,15 @@
 
 #include <boost/test/unit_test.hpp>
 
+// Tests are single-threaded and drive the ProtocolRegistry contract
+// handler directly. The handler is EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+// suppress the analyzer for this file rather than take a lock the
+// tests do not need.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+
 // anonymous namespace
 namespace {
 void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, const std::string& value,
@@ -186,3 +195,7 @@ BOOST_AUTO_TEST_CASE(protocol_DeletingEntryShouldSuppressReversionShouldRestore)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -149,7 +149,7 @@ void RemoveTestBeacon(const GRC::Cpid cpid) NO_THREAD_SAFETY_ANALYSIS
 }
 
 void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, const std::string& value,
-                      const int& height, const bool& reset_registry = false)
+                      const int& height, const bool& reset_registry = false) NO_THREAD_SAFETY_ANALYSIS
 {
     GRC::ProtocolRegistry& registry = GRC::GetProtocolRegistry();
 

--- a/src/test/gridcoin/scraper_registry_tests.cpp
+++ b/src/test/gridcoin/scraper_registry_tests.cpp
@@ -7,6 +7,15 @@
 
 #include <boost/test/unit_test.hpp>
 
+// Tests are single-threaded and drive the ScraperRegistry contract
+// handler directly. The handler is EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+// suppress the analyzer for this file rather than take a lock the
+// tests do not need.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+
 // anonymous namespace
 namespace {
 void AddRemoveScraperEntryV1(const std::string& address, const std::string& value,
@@ -538,3 +547,7 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/test/gridcoin_tests.cpp
+++ b/src/test/gridcoin_tests.cpp
@@ -33,7 +33,7 @@ struct GridcoinTestsConfig
 };
 
 void AddProtocolEntry(const uint32_t& payload_version, const std::string& key, const std::string& value,
-                      const CBlockIndex index, const bool& reset_registry = false)
+                      const CBlockIndex index, const bool& reset_registry = false) NO_THREAD_SAFETY_ANALYSIS
 {
     GRC::ProtocolRegistry& registry = GRC::GetProtocolRegistry();
 
@@ -103,6 +103,15 @@ BOOST_AUTO_TEST_SUITE_END()
 //
 // CBR tests
 //
+
+// Tests drive the ProtocolRegistry contract handler directly (Reset,
+// AddProtocolEntry helper above which calls Add). The handler is
+// EXCLUSIVE_LOCKS_REQUIRED(cs_main); suppress the analyzer for these
+// single-threaded tests rather than take a lock they do not need.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 
 BOOST_AUTO_TEST_SUITE(gridcoin_cbr_tests)
 
@@ -365,3 +374,7 @@ BOOST_AUTO_TEST_CASE(gridcoin_PriorObsoleteConfigurableCBRShouldNotResortToDefau
 
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/test/orphan_block_tests.cpp
+++ b/src/test/orphan_block_tests.cpp
@@ -6,6 +6,15 @@
 
 #include <boost/test/unit_test.hpp>
 
+// Tests construct OrphanBlockManager instances locally and exercise them
+// single-threaded. The handler methods are EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+// under the thread-safety annotation rollout; suppress the analyzer for
+// this file rather than take a lock the tests do not need.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
+
 namespace {
 
 //! Create a minimal test block with a given previous hash and a unique nTime
@@ -334,3 +343,7 @@ BOOST_AUTO_TEST_CASE(clear_empties_everything)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -756,6 +756,15 @@ BOOST_AUTO_TEST_CASE(multiple_state_transitions)
     }
 }
 
+// Single-threaded test that drives CWallet::transactionAddedToMempool
+// directly; that method is EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+// LOCKS_EXCLUDED(cs_wallet). The test holds cs_wallet but not cs_main,
+// which mirrors the wallet-internal callback shape we're pinning here.
+// Suppress the analyzer for this test case.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 BOOST_AUTO_TEST_CASE(transaction_added_to_mempool_preserves_inmempool_state)
 {
     // Pins the invariant CommitTransaction relies on at wallet.cpp:3324:
@@ -812,6 +821,9 @@ BOOST_AUTO_TEST_CASE(transaction_added_to_mempool_preserves_inmempool_state)
         BOOST_CHECK(test_wallet.mapWallet[hash].state<TxStateInactive>() == nullptr);
     }
 }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -34,8 +34,8 @@
 #include <set>
 #include <stdexcept>
 
-extern GRC::SeenStakes g_seen_stakes;
-extern GRC::ChainTrustCache g_chain_trust;
+extern GRC::SeenStakes g_seen_stakes GUARDED_BY(cs_main);
+extern GRC::ChainTrustCache g_chain_trust GUARDED_BY(cs_main);
 
 static constexpr CAmount nGenesisSupply = 340569880;
 bool fColdBoot = true;
@@ -484,7 +484,7 @@ bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPr
 // guaranteed to be in main chain by sync-checkpoint. This rule is
 // introduced to help nodes establish a consistent view of the coin
 // age (trust score) of competing branches.
-bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge)
+bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     arith_uint256 bnCentSecond = 0;  // coin age in the unit of cent-seconds
     nCoinAge = 0;
@@ -719,7 +719,7 @@ int64_t ReturnCurrentMoneySupply(CBlockIndex* pindexcurrent) EXCLUSIVE_LOCKS_REQ
     return (pindexcurrent->pprev? pindexcurrent->pprev->nMoneySupply : nGenesisSupply);
 }
 
-bool GetCoinstakeAge(CTxDB& txdb, const CBlock& block, uint64_t& out_coin_age)
+bool GetCoinstakeAge(CTxDB& txdb, const CBlock& block, uint64_t& out_coin_age) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     out_coin_age = 0;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -245,7 +245,7 @@ bool HasMasterKeyInput(const CTransaction& tx, const MapPrevTx& inputs, int bloc
     return false;
 }
 
-bool DisconnectInputs(CTransaction& tx, CTxDB& txdb)
+bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Relinquish previous transactions' spent pointers
     if (!tx.IsCoinBase())
@@ -528,7 +528,7 @@ bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge) EXCLUSI
 }
 
 
-int GetDepthInMainChain(const CTxIndex& txi)
+int GetDepthInMainChain(const CTxIndex& txi) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Read block header
     CBlock block;
@@ -1561,7 +1561,7 @@ bool CheckBlockSignature(const CBlock& block)
 //! \param tx The transaction that contains the contract
 //! \return true if successfully validated
 //!
-bool ValidateMRC(const GRC::Contract& contract, const CTransaction& tx, int& DoS)
+bool ValidateMRC(const GRC::Contract& contract, const CTransaction& tx, int& DoS) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // The MRC transaction should only have one contract on it, and the contract type should be MRC (which we already
     // know to arrive at this virtual method implementation).
@@ -1707,7 +1707,7 @@ bool ValidateMRC(const GRC::Contract& contract, const CTransaction& tx, int& DoS
 //! \param mrc The MRC contract
 //! \return true if successfully validated
 //!
-bool ValidateMRC(const CBlockIndex* mrc_last_pindex, const GRC::MRC &mrc)
+bool ValidateMRC(const CBlockIndex* mrc_last_pindex, const GRC::MRC &mrc) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     int64_t research_owed = 0;
     const int64_t& mrc_time = mrc_last_pindex->nTime;

--- a/src/validation.h
+++ b/src/validation.h
@@ -82,6 +82,12 @@ bool DisconnectInputs(CTransaction& tx, CTxDB& txdb) EXCLUSIVE_LOCKS_REQUIRED(cs
     @param[out] fInvalid	returns true if tx is invalid
     @return	Returns true if all inputs are in txdb or mapTestPool
 */
+// No EXCLUSIVE_LOCKS_REQUIRED(cs_main): FetchInputs reads only txdb (its
+// own subsystem) and mempool (which takes mempool.cs internally via
+// mempool.lookup); it does not touch mapBlockIndex / pindexBest /
+// nBestHeight. Block-processing callers (ConnectInputs / CreateNewBlock)
+// hold cs_main for other reasons, but FetchInputs itself is callable
+// from RPC paths (signrawtransaction*) without cs_main.
 bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const std::map<uint256, CTxIndex>& mapTestPool, bool fBlock, bool fMiner, MapPrevTx& inputsRet, bool& fInvalid);
 
 /** Sanity check previous transactions, then, if all checks succeed,
@@ -106,8 +112,8 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
 bool DisconnectBlock(CBlock& block, CTxDB& txdb, CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool ConnectBlock(CBlock& block, CValidationState& state, CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, const uint256& hashProof) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true, bool fLoadingIndex=false);
-bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me);
+bool CheckBlock(const CBlock& block, CValidationState& state, int height1, bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true, bool fLoadingIndex=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool AcceptBlock(CBlock& block, CValidationState& state, bool generated_by_me) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool CheckBlockSignature(const CBlock& block);
 
 // Returns the script flags which should be checked for a given block

--- a/src/validation.h
+++ b/src/validation.h
@@ -97,7 +97,7 @@ bool FetchInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, const s
     */
 bool ConnectInputs(CTransaction& tx, CValidationState& state, CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx, const CBlockIndex* pindexBlock, bool fBlock, bool fMiner) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge); // ppcoin: get transaction coin age
+bool GetCoinAge(const CTransaction& tx, CTxDB& txdb, uint64_t& nCoinAge) EXCLUSIVE_LOCKS_REQUIRED(cs_main); // ppcoin: get transaction coin age
 
 int GetDepthInMainChain(const CTxIndex& txi) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -114,6 +114,14 @@ UniValue getinfo(const UniValue& params, bool fHelp)
         connections = (int)vNodes.size();
     }
 
+    // Same pattern: snapshot the peer-reported external IP before the
+    // heavier cs_main+cs_wallet acquisition.
+    std::string addr_seen_by_peer_ip;
+    {
+        LOCK(cs_addrSeenByPeer);
+        addr_seen_by_peer_ip = addrSeenByPeer.ToStringIP();
+    }
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     obj.pushKV("version",       FormatFullVersion());
@@ -131,7 +139,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("moneysupply",   ValueFromAmount(pindexBest->nMoneySupply));
     obj.pushKV("connections",   connections);
     obj.pushKV("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string()));
-    obj.pushKV("ip",            addrSeenByPeer.ToStringIP());
+    obj.pushKV("ip",            addr_seen_by_peer_ip);
 
     diff.pushKV("current", GRC::GetCurrentDifficulty());
     diff.pushKV("target", GRC::GetTargetDifficulty());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -105,6 +105,15 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     UniValue obj(UniValue::VOBJ);
     UniValue diff(UniValue::VOBJ);
 
+    // Snapshot vNodes.size() under cs_vNodes before acquiring the heavier
+    // cs_main + cs_wallet pair so the size read is GUARDED_BY-clean and we
+    // do not introduce a new cs_main→cs_vNodes ordering edge.
+    int connections;
+    {
+        LOCK(cs_vNodes);
+        connections = (int)vNodes.size();
+    }
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     obj.pushKV("version",       FormatFullVersion());
@@ -120,7 +129,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.pushKV("timeoffset",    GetTimeOffset());
     obj.pushKV("uptime",        g_timer.GetElapsedTime("uptime", "default") / 1000);
     obj.pushKV("moneysupply",   ValueFromAmount(pindexBest->nMoneySupply));
-    obj.pushKV("connections",   (int)vNodes.size());
+    obj.pushKV("connections",   connections);
     obj.pushKV("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string()));
     obj.pushKV("ip",            addrSeenByPeer.ToStringIP());
 


### PR DESCRIPTION
## Summary

Brings the codebase to effectively complete coverage under the project's clang `-Wthread-safety` analyzer. This is the follow-up rollout to PR #2869 (Phase 1) — touches GRC::Quorum and the accrual chain, `gridcoin/staking` + `node/orphan_blocks`, the entire contract dispatcher + every concrete handler, `main.h`/`main.cpp`, `validation.h`/`validation.cpp`, `miner.h`/`miner.cpp`, `net.h`/`net.cpp`, the RPC layer (`rpc/blockchain.cpp`, `rpc/mining.cpp`, `rpc/dataacq.cpp`, `rpc/net.cpp`, `rpc/rawtransaction.cpp`), `wallet/rpcwallet.cpp`, `qt/researcher/researchermodel.cpp`, `serialize.h`, the scraper config block, and closes four data races identified during the work (issue #2979). All TUs compile clean under `WERROR_THREAD_SAFETY=ON` across `gridcoin_util`, `gridcoinqt`, and `test_gridcoin`.

10 commits total. The first six are pure annotation propagation + minimal scoped LOCK insertions where the annotation surfaced a real gap. The last four are dedicated mutex additions (or a header-annotation mirror in one case) that close the races filed in #2979.

## What's not in scope

- **Wallet `hashBlock` / `m_state` internals** — recently refactored in #2839 (merged); this PR does not re-touch the core wallet transaction state machinery.
- **Bitcoin-core-inherited primitives** (`script/`, `crypto/`) — already annotated upstream where applicable; nothing surfaced in this codebase's TSA build.
- **VoteResolver / `GetMagnitudeFactor`** — existing suppressions intentionally preserved per `feedback_voting_result_cs_main_scope.md`. Wait for the voting-redesign replacement.
- **`auditsnapshotaccrual` per-CPID scope** — deferred to follow-up #2978. Rarely-run RPC; the outer plural form was fixed here.

## What's in scope

### Annotation rollout (commits 1–6)

| Commit | Subsystem | Notes |
|--------|-----------|-------|
| ed620b039 | `GRC::Quorum` + accrual cascade | 2 scoped RPC handler LOCKs (`superblockage`, `auditsnapshotaccruals` — see follow-up #2978) |
| 4eea92ec7 | `gridcoin/staking` + `node/orphan_blocks` | 1 scoped LOCK in `StakeMiner` for `GetStakeSplitStatusAndParams` |
| a74d46578 | `gridcoin/contract` (dispatcher + 6 concrete handlers) | Zero new LOCKs |
| 0b87cc85f | `main.h`/`main.cpp` gaps + test pragmas | 2 scoped LOCKs in `init.cpp` startup paths |
| 039138cb4 | `validation.h`/`validation.cpp` + miner gaps | Zero new LOCKs |
| b2c9d868b | Header-level extern globals (`vNodes`, `mapRelay`/`vRelayExpiration`, `nBestHeight` in `net.h`, `pindex*`/`hashBestChain`/`nBestHeight` in main.cpp definitions) | 3 scoped `LOCK(cs_vNodes)` snapshots replacing previously-racy `vNodes.size()` reads |

### #2979 closures (commits 7–10)

| Commit | Item | Approach |
|--------|------|----------|
| 477b65c39 | `msMiningErrors` data race | Dedicated `cs_msMiningErrors` CCriticalSection; LOCK at writer + each of 2 readers (with copy-out before release) |
| e69ff4d06 | `addrSeenByPeer` data race | Same shape; dedicated `cs_addrSeenByPeer`; snapshot-before-LOCK2 at the two RPC reader call sites |
| c15e5256b | Scraper config block — **misdiagnosed in #2979** | The cpp definitions already had `GUARDED_BY(cs_ScraperGlobals)`; only the matching extern decls in `scraper.h` were missing the annotation. Pure header-annotation mirror; zero caller changes needed |
| c9608ad80 | `mapAlreadyAskedFor` mixed-locking | Dedicated leaf-level `cs_mapAlreadyAskedFor`; LOCK at all 9 access sites (8 in main.cpp/scraper_net.cpp + `CNode::AskFor` inline in net.h) |

Closes #2979.

## LOCK insertions: 8 total, all scoped, all lock-order-audited

Each new LOCK was placed deliberately, and each was checked against the canonical `cs_main` → `cs_wallet` → subsystem ordering documented in `doc/developer-notes.md`. Summary:

- **3 scoped `LOCK(cs_main)` for chain-state reads** — `superblockage` RPC, `auditsnapshotaccruals` RPC outer scope, two `init.cpp` startup PrintBlockTree call sites. Each is the first lock acquired on the thread; no nesting concern.
- **1 scoped `LOCK(cs_main)` in `StakeMiner`** — wraps `GetStakeSplitStatusAndParams` (which needs cs_main for the internal `GetAverageDifficulty(160)` chain walk) so the surrounding `MilliSleep(nMinerSleep)` stays lock-free. Sequential, not nested under the pre-existing per-iteration LOCK lower in the loop body.
- **3 scoped `LOCK(cs_vNodes)` snapshots** — `vNodes.size()` reads in `ProcessMessage` version handler, `getinfo` RPC (rpc/net.cpp), and `getinfo` RPC (wallet/rpcwallet.cpp). All sequential before the following cs_main / cs_main+cs_wallet acquisition.
- **1 deliberately-placed `LOCK(cs_main)` move** (commit 0b87cc85f, main.cpp): `cPeerBlockCounts.input()` in the `ProcessMessage` version handler was inside the later `LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts)` block — wrong, since cs_mapManifest is a subsystem lock and acquiring cs_main inside it would reverse the canonical ordering. Moved up into the existing cs_main scope ~25 lines above where the dependent read (`pfrom->nStartingHeight`) is already finalized.

No new lock-order edges introduced. No nested locks taken. The dedicated mutexes added in commits 7–10 (`cs_msMiningErrors`, `cs_addrSeenByPeer`, `cs_mapAlreadyAskedFor`) are leaf-level — each one only ever protects its single global and is always taken in isolate-and-release blocks.

## Test-file convention

Where annotations surfaced existing TSA violations in single-threaded test code that drives subsystem handlers directly, the existing project convention was followed: `#pragma clang diagnostic ignored "-Wthread-safety-analysis"` blocks scoped to the file or test case, matching the pattern already in `block_finder_tests.cpp`, `beacon_tests.cpp`, and `superblock_tests.cpp`. No LOCKs were added inside tests.

Files touched with file-scope or per-test pragmas: `project_tests.cpp`, `protocol_tests.cpp`, `scraper_registry_tests.cpp`, `orphan_block_tests.cpp`, `gridcoin_tests.cpp` (cbr suite), `dos_tests.cpp`, and one pre-existing latent issue in `wallet_tests.cpp` (`transaction_added_to_mempool_preserves_inmempool_state`). `researcher_tests.cpp`'s `AddProtocolEntry` helper uses `NO_THREAD_SAFETY_ANALYSIS` on the helper itself.

## Worth flagging — annotation choices that warrant a second look

A few decisions involved trade-offs and would benefit from reviewer scrutiny:

1. **`SendMessages` was deliberately left unannotated.** The caller (`ThreadMessageHandler2`) holds `cs_main` via `TRY_LOCK`, but the body has many internal `LOCK(cs_main)` blocks per section. Annotating the function `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` causes TSA to flag every internal re-acquire as "already held" — even though `cs_main` is recursive and the runtime behavior is correct. The header now carries an explicit comment documenting this. Same trade-off applies to `CreateRestOfTheBlock` in `miner.cpp`.

2. **`FetchInputs` was deliberately left unannotated.** Initially I marked it `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` as a conservative match for block-processing callers, but the function only reads `txdb` (its own subsystem) and `mempool` (which takes `mempool.cs` internally via `mempool.lookup`). RPC paths (`signrawtransaction*`) legitimately call it without `cs_main`. Backed out and replaced with a documentation comment.

3. **One `NO_THREAD_SAFETY_ANALYSIS` lambda in main.cpp.** `ProcessBlock` passes a lambda to `g_orphan_blocks.ProcessQueue` (which is `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`). TSA cannot propagate the requirement through the `std::function` indirection into the lambda body — same pattern as `beacon.cpp`'s `ChainletErrorHandle` lambda (line 852).

4. **`serialize.h` Unserialize template now wraps in the same TSA suppression that Serialize already had.** Necessary because `Contract::Unserialize` calls `Body::ResetType` which reads `nBestHeight`; the generic template instantiation point is too broad for TSA to reason about. The Serialize side has had this suppression for years; Unserialize now matches.

## Verification

Built and verified clean across all three targets under the CI Thread-Safety configuration:

```
CC=clang CXX=clang++ cmake -B build_tsa \
    -DENABLE_GUI=ON -DENABLE_TESTS=ON -DUSE_QT6=ON \
    -DWERROR_THREAD_SAFETY=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build_tsa --target gridcoin_util gridcoinqt test_gridcoin --parallel $(nproc)
```

All TUs compile clean under `-Werror=thread-safety`. Only the unrelated BDB-library PIE link incompatibility (pre-existing on Tumbleweed clang) prevents test_gridcoin from linking — TSA verification itself is complete since TSA runs at compile time.

`test/lint/lint-all.sh` clean against this branch — the codespell warnings flagged in its output are pre-existing typos in files I didn't introduce (verified by `git blame`).

## Isolated testnet validation

Cherry-picked onto `testnet_v13_checkpoint_removed` (origin/development + the testnet checkpoint-removal hack) and soaked on the 4-node isolated mesh under the pathological wallet shapes described in `reference_isolated_testnet_pathological_wallets.md`.

Soaked binary: `gridcoinresearch-5.5.0.2-testnet_v13_checkpoint_removed-a0ff8f53f` (10 PR commits + the Copilot-review fixup `a0ff8f53f`).

**Result after the overnight run:**

| Metric | Value |
|---|---|
| Blocks accepted | +537 across all four nodes (2777334 → 2777871, locked in step) |
| Peers per node | 6 / 6 / 6 / 6 (full mesh, no flapping) |
| Staking | nodes 1-3 active producers, node 4 non-cruncher per config |
| Scraper convergence | 3 publishing scrapers, 16-part current, **36 past convergences completed** |
| `Assertion failed`, `abort`, `terminate`, `deadlock`, `POTENTIAL DEADLOCK`, `sanitizer`, `UBSAN`, `ASAN`, `TSAN` hits | **0** across all four debug.logs |
| `cannot acquire`, `lock order`, `invariant.*violated` hits | **0** across all four debug.logs |
| Lock-acquisition timings | `StakeMiner: lock cs_main: elapsed time: 0 ms` (uncontended) |

Paths exercised by the soak that map directly to the new annotations / mutexes:

- **`cs_main` annotated paths:** `ProcessBlock` → `AcceptBlock` → `ConnectBlock` (537 acceptances); `StakeMiner` per-iteration `LOCK(cs_main)` for `GetStakeSplitStatusAndParams` / `GetAverageDifficulty(160)`; `FindStakeModifierRev` chain walks; `Tally::GetSnapshotComputer` / `Quorum::CurrentSuperblock` on every accrual cycle.
- **`cs_msMiningErrors`:** `StoreResearcher` writes (each producer's status set to "Eligible for Research Rewards" on startup); `getstakinginfo` RPC reads on every probe.
- **`cs_addrSeenByPeer`:** writes on each version-handshake of the 6-peer mesh; reads on every `getinfo` probe.
- **`cs_mapAlreadyAskedFor`:** TX/BLOCK handler erases under cs_main; `CSplitBlob::RecvPart` standalone erases (the actual race the dedicated mutex was added to close); `CNode::AskFor` inline calls from inv churn; `SendMessages` getdata loop reads + re-check + writes (the Copilot-fixup path).
- **`cs_vNodes` snapshot pattern:** every `getinfo` RPC + every version-handler peer count check.
- **`cs_ScraperGlobals`:** 36 convergence cycles read the config block; `ApplyCacheAppCacheEntries` writes.

Bottom line — the annotations are correct, no new lock-order edges introduced or existing ones disturbed, the dedicated mutexes added in commits 7-10 + the Copilot fixup behave under sustained real-world load on a heavy-stake testnet mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


