### PR TITLE
qt: converge subtract-fee on actual wallet fee, not first-success (#2981)

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -443,11 +443,25 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
             // Requires a non-empty snapshot — if every prior pass failed
             // we have no input set to pin and we fall through to the
             // TransactionCreationFailed return below.
+            //
+            // Pinning the inputs locks transaction size against
+            // SelectCoins-driven input-count flipping, but the wallet's
+            // own internal fee-bumping can still raise the fee one more
+            // notch on the pinned tx: sub-CENT change handling
+            // (wallet.cpp:3064-3078) moves a tiny nChange into the fee
+            // when nFeeRet < GetBaseFee, GetMinFee's dust-spam guard
+            // raises the floor when any output is below CENT, and
+            // small per-signature length variation can push nBytes
+            // across the 1 KB byte tier if the snapshot iteration sat
+            // right at the boundary. So we run a short bounded loop on
+            // the rescue too, with the same strict-equality convergence
+            // test as the outer loop. With inputs pinned the wallet's
+            // fee is monotonic across rescue iterations, and the rescue
+            // converges in 1-2 attempts in practice; if it does not
+            // converge in 5, bail rather than commit a mismatched
+            // subtract-fee tx.
             if (!fConverged && !vinsAtMaxFee.empty())
             {
-                if (!BuildSubtractedVecSend(nMaxFeeSeen))
-                    return SendCoinsReturn(FeeExceedsSubtractedAmount, nMaxFeeSeen);
-
                 // Copy any caller-supplied options (destChange,
                 // fAllowWatchOnly) and add the pinned outpoints. CCoinControl
                 // uses default copy semantics; setSelected, destChange, and
@@ -457,8 +471,33 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                 for (const COutPoint& op : vinsAtMaxFee)
                     pinControl.Select(op);
 
-                nFeeRequired = 0;
-                fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, &pinControl);
+                int64_t nRescueFee = nMaxFeeSeen;
+                bool fRescueConverged = false;
+                for (int nRescueAttempt = 0; nRescueAttempt < 5; ++nRescueAttempt)
+                {
+                    if (!BuildSubtractedVecSend(nRescueFee))
+                        return SendCoinsReturn(FeeExceedsSubtractedAmount, nRescueFee);
+
+                    int64_t nRescuePrev = nRescueFee;
+                    nFeeRequired = 0;
+                    fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, &pinControl);
+                    if (!fCreated)
+                        break;
+
+                    if (nFeeRequired == nRescuePrev)
+                    {
+                        fRescueConverged = true;
+                        break;
+                    }
+                    nRescueFee = nFeeRequired;
+                }
+
+                // Non-converging rescue: fall through to the
+                // TransactionCreationFailed return below rather than
+                // commit a tx whose subtract-fee accounting doesn't
+                // match the wallet's actual charge.
+                if (!fRescueConverged)
+                    fCreated = false;
             }
         }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -7,6 +7,7 @@
 
 #include "node/ui_interface.h"
 #include "wallet/wallet.h"
+#include "wallet/coincontrol.h"
 #include "main.h"
 #include <key_io.h>
 #include "util.h"
@@ -319,23 +320,50 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         int64_t nFeeRequired = 0;
         bool fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
 
-        // If any recipient has "subtract fee from amount" enabled, rebuild the
-        // outputs with the fee deducted and create the transaction again.
-        // This runs even if the first pass failed (e.g. sending entire balance),
-        // since nFeeRequired is initialized to nTransactionFee and provides a
-        // reasonable starting estimate.
+        // If any recipient has "subtract fee from amount" enabled, rebuild
+        // the outputs with the fee deducted and create the transaction
+        // again. This runs even if the first pass failed (e.g. sending
+        // entire balance), since CWallet::CreateTransaction overwrites the
+        // caller's nFeeRet to nTransactionFee on entry (wallet.cpp:2964)
+        // and bumps from there — so even a failed pass leaves a reasonable
+        // starting estimate.
         //
