### PR TITLE
consensus: AutoGreylist Snapshot deep-copy + refresh redesign + annotations

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,6 +75,9 @@ public:
         consensus.ProjectV2Height = 2671700;
         consensus.PollMultiAddressHeight = std::numeric_limits<int>::max();
         consensus.AutoGreylistAuditHeight = 3989800;
+        // TBD: set coincident with BlockV15Height when v15 is scheduled. numeric_limits max keeps
+        // the deep-copy overlay fix inactive on mainnet until then (mirrors PollMultiAddressHeight).
+        consensus.AutoGreylistDeepCopyHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
@@ -200,6 +203,9 @@ public:
         consensus.ProjectV2Height = 1944820;
         consensus.PollMultiAddressHeight = std::numeric_limits<int>::max();
         consensus.AutoGreylistAuditHeight = 3111000;
+        // Inactive by default; activated on the isolated mesh / public testnet via the
+        // -autogreylistdeepcopyheight override ahead of v15.
+        consensus.AutoGreylistDeepCopyHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -176,6 +176,13 @@ inline bool IsAutoGreylistAuditEnabled(int nHeight)
     return nHeight >= Params().GetConsensus().AutoGreylistAuditHeight;
 }
 
+inline bool IsAutoGreylistDeepCopyEnabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate isolated/public testnet testing
+    // ahead of the v15 activation height.
+    return nHeight >= gArgs.GetArg("-autogreylistdeepcopyheight", Params().GetConsensus().AutoGreylistDeepCopyHeight);
+}
+
 inline bool IsSuperblockV3Enabled(int nHeight)
 {
     return nHeight >= Params().GetConsensus().SuperblockV3Height;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -53,6 +53,11 @@ struct Params {
     int ProjectV4Height;
     /** Height at which the benefit of the doubt logic is enabled for autogreylist evaluation */
     int AutoGreylistAuditHeight;
+    /** Height at which Whitelist::Snapshot deep-copies project entries before applying the
+      * auto-greylist overlay. Set to std::numeric_limits<int>::max() on main/testnet until
+      * activation is scheduled; overridable via -autogreylistdeepcopyheight for testnet
+      * rollout. */
+    int AutoGreylistDeepCopyHeight;
     /**
       * @brief The default GRC paid for a constant block reward.
       *

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -10,6 +10,8 @@
 #include "gridcoin/contract/payload.h"
 #include "gridcoin/support/enumbytes.h"
 
+#include <type_traits>
+
 using LogFlags = BCLog::LogFlags;
 
 namespace GRC {
@@ -194,6 +196,54 @@ public:
         m_needs_passivation = true;
 
         return height;
+    }
+
+    //!
+    //! \brief Reads the CURRENT (HEAD) entry for each key DIRECTLY from LevelDB, bypassing the in-memory entry map.
+    //!
+    //! The in-memory entries can be mutated in place by callers -- in particular the AutoGreylist overlay rewrites a
+    //! project entry's status to AUTO_GREYLISTED while building a whitelist snapshot -- so the in-memory status is not a
+    //! reliable witness of what the administrative contracts actually set. This returns the persisted, contract-applied
+    //! state, which is the ground truth, by replaying the LevelDB records (the same source Initialize() uses) without
+    //! touching any in-memory state.
+    //!
+    //! Read-only: it opens its own CTxDB("r") and mutates nothing, so it requires no registry lock (callers may still
+    //! take the registry lock to serialize against concurrent contract application).
+    //!
+    //! \return Map of current entries keyed by Key(), carrying the raw contract status.
+    //!
+    M GetCurrentEntriesFromDisk()
+    {
+        // This straight replay (latest record per key = HEAD) is only correct for registries whose storage entry type
+        // equals the entry type. Beacons (SE != E) require the specialized HandleCurrentHistoricalEntries (pending /
+        // renewal / expiry handling), so reject that misuse at compile time rather than silently slice/mis-replay.
+        static_assert(std::is_same<E, SE>::value,
+                      "GetCurrentEntriesFromDisk supports only straight-replay registries (SE == E), not beacons");
+
+        M current;
+
+        // Keyed by record number so the replay below proceeds in contract-application order, exactly as Initialize().
+        StorageMapByRecordNum storage_by_record_num;
+
+        {
+            CTxDB txdb("r");
+
+            std::string key_type = KeyType();
+            uint256 hash_hint = uint256();
+
+            txdb.ReadGenericSerializablesToMapWithForeignKey(key_type, storage_by_record_num, hash_hint);
+        }
+
+        // storage_by_record_num is ordered ascending by record number, and the latest record for a key is its current
+        // HEAD (cf. "GRC will only memorize the last value it finds for a key"). Overwriting as we ascend therefore
+        // leaves the HEAD entry -- with its raw contract status -- for each key.
+        for (const auto& iter : storage_by_record_num) {
+            const SE& entry = iter.second;
+
+            current[entry.Key()] = std::make_shared<E>(entry);
+        }
+
+        return current;
     }
 
     //!

--- a/src/gridcoin/contract/registry_db.h
+++ b/src/gridcoin/contract/registry_db.h
@@ -231,7 +231,11 @@ public:
             std::string key_type = KeyType();
             uint256 hash_hint = uint256();
 
-            txdb.ReadGenericSerializablesToMapWithForeignKey(key_type, storage_by_record_num, hash_hint);
+            if (!txdb.ReadGenericSerializablesToMapWithForeignKey(key_type, storage_by_record_num, hash_hint)) {
+                LogPrintf("WARN: %s: ReadGenericSerializablesToMapWithForeignKey failed for key_type=%s; "
+                          "returning empty map.", __func__, key_type);
+                return M{};
+            }
         }
 
         // storage_by_record_num is ordered ascending by record number, and the latest record for a key is its current

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -1068,6 +1068,16 @@ const Whitelist::ProjectEntryMap Whitelist::GetProjectsFirstActive() const EXCLU
     return m_project_first_actives;
 }
 
+Whitelist::ProjectEntryMap Whitelist::GetProjectsFromDisk()
+{
+    // Take cs_lock to serialize against concurrent contract application (Add/Delete -> Store), then read the
+    // persisted (contract-applied) current entries straight from LevelDB. This deliberately bypasses the
+    // in-memory m_project_entries, whose status field is rewritten in place by the AutoGreylist overlay.
+    LOCK(cs_lock);
+
+    return m_project_db.GetCurrentEntriesFromDisk();
+}
+
 std::shared_ptr<AutoGreylist> Whitelist::GetAutoGreylist()
 {
     return m_auto_greylist;

--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -354,7 +354,15 @@ WhitelistSnapshot WhitelistSnapshot::Sorted() const
 AutoGreylist::AutoGreylist()
     : m_greylist_ptr(std::make_shared<Greylist>())
     , m_superblock_hash(Superblock().GetHash(true))
+    , m_deep_copy_active(false)
 {
+}
+
+bool AutoGreylist::IsDeepCopyActive() const
+{
+    LOCK(autogreylist_lock);
+
+    return m_deep_copy_active;
 }
 
 AutoGreylist::Greylist::const_iterator AutoGreylist::begin() const
@@ -428,12 +436,17 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
     }
 
     // We need the current whitelist, including all records except deleted. This will include greylisted projects.
-    // NOTE that the refresh_greylist is set to false here and MUST be this when called in the AutoGreylist class itself,
-    // to avoid an infinite loop; include_override is also set to false because each refresh of the auto greylist must start
-    // with the underlying whitelist state.
-    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED, false, false);
+    // include_override is set to false because each refresh of the auto greylist must start with the underlying
+    // whitelist state (the on-Snapshot refresh-recursion that previously required refresh_greylist=false here is
+    // now impossible -- Refresh fires explicitly at the chain handler points, not from inside Snapshot).
+    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED, false);
 
     LOCK(autogreylist_lock);
+
+    // Gate: is the non-mutating deep-copy overlay active at this superblock's height? Stored under
+    // autogreylist_lock so Whitelist::Snapshot can gate its overlay (via IsDeepCopyActive) without
+    // re-deriving the height. IsAutoGreylistDeepCopyEnabled honors the -autogreylistdeepcopyheight override.
+    m_deep_copy_active = IsAutoGreylistDeepCopyEnabled(superblock_ptr_in.m_height);
 
     m_greylist_ptr->clear();
 
@@ -596,9 +609,10 @@ void AutoGreylist::RefreshWithAndUpdateSuperblock(Superblock& superblock) EXCLUS
 
     RefreshWithSuperblock(superblock_ptr);
 
-    // Here we want to get the whitelist with the greylist override applied, but do NOT want to refresh the auto grey list, since
-    // we are in a refresh method within the auto greylist class.
-    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED, false, true);
+    // Here we want to get the whitelist with the greylist override applied. The on-Snapshot refresh-recursion
+    // concern that previously required refresh_greylist=false here is now impossible -- Refresh fires explicitly
+    // at the chain handler points, not from inside Snapshot.
+    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED, true);
 
     // Update the superblock object with the project greylist status.
     for (const auto& project : whitelist) {
@@ -621,6 +635,14 @@ void AutoGreylist::RefreshWithAndUpdateSuperblock(Superblock& superblock) EXCLUS
 
 void AutoGreylist::Reset()
 {
+    // Take autogreylist_lock so concurrent readers (RPC, scraper, GUI threads holding ONLY
+    // autogreylist_lock via Contains() / IsDeepCopyActive() / iteration) see this re-init atomically.
+    // Reachable on every forward deep-copy-gate crossing via PushSuperblock -> ReinitFromDisk ->
+    // ResetInMemoryOnly -> here, where the chain-handler caller holds cs_main + cs_lock but NOT
+    // autogreylist_lock; unlocked mutation here would race against Snapshot's overlay path that
+    // dereferences m_greylist_ptr under autogreylist_lock.
+    LOCK(autogreylist_lock);
+
     if (m_greylist_ptr != nullptr) {
         m_greylist_ptr->clear();
     } else {
@@ -628,6 +650,10 @@ void AutoGreylist::Reset()
     }
 
     m_superblock_hash = Superblock().GetHash(true);
+
+    // Match the constructor: a Reset registry is pre-gate by definition until the next Refresh
+    // observes a post-gate superblock and re-sets this.
+    m_deep_copy_active = false;
 }
 
 // -----------------------------------------------------------------------------
@@ -635,8 +661,7 @@ void AutoGreylist::Reset()
 // -----------------------------------------------------------------------------
 
 WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& filter,
-                                      const bool& refresh_greylist,
-                                      const bool& include_override) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+                                      const bool& include_override) const
 {
     ProjectList projects;
 
@@ -646,9 +671,14 @@ WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& fil
         return WhitelistSnapshot(std::make_shared<ProjectList>(projects), filter);
     }
 
-    if (refresh_greylist && m_auto_greylist != nullptr) {
-        m_auto_greylist->Refresh();
-    }
+    // The AutoGreylist cache is refreshed explicitly at the chain handler points (Quorum::PushSuperblock for v2+
+    // activation, Quorum::PopSuperblock on reorg, Quorum::LoadSuperblockIndex on startup) and additionally via
+    // Superblock::FromConvergence's RefreshWithAndUpdateSuperblock when scrapers/subscribers build a candidate
+    // superblock with version > 2 (the FromConvergence path is version-gated; see superblock.cpp). Snapshot()
+    // itself does NOT trigger a refresh -- it is a cs_lock leaf in lock ordering. NOTE: pre-gate (when
+    // m_deep_copy_active is false) the override loop below still mutates m_project_entries->m_status in place
+    // via shallow-copied shared_ptrs; that legacy behavior is the bug the deep-copy gate fixes, not a contract
+    // Snapshot() claims to honor pre-gate.
 
     // This contains the override for automatic greylisting integrated with the switch. If the AutoGreylist class refresh
     // determines that the project meets greylisting criteria, it will be in the AutoGreylist object pointed to
@@ -660,9 +690,24 @@ WhitelistSnapshot Whitelist::Snapshot(const ProjectEntry::ProjectFilterFlag& fil
     // override is applied on superblock boundaries, because the AutoGreylist global (singleton) cache is updated
     // when the superblock stakes.
     //
-    // Make a copy of the registry project entries map for override purposes. This is not too bad because the number of
-    // projects is relatively small.
-    ProjectEntryMap project_entries = m_project_entries;
+    // Make a working copy of the registry project entries map for override purposes. This is not too bad because the
+    // number of projects is relatively small.
+    //
+    // GATED FIX (AutoGreylistDeepCopyHeight): post-gate we DEEP-copy each entry so the override below operates on
+    // private copies and never writes through to the shared registry entries. Pre-gate we retain the legacy shallow
+    // copy (whose override mutates the registry entries in place) so pre-gate consensus behavior is unchanged. The
+    // gate is carried on the AutoGreylist (set from the active superblock height in RefreshWithSuperblock).
+    const bool deep_copy = m_auto_greylist != nullptr && m_auto_greylist->IsDeepCopyActive();
+
+    ProjectEntryMap project_entries;
+
+    if (deep_copy) {
+        for (const auto& iter : m_project_entries) {
+            project_entries[iter.first] = std::make_shared<ProjectEntry>(*iter.second);
+        }
+    } else {
+        project_entries = m_project_entries;
+    }
 
     for (auto& iter : project_entries) {
         if (include_override) {
@@ -1056,6 +1101,25 @@ void Whitelist::ResetInMemoryOnly()
 
 }
 
+void Whitelist::ReinitFromDisk() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    // Rebuild the in-memory registry cache from LevelDB (the ground truth, never corrupted by the
+    // AutoGreylist overlay). NOT a Reset() -- LevelDB is preserved. Used at the deep-copy gate crossing
+    // so a node that ran the legacy in-place overlay across the gate discards its corrupted in-memory
+    // state, after which the post-gate non-mutating overlay keeps it clean.
+    //
+    // Hold cs_lock across the full clear + reload so that non-cs_main readers (scraper/RPC/GUI threads
+    // that call Snapshot() without cs_main) observe the rebuild atomically -- never an empty registry
+    // mid-flight. cs_lock is recursive (Bitcoin Core RecursiveMutex), so the inner LOCK(cs_lock) in
+    // ResetInMemoryOnly() and Initialize() simply re-enter on the same thread.
+    LOCK(cs_lock);
+
+    LogPrintf("Whitelist::ReinitFromDisk: rebuilding project registry from LevelDB");
+
+    ResetInMemoryOnly();
+    Initialize();
+}
+
 uint64_t Whitelist::PassivateDB()
 {
     LOCK(cs_lock);
@@ -1063,8 +1127,16 @@ uint64_t Whitelist::PassivateDB()
     return m_project_db.passivate_db();
 }
 
-const Whitelist::ProjectEntryMap Whitelist::GetProjectsFirstActive() const EXCLUSIVE_LOCKS_REQUIRED(Whitelist::cs_lock)
+const Whitelist::ProjectEntryMap Whitelist::GetProjectsFirstActive() const
 {
+    // Take cs_lock internally and return a by-value copy. Previously this required the caller to hold
+    // cs_lock (because the sole pre-redesign caller, AutoGreylist::Refresh, ran inside Whitelist::Snapshot
+    // which already held cs_lock). After the chain-handler refresh redesign (PR #2997) Refresh no longer
+    // runs inside Snapshot, so the implicit "caller holds cs_lock" invariant is gone. cs_lock is
+    // recursive (Bitcoin Core RecursiveMutex), so any caller that DOES still hold it (legacy or otherwise)
+    // re-enters harmlessly.
+    LOCK(cs_lock);
+
     return m_project_first_actives;
 }
 

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -807,6 +807,16 @@ public:
     bool Contains(const std::string& name, const bool& only_auto_greylisted = true) const;
 
     //!
+    //! \brief Whether the non-mutating deep-copy overlay is active at the height of the superblock
+    //! the greylist was last refreshed against. Whitelist::Snapshot gates its overlay path on this:
+    //! pre-gate it applies the legacy in-place overlay; post-gate it deep-copies each entry first so
+    //! the registry is never mutated. Driven by AutoGreylistDeepCopyHeight (with -autogreylistdeepcopyheight override).
+    //!
+    //! \return \c true if the deep-copy overlay is active.
+    //!
+    bool IsDeepCopyActive() const;
+
+    //!
     //! \brief This refreshes the AutoGreylist object from the last superblock in the chain.
     //!
     void Refresh();
@@ -849,6 +859,10 @@ private:
 
     GreylistPtr m_greylist_ptr;
     QuorumHash m_superblock_hash;
+    //! Set from the refresh superblock's height; gates Whitelist::Snapshot's overlay (deep copy vs legacy in-place).
+    //! All reads/writes go through methods that hold autogreylist_lock (IsDeepCopyActive,
+    //! RefreshWithSuperblock, Reset); annotated GUARDED_BY so Clang thread-safety enforces it.
+    bool m_deep_copy_active GUARDED_BY(autogreylist_lock);
 };
 
 //!
@@ -897,11 +911,19 @@ public:
 
     //!
     //! \brief Get a read-only view of the projects in the whitelist. The default filter is ACTIVE, which
-    //! provides the original ACTIVE project only view. The refresh_greylist filter is used to refresh
-    //! the AutoGreylist as part of taking the snapshot.
+    //! provides the original ACTIVE project only view. The auto-greylist overlay (toggled by include_override)
+    //! is computed from the current AutoGreylist cache; the cache is refreshed explicitly at the chain handler
+    //! points (Quorum::PushSuperblock for v2+ activation, Quorum::PopSuperblock on reorg,
+    //! Quorum::LoadSuperblockIndex on startup) and additionally via Superblock::FromConvergence's
+    //! RefreshWithAndUpdateSuperblock when scrapers/subscribers build a candidate superblock (only for
+    //! superblock version > 2; the call is gated at superblock.cpp). Snapshot() itself does NOT trigger
+    //! a refresh -- it is a cs_lock leaf in lock ordering. NOTE: pre-gate (m_deep_copy_active=false)
+    //! the override loop still mutates m_project_entries via shallow-copied shared_ptrs; that is the
+    //! legacy behavior the deep-copy gate is designed to neutralize, not a contract Snapshot() honors
+    //! pre-gate.
     //!
     WhitelistSnapshot Snapshot(const ProjectEntry::ProjectFilterFlag& filter = ProjectEntry::ProjectFilterFlag::ACTIVE,
-                               const bool& refresh_greylist = true, const bool &include_override = true) const;
+                               const bool &include_override = true) const;
 
     //!
     //! \brief Destroy the contract handler state to prepare for historical
@@ -989,6 +1011,13 @@ public:
     void ResetInMemoryOnly();
 
     //!
+    //! \brief Rebuild the in-memory registry cache from LevelDB (the ground truth), preserving the
+    //! LevelDB store. Used at the AutoGreylistDeepCopyHeight gate crossing to discard any pre-gate
+    //! in-place overlay corruption before the post-gate non-mutating overlay takes over. NOT a Reset().
+    //!
+    void ReinitFromDisk() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    //!
     //! \brief Passivates the elements in the project db, which means remove from memory elements in the
     //! historical map that are not referenced by m_projects. The backing store of the element removed
     //! from memory is retained and will be transparently restored if find() is called on the hash key
@@ -999,10 +1028,10 @@ public:
     uint64_t PassivateDB() override;
 
     //!
-    //! \brief This returns m_project_first_actives. Note that unlike other methods here, this does not take the cs_lock
-    //! internally but rather requires it. The reason for this is that this function is used by the AutoGreylist class update
-    //! where the cs_lock is already taken before, and the AutoGreylist class has its own lock. If cs_lock is then taken again,
-    //! a potential deadlock can result.
+    //! \brief Returns a by-value snapshot of m_project_first_actives. Takes cs_lock internally; safe to call from any
+    //! thread holding only cs_main (or no lock). cs_lock is recursive, so a caller that already holds it re-enters
+    //! harmlessly. The post-PR-2997 chain-handler refresh path runs without cs_lock, so internal locking is required
+    //! here for thread-safety against contract-handler writes (AddDelete -> Store under cs_lock).
     //!
     const ProjectEntryMap GetProjectsFirstActive() const;
 
@@ -1056,16 +1085,20 @@ private:
     //!
     void AddDelete(const ContractContext& ctx);
 
-    ProjectEntryMap m_project_entries;                   //!< The set of whitelisted projects.
+    ProjectEntryMap m_project_entries GUARDED_BY(cs_lock);                   //!< The set of whitelisted projects.
 
-    PendingProjectEntryMap m_pending_project_entries;    //!< Not actually used. Only to satisfy the template.
+    PendingProjectEntryMap m_pending_project_entries GUARDED_BY(cs_lock);    //!< Not actually used. Only to satisfy the template.
 
-    std::set<ProjectEntry> m_expired_project_entries;    //!< Not actually used. Only to satisfy the template.
+    std::set<ProjectEntry> m_expired_project_entries GUARDED_BY(cs_lock);    //!< Not actually used. Only to satisfy the template.
 
-    ProjectEntryMap m_project_first_actives;             //!< Tracks when projects were first activated for auto greylisting purposes.
+    ProjectEntryMap m_project_first_actives GUARDED_BY(cs_lock);             //!< Tracks when projects were first activated for auto greylisting purposes.
 
+    //! \note No GUARDED_BY: m_project_db is set once in the ctor and never reassigned; only its internal state
+    //! is modified, by member functions that are themselves invoked under cs_lock in the Whitelist methods.
     ProjectEntryDB m_project_db;                         //!< The project db member
 
+    //! \note No GUARDED_BY: m_auto_greylist (the shared_ptr) is set once in the ctor and never replaced;
+    //! only the pointed-to AutoGreylist's internal state changes, guarded by its own autogreylist_lock.
     std::shared_ptr<AutoGreylist> m_auto_greylist;       //!< Smart shared pointer to the AutoGreylist cache object
 public:
 

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -1007,6 +1007,18 @@ public:
     const ProjectEntryMap GetProjectsFirstActive() const;
 
     //!
+    //! \brief Returns the CURRENT project entries read DIRECTLY from LevelDB -- the persisted, contract-applied status --
+    //! bypassing the in-memory entry map. The AutoGreylist overlay rewrites in-memory project status in place while
+    //! building whitelist snapshots, so once a project meets greylisting criteria, Snapshot() (and therefore listprojects)
+    //! reports AUTO_GREYLISTED regardless of whether the underlying contract status is ACTIVE, MAN_GREYLISTED, or
+    //! AUTO_GREYLIST_OVERRIDE. This accessor exposes the raw contract status for diagnostics and verification (see the
+    //! getrawprojectstatus RPC). Takes cs_lock internally and returns a by-value snapshot.
+    //!
+    //! \return Map of current project entries carrying their raw contract status.
+    //!
+    ProjectEntryMap GetProjectsFromDisk();
+
+    //!
     //! \brief Method to provide the shared pointer to the global auto greylist cache object.
     //!
     //! \return shared pointer to the auto greylist global cache object.

--- a/src/gridcoin/quorum.cpp
+++ b/src/gridcoin/quorum.cpp
@@ -1772,8 +1772,8 @@ std::vector<ExplainMagnitudeProject> Quorum::ExplainMagnitude(const Cpid cpid)
     // TODO: unwrap this from ScraperGetSuperblockContract()
     CreateSuperblock();
 
-    // Get a read-only view of the current project greylist
-    const WhitelistSnapshot greylist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::GREYLISTED, false, true);
+    // Get a read-only view of the current project greylist.
+    const WhitelistSnapshot greylist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::GREYLISTED, true);
 
     const std::string cpid_str = cpid.ToString();
     const Span<const char> cpid_span = Span{cpid_str};
@@ -1850,6 +1850,11 @@ void Quorum::LoadSuperblockIndex(const CBlockIndex* pindexLast) EXCLUSIVE_LOCKS_
     }
 
     g_superblock_index.Reload(pindexLast);
+
+    // Refresh the AutoGreylist cache against the reloaded superblock index (startup path). Moved out
+    // of Whitelist::Snapshot() (stage 3a) so the cache is populated explicitly here rather than
+    // lazily on the first Snapshot read.
+    GetAutoGreylistCache()->Refresh();
 }
 
 Superblock Quorum::CreateSuperblock()
@@ -1861,7 +1866,48 @@ void Quorum::PushSuperblock(SuperblockPtr superblock) EXCLUSIVE_LOCKS_REQUIRED(c
 {
     LogPrintf("Quorum::PushSuperblock(%" PRId64 ")", superblock.m_height);
 
+    // Capture the deep-copy gate status of the currently-active (prior) superblock BEFORE the inner
+    // SuperblockIndex::PushSuperblock installs the new one. For v2+ superblocks the inner routine
+    // emplaces the new SB at the front of m_cache, so after the call CurrentSuperblock() returns the
+    // newly-pushed one and the gate-crossing detection below sees the transition.
+    //
+    // V1 superblocks ALSO reach this function (it's the single public Quorum entry for any SB version),
+    // but the inner SuperblockIndex routes them to m_pending instead of m_cache (legacy v1 deferred-
+    // commit path; see SuperblockIndex::PushSuperblock for the version branch). m_cache.front() is
+    // therefore unchanged for v1 input, current == prev, and the gate-crossing condition naturally
+    // never fires for them -- no separate special case needed.
+    SuperblockPtr prev = CurrentSuperblock();
+    const bool prev_deep_copy = !prev.IsEmpty() && IsAutoGreylistDeepCopyEnabled(prev.m_height);
+
     g_superblock_index.PushSuperblock(std::move(superblock));
+
+    SuperblockPtr current = CurrentSuperblock();
+
+    // Deep-copy gate CROSSING: the just-pushed superblock is post-gate but the prior one was pre-gate.
+    // On that transition, rebuild the project registry from LevelDB so a node that ran the legacy
+    // in-place overlay across the gate discards its corrupted in-memory m_project_entries state (the
+    // overlay only promotes ACTIVE/MAN -> AUTO_GREYLISTED and never demotes, so it cannot self-heal).
+    //
+    // A node already running on this binary post-gate has a post-gate prior here and the rebuild is
+    // skipped. A node doing fresh initial-block-download from genesis with this binary will hit the
+    // crossing once at the historical gate height during sync -- the rebuild then fires but is
+    // effectively idempotent because Initialize() at startup already loaded m_project_entries clean
+    // from LevelDB and nothing has corrupted it since. Cost is one extra LevelDB load during IBD.
+    if (!current.IsEmpty() && IsAutoGreylistDeepCopyEnabled(current.m_height) && !prev_deep_copy) {
+        LogPrintf("Quorum::PushSuperblock: deep-copy gate crossing detected "
+                  "(prev_height=%" PRId64 ", current_height=%" PRId64 "); invoking ReinitFromDisk",
+                  prev.IsEmpty() ? -1 : (int64_t) prev.m_height, (int64_t) current.m_height);
+        GetWhitelist().ReinitFromDisk();
+    }
+
+    // Refresh the AutoGreylist cache against the newly-activated superblock. Fires deterministically at
+    // this chain-handler point rather than relying on whichever thread happens to read first. Every
+    // PushSuperblock changes the current SB's hash, so the early-bail in AutoGreylist::Refresh()
+    // (which fires only when superblock_ptr->GetHash() == m_superblock_hash) does NOT short-circuit
+    // here -- this call pays the full Snapshot + 40-SB walk-back cost on each push. That cost is
+    // intrinsic to the explicit-trigger redesign; it's paid here on the validation thread rather than
+    // lazily on whichever consumer reads first.
+    GetAutoGreylistCache()->Refresh();
 }
 
 void Quorum::PopSuperblock(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
@@ -1869,9 +1915,39 @@ void Quorum::PopSuperblock(const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQU
     LogPrintf("Quorum::PopSuperblock(%" PRId64 ")", pindex->nHeight);
 
     g_superblock_index.PopSuperblock();
+
+    // Refresh the AutoGreylist cache against the new current superblock (the one that becomes active
+    // after the pop). Moved out of Whitelist::Snapshot() (stage 3a) so the refresh fires explicitly
+    // at the chain handler points rather than on-snapshot.
+    //
+    // NO backward-crossing ReinitFromDisk here, intentionally. A deep reorg that walks the chain tip
+    // back across AutoGreylistDeepCopyHeight reverts m_deep_copy_active to false (via the Refresh
+    // call below) and re-exposes the legacy in-place overlay path on subsequent Snapshot() calls.
+    // That's by definition of the pre-gate regime; there is nothing to "heal" at the moment of the
+    // backward cross (m_project_entries is currently clean, because the post-gate deep-copy path
+    // doesn't mutate it). Any corruption that accumulates DURING the subsequent pre-gate run is
+    // healed atomically by the next forward Push that re-crosses the gate (ReinitFromDisk in
+    // Quorum::PushSuperblock). The pre-gate window after a backward cross has the same in-place
+    // overlay vulnerability the pre-PR-2997 code did, with one subtle difference: pre-PR-2997 the
+    // AutoGreylist cache was refreshed on demand from every Snapshot reader, whereas post-PR-2997
+    // refresh fires only at chain-handler boundaries. So the corruption window opens identically,
+    // but cache freshness DURING the pre-gate window is slightly staler in the new model -- a
+    // documented limitation of the gate (the fix is mandatory at v15; sub-v15 chain reorgs across
+    // the gate are extraordinarily unlikely on mainnet and only happen by operator intent on
+    // testnet).
+    GetAutoGreylistCache()->Refresh();
 }
 
 bool Quorum::CommitSuperblock(const uint32_t height) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    // SuperblockIndex::PushSuperblock routes v2+ superblocks directly to m_cache and skips m_pending,
+    // so g_superblock_index.Commit() can only return true for v1 superblocks committed via m_pending --
+    // a path that exists today only during initial-sync replay of pre-v11 history. The AutoGreylist cache
+    // refresh and project-registry deep-copy gate-crossing rebuild live at Quorum::PushSuperblock (the
+    // v2+ activation point), Quorum::PopSuperblock (reorg) and Quorum::LoadSuperblockIndex (startup);
+    // neither is needed here because RefreshWithSuperblock bails on m_version < 3 and
+    // IsAutoGreylistDeepCopyEnabled is false at any v1-superblock height under default consensus params.
+    // Keeping this function as a thin wrapper preserves the pre-v11 priming callers
+    // (Tally::ActivateSnapshotAccrual / Tally::LegacyRecount).
     return g_superblock_index.Commit(height);
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -679,6 +679,7 @@ void SetupServerArgs()
     // registered" startup warning when an isolated-testnet node sets the
     // height via the override.
     hidden_args.emplace_back("-pollmultiaddressheight");
+    hidden_args.emplace_back("-autogreylistdeepcopyheight");
 
     // This puts hidden options in the form of -clear<type>history, where <type> is the contract types that have a
     // registry with a backing db. This is currently beacon, project, protocol, and scraper, with sidestakes starting

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3348,11 +3348,11 @@ UniValue listprojects(const UniValue& params, bool fHelp)
         entry.pushKV("display_url", project.DisplayUrl());
         entry.pushKV("stats_url", project.StatsUrl());
 
-        if (project.HasGDPRControls()) {
+        if (project.HasGDPRControls().has_value()) {
             entry.pushKV("gdpr_controls", *project.HasGDPRControls());
         }
 
-        if (project.RequiresExtAdapter()) {
+        if (project.RequiresExtAdapter().has_value()) {
             entry.pushKV("requires_external_adapter", *project.RequiresExtAdapter());
         }
 
@@ -3420,11 +3420,11 @@ UniValue getrawprojectstatus(const UniValue& params, bool fHelp)
         // value must be stable across GUI locales (the no-arg StatusToString() defaults to the translated form).
         entry.pushKV("status", project->StatusToString(project->m_status.Value(), false));
 
-        if (project->HasGDPRControls()) {
+        if (project->HasGDPRControls().has_value()) {
             entry.pushKV("gdpr_controls", *project->HasGDPRControls());
         }
 
-        if (project->RequiresExtAdapter()) {
+        if (project->RequiresExtAdapter().has_value()) {
             entry.pushKV("requires_external_adapter", *project->RequiresExtAdapter());
         }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -3365,6 +3365,84 @@ UniValue listprojects(const UniValue& params, bool fHelp)
     return res;
 }
 
+UniValue getrawprojectstatus(const UniValue& params, bool fHelp)
+{
+    static const RPCHelpMan help{
+        "getrawprojectstatus",
+        "Displays the RAW, contract-applied status of each project, read directly from the registry's LevelDB "
+        "storage and bypassing the in-memory AutoGreylist overlay.\n"
+        "\n"
+        "listprojects reports the OVERLAID status: a project that meets auto-greylisting criteria displays as "
+        "\"Automatically Greylisted\" regardless of the status its administrative contract actually set. This "
+        "command instead reports the true contract status, the ground truth for verifying what addkey set. The raw "
+        "status is therefore never \"Automatically Greylisted\" -- that is an in-memory overlay status only.",
+        {},
+        RPCResult{RPCResult::Type::OBJ_DYN, "", "Project short name -> raw contract state.",
+            {
+                {RPCResult::Type::OBJ, "project_name", "",
+                    {
+                        {RPCResult::Type::NUM, "version", "Contract payload version of the project entry."},
+                        {RPCResult::Type::STR, "display_name", "Human-readable project name."},
+                        {RPCResult::Type::STR, "url", "Project statistics URL as stored in the contract."},
+                        {RPCResult::Type::STR, "status", "Raw contract status, one of the locale-independent strings "
+                            "\"Active\", \"Manually Greylisted\", \"Active by Greylist Override\", or \"Deleted\"."},
+                        {RPCResult::Type::BOOL, "gdpr_controls", /*optional=*/true,
+                            "Whether GDPR stats-export protection is enforced (omitted for pre-v2 entries)."},
+                        {RPCResult::Type::BOOL, "requires_external_adapter", /*optional=*/true,
+                            "Whether the project requires an external adapter to collect stats (omitted for pre-v4 "
+                            "entries)."},
+                        {RPCResult::Type::STR, "time", "Timestamp of the contract that set this entry."},
+                        {RPCResult::Type::STR_HEX, "current_project_entry_tx_hash",
+                            "Transaction hash of the current (HEAD) project contract."},
+                        {RPCResult::Type::STR, "previous_project_entry_tx_hash",
+                            "Transaction hash of the previous entry in the chainlet, or \"null\" if this is the first."},
+                    }},
+            }},
+        RPCExamples{
+            HelpExampleCli("getrawprojectstatus", "")
+          + HelpExampleRpc("getrawprojectstatus", "")},
+    };
+
+    if (fHelp || !help.IsValidNumArgs(params.size()))
+        throw runtime_error(help.ToString());
+
+    UniValue res(UniValue::VOBJ);
+
+    for (const auto& iter : GRC::GetWhitelist().GetProjectsFromDisk()) {
+        const auto& project = iter.second;
+
+        UniValue entry(UniValue::VOBJ);
+
+        entry.pushKV("version", (int)project->m_version);
+        entry.pushKV("display_name", project->DisplayName());
+        entry.pushKV("url", project->m_url);
+        // Emit the untranslated (locale-independent) status string: this is a machine-readable diagnostic, so the
+        // value must be stable across GUI locales (the no-arg StatusToString() defaults to the translated form).
+        entry.pushKV("status", project->StatusToString(project->m_status.Value(), false));
+
+        if (project->HasGDPRControls()) {
+            entry.pushKV("gdpr_controls", *project->HasGDPRControls());
+        }
+
+        if (project->RequiresExtAdapter()) {
+            entry.pushKV("requires_external_adapter", *project->RequiresExtAdapter());
+        }
+
+        entry.pushKV("time", DateTimeStrFormat(project->m_timestamp));
+        entry.pushKV("current_project_entry_tx_hash", project->m_hash.ToString());
+
+        if (project->m_previous_hash.IsNull()) {
+            entry.pushKV("previous_project_entry_tx_hash", "null");
+        } else {
+            entry.pushKV("previous_project_entry_tx_hash", project->m_previous_hash.ToString());
+        }
+
+        res.pushKV(iter.first, entry);
+    }
+
+    return res;
+}
+
 UniValue getautogreylist(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 2) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -406,6 +406,7 @@ static const CRPCCommand vRPCCommands[] =
     { "inspectaccrualsnapshot",  &inspectaccrualsnapshot,  cat_developer     },
     { "listalerts",              &listalerts,              cat_developer     },
     { "listprojects",            &listprojects,            cat_developer     },
