### PR TITLE
refactor: BeaconRegistry thread-safety per the contract-registry locking model (4/4)

### DIFF
--- a/doc/contract_registry_locking_design.md
+++ b/doc/contract_registry_locking_design.md
@@ -213,3 +213,31 @@ Confirm the analysis is active before trusting a clean build:
 `grep HAVE_CLANG_THREAD_SAFETY build/CMakeCache.txt` should show `=1`. Wipe
 `build/` when switching compilers — a reconfigure does not switch the compiler
 of an existing build directory.
+
+## Enforcement limitation: polymorphic calls through `IContractHandler`
+
+The registries are reached two ways. Most consumers use the concrete global
+accessor (`GetBeaconRegistry()`, `GetProtocolRegistry()`, …) — there the analyzer
+sees the concrete method's annotations and enforces them. But the contract
+machinery also reaches them **polymorphically** through the `IContractHandler`
+base interface: `RegistryBookmarks::GetRegistryWithDB()` returns
+`IContractHandler&`, and the contract-replay, block-connect/disconnect, startup
+coherence, and passivation paths call `Initialize` / `GetDBHeight` /
+`SetDBHeight` / `PassivateDB` through that base reference.
+
+At those base-type call sites the analyzer **cannot** enforce a lock, and the
+base virtual declarations are intentionally left unannotated. The reason is
+structural: the same virtual has *different* locking contracts across the
+registries — pattern (a) (BeaconRegistry) requires `cs_main`, while pattern (b)
+takes `cs_lock` internally and requires nothing of the caller. A single
+annotation on the base would be wrong for one pattern or the other, so the base
+stays unannotated and these polymorphic call sites are statically unchecked.
+
+This is safe in practice: every such call site is a chain-processing path that
+already holds `cs_main` (contract replay, block connect/disconnect, startup
+coherence recovery, DB passivation) — which satisfies pattern (a) and is
+harmless for pattern (b). The gap is purely in *static enforcement*: a future
+caller invoking these through the base reference without `cs_main` would not be
+flagged by the analyzer. New consumers should therefore either go through the
+concrete registry accessor (where annotations are enforced) or hold `cs_main`
+explicitly on the chain-processing path.

--- a/src/gridcoin/beacon.h
+++ b/src/gridcoin/beacon.h
@@ -836,7 +836,7 @@ public:
     //!
     //! \return block height.
     //!
-    int GetDBHeight() override;
+    int GetDBHeight() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Function normally only used after a series of reverts during block disconnects, because
@@ -847,13 +847,13 @@ public:
     //!
     //! \param height to set the storage DB bookmark.
     //!
-    void SetDBHeight(int& height) override;
+    void SetDBHeight(int& height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Resets the maps in the BeaconRegistry but does not disturb the underlying LevelDB
     //! storage. This is only used during testing in the testing harness.
     //!
-    void ResetInMemoryOnly();
+    void ResetInMemoryOnly() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Passivates the elements in the beacon db, which means remove from memory elements in the
@@ -863,7 +863,7 @@ public:
     //!
     //! \return The number of elements passivated.
     //!
-    uint64_t PassivateDB() override;
+    uint64_t PassivateDB() override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief This function walks the linked beacon entries back (using the m_previous_hash member) from a provided
@@ -881,14 +881,14 @@ public:
     //! \brief Returns whether IsContract correction is needed in ReplayContracts during initialization
     //! \return
     //!
-    bool NeedsIsContractCorrection();
+    bool NeedsIsContractCorrection() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Sets the state of the IsContract needs correction flag in memory and LevelDB
     //! \param flag The state to set
     //! \return
     //!
-    bool SetNeedsIsContractCorrection(bool flag);
+    bool SetNeedsIsContractCorrection(bool flag) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //!
     //! \brief Specializes the template RegistryDB for the ScraperEntry class
@@ -902,13 +902,8 @@ public:
                        HistoricalBeaconMap> BeaconDB;
 
 private:
-    //!
-    //! \brief Protects the registry with multithreaded access. This is implemented INTERNAL to the registry class.
-    //!
-    mutable CCriticalSection cs_lock;
-
-    BeaconMap m_beacons;        //!< Contains the active registered beacons.
-    PendingBeaconMap m_pending; //!< Contains beacons awaiting verification.
+    BeaconMap m_beacons        GUARDED_BY(cs_main); //!< Contains the active registered beacons.
+    PendingBeaconMap m_pending GUARDED_BY(cs_main); //!< Contains beacons awaiting verification.
 
     //!
     //! \brief In-memory side map of ownership proofs for pending beacons.
@@ -916,7 +911,7 @@ private:
     //! Keyed by the pending beacon's CKeyID. Rebuilt from contract replay on
     //! restart (same lifecycle as m_pending itself). Not persisted to LevelDB.
     //!
-    std::map<CKeyID, OwnershipProof> m_pending_ownership_proofs;
+    std::map<CKeyID, OwnershipProof> m_pending_ownership_proofs GUARDED_BY(cs_main);
 
     //!
     //! \brief Contains pending beacons that have expired.
@@ -932,15 +927,15 @@ private:
     //!
     //! This set is cleared and repopulated at each SB accepted by the node with the current expired pending beacons.
     //!
-    std::set<Beacon_ptr> m_expired_pending;
+    std::set<Beacon_ptr> m_expired_pending GUARDED_BY(cs_main);
 
-    BeaconMap m_beacon_first_entries {}; //!< Not used here. Only to satisfy the template.
+    BeaconMap m_beacon_first_entries GUARDED_BY(cs_main) {}; //!< Not used here. Only to satisfy the template.
 
     //!
     //! \brief The member variable that is the instance of the beacon database. This is private to the
     //! beacon registry and is only accessible by beacon registry functions.
     //!
-    BeaconDB m_beacon_db;
+    BeaconDB m_beacon_db GUARDED_BY(cs_main);
 
     //!
     //! \brief The function that is used in Add() to try to renew a beacon by matching the incoming beacon's
@@ -953,7 +948,7 @@ private:
     //!
     //! \return Success or failure of renewal attempt.
     //!
-    bool TryRenewal(Beacon_ptr& current_beacon_ptr, int& height, const BeaconPayload& payload);
+    bool TryRenewal(Beacon_ptr& current_beacon_ptr, int& height, const BeaconPayload& payload) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 public:
     //!
@@ -961,7 +956,7 @@ public:
     //!
     //! \return Current beacon database instance.
     //!
-    BeaconDB& GetBeaconDB();
+    BeaconDB& GetBeaconDB() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 }; // BeaconRegistry
 