-        // The outer loop refines the subtracted fee until it converges with the
-        // fee the wallet actually charges. A single retry is not enough because
-        // CreateTransaction's own internal fee-bumping (sub-CENT change
-        // handling at wallet.cpp:3064, GetMinFee dust-spam guard, byte-tier
-        // crossing) can return an nFeeRequired that exceeds the value we just
-        // subtracted from the recipient. If we stop iterating at first-success,
-        // wtx commits with too little subtracted: the recipient gets more than
-        // intended and the "extra" fee silently comes from the sender's change
-        // instead of being deducted from the amount (issue #2981). Loop until
-        // nFeeRequired stops growing; the 10-attempt cap protects against a
-        // pathological non-converging case.
+        // The loop refines the subtracted fee against the fee the wallet
+        // actually charges. A single retry is not enough because the
+        // wallet's own internal fee-bumping (sub-CENT change handling at
+        // wallet.cpp:3064, GetMinFee dust-spam guard, byte-tier crossing)
+        // can return an nFeeRequired that exceeds what we subtracted —
+        // committing at that point under-debits the recipient and silently
+        // absorbs the surplus into the sender's change (issue #2981).
+        //
+        // We require strict equality (subtracted == returned) for
+        // convergence. The earlier `<=` form let the inverse case
+        // (returned < subtracted) commit silently, over-debiting the
+        // recipient and "saving" the difference back to the sender's
+        // change.
+        //
+        // In a uniform-UTXO wallet, the loop can enter a 2-cycle: when
+        // the higher fee is subtracted, the target shrinks and the wallet
+        // picks fewer inputs (size drops below 1 KB → tier-1 fee, e.g.
+        // 0.001); when the lower fee is subtracted, the target grows and
+        // the wallet picks more inputs (size crosses 1 KB → tier-2 fee,
+        // 0.002). The two states map to each other and strict equality
+        // never fires. Constructable: ten 400.000-GRC UTXOs, send 2400.001
+        // with subtract-fee — the loop alternates 0.001 / 0.002
+        // indefinitely.
+        //
+        // To force a deterministic, convergent commit in such a case,
+        // track the largest fee observed during the loop and the input
+        // set that produced it. If the loop exits without strict
+        // convergence — whether from oscillation or from a slower
+        // non-converging case hitting the 10-attempt cap — pin coin
+        // selection to that input set via CCoinControl and re-create
+        // the transaction with the larger fee subtracted. With inputs
+        // pinned, SelectCoins returns exactly those outpoints
+        // (wallet.cpp:2750-2758), the transaction size is fixed, the
+        // wallet's computed fee matches our subtraction, and the commit
+        // converges. The sender pays exactly the entered amount; the
+        // recipient receives (entered − higher fee).
         if (fAnySubtractFeeFromAmount)
         {
             int nSubtractRecipients = 0;
@@ -344,10 +372,13 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                 if (rcp.fSubtractFeeFromAmount) ++nSubtractRecipients;
             }
 
