### PR TITLE
refactor: ScraperRegistry thread-safety per the contract-registry locking model (2/4)

### DIFF
--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -235,8 +235,14 @@ ScraperEntryPayload ScraperEntryPayload::Parse(const std::string& key, const std
 // -----------------------------------------------------------------------------
 // Class: ScraperRegistry
 // -----------------------------------------------------------------------------
-const ScraperRegistry::ScraperMap& ScraperRegistry::Scrapers() const
+ScraperRegistry::ScraperMap ScraperRegistry::Scrapers() const
 {
+    LOCK(cs_lock);
+
+    // Returns a by-value snapshot. The map is copied under the lock; its
+    // ScraperEntry_ptr (shared_ptr) elements are shared, not deep-copied.
+    // Entries are immutable once published (mutations swap the pointer, never
+    // mutate a live entry), so the snapshot is safe to use after the lock drops.
     return m_scrapers;
 }
 
@@ -560,11 +566,6 @@ uint64_t ScraperRegistry::PassivateDB()
     LOCK(cs_lock);
 
     return m_scraper_db.passivate_db();
-}
-
-ScraperRegistry::ScraperEntryDB &ScraperRegistry::GetScraperDB()
-{
-    return m_scraper_db;
 }
 
 template<> const std::string ScraperRegistry::ScraperEntryDB::KeyType()

--- a/src/gridcoin/scraper/scraper_registry.h
+++ b/src/gridcoin/scraper/scraper_registry.h
@@ -446,9 +446,12 @@ public:
     //! \brief Get the collection of current scraper entries. Note that this INCLUDES deleted
     //! scraper entries.
     //!
-    //! \return \c A reference to the current scraper entries stored in the registry.
+    //! \return A by-value snapshot of the current scraper entries, taken under cs_lock.
+    //! The map is copied; its ScraperEntry_ptr (shared_ptr) elements are shared, not
+    //! deep-copied. Entries are immutable once published, so the snapshot is safe to use
+    //! without holding any lock. See doc/contract_registry_locking_design.md.
     //!
-    const ScraperMap& Scrapers() const;
+    ScraperMap Scrapers() const;
 
     //!
     //! \brief A shim method to cross-wire this into the existing scraper code
@@ -622,18 +625,14 @@ private:
     //!
     void AddDelete(const ContractContext& ctx);
 
-    ScraperMap m_scrapers;                   //!< Contains the current scraper entries, including entries marked DELETED.
-    PendingScraperMap m_pending_scrapers {}; //!< Not actually used for scrapers. To satisfy the template only.
+    ScraperMap m_scrapers GUARDED_BY(cs_lock);                   //!< Contains the current scraper entries, including entries marked DELETED.
+    PendingScraperMap m_pending_scrapers GUARDED_BY(cs_lock) {}; //!< Not actually used for scrapers. To satisfy the template only.
 
-    std::set<ScraperEntry> m_expired_scraper_entries {}; //!< Not actually used for scrapers. To satisfy the template only.
+    std::set<ScraperEntry> m_expired_scraper_entries GUARDED_BY(cs_lock) {}; //!< Not actually used for scrapers. To satisfy the template only.
 
-    ScraperMap m_first_scraper_entries {};   //!< Not used here. To satisfy the template only.
+    ScraperMap m_first_scraper_entries GUARDED_BY(cs_lock) {};   //!< Not used here. To satisfy the template only.
 
-    ScraperEntryDB m_scraper_db;
-
-public:
-
-    ScraperEntryDB& GetScraperDB();
+    ScraperEntryDB m_scraper_db GUARDED_BY(cs_lock);
 }; // ScraperRegistry
 
 //!

--- a/src/test/gridcoin/scraper_registry_tests.cpp
+++ b/src/test/gridcoin/scraper_registry_tests.cpp
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_legacy
 
     BOOST_CHECK(resurrected_scraper->first == "SLbdvKZHmtu49VUWm88rbcCo9DaC8Z2urV");
     BOOST_CHECK(resurrected_scraper->second.value == "true");
-    BOOST_CHECK(resurrected_scraper->second.timestamp = 6);
+    BOOST_CHECK(resurrected_scraper->second.timestamp == 6);
 }
 
 
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
 
     BOOST_CHECK(resurrected_scraper->first == "SLbdvKZHmtu49VUWm88rbcCo9DaC8Z2urV");
     BOOST_CHECK(resurrected_scraper->second.value == "true");
-    BOOST_CHECK(resurrected_scraper->second.timestamp = 6);
+    BOOST_CHECK(resurrected_scraper->second.timestamp == 6);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gridcoin/scraper_registry_tests.cpp
+++ b/src/test/gridcoin/scraper_registry_tests.cpp
@@ -102,7 +102,6 @@ BOOST_AUTO_TEST_CASE(scraper_entries_added_to_scraper_work_correctly_legacy)
     uint64_t time = 0;
 
     auto& registry = GRC::GetScraperRegistry();
-    const auto& scraper_map = registry.Scrapers();
 
     std::vector<std::string> scraper_entries { {"RxKVQ1SGpgyUfMv1zdygmiLi24mxG34k6f",
                                                "S2wGoFavFzTnpaxn6XqLmJDE9FppHiMrCn",
@@ -122,6 +121,9 @@ BOOST_AUTO_TEST_CASE(scraper_entries_added_to_scraper_work_correctly_legacy)
                                 time++,
                                 false);
     }