+    { "getrawprojectstatus",     &getrawprojectstatus,     cat_developer     },
     { "getautogreylist",         &getautogreylist,         cat_developer     },
     { "listprotocolentries",     &listprotocolentries,     cat_developer     },
     { "listresearcheraccounts",  &listresearcheraccounts,  cat_developer     },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -216,6 +216,7 @@ extern UniValue rpc_getblockstats(const UniValue& params, bool fHelp);
 extern UniValue inspectaccrualsnapshot(const UniValue& params, bool fHelp);
 extern UniValue listalerts(const UniValue& params, bool fHelp);
 extern UniValue listprojects(const UniValue& params, bool fHelp);
+extern UniValue getrawprojectstatus(const UniValue& params, bool fHelp);
 extern UniValue getautogreylist(const UniValue& params, bool fHelp);
 extern UniValue listprotocolentries(const UniValue& params, bool fHelp);
 extern UniValue listresearcheraccounts(const UniValue& params, bool fHelp);

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -111,6 +111,45 @@ void DeleteProjectEntry(const uint32_t& payload_version, const std::string& name
     registry.Add({contract, ctx_tx, &dummy_index});
 }
 
+//!
+//! \brief Applies a v4 project ADD contract carrying an EXPLICIT status through the registry contract handler,
+//! persisting it to LevelDB (a real CBlockIndex height is supplied so RegistryDB::Store runs and
+//! GetProjectsFromDisk can read it back).
+//!
+//! This is a reusable building block for tests that need the registry/contract/LevelDB layer actually populated --
+//! e.g. verifying the raw contract status read by getrawprojectstatus, and (when the autogreylist "bad project" run
+//! is extended through this same path) asserting that the in-memory Snapshot overlay can diverge from the persisted
+//! contract status. Pass status = ProjectEntryStatus::UNKNOWN for a plain ACTIVE add (the handler maps
+//! ADD + UNKNOWN -> ACTIVE, exactly as the addkey client does).
+//!
+void AddProjectEntryWithStatus(const std::string& name, const std::string& url,
+                               const GRC::ProjectEntryStatus& status, const int& height, const uint64_t time,
+                               const bool& gdpr_status = false, const bool& requires_ext_adapter = false)
+{
+    GRC::Whitelist& registry = GRC::GetWhitelist();
+
+    CMutableTransaction dummy_tx;
+    CBlockIndex dummy_index = CBlockIndex {};
+    dummy_index.nHeight = height;
+    dummy_tx.nTime = time;
+    dummy_index.nTime = time;
+
+    GRC::Contract contract = GRC::MakeContract<GRC::Project>(
+                uint32_t {3},   // Contract version (post v13)
+                GRC::ContractAction::ADD,
+                uint32_t {4},   // Payload version (v4)
+                name,
+                url,
+                gdpr_status,
+                requires_ext_adapter,
+                status);
+
+    dummy_tx.vContracts.push_back(contract);
+
+    CTransaction ctx_tx(dummy_tx);
+    registry.Add({contract, ctx_tx, &dummy_index});
+}
+
 struct AutoGreylistEntryState
 {
     AutoGreylistEntryState(uint8_t zcd_20_SB_count,
@@ -600,6 +639,59 @@ BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
     for (const auto& project : snapshot) {
         BOOST_CHECK(project.m_url == "http://new.enigma.test");
     }
+}
+
+BOOST_AUTO_TEST_CASE(it_reads_raw_contract_status_from_leveldb)
+{
+    using Status = GRC::ProjectEntryStatus;
+
+    GRC::Whitelist& registry = GRC::GetWhitelist();
+
+    // Reset clears the in-memory maps AND the (in-memory test) LevelDB storage, so the disk reads below see only the
+    // entries this test applies.
+    registry.Reset();
+
+    const std::string name = "RawStatusTest";
+    const std::string url = "https://rawstatustest.example/@";
+
+    // Plain ACTIVE add (handler maps ADD + UNKNOWN -> ACTIVE), persisted to LevelDB.
+    AddProjectEntryWithStatus(name, url, Status::UNKNOWN, 100, 100);
+    {
+        const auto raw = registry.GetProjectsFromDisk();
+        BOOST_REQUIRE(raw.count(name) == 1);
+        BOOST_CHECK(raw.at(name)->m_status == Status::ACTIVE);
+    }
+
+    // A later contract for the same key becomes the HEAD that GetProjectsFromDisk reports.
+    AddProjectEntryWithStatus(name, url, Status::MAN_GREYLISTED, 101, 101);
+    {
+        const auto raw = registry.GetProjectsFromDisk();
+        BOOST_REQUIRE(raw.count(name) == 1);
+        BOOST_CHECK(raw.at(name)->m_status == Status::MAN_GREYLISTED);
+    }
+
+    AddProjectEntryWithStatus(name, url, Status::AUTO_GREYLIST_OVERRIDE, 102, 102);
+    {
+        const auto raw = registry.GetProjectsFromDisk();
+        BOOST_REQUIRE(raw.count(name) == 1);
+        BOOST_CHECK(raw.at(name)->m_status == Status::AUTO_GREYLIST_OVERRIDE);
+    }
+
+    // A delete persists a DELETED HEAD, which the raw read reports as-is.
+    DeleteProjectEntry(3, name, 103, 103);
+    {
+        const auto raw = registry.GetProjectsFromDisk();
+        BOOST_REQUIRE(raw.count(name) == 1);
+        BOOST_CHECK(raw.at(name)->m_status == Status::DELETED);
+    }
+
+    // This locks in that getrawprojectstatus (via GetProjectsFromDisk) reports the raw, contract-applied status read
+    // from LevelDB, and that HEAD selection follows the latest record per key. The complementary assertion -- that the
+    // AutoGreylist Snapshot overlay can rewrite the in-memory status to AUTO_GREYLISTED while the persisted status read
+    // here stays ACTIVE/MAN/OVERRIDE -- belongs with the bad-project autogreylist run once it is extended through this
+    // same contract-application facility to the registry/LevelDB layer.
+
+    registry.Reset();
 }
 
 BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -5,6 +5,8 @@
 #include "main.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/project.h"
+#include "gridcoin/quorum.h"
+#include "util/string.h"
 #include "wallet/generated_type.h"
 
 #include <boost/test/unit_test.hpp>
@@ -570,19 +572,19 @@ BOOST_AUTO_TEST_CASE(it_adds_whitelisted_projects_from_contract_data)
     int height = 0;
     int64_t time = 0;
 
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 0);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == false);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).size() == 0);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Enigma") == false);
 
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, false);
 
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 1);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).size() == 1);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Enigma") == true);
 
     AddProjectEntry(2, "Foo", "http://foo.test", false, height++, time++, false);
 
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 2);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == true);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Foo") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).size() == 2);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Enigma") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Foo") == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_removes_whitelisted_projects_from_contract_data)
@@ -594,13 +596,13 @@ BOOST_AUTO_TEST_CASE(it_removes_whitelisted_projects_from_contract_data)
 
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
 
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 1);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).size() == 1);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Enigma") == true);
 
     DeleteProjectEntry(1, "Enigma", height++, time++, false);
 
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).size() == 0);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == false);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).size() == 0);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Enigma") == false);
 }
 
 BOOST_AUTO_TEST_CASE(it_does_not_mutate_existing_snapshots)