-            for (int nAttempt = 0; nAttempt < 10; ++nAttempt)
-            {
+            // Rebuild vecSend with the given fee distributed across the
+            // subtract-fee recipients. Returns false if any opted-in
+            // recipient's amount would drop to zero or negative; the
+            // caller should respond with FeeExceedsSubtractedAmount.
+            auto BuildSubtractedVecSend = [&](int64_t nFee) -> bool {
                 vecSend.clear();
-                int64_t nFeeRemainder = nFeeRequired % nSubtractRecipients;
+                int64_t nFeeRemainder = nFee % nSubtractRecipients;
                 bool fFirst = true;
                 for (const SendCoinsRecipient& rcp : recipients)
                 {
@@ -357,7 +388,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
 
                     if (rcp.fSubtractFeeFromAmount)
                     {
-                        nAmount -= nFeeRequired / nSubtractRecipients;
+                        nAmount -= nFee / nSubtractRecipients;
                         // First opted-in recipient absorbs the truncation remainder
                         if (fFirst)
                         {
@@ -365,25 +396,69 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                             fFirst = false;
                         }
                         if (nAmount <= 0)
-                        {
-                            return SendCoinsReturn(FeeExceedsSubtractedAmount, nFeeRequired);
-                        }
+                            return false;
                     }
 
                     vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
                 }
+                return true;
+            };
+
+            // Track the largest fee returned and the input set that
+            // produced it. Seed from pass 1 if it succeeded; otherwise
+            // the first successful iteration below populates it.
+            int64_t nMaxFeeSeen = nFeeRequired;
+            std::vector<COutPoint> vinsAtMaxFee;
+            if (fCreated)
+            {
+                for (const CTxIn& in : wtx.vin)
+                    vinsAtMaxFee.push_back(in.prevout);
+            }
+            bool fConverged = false;
+
+            for (int nAttempt = 0; nAttempt < 10; ++nAttempt)
+            {
+                if (!BuildSubtractedVecSend(nFeeRequired))
+                    return SendCoinsReturn(FeeExceedsSubtractedAmount, nFeeRequired);
 
                 int64_t nFeePrev = nFeeRequired;
                 fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
 
-                // Converged: the wallet's actual fee is <= what we already
-                // subtracted. (If fCreated is false at this point we will fall
-                // through to the TransactionCreationFailed return below.)
-                if (nFeeRequired <= nFeePrev)
+                if (fCreated && nFeeRequired == nFeePrev)
+                {
+                    fConverged = true;
                     break;
+                }
 
-                // Fee grew during the build (size bump, dust guard, sub-CENT
-                // change). Re-subtract the new fee and try again.
+                if (fCreated && nFeeRequired > nMaxFeeSeen)
+                {
+                    nMaxFeeSeen = nFeeRequired;
+                    vinsAtMaxFee.clear();
+                    for (const CTxIn& in : wtx.vin)
+                        vinsAtMaxFee.push_back(in.prevout);
+                }
+            }
+
+            // Rescue pass for oscillation or cap-without-convergence.
+            // Requires a non-empty snapshot — if every prior pass failed
+            // we have no input set to pin and we fall through to the
+            // TransactionCreationFailed return below.
+            if (!fConverged && !vinsAtMaxFee.empty())
+            {
+                if (!BuildSubtractedVecSend(nMaxFeeSeen))
+                    return SendCoinsReturn(FeeExceedsSubtractedAmount, nMaxFeeSeen);
+
+                // Copy any caller-supplied options (destChange,
+                // fAllowWatchOnly) and add the pinned outpoints. CCoinControl
+                // uses default copy semantics; setSelected, destChange, and
+                // fAllowWatchOnly are all carried over.
+                CCoinControl pinControl;
+                if (coinControl) pinControl = *coinControl;
+                for (const COutPoint& op : vinsAtMaxFee)
+                    pinControl.Select(op);
+
+                nFeeRequired = 0;
+                fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, &pinControl);
             }
         }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -325,12 +325,17 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         // since nFeeRequired is initialized to nTransactionFee and provides a
         // reasonable starting estimate.
         //
-        // The outer loop handles fee refinement: CreateTransaction may discover
-        // that the actual fee (based on transaction size) exceeds the initial
-        // estimate. When that happens, it updates nFeeRequired and fails because
-        // SelectCoins can't cover the higher total. We detect the fee increase,
-        // rebuild outputs with the new fee, and retry. This converges quickly
-        // since fees are monotonically non-decreasing and bounded by tx size.
+        // The outer loop refines the subtracted fee until it converges with the
+        // fee the wallet actually charges. A single retry is not enough because
+        // CreateTransaction's own internal fee-bumping (sub-CENT change
+        // handling at wallet.cpp:3064, GetMinFee dust-spam guard, byte-tier
+        // crossing) can return an nFeeRequired that exceeds the value we just
+        // subtracted from the recipient. If we stop iterating at first-success,
+        // wtx commits with too little subtracted: the recipient gets more than
+        // intended and the "extra" fee silently comes from the sender's change
+        // instead of being deducted from the amount (issue #2981). Loop until
+        // nFeeRequired stops growing; the 10-attempt cap protects against a
+        // pathological non-converging case.
         if (fAnySubtractFeeFromAmount)
         {
             int nSubtractRecipients = 0;
@@ -339,7 +344,6 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                 if (rcp.fSubtractFeeFromAmount) ++nSubtractRecipients;
             }
 
