### PR TITLE
contract: fix end()-iterator dereference in registry Revert() error paths

### DIFF
--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -906,7 +906,7 @@ void Whitelist::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRED(cs_m
     if (entry_to_revert == m_project_entries.end()) {
         error("%s: The project entry for key %s to revert was not found in the project entry map.",
               __func__,
-              entry_to_revert->second->m_name);
+              payload->m_name);
 
         // If there is no record in the current m_project_entries map, then there is nothing to do here. This
         // should not occur.

--- a/src/gridcoin/protocol.cpp
+++ b/src/gridcoin/protocol.cpp
@@ -448,7 +448,7 @@ void ProtocolRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIR
     if (entry_to_revert == m_protocol_entries.end()) {
         error("%s: The protocol entry for key %s to revert was not found in the protocol entry map.",
               __func__,
-              entry_to_revert->second->m_key);
+              payload->m_entry.m_key);
 
         // If there is no record in the current m_protocol_entries map, then there is nothing to do here. This
         // should not occur.

--- a/src/gridcoin/scraper/scraper_registry.cpp
+++ b/src/gridcoin/scraper/scraper_registry.cpp
@@ -435,7 +435,7 @@ void ScraperRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUIRE
     if (entry_to_revert == m_scrapers.end()) {
         error("%s: The scraper entry for address %s to revert was not found in the scraper entry map.",
               __func__,
-              EncodeDestination(entry_to_revert->second->GetAddress()));
+              EncodeDestination(CTxDestination(payload->m_scraper_entry.m_key)));
 
         // If there is no record in the current m_scrapers map, then there is nothing to do here. This
         // should not occur.

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -804,7 +804,7 @@ void SideStakeRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUI
     if (entry_to_revert == m_mandatory_sidestake_entries.end()) {
         error("%s: The SideStake entry for key %s to revert was not found in the SideStake entry map.",
               __func__,
-              EncodeDestination(entry_to_revert->second->m_destination));
+              EncodeDestination(payload->m_entry.m_destination));
 
         // If there is no record in the current m_sidestake_entries map, then there is nothing to do here. This
         // should not occur.


### PR DESCRIPTION
## Summary

Each contract registry's `Revert()` looks up the entry to revert and, on the "not found" branch, logs an error that **dereferences the iterator just proven to be `end()`** — undefined behaviour on a past-the-end `std::map` iterator:

```cpp
auto entry_to_revert = <map>.find(<payload key>);
if (entry_to_revert == <map>.end()) {
    error("... %s ...", __func__, entry_to_revert->second-><field>);  // UB
    return;
}
```

It is a "should not occur" path (the entry being reverted should always be present), so it is dormant in normal operation — but it turns a defensive diagnostic into UB exactly when something is already anomalous (corruption, an odd reorg, an upstream bug), in consensus reversion code.

## Fix

Log the **payload key** (the same expression passed to `.find()`) instead of dereferencing the not-found iterator:

| Registry | Now logs |
|---|---|
| `ScraperRegistry` | `EncodeDestination(CTxDestination(payload->m_scraper_entry.m_key))` |
| `ProtocolRegistry` | `payload->m_entry.m_key` |
| `SideStakeRegistry` | `EncodeDestination(payload->m_entry.m_destination)` |
| `Whitelist` (project) | `payload->m_name` |

`BeaconRegistry` is **not affected**: its chainlet integrity handler (`ChainletErrorHandle`) throws `std::runtime_error`, so control never falls through to a deref.

The subsequent `entry_to_revert->second` dereferences in each method are reached only after the early `return` above, so they are safe and unchanged.

## Test plan

- [x] Clean Clang build (no new warnings)
- [x] Full unit test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)