### PR TITLE
refactor: SideStakeRegistry thread-safety per the contract-registry locking model (3/4)

### DIFF
--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -909,7 +909,7 @@ int SideStakeRegistry::Initialize()
     // Add the local sidestakes specified in the config file(s) to the local sidestakes map.
     LoadLocalSideStakesFromConfig();
 
-    m_local_entry_already_saved_to_config = false;
+    m_local_entry_already_saved_to_config.store(false, std::memory_order_relaxed);
 
     return height;
 }
@@ -954,8 +954,8 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
     // and we want to then ignore the update signal from the r-w file change that calls this function for
     // that action (only) and then reset the flag to be responsive to any changes on the core r-w file side
     // through changesettings, for example.
-    if (m_local_entry_already_saved_to_config) {
-        m_local_entry_already_saved_to_config = false;
+    if (m_local_entry_already_saved_to_config.load(std::memory_order_relaxed)) {
+        m_local_entry_already_saved_to_config.store(false, std::memory_order_relaxed);
 
         return;
     }
@@ -1142,7 +1142,7 @@ bool SideStakeRegistry::SaveLocalSideStakesToConfig()
 
     status = updateRwSettings(settings);
 
-    m_local_entry_already_saved_to_config = true;
+    m_local_entry_already_saved_to_config.store(true, std::memory_order_relaxed);
 
     return status;
 }
@@ -1167,13 +1167,6 @@ void SideStakeRegistry::SubscribeToCoreSignals()
 void SideStakeRegistry::UnsubscribeFromCoreSignals()
 {
   // Disconnect signals from client (no-op currently)
-}
-
-SideStakeRegistry::SideStakeDB &SideStakeRegistry::GetSideStakeDB()
-{
-    LOCK(cs_lock);
-
-    return m_sidestake_db;
 }
 
 template<> const std::string SideStakeRegistry::SideStakeDB::KeyType()

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -1096,8 +1096,17 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
 
             if (iter == vLocalSideStakes.end()) {
                 // Entry in map is no longer found in config files, so mark map entry inactive.
-
-                entry.second->m_status = LocalSideStake::LocalSideStakeStatus::INACTIVE;
+                //
+                // Copy-on-write: reseat the slot to a new INACTIVE entry rather than mutating the
+                // published object in place. A by-value snapshot (SideStakeEntries/Try/etc.) shares
+                // the LocalSideStake_ptr, so mutating in place would race a lock-free snapshot reader;
+                // reseating leaves the captured object untouched. Done under cs_lock (safe). The
+                // reader may then observe slightly stale data (the "safe != correct" boundary), which
+                // is acceptable here — local sidestakes are non-consensus and self-correct next
+                // iteration. See doc/contract_registry_locking_design.md.
+                auto inactive_entry = std::make_shared<LocalSideStake>(*entry.second);
+                inactive_entry->m_status = LocalSideStake::LocalSideStakeStatus::INACTIVE;
+                entry.second = inactive_entry;
             }
         }
     }

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_SIDESTAKE_H
 
 #include <key_io.h>
+#include <atomic>
 #include "gridcoin/contract/handler.h"
 #include "gridcoin/contract/payload.h"
 #include "gridcoin/contract/registry_db.h"
@@ -881,21 +882,25 @@ private:
     void SubscribeToCoreSignals();
     void UnsubscribeFromCoreSignals();
 
-    LocalSideStakeMap m_local_sidestake_entries;          //!< Contains the local (non-contract) sidestake entries.
-    MandatorySideStakeMap m_mandatory_sidestake_entries;  //!< Contains the mandatory sidestake entries, including DELETED.
-    PendingSideStakeMap m_pending_sidestake_entries {};   //!< Not used. Only to satisfy the template.
+    LocalSideStakeMap m_local_sidestake_entries GUARDED_BY(cs_lock);          //!< Contains the local (non-contract) sidestake entries.
+    MandatorySideStakeMap m_mandatory_sidestake_entries GUARDED_BY(cs_lock);  //!< Contains the mandatory sidestake entries, including DELETED.
+    PendingSideStakeMap m_pending_sidestake_entries GUARDED_BY(cs_lock) {};   //!< Not used. Only to satisfy the template.
 