-            // Retry limit prevents infinite loops in pathological cases
             for (int nAttempt = 0; nAttempt < 10; ++nAttempt)
             {
                 vecSend.clear();
@@ -372,11 +376,14 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                 int64_t nFeePrev = nFeeRequired;
                 fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
 
-                if (fCreated || nFeeRequired <= nFeePrev)
+                // Converged: the wallet's actual fee is <= what we already
+                // subtracted. (If fCreated is false at this point we will fall
+                // through to the TransactionCreationFailed return below.)
+                if (nFeeRequired <= nFeePrev)
                     break;
 
-                // Fee increased (tx was larger than estimated) — retry with
-                // the updated fee subtracted from recipient amounts.
+                // Fee grew during the build (size bump, dust guard, sub-CENT
+                // change). Re-subtract the new fee and try again.
             }
         }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -445,21 +445,34 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
             // TransactionCreationFailed return below.
             //
             // Pinning the inputs locks transaction size against
-            // SelectCoins-driven input-count flipping, but the wallet's
-            // own internal fee-bumping can still raise the fee one more
-            // notch on the pinned tx: sub-CENT change handling
-            // (wallet.cpp:3064-3078) moves a tiny nChange into the fee
-            // when nFeeRet < GetBaseFee, GetMinFee's dust-spam guard
-            // raises the floor when any output is below CENT, and
-            // small per-signature length variation can push nBytes
-            // across the 1 KB byte tier if the snapshot iteration sat
-            // right at the boundary. So we run a short bounded loop on
-            // the rescue too, with the same strict-equality convergence
-            // test as the outer loop. With inputs pinned the wallet's
-            // fee is monotonic across rescue iterations, and the rescue
-            // converges in 1-2 attempts in practice; if it does not
-            // converge in 5, bail rather than commit a mismatched
-            // subtract-fee tx.
+            // SelectCoins-driven input-count flipping. Under default
+            // Gridcoin fee parameters and reasonable UTXO shapes the
+            // wallet returns the same fee on the rescue call that
+            // produced the snapshot — fee-tier transitions happen at
+            // the 1 KB byte boundary, and the only remaining structural
+            // variation (change-vout present/absent, ±34 bytes) plus
+            // per-signature DER length variation (1-2 bytes per input)
+            // are not enough to cross 1 KB at typical input counts:
+            // 6 pinned inputs span 936-970 bytes (tier 1×), 7 pinned
+            // span 1084-1118 bytes (tier 2×). So in practice the rescue
+            // converges in iter 0.
+            //
+            // The bounded loop is defensive against pathologies I can
+            // describe but cannot construct concretely: keypool
+            // exhaustion mid-rescue (CreateTransaction returns false on
+            // reservekey.GetReservedKey), an unusually low custom
+            // -paytxfee combined with an adversarial UTXO sum that
+            // re-activates the sub-CENT change handler at
+            // wallet.cpp:3064-3078 (which is dormant under defaults
+            // because the trigger nFeeRet < GetBaseFee is false once
+            // nFeeRet equals the default nTransactionFee), or a future
+            // change to wallet internals that introduces new
+            // fee-determining factors. The strict-equality convergence
+            // check matches the outer loop; on non-convergence we set
+            // fCreated = false so the caller returns
+            // TransactionCreationFailed rather than commit a tx whose
+            // subtract-fee accounting doesn't match the wallet's actual
+            // charge.
             if (!fConverged && !vinsAtMaxFee.empty())
             {
                 // Copy any caller-supplied options (destChange,

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -330,11 +330,17 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         //
         // The loop refines the subtracted fee against the fee the wallet
         // actually charges. A single retry is not enough because the
-        // wallet's own internal fee-bumping (sub-CENT change handling at
-        // wallet.cpp:3064, GetMinFee dust-spam guard, byte-tier crossing)
-        // can return an nFeeRequired that exceeds what we subtracted —
-        // committing at that point under-debits the recipient and silently
-        // absorbs the surplus into the sender's change (issue #2981).
+        // wallet's own internal fee-bumping — primarily byte-tier
+        // crossing where nPayFee = nTransactionFee * (1 + nBytes/1000)
+        // jumps when the signed tx crosses each 1 KB boundary
+        // (wallet.cpp:3191) — can return an nFeeRequired that exceeds
+        // what we subtracted. Committing at that point under-debits the
+        // recipient and silently absorbs the surplus into the sender's
+        // change (issue #2981). Sub-CENT change handling
+        // (wallet.cpp:3064-3078) is a second potential fee-bumper but
+        // is dormant under default fee parameters because its trigger
+        // `nFeeRet < GetBaseFee` is false when nFeeRet is seeded from
+        // the default nTransactionFee.
         //
         // We require strict equality (subtracted == returned) for
         // convergence. The earlier `<=` form let the inverse case
@@ -405,12 +411,21 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
             };
 
             // Track the largest fee returned and the input set that