### PR DESCRIPTION
## Summary

Final registry in the per-registry thread-safety series (model + Protocol: #2986; Scraper: #2987; SideStake: #2989). BeaconRegistry is **pattern (a)** — it has no non-`cs_main` access path, so its members are `GUARDED_BY(cs_main)` and its methods are `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`, with **no** internal `cs_lock` (the opposite of the pattern-(b) registries). Model doc: `doc/contract_registry_locking_design.md`.

## BeaconRegistry changes (`beacon.h`)

- The six data members (`m_beacons`, `m_pending`, `m_pending_ownership_proofs`, `m_expired_pending`, `m_beacon_first_entries`, `m_beacon_db`) gain `GUARDED_BY(cs_main)`.
- The vestigial `cs_lock` is **removed** — declared but acquired nowhere in the tree (zero `LOCK(cs_lock)` in `beacon.cpp`). Pattern (a) has no second lock.
- Eight member-accessing methods that were not yet annotated gain `EXCLUSIVE_LOCKS_REQUIRED(cs_main)`: `GetDBHeight`, `SetDBHeight`, `ResetInMemoryOnly`, `PassivateDB`, `NeedsIsContractCorrection`, `SetNeedsIsContractCorrection`, `TryRenewal`, `GetBeaconDB`. The analyzer flagged each member access; every caller already holds `cs_main` (no call-site changes needed).
- `GetBeaconDB()` is **retained** (annotated): unlike the pattern-(b) `GetXxxDB` accessors (removed as incoherent under a *private* lock), a reference accessor under `cs_main` is legitimate — `cs_main` is a shared, caller-held lock. It has a real production caller (`mrc.cpp`) plus test callers.

## Design-doc note (second commit)

The `/review` of this change surfaced a static-enforcement gap worth documenting: calls reaching the registries **polymorphically** through the `IContractHandler` base interface (`RegistryBookmarks::GetRegistryWithDB()` returns `IContractHandler&`) bypass the analyzer's lock check, because the base virtuals are intentionally unannotated — the same virtual has different contracts across registries (pattern (a) needs `cs_main`; pattern (b) takes `cs_lock` internally). This is safe — every such call site is a chain-processing path already under `cs_main` — but it's a static gap, so the doc now records it with guidance for new consumers.

## Series

#2986 (Protocol + doc), #2987 (Scraper), #2988 (Revert deref fix), #2989 (SideStake) — all merged. This completes the registry set. **Whitelist** remains deferred (its `Snapshot()` is entangled with the AutoGreylist refresh path; separate work).

## Test plan

- [x] Clean Clang build, whole tree, `-Werror=thread-safety-analysis` + `WERROR_THREAD_SAFETY=ON` (`HAVE_CLANG_THREAD_SAFETY=1`)
- [x] Full unit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)