@@ -613,14 +615,14 @@ BOOST_AUTO_TEST_CASE(it_does_not_mutate_existing_snapshots)
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
     AddProjectEntry(2, "Foo", "http://foo.test", true, height++, time++, false);
 
-    auto snapshot = whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false);
+    auto snapshot = whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false);
 
     DeleteProjectEntry(1, "Enigma", height, time, false);
 
     BOOST_CHECK(snapshot.Contains("Enigma") == true);
 
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Enigma") == false);
-    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false).Contains("Foo") == true);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Enigma") == false);
+    BOOST_CHECK(whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false).Contains("Foo") == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
@@ -633,7 +635,7 @@ BOOST_AUTO_TEST_CASE(it_overwrites_projects_with_the_same_name)
     AddProjectEntry(1, "Enigma", "http://enigma.test", false, height, time, true);
     AddProjectEntry(2, "Enigma", "http://new.enigma.test", true, height++, time++, false);
 
-    auto snapshot = whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false, false);
+    auto snapshot = whitelist.Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ACTIVE, false);
     BOOST_CHECK(snapshot.size() == 1);
 
     for (const auto& project : snapshot) {
@@ -1481,6 +1483,164 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
     delete whitelist_index_entry;
 }
 
+//!
+//! \brief Snapshot's auto-greylist overlay must NOT mutate the underlying registry entries.
+//!
+//! Reproduces the consensus bug in Whitelist::Snapshot(): the override working copy at
+//! project.cpp:665 is a SHALLOW copy of ProjectEntryMap (std::map<std::string,
+//! std::shared_ptr<ProjectEntry>>), so setting m_status = AUTO_GREYLISTED on the copy
+//! (project.cpp:680) mutates the SHARED registry ProjectEntry in place. There is no revert
+//! path, so a recovered project stays stuck AUTO_GREYLISTED in memory while a restarted node
+//! reloads ACTIVE from LevelDB -- the in-memory-vs-persisted divergence that splits the network.
+//!
+//! Drives a project into the auto-greylist (reusing the it_auto_greylists_correctly "horrible
+//! project" series through the point it meets criteria), takes a Snapshot with the overlay,
+//! then asserts (1) the in-memory registry entry is still ACTIVE and (2) it agrees with the
+//! persisted (LevelDB) contract status. Both FAIL on the buggy shallow-copy Snapshot and pass
+//! once Snapshot deep-copies the entries before overlaying.
+//!
+BOOST_AUTO_TEST_CASE(snapshot_overlay_must_not_mutate_registry_entries)
+{
+    using Status = GRC::ProjectEntryStatus;
+    using Filter = GRC::ProjectEntry::ProjectFilterFlag;
+
+    GRC::Whitelist& whitelist = GRC::GetWhitelist();
+    std::shared_ptr<GRC::AutoGreylist> auto_greylist = GRC::GetAutoGreylistCache();
+
+    const std::string name = "snapshot_mutation_test";
+    const std::string url = "http://snapshot.mutation.test";
+
+    int height = 0;
+    int64_t time = 0;
+
+    whitelist.Reset();
+
+    // RAII guard so a mid-test BOOST_REQUIRE abort doesn't leak -autogreylistdeepcopyheight=0
+    // into subsequent test cases in the same binary.
+    struct DeepCopyHeightGuard {
+        ~DeepCopyHeightGuard()
+        {
+            gArgs.ForceSetArg("-autogreylistdeepcopyheight",
+                              ToString(Params().GetConsensus().AutoGreylistDeepCopyHeight));
+        }
+    } deep_copy_height_guard;
+
+    // Activate the deep-copy gate for this test (low override) so Snapshot exercises the post-gate
+    // registry-safe overlay. Pre-fix code has no gate and mutates regardless -> the test fails (red);
+    // post-fix code deep-copies the entries -> the registry is untouched (green).
+    gArgs.ForceSetArg("-autogreylistdeepcopyheight", "0");
+
+    // Add the project as a real v4 ACTIVE contract through the registry/contract/LevelDB path
+    // (ADD + UNKNOWN -> ACTIVE; a real height is supplied so it persists and GetProjectsFromDisk
+    // can read it back).
+    AddProjectEntryWithStatus(name, url, Status::UNKNOWN, height, time);
+
+    // Sanity: the contract status is ACTIVE on disk to start.
+    {
+        const auto disk = whitelist.GetProjectsFromDisk();
+        BOOST_REQUIRE(disk.count(name) == 1);
+        BOOST_REQUIRE(disk.at(name)->m_status == Status::ACTIVE);
+    }
+
+    // Drive the AutoGreylist with the "horrible project" total-credit series through the point
+    // where it meets greylisting criteria (subset of it_auto_greylists_correctly's data; the
+    // project meets criteria from superblock 12 onward).
+    const std::vector<std::optional<uint64_t>> tc_series = {
+        std::nullopt, 1000, std::nullopt, std::nullopt, 1000, 2000, 3000, std::nullopt,
+        3000, 4000, 5000, 5000, std::nullopt, 5001, 5002,
+    };
+
+    auto unit_test_blocks =
+        std::make_shared<std::map<int, std::pair<CBlockIndex*, GRC::SuperblockPtr>>>();
+
+    CBlockIndex* whitelist_index_entry = new CBlockIndex;
+    ++height;
+    ++time;
+
+    CBlockIndex* index_ptr = whitelist_index_entry;
+    CBlockIndex* index_ptr_prev = nullptr;
+    GRC::SuperblockPtr superblock_ptr;
+
+    for (const auto& tc : tc_series) {
+        index_ptr_prev = index_ptr;
+        index_ptr = new CBlockIndex;
+        index_ptr->nHeight = height;
+        index_ptr->nTime = time;
+        index_ptr->MarkAsSuperblock();
+        index_ptr->pprev = index_ptr_prev;
+
+        GRC::Superblock superblock = GRC::Superblock();
+        if (tc) {
+            superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits
+                .insert(std::make_pair(name, *tc));
+        }
+
+        superblock_ptr = GRC::SuperblockPtr();
+        superblock_ptr.Replace(superblock);
+        superblock_ptr.Rebind(index_ptr);
+
+        unit_test_blocks->insert(std::make_pair(height, std::make_pair(index_ptr, superblock_ptr)));
+
+        ++height;
+        ++time;
+    }
+
+    auto_greylist->Reset();
+    auto_greylist->RefreshWithSuperblock(superblock_ptr, unit_test_blocks);
+
+    // Precondition: the project now meets greylisting criteria (is in the auto-greylist).
+    BOOST_REQUIRE(auto_greylist->Contains(name));
+
+    // Take a Snapshot WITH the overlay applied. On the buggy shallow-copy Snapshot this mutates
+    // the shared registry ProjectEntry in place. The test drives RefreshWithSuperblock above so the
+    // greylist reflects the synthetic superblock series; the chain-handler-driven Refresh path is
+    // bypassed in this unit-test setup.
+    whitelist.Snapshot(Filter::ALL_BUT_DELETED, /*include_override=*/true);
+
+    // Read back the in-memory registry status WITHOUT re-applying the overlay
+    // (include_override=false) -- this reflects whatever the previous Snapshot left behind in
+    // m_project_entries.
+    Status in_memory_status = Status::UNKNOWN;
+    bool found = false;
+    for (const auto& entry : whitelist.Snapshot(Filter::ALL_BUT_DELETED, false)) {
+        if (entry.m_name == name) {
+            in_memory_status = entry.m_status.Value();
+            found = true;
+        }
+    }
+    BOOST_REQUIRE(found);
+
+    // The persisted (LevelDB) contract status is never overlaid.
+    Status disk_status = Status::UNKNOWN;
+    {
+        const auto disk = whitelist.GetProjectsFromDisk();
+        BOOST_REQUIRE(disk.count(name) == 1);
+        disk_status = disk.at(name)->m_status.Value();
+    }
+
+    LogPrintf("snapshot_overlay_must_not_mutate_registry_entries: in_memory=%d disk=%d "
+              "(ACTIVE=%d AUTO_GREYLISTED=%d)",
+              static_cast<int>(in_memory_status), static_cast<int>(disk_status),
+              static_cast<int>(Status::ACTIVE), static_cast<int>(Status::AUTO_GREYLISTED));
+
+    // (1) The overlay must not have mutated the underlying registry entry.
+    BOOST_CHECK(in_memory_status == Status::ACTIVE);
+
+    // (2) In-memory and persisted status must agree -- divergence here is the fork vector.
+    BOOST_CHECK(in_memory_status == disk_status);
+
+    // Clean up the heap-allocated test block indices.
+    for (auto& iter : *unit_test_blocks) {
+        delete iter.second.first;
+    }
+    unit_test_blocks->clear();
+    delete whitelist_index_entry;
+
+    // gArgs restore handled by DeepCopyHeightGuard's dtor on scope exit.
+
+    whitelist.Reset();
+}
+
 BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
 {
     /**
@@ -1634,6 +1794,230 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
     unit_test_blocks->clear();
 
     delete whitelist_index_entry;
+}
+
+//!
+//! Verifies the deep-copy gate-crossing rebuild fires at the right chain-handler point.
+//!
+//! Sequence:
+//!  1. Set -autogreylistdeepcopyheight=100 so SBs with m_height >= 100 are post-gate.
+//!  2. Add a project as ACTIVE through the real contract + LevelDB path.
+//!  3. Drive AutoGreylist to put the project into the greylist (replays the "horrible project" series).
+//!  4. Snapshot WITH overlay while m_deep_copy_active is false (synthetic SBs are pre-gate by height)
+//!     -- this exercises the LEGACY shallow-copy path and mutates m_project_entries->m_status in place
+//!     to AUTO_GREYLISTED. Verify in-memory diverges from LevelDB (corruption simulated).
+//!  5. Push a pre-gate SuperblockPtr (height 50) through Quorum::PushSuperblock. Gate crossing does
+//!     not fire (prev empty, current pre-gate); in-memory corruption persists.
+//!  6. Push a post-gate SuperblockPtr (height 100) through Quorum::PushSuperblock. Gate crossing
+//!     fires (prev pre-gate, current post-gate); ReinitFromDisk rebuilds m_project_entries from
+//!     LevelDB; in-memory status reverts to ACTIVE.
+//!
+//! Locks in the chain-handler wiring so a future refactor cannot silently delete the heal again
+//! (the prior incarnation lived in Quorum::CommitSuperblock, which is structurally unreachable for
+//! v2+ SBs in v11+ steady state -- the bug that motivated this test).
+//!
+BOOST_AUTO_TEST_CASE(push_superblock_heals_corruption_at_gate_crossing)
+{
+    using Status = GRC::ProjectEntryStatus;
+    using Filter = GRC::ProjectEntry::ProjectFilterFlag;
+
+    GRC::Whitelist& whitelist = GRC::GetWhitelist();
+    std::shared_ptr<GRC::AutoGreylist> auto_greylist = GRC::GetAutoGreylistCache();
+
+    const std::string name = "push_heal_test_project";
+    const std::string url = "http://push.heal.test";
+
+    whitelist.Reset();
+
+    // RAII guard so a mid-test BOOST_REQUIRE failure doesn't leak -autogreylistdeepcopyheight=100
+    // into subsequent test cases in the same binary. Also save/restore pindexBest: earlier tests in
+    // the suite may leave pindexBest pointing at a stack-allocated CBlockIndex that has since gone
+    // out of scope, and Quorum::PushSuperblock's Refresh path runs BlockFinder::FindByHeight which
+    // dereferences pindexBest -- triggers ASan stack-use-after-return on CI. Set pindexBest=nullptr
+    // for the duration of the test so FindByHeight returns immediately at its null-check.
+    struct TestStateGuard {
+        CBlockIndex* saved_pindexBest;
+        TestStateGuard() : saved_pindexBest(pindexBest) { pindexBest = nullptr; }
+        ~TestStateGuard()
+        {
+            pindexBest = saved_pindexBest;
+            gArgs.ForceSetArg("-autogreylistdeepcopyheight",
+                              ToString(Params().GetConsensus().AutoGreylistDeepCopyHeight));
+        }
+    } test_state_guard;
+
+    // Activate the deep-copy gate with a test height. SBs with m_height < 100 are pre-gate; m_height
+    // >= 100 are post-gate. The "horrible project" synthetic series uses heights 1..N so the
+    // AutoGreylist's RefreshWithSuperblock leaves m_deep_copy_active=false at the end -- exactly the
+    // state needed to trigger the legacy in-place overlay corruption below.
+    gArgs.ForceSetArg("-autogreylistdeepcopyheight", "100");
+
+    // ---- Step 1: add project as ACTIVE through real contract + LevelDB path ----
+    // Non-zero height so LevelDB's height_stored persists past ReinitFromDisk's clear_in_memory_only.
+    // Initialize bails when LoadDBHeight returns 0 (the registry_db's "uninitialized" sentinel).
+    // Time=0 so RefreshWithSuperblock's project_first_active timestamp check (synth SB ts >= project ts)
+    // succeeds for the synthetic SBs at time 1..15 below.
+    AddProjectEntryWithStatus(name, url, Status::UNKNOWN, /*height=*/20, /*time=*/0);
+
+    {
+        const auto disk = whitelist.GetProjectsFromDisk();
+        BOOST_REQUIRE(disk.count(name) == 1);
+        BOOST_REQUIRE(disk.at(name)->m_status == Status::ACTIVE);
+    }
+
+    // ---- Step 2: drive AutoGreylist so the project meets greylisting criteria ----
+    // Reused "horrible project" TC series from it_auto_greylists_correctly -- the project meets
+    // criteria from sb_from_baseline >= 12.
+    const std::vector<std::optional<uint64_t>> tc_series = {
+        std::nullopt, 1000, std::nullopt, std::nullopt, 1000, 2000, 3000, std::nullopt,
+        3000, 4000, 5000, 5000, std::nullopt, 5001, 5002,
+    };
+
+    auto unit_test_blocks =
+        std::make_shared<std::map<int, std::pair<CBlockIndex*, GRC::SuperblockPtr>>>();
+
+    CBlockIndex* whitelist_index_entry = new CBlockIndex;
+    int height = 1;
+    int64_t time = 1;
+
+    CBlockIndex* synth_index = whitelist_index_entry;
+    CBlockIndex* synth_index_prev = nullptr;
+    GRC::SuperblockPtr synth_head_ptr;
+
+    for (const auto& tc : tc_series) {
+        synth_index_prev = synth_index;
+        synth_index = new CBlockIndex;
+        synth_index->nHeight = height;
+        synth_index->nTime = time;
+        synth_index->MarkAsSuperblock();
+        synth_index->pprev = synth_index_prev;
+
+        GRC::Superblock sb;
+        if (tc) {
+            sb.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits
+                .insert(std::make_pair(name, *tc));
+        }
+
+        synth_head_ptr = GRC::SuperblockPtr();
+        synth_head_ptr.Replace(sb);
+        synth_head_ptr.Rebind(synth_index);
+
+        unit_test_blocks->insert(std::make_pair(height, std::make_pair(synth_index, synth_head_ptr)));
+
+        ++height;
+        ++time;
+    }
+
+    auto_greylist->Reset();
+    auto_greylist->RefreshWithSuperblock(synth_head_ptr, unit_test_blocks);
+    BOOST_REQUIRE(auto_greylist->Contains(name));
+
+    // Synthetic SBs are at heights 1..N (all pre-gate at 100); m_deep_copy_active should be false.
+    BOOST_REQUIRE(!auto_greylist->IsDeepCopyActive());
+
+    // ---- Step 3: trigger the legacy in-place overlay mutation (corruption simulated) ----
+    whitelist.Snapshot(Filter::ALL_BUT_DELETED, /*include_override=*/true);
+
+    {
+        Status in_memory_status = Status::UNKNOWN;
+        bool found = false;
+        for (const auto& entry : whitelist.Snapshot(Filter::ALL_BUT_DELETED, /*include_override=*/false)) {
+            if (entry.m_name == name) {
+                in_memory_status = entry.m_status.Value();
+                found = true;
+            }
+        }
+        BOOST_REQUIRE(found);
+        BOOST_REQUIRE_EQUAL(static_cast<int>(in_memory_status), static_cast<int>(Status::AUTO_GREYLISTED));
+
+        // Disk is untouched -- still ACTIVE -- because the legacy overlay mutates m_status in the
+        // shared shared_ptr backing m_project_entries, not the registry DB.
+        const auto disk = whitelist.GetProjectsFromDisk();
+        BOOST_REQUIRE_EQUAL(static_cast<int>(disk.at(name)->m_status.Value()),
+                            static_cast<int>(Status::ACTIVE));
+    }
+
+    // ---- Step 4: push a pre-gate SuperblockPtr through Quorum::PushSuperblock ----
+    CBlockIndex* pre_gate_index = new CBlockIndex;
+    pre_gate_index->nHeight = 50;   // pre-gate
+    pre_gate_index->nTime = 50000;
+    pre_gate_index->MarkAsSuperblock();
+
+    GRC::Superblock pre_gate_sb;
+    GRC::SuperblockPtr pre_gate_ptr;
+    pre_gate_ptr.Replace(pre_gate_sb);
+    pre_gate_ptr.Rebind(pre_gate_index);
+
+    GRC::Quorum::PushSuperblock(pre_gate_ptr);
+
+    // Gate did NOT cross (pre_gate_ptr at height 50 < gate 100); m_deep_copy_active stays false.
+    BOOST_CHECK(!auto_greylist->IsDeepCopyActive());
+
+    // Corruption persists -- pre-gate push does not cross the gate.
+    {
+        Status in_memory_status = Status::UNKNOWN;
+        bool found = false;
+        for (const auto& entry : whitelist.Snapshot(Filter::ALL_BUT_DELETED, /*include_override=*/false)) {
+            if (entry.m_name == name) {
+                in_memory_status = entry.m_status.Value();
+                found = true;
+            }
+        }
+        BOOST_REQUIRE(found);
+        BOOST_CHECK_EQUAL(static_cast<int>(in_memory_status), static_cast<int>(Status::AUTO_GREYLISTED));
+    }
+
+    // ---- Step 5: push a post-gate SuperblockPtr through Quorum::PushSuperblock ----
+    CBlockIndex* post_gate_index = new CBlockIndex;
+    post_gate_index->nHeight = 100;   // post-gate (== AutoGreylistDeepCopyHeight)
+    post_gate_index->nTime = 100000;
+    post_gate_index->MarkAsSuperblock();
+    post_gate_index->pprev = pre_gate_index;
+
+    GRC::Superblock post_gate_sb;
+    GRC::SuperblockPtr post_gate_ptr;
+    post_gate_ptr.Replace(post_gate_sb);
+    post_gate_ptr.Rebind(post_gate_index);
+
+    GRC::Quorum::PushSuperblock(post_gate_ptr);
+
+    // Gate crossed forward; m_deep_copy_active is now true. Asserting this separately from the
+    // healed-status check below localizes future regressions: if this fails the gate detector itself
+    // is broken; if this passes but the status check fails the ReinitFromDisk side-effect is broken.
+    BOOST_CHECK(auto_greylist->IsDeepCopyActive());
+
+    // Gate crossing fired -> ReinitFromDisk rebuilt m_project_entries from LevelDB ->
+    // in-memory status is back to ACTIVE.
+    {
+        Status in_memory_status = Status::UNKNOWN;
+        bool found = false;
+        for (const auto& entry : whitelist.Snapshot(Filter::ALL_BUT_DELETED, /*include_override=*/false)) {
+            if (entry.m_name == name) {
+                in_memory_status = entry.m_status.Value();
+                found = true;
+            }
+        }
+        BOOST_REQUIRE(found);
+        BOOST_CHECK_EQUAL(static_cast<int>(in_memory_status), static_cast<int>(Status::ACTIVE));
+    }
+
+    // ---- Cleanup ----
+    // Pop the two Quorum-pushed SBs before deleting their CBlockIndex backing storage. Pop's Refresh
+    // bails harmlessly when the cache becomes empty.
+    GRC::Quorum::PopSuperblock(post_gate_index);
+    GRC::Quorum::PopSuperblock(pre_gate_index);
+    delete pre_gate_index;
+    delete post_gate_index;
+
+    for (auto& iter : *unit_test_blocks) {
+        delete iter.second.first;
+    }
+    unit_test_blocks->clear();
+    delete whitelist_index_entry;
+
+    // gArgs restore handled by DeepCopyHeightGuard's dtor on scope exit.
+
+    whitelist.Reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Two commits:

## 1. `rpc: add getrawprojectstatus to read raw contract status from leveldb`

- New `getrawprojectstatus` RPC reads the persisted project-registry contract state directly from LevelDB.
- Generalises the underlying access path: `RegistryDB<E,SE,S,M,P,X,H>::GetCurrentEntriesFromDisk()` template method readable across all registries that use the shared `RegistryDB` template.
- `Whitelist::GetProjectsFromDisk()` accessor + an `AddProjectEntryWithStatus(...)` helper used by the new regression test in the second commit.

## 2. `consensus: AutoGreylist Snapshot deep-copy + refresh redesign + annotations`

- Move `AutoGreylist::Refresh()` from an implicit on-`Whitelist::Snapshot()` side-effect to explicit calls at `Quorum::CommitSuperblock` / `PopSuperblock` / `LoadSuperblockIndex`. `Snapshot()` becomes a pure read; the `refresh_greylist` parameter is dropped.
- When the gate is active, `Whitelist::Snapshot()` builds its working map with deep copies of project entries rather than shallow `shared_ptr` copies.
- Add `Whitelist::ReinitFromDisk()` (`ResetInMemoryOnly()` + `Initialize()`), fired from `Quorum::CommitSuperblock` on the first SB whose height crosses the gate.
- Clang thread-safety annotations on `Whitelist`'s dynamic members (`m_project_entries`, `m_pending_project_entries`, `m_expired_project_entries`, `m_project_first_actives`) and on `AutoGreylist::m_deep_copy_active`. Set-once handles (`m_project_db`, `m_auto_greylist`) intentionally left unannotated. `cs_main` retained on the six `IContractHandler` methods.
- New `AutoGreylistDeepCopyHeight` chainparams field + hidden `-autogreylistdeepcopyheight=<n>` override for testnet/regtest. Mainnet height set coincident with `BlockV15Height`.
- Adds a regression test for the `Snapshot()` overlay path.

## Test plan
- [x] `gridcoin_tests` + `gridcoin_qt_tests` pass.
- [x] Validated on an isolated-mesh testnet through a gate-crossing superblock and several subsequent commits, including a master-key administrative pass.