-            // produced it. Seed from pass 1 if it succeeded; otherwise
-            // the first successful iteration below populates it.
-            int64_t nMaxFeeSeen = nFeeRequired;
+            // produced it. Seed from pass 1 only if it succeeded —
+            // seeding nMaxFeeSeen from a *failed* pass-1 call would
+            // leave a phantom high fee with no corresponding snapshot
+            // (the wallet sets nFeeRet = nTransactionFee on entry and
+            // can bump it before returning false), which would then
+            // block subsequent successful iterations with lower fees
+            // from populating vinsAtMaxFee via the `>` comparison.
+            // Inside the loop, snapshot on the first success regardless
+            // of fee value (vinsAtMaxFee.empty()) so we always have a
+            // valid input set to pin if the rescue is needed.
+            int64_t nMaxFeeSeen = 0;
             std::vector<COutPoint> vinsAtMaxFee;
             if (fCreated)
             {
+                nMaxFeeSeen = nFeeRequired;
                 for (const CTxIn& in : wtx.vin)
                     vinsAtMaxFee.push_back(in.prevout);
             }
@@ -430,7 +445,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
                     break;
                 }
 
-                if (fCreated && nFeeRequired > nMaxFeeSeen)
+                if (fCreated && (vinsAtMaxFee.empty() || nFeeRequired > nMaxFeeSeen))
                 {
                     nMaxFeeSeen = nFeeRequired;
                     vinsAtMaxFee.clear();


### PR DESCRIPTION
## Summary

Fixes #2981 — "always subtract fee from amount when chosen to do so."

The bug: when "Subtract fee from amount" is checked in the send dialog, the recipient was sometimes under-debited. The "extra fee" portion (the part of the wallet's final fee that exceeded the GUI's initial estimate) silently came from the sender's change output instead of being subtracted from the recipient as requested.

What started as a one-line break-condition tweak in `WalletModel::sendCoins` evolved through Copilot review into a small mechanism: strict-equality convergence in the outer loop plus a bounded "rescue" pass that pins coin selection via `CCoinControl` to break a 2-cycle that can otherwise oscillate indefinitely. Detailed root-cause analysis posted as a comment on the issue: https://github.com/gridcoin-community/Gridcoin-Research/issues/2981#issuecomment-4556513609.

## Root cause

`src/qt/walletmodel.cpp`'s subtract-fee retry loop used a short-circuit break:

```cpp
if (fCreated || nFeeRequired <= nFeePrev)
    break;
```

`fCreated=true` does **not** imply that `nFeeRequired` matches what we just subtracted. `CWallet::CreateTransaction` runs its own internal fee-convergence loop, and that loop can bump the fee primarily via **byte-tier crossing** in `nPayFee = nTransactionFee * (1 + nBytes/1000)` (`wallet.cpp:3191`) — when the signed transaction crosses each 1 KB boundary, the fee tier jumps. Sub-CENT change handling at `wallet.cpp:3064-3078` is a secondary path but is dormant under default fee parameters (its trigger `nFeeRet < GetBaseFee` is false when `nFeeRet` is seeded from the default `nTransactionFee`). The `GetMinFee` dust-spam branch at `fees.h:55-60` is structurally unreachable — `nMinFee = (1+nBytes/1000)*nBaseFee` is always `>= nBaseFee`, so the `nMinFee < nBaseFee` gate never opens.

When `CreateTransaction` succeeds with a returned fee greater than what the GUI subtracted, the recipient is under-debited:

- `wtx` commits with `amount = raw - nFeePrev`
- The wallet charges `nFeeRequired_final` (some larger value)
- The difference comes from the sender's change

The reporter's description — "Send a so-called 'large' (even almost worthlessly small, but historically large) transaction that has extra fee (won't subtract from amount)" — maps directly to the byte-tier-crossing case.

## How the bug got there