-    std::set<SideStake> m_expired_sidestake_entries {};   //!< Not used. Only to satisfy the template.
+    std::set<SideStake> m_expired_sidestake_entries GUARDED_BY(cs_lock) {};   //!< Not used. Only to satisfy the template.
 
-    MandatorySideStakeMap m_sidestake_first_entries {};   //!< Not used. Only to satisfy the template.
+    MandatorySideStakeMap m_sidestake_first_entries GUARDED_BY(cs_lock) {};   //!< Not used. Only to satisfy the template.
 
-    SideStakeDB m_sidestake_db;                           //!< The internal sidestake db object for leveldb persistence.
+    SideStakeDB m_sidestake_db GUARDED_BY(cs_lock);                           //!< The internal sidestake db object for leveldb persistence.
 
-    bool m_local_entry_already_saved_to_config = false;   //!< Flag to prevent reload on signal if individual entry saved already.
-
-public:
-
-    SideStakeDB& GetSideStakeDB();
+    //! \brief Flag to prevent reload on signal if an individual entry was saved already.
+    //!
+    //! Read at the top of LoadLocalSideStakesFromConfig() (a core-signal callback)
+    //! without cs_lock, and written by SaveLocalSideStakesToConfig() / Initialize().
+    //! A cross-thread read/write of a plain bool is undefined behaviour, so this is
+    //! std::atomic<bool>. All accesses use memory_order_relaxed: it is a pure debounce
+    //! flag, no other state is published through it. It is deliberately NOT
+    //! GUARDED_BY(cs_lock) — it is accessed outside the registry lock by design.
+    std::atomic<bool> m_local_entry_already_saved_to_config{false};
 }; // sidestakeRegistry
 
 //!


### PR DESCRIPTION
## Summary

Third in the per-registry series applying the contract-registry thread-safety locking model (model + ProtocolRegistry: #2986, merged; ScraperRegistry: #2987). This applies it to **SideStakeRegistry** (pattern (b)). Model doc: `doc/contract_registry_locking_design.md`.

## SideStakeRegistry changes

- The data members become private + `GUARDED_BY(cs_lock)`.
- `m_local_entry_already_saved_to_config` becomes `std::atomic<bool>` (was a plain `bool`). It is read at the top of `LoadLocalSideStakesFromConfig()` — a `RwSettingsUpdated` core-signal callback — **without** `cs_lock`, and written under `cs_lock` elsewhere. A cross-thread read/write of a non-atomic bool is UB, so it is atomic (relaxed; pure debounce flag). It is deliberately **not** `GUARDED_BY(cs_lock)` — it's accessed outside the registry lock by design.
- No `cs_lock` annotation on any public method. The read accessors (`SideStakeEntries`, `ActiveSideStakeEntries`, `Try`, `TryActive`) already take `cs_lock` internally and return **by value** — no signature change needed. Chain handlers keep `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` and take `cs_lock` internally.
- Removed `GetSideStakeDB()` — public accessor that locked, then returned a reference to the guarded backing DB after the lock dropped (reference-after-unlock), with zero callers. Internal code uses the (private) `m_sidestake_db` directly.

## Copy-on-write fix (second commit)

While verifying the immutable-once-published invariant the by-value-snapshot model relies on, the review surfaced the one path that violated it: `LoadLocalSideStakesFromConfig()` marked a local entry `INACTIVE` by mutating `m_status` **in place** on the map-held object. Because `SideStake` snapshots **share** the `LocalSideStake_ptr`, a lock-free snapshot holder (miner, block-reward construction, the Qt model) raced that write. Converted to copy-on-write (reseat the slot to a new `INACTIVE` object, leaving the captured object untouched). Low severity — pre-existing, local sidestakes are non-consensus, the worst case is a one-iteration-stale local sidestake in the miner (the design's "safe ≠ correct" boundary, acceptable here) — but it makes the registry genuinely conform to the model.

## Series

#2986 (merged, Protocol + doc), #2987 (Scraper), this (SideStake). Remaining: BeaconRegistry (pattern (a)). Whitelist deferred.

## Test plan

- [x] Clean Clang build, `-Werror=thread-safety-analysis` + `WERROR_THREAD_SAFETY=ON`
- [x] Full unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)