+
+    // Scrapers() returns a by-value snapshot under cs_lock; re-snapshot after each mutation.
+    auto scraper_map = registry.Scrapers();
 
     BOOST_CHECK(scraper_map.size() == 7);
 
@@ -155,7 +157,6 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_legacy
     uint64_t time = 0;
 
     auto& registry = GRC::GetScraperRegistry();
-    const auto& scraper_map = registry.Scrapers();
 
     std::vector<std::string> scraper_entries { {"RxKVQ1SGpgyUfMv1zdygmiLi24mxG34k6f",
                                                "S2wGoFavFzTnpaxn6XqLmJDE9FppHiMrCn",
@@ -176,6 +177,9 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_legacy
                                 false);
     }
 
+    // Scrapers() returns a by-value snapshot under cs_lock; re-snapshot after each mutation.
+    auto scraper_map = registry.Scrapers();
+
     BOOST_CHECK(scraper_map.size() == 7);
 
     // Deauthorize a scraper
@@ -185,6 +189,8 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_legacy
                             height++,
                             time++,
                             false);
+
+    scraper_map = registry.Scrapers();
 
     // Still should be 7 current elements.
     BOOST_CHECK(scraper_map.size() == 7);
@@ -246,6 +252,8 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_legacy
     GRC::ContractContext ctx(contract, ctx_tx, &dummy_index);
 
     registry.Add(ctx);
+
+    scraper_map = registry.Scrapers();
 
     // Native map should still be 7 elements
     BOOST_CHECK(scraper_map.size() == 7);
@@ -323,6 +331,8 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_legacy
     int post_revert_height = 8;
     registry.SetDBHeight(post_revert_height);
 
+    scraper_map = registry.Scrapers();
+
     // After reversion...
     // Native map should be back to 7 elements.
     BOOST_CHECK(scraper_map.size() == 7);
@@ -352,7 +362,6 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
     uint64_t time = 0;
 
     auto& registry = GRC::GetScraperRegistry();
-    const auto& scraper_map = registry.Scrapers();
 
     std::vector<std::string> scraper_entries { {"RxKVQ1SGpgyUfMv1zdygmiLi24mxG34k6f",
                                                "S2wGoFavFzTnpaxn6XqLmJDE9FppHiMrCn",
@@ -373,6 +382,9 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
                                 false);
     }
 
+    // Scrapers() returns a by-value snapshot under cs_lock; re-snapshot after each mutation.
+    auto scraper_map = registry.Scrapers();
+
     BOOST_CHECK(scraper_map.size() == 7);
 
     // Deauthorize a scraper
@@ -382,6 +394,8 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
                             height++,
                             time++,
                             false);
+
+    scraper_map = registry.Scrapers();
 
     // Still should be 7 current elements.
     BOOST_CHECK(scraper_map.size() == 7);
@@ -449,6 +463,8 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
 
     registry.Add(ctx);
 
+    scraper_map = registry.Scrapers();
+
     // Native map should still be 7 elements
     BOOST_CHECK(scraper_map.size() == 7);
 
@@ -523,6 +539,8 @@ BOOST_AUTO_TEST_CASE(scraper_entry_deauthorize_and_delete_works_correctly_native
 
     int post_revert_height = 8;
     registry.SetDBHeight(post_revert_height);
+
+    scraper_map = registry.Scrapers();
 
     // After reversion...
     // Native map should be back to 7 elements.


### PR DESCRIPTION
## Summary

Second in the per-registry series applying the contract-registry thread-safety locking model (model + ProtocolRegistry landed in #2986). This PR applies the same model to **ScraperRegistry** (pattern (b)). The model is documented in `doc/contract_registry_locking_design.md` (added in #2986).

## ScraperRegistry changes

- The five private members become `GUARDED_BY(cs_lock)`.
- `Scrapers()` returns a **by-value snapshot** under `cs_lock` instead of `const ScraperMap&` (the old reference could be iterated while a chain handler mutated the map). The sole production caller is a read-only range-for in RPC — unaffected.
- **No `cs_lock` annotation on any public method.** The existing read accessors and `Try`/`TryAuthorized` already take `cs_lock` internally and return `shared_ptr`/by-value, which is safe because entries are immutable once published.
- Removed `GetScraperDB()` — a public accessor handing out a reference to the `cs_lock`-guarded backing DB (encapsulation violation under the model), with zero callers; internal code uses the (private) `m_scraper_db` directly.
- `scraper_registry_tests.cpp`: the three tests aliased `Scrapers()` as a live map and re-read it across add/deauthorize/remove/revert; converted to re-snapshot after each mutation (no assertions changed). A separate commit also fixes a pre-existing vacuous assertion (`timestamp = 6` → `== 6`) in the resurrection checks.

Chain handlers keep `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` and take `cs_lock` internally.

## Series

Model + ProtocolRegistry: #2986 (merged). Remaining after this: SideStakeRegistry (pattern (b)), BeaconRegistry (pattern (a)). Whitelist deferred (entangled with the AutoGreylist refresh path).

## Test plan

- [x] Clean Clang build, `-Werror=thread-safety-analysis` + `WERROR_THREAD_SAFETY=ON` (`HAVE_CLANG_THREAD_SAFETY=1`)
- [x] Full unit suite passes (`scraper_registry_tests`: 3 cases, re-snapshot conversion verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)