Introduced by `8f18b7672` ("qt: fix subtract-fee failing when sending entire balance"). That commit fixed a real bug — pass 1 failing for entire-balance sends — by removing an `if (fCreated &&` guard that prevented pass 2 from ever running. But it extended too aggressively: it kept the `fCreated` short-circuit *inside* the retry loop's break condition, on the implicit assumption that `fCreated=true` ⇒ "the wallet's final fee equals what we just subtracted." That assumption holds for small/clean transactions but breaks down whenever `CreateTransaction`'s internal fee-bumping path runs.

## The fix

Three layered changes to `WalletModel::sendCoins`:

**1. Strict-equality convergence.** The break test went from `fCreated || nFeeRequired <= nFeePrev` to `fCreated && nFeeRequired == nFeePrev`. The original `<=` form let the inverse direction commit silently — when `CreateTransaction` returns a *lower* fee than what was just subtracted (subtraction shrinks the target enough for `SelectCoins` to pick fewer inputs → smaller tx → lower `nPayFee`), the outer loop broke with the recipient over-debited.

**2. Snapshot tracking.** Across the outer loop, track the largest fee returned by any successful `CreateTransaction` and the input set that produced it (`vinsAtMaxFee`, copied from `wtx.vin` after the call). Seeded from pass 1 if it succeeded; otherwise snapshot on the first successful iteration regardless of fee value (the `vinsAtMaxFee.empty()` bypass), so the rescue always has a valid input set to pin.

**3. Bounded rescue pass via coin control.** In a uniform-UTXO wallet the outer loop can enter a 2-cycle that strict equality alone never breaks:

- Subtract the higher fee → target shrinks → `SelectCoins` picks fewer inputs (size drops below 1 KB → tier-1× → returned fee 0.001)
- Subtract the lower fee → target grows → `SelectCoins` picks more inputs (size crosses 1 KB → tier-2× → returned fee 0.002)

The two states map to each other. Constructable: ten 400.000-GRC UTXOs, send 2400.001 GRC with subtract-fee → the loop alternates 0.001 / 0.002 indefinitely.

After the outer loop exits without convergence, the rescue pass copies any caller-supplied `CCoinControl` options, adds the pinned outpoints from `vinsAtMaxFee`, and re-creates the transaction. With inputs pinned, `SelectCoins` returns exactly those outpoints (`wallet.cpp:2750-2758`) and the transaction size is fixed. The rescue itself runs a short bounded loop (5 attempts) with the same strict-equality convergence test — defensive against any residual fee-bumping inside the pinned-input call — and falls through to `TransactionCreationFailed` if it can't converge, rather than commit a tx whose subtract-fee accounting doesn't match the wallet's actual charge.

Net user-visible behavior after the rescue: sender pays exactly the entered amount, recipient receives `entered − higher_fee`.

## Scenarios covered

| Scenario | Outer loop | Rescue | Outcome |
|---|---|---|---|
| Entire-balance send (original 8f18b7672 case) | pass 1 fails, iter 0 succeeds and converges | skipped | ✓ |
| Standard send, no fee bump | converges in iter 0 | skipped | ✓ |
| Byte-tier crossing on retry (the #2981 failure mode) | converges in iter 1–2 | skipped | ✓ |
| 2-cycle oscillation (uniform UTXOs at byte-tier boundary) | 10-attempt cap exits without convergence | runs, converges in iter 0 with pinned inputs | ✓ |
| Slow non-convergence (theoretical) | 10-attempt cap exits | rescue with bounded 5-iter loop | ✓ converges, or `TransactionCreationFailed` |
| Recipient amount → 0 from subtraction | `BuildSubtractedVecSend` returns false in outer loop or rescue | — | `FeeExceedsSubtractedAmount` |
| Pass 1 + all 10 iters fail | `vinsAtMaxFee` empty | skipped (no input set to pin) | `TransactionCreationFailed` |

## Rescue convergence analysis

The 5-attempt bound on the rescue is the kind of structure that invites "but under what conditions can it actually blow through?" Worked through this carefully against the current code; the short answer is **under default Gridcoin fee parameters and reasonable UTXO shapes, the rescue converges in iter 0 in essentially every case**, and the bound exists as a guard against theoretical pathologies that I can describe but not construct concretely.

### Why iter-0 convergence is the norm

With inputs pinned, `nValueIn` is fixed. The wallet's fee response is then determined by transaction size (`nBytes`), and `nBytes` only varies with the output count (change vout present or absent, ±34 bytes) plus per-signature DER length variation (1-2 bytes per input). At typical input counts the byte-tier remains constant across these variations:

| Pinned inputs | 1 vout (no change) | 2 vouts (with change) | Tier flip across change-vout flip? |
|---|---|---|---|
| 6 | 14 + 6·148 + 34 = **936** | 14 + 6·148 + 68 = **970** | No (both < 1000) |
| 7 | 14 + 7·148 + 34 = **1084** | 14 + 7·148 + 68 = **1118** | No (both > 1000) |

The 34-byte change-vout difference is too small to cross 1 KB at either of the input counts where natural 2-cycle oscillation occurs (6 vs 7). Signature length variance compounds at ~14 bytes total across 7 inputs — also not enough to cross from a 1084-byte base.

### Cases I tried and ruled out

| Construction | Why it doesn't blow through |
|---|---|
| 10 × 400 GRC, send 2400.001 (the natural oscillation) | Rescue with 7 × 400 pinned + subtract 0.002 returns exactly 0.002. Converges in iter 0. |
| Two subtract-fee recipients with one near zero | Fails at `BuildSubtractedVecSend` (returns `FeeExceedsSubtractedAmount`), not at the rescue cap. |
| Pinned sum = `entered` exactly (forces `nChange = 0`) | Math constraint: requires the subtracted fee `X < 0`, impossible. |
| Many recipients (e.g., 5 inputs + 7 recipients) where output count crosses 1 KB | Possible *in principle* (7 vouts: 992 bytes tier 1×; 8 vouts: 1026 bytes tier 2×), but the math for sustaining a cycle across rescue iterations doesn't work out — `nChange` grows monotonically once we subtract more than the wallet wants. |
| `-paytxfee=0.0001` (10× smaller, activates sub-CENT change handler) | Once the wallet's inner loop bumps `nFeeRet` to `>= GetBaseFee`, the sub-CENT trigger goes dormant. Rescue still converges. |
| `GetMinFee` dust-spam guard (any output < CENT) | Dead code under current Gridcoin policy: `nMinFee = (1+nBytes/1000)·nBaseFee >= nBaseFee` always, so the `nMinFee < nBaseFee` gate at `fees.h:55` never opens. |

### What the cap defends against

The 5-iteration bound is for pathologies I can name but couldn't construct:
- Keypool exhaustion mid-rescue (`reservekey.GetReservedKey` returns false → `fCreated = false` → break)
- An unusually low custom `-paytxfee` (well below `GetBaseFee`) combined with an adversarial UTXO sum that re-activates the sub-CENT change handler in a way I couldn't trigger on paper
- A future change to wallet internals (e.g., dynamic message fees, new fee tiers) that introduces new fee-determining factors

On non-convergence the rescue sets `fCreated = false` so the caller returns `TransactionCreationFailed` rather than commit a mismatched subtract-fee tx. Bounded failure mode rather than runaway.

## Future work: push subtract-fee into the wallet (Bitcoin Core-style refactor)

The mechanism in this PR is a working solution but is structurally a Rube Goldberg — a GUI-level convergence loop on top of the wallet's internal fee-convergence loop on top of byte-tier policy, all to compensate for the wallet having no knowledge that the GUI wants the fee subtracted from the recipient. Modern Bitcoin Core eliminated this layering entirely: `CRecipient` carries a per-recipient `fSubtractFeeFromAmount` flag, the Qt `WalletModel` just collects the flagged recipients and calls `m_wallet->createTransaction(...)`, and the wallet's `CreateTransactionInternal` does a single-pass `to_reduce = fee_needed - current_fee` calculation and distributes the difference across the marked recipients. No retry loops at either layer.

That refactor is out of scope for this fix because it requires:
- New `CRecipient`-style struct with a per-recipient subtract-fee flag, plumbed through `CWallet::CreateTransaction`'s signature (used widely)
- Modernizing fee estimation (Gridcoin's wallet still uses the older tier-based `nPayFee` model; Bitcoin Core's single-pass relies on accurate `m_effective_feerate.GetFee(nBytes)` plus modern coin selection like BnB)
- Touching the wallet's inner fee-convergence loop in a way that affects every send path, not just GUI subtract-fee

But once we ship this fix, the right follow-up is to consider going that direction — eliminate the GUI-side convergence + rescue, and let the wallet handle subtract-fee natively in one pass like Bitcoin Core does. Tracked at #2984.

## Why no unit test in this PR

The subtract-fee retry loop is embedded inside `WalletModel::sendCoins`, which depends on the full `CWallet` + Qt machinery. The existing Qt test suite (`src/qt/test/`) doesn't have a `CWallet` mocking framework — `wallet_event_queue_tests.cpp` is the closest analog and it tests a pure data structure with no wallet interaction.

A proper regression test would need either:
- Mocking `CreateTransaction` to return controlled fee progressions (would need a virtual seam through `CWallet` — material refactor)
- A Python functional test driving the GUI end-to-end (the framework for which is being added in #2976, not yet merged)

Both are out of scope for this fix. Once #2976 lands a functional test framework, a regression test for both the convergence loop and the rescue is small.

## Verification

- Compile-clean on the standard CMake build (gridcoin_util, gridcoinqt, test_gridcoin all build, all existing unit tests pass)
- Manual reproduction guide is in the bug report; the fix flips the behaviour from "subtract initial-estimate" to "subtract converged-fee"

## Isolated testnet validation

Validated on a 4-node isolated testnet (instances 8/9/10/11 → node1/2/3/4) running the cherry-picked fix.

### Test parameters

- Sender wallet: node4 (instance 11) — deliberately fragmented, ~300 small UTXOs of varied denominations (median ~396 GRC). This shape is what triggers the byte-tier-crossing failure mode in production.
- Recipient: a fresh address on node1.
- Send: 3000 GRC with subtract-fee checked.
- Default `nTransactionFee = 0.001` GRC, default v2 transactions.

### Transaction artifact

txid `5ba4f651f01d9c72f37be4387a9cb0770c7c7c984e09e8490e276f5140b664ad` ([viewable on the testnet node](#isolated-testnet)):

- nBytes ≈ 1100 (above the 1 KB byte tier → 2× fee tier)
- `nPayFee = 0.001 * 2 = 0.002`
- Recipient amount: `3000 − 0.002 = 2999.998` GRC ✓
- Sender balance delta: exactly `3000.000` GRC ✓
- Miner fee: `0.002` GRC ✓

### Cross-check against the bug semantics

| Metric | Expected (fixed) | Observed |
|---|---|---|
| Recipient | `entered − fee = 2999.998` | 2999.998 ✓ |
| Sender balance delta | exactly `entered = 3000.000` | 3000.000 ✓ |
| On-chain fee | `0.002` (tier 2) | 0.002 ✓ |

### What the buggy version would have produced

| Metric | Buggy outcome |
|---|---|
| Recipient | 2999.**999** (only the 0.001 initial estimate subtracted) |
| Sender balance delta | 3000.**001** (the extra 0.001 silently coming from change) |
| Visible discrepancy | sender pays 0.001 more than entered, recipient gets 0.001 more than `entered − fee` |

### What this proves

The retry loop's new convergence test correctly iterates past the byte-tier-crossing fee bump:

- Iter 0: `nFeePrev = 0.001` (initial), `CreateTransaction` returns `nFeeRequired = 0.002` (tier triggered). `0.002 != 0.001` ⇒ loop continues.
- Iter 1: `nFeePrev = 0.002`, `CreateTransaction` returns `nFeeRequired = 0.002` (smaller recipient keeps the same tx size). `0.002 == 0.002` ⇒ converged, break.

Iteration-1's amounts are what got committed to `wtx`; the on-chain artifact confirms recipient = entered − 0.002 exactly.

The 2-cycle oscillation case and the rescue pass are not directly exercised by this single test (node4's mixed UTXO shape doesn't naturally hit the uniform-UTXO 6-vs-7 boundary). They have been analyzed concretely in the *Rescue convergence analysis* section above. A targeted oscillation test on a synthetically-uniform wallet shape is queued as follow-up validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

