### PR TITLE
qt: tx-table windowed-model phase 1 — container + ordering swap

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -127,8 +127,8 @@ public:
         {
             LOCK2(cs_main, wallet->cs_wallet);
 
-            bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
-            int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
+            const bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
+            const int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
 
             // Reserve a reasonable upper bound up front to avoid the
             // ~18 reallocations a 300k-tx wallet would otherwise pay.
@@ -138,11 +138,22 @@ public:
 
             for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
             {
-                if (TransactionRecord::showTransaction(it->second, fLimitTxnDisplay, limitTxnDateTime))
-                {
-                    const QList<TransactionRecord> decomposed =
-                        TransactionRecord::decomposeTransaction(wallet, it->second);
-                    cachedWallet.insert(cachedWallet.end(), decomposed.begin(), decomposed.end());
+                if (!TransactionRecord::showTransaction(it->second)) continue;
+
+                const QList<TransactionRecord> decomposed =
+                    TransactionRecord::decomposeTransaction(wallet, it->second);
+
+                // Apply the datetime-limit filter at the RECORD level on
+                // rec.time (= CWalletTx::GetTxTime), matching the Date
+                // column shown in the GUI and the cutoff applied in
+                // applyTxAdded. showTransaction's wtx-level cutoff
+                // compares wtx.nTime (signing time), which can drift
+                // from GetTxTime for confirmed txs and produces a
+                // visibly inconsistent filter on initial load vs
+                // incremental adds.
+                for (const TransactionRecord& rec : decomposed) {
+                    if (fLimitTxnDisplay && rec.time < limitTxnDateTime) continue;
+                    cachedWallet.push_back(rec);
                 }
             }
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -18,6 +18,12 @@
 #include <QDateTime>
 #include <QtAlgorithms>
 
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter,
@@ -27,20 +33,26 @@ static int column_alignments[] = {
         Qt::AlignRight|Qt::AlignVCenter
     };
 
-// Comparison operator for sort/binary search of model tx list
-struct TxLessThan
+// Composite-key ordering for the cached transaction list. Three-level key:
+//
+//   1. time DESCENDING — newest first; matches the default user-facing
+//      ordering for the table.
+//   2. hash ASCENDING  — clusters all decomposed records of one tx into a
+//      contiguous range. Without this, two txs that share a wall-clock
+//      second AND have overlapping decomposition indices would interleave
+//      (A0, B0, A1, B1), forcing insert/remove to handle disjoint ranges.
+//      With hash at second level, each tx is always a coherent block.
+//   3. idx ASCENDING   — within a single tx (same time, same hash), preserves
+//      the order produced by TransactionRecord::decomposeTransaction. idx
+//      values are unique within a tx, so this is a true total order: no two
+//      records ever compare equal.
+struct TxRecordOrder
 {
     bool operator()(const TransactionRecord &a, const TransactionRecord &b) const
     {
-        return a.hash < b.hash;
-    }
-    bool operator()(const TransactionRecord &a, const uint256 &b) const
-    {
-        return a.hash < b;
-    }
-    bool operator()(const uint256 &a, const TransactionRecord &b) const
-    {
-        return a < b.hash;
+        if (a.time != b.time) return a.time > b.time;
+        if (a.hash != b.hash) return a.hash < b.hash;
+        return a.idx < b.idx;
     }
 };
 
@@ -58,17 +70,56 @@ public:
     WalletModel *walletModel;
     TransactionTableModel *parent;
 
-    /* Local cache of wallet.
-     * As it is in the same order as the CWallet, by definition
-     * this is sorted by sha256.
-     */
-    QList<TransactionRecord> cachedWallet;
+    //!
+    //! \brief Local cache of wallet transactions, sorted by TxRecordOrder
+    //! (time DESC, hash ASC, idx ASC). Each entry is one row of the table.
+    //!
+    //! Companion `hashIndex` maps tx-hash → vector positions for O(1)
+    //! lookup. Records with the same hash are always contiguous in the
+    //! vector (the second-level hash tiebreaker in TxRecordOrder
+    //! guarantees this).
+    //!
+    std::vector<TransactionRecord> cachedWallet;
+    std::unordered_multimap<uint256, std::size_t, BlockHasher> hashIndex;
+
+    //!
+    //! \brief Rebuild hashIndex from cachedWallet from scratch. Used after
+    //! loadWallet() and any bulk operation where it's cheaper to rebuild
+    //! than to maintain incrementally.
+    //!
+    void rebuildHashIndex()
+    {
+        hashIndex.clear();
+        hashIndex.reserve(cachedWallet.size());
+        for (std::size_t i = 0; i < cachedWallet.size(); ++i) {
+            hashIndex.emplace(cachedWallet[i].hash, i);
+        }
+    }
+
+    //!
+    //! \brief Bump every hashIndex value whose position is >= `from` by
+    //! `delta`. Used to maintain the index after a vector insert (positive
+    //! delta) or erase (negative delta).
+    //!
+    //! O(M) where M = total hashIndex entries. Acceptable per design
+    //! (the typical insert/remove is rare and pays this only once).
+    //!
+    void shiftHashIndex(std::size_t from, std::ptrdiff_t delta)
+    {
+        for (auto& kv : hashIndex) {
+            if (kv.second >= from) {
+                kv.second = static_cast<std::size_t>(
+                    static_cast<std::ptrdiff_t>(kv.second) + delta);
+            }
+        }
+    }
 
     /* Query entire wallet anew from core.
      */
     void loadWallet()
     {
         cachedWallet.clear();
+        hashIndex.clear();
         {
             LOCK2(cs_main, wallet->cs_wallet);
 
@@ -79,14 +130,20 @@ public:
             {
                 if (TransactionRecord::showTransaction(it->second, fLimitTxnDisplay, limitTxnDateTime))
                 {
-                    cachedWallet.append(TransactionRecord::decomposeTransaction(wallet, it->second));
+                    const QList<TransactionRecord> decomposed =
+                        TransactionRecord::decomposeTransaction(wallet, it->second);
+                    for (const TransactionRecord& rec : decomposed) {
+                        cachedWallet.push_back(rec);
+                    }
                 }
             }
         }
+        std::sort(cachedWallet.begin(), cachedWallet.end(), TxRecordOrder());
+        rebuildHashIndex();
     }
 
 
-    /* Update QList using new query from core.
+    /* Reset the cached transaction list with a fresh query from core.
      */
     void refreshWallet()
     {
@@ -108,10 +165,13 @@ public:
     //!   producer side, so no wallet lookup is needed. The consumer applies
     //!   the user's datetime-limit filter (a record-level predicate on
     //!   record.time) and inserts the surviving records as a contiguous
-    //!   range at the binary-search position determined by the tx hash.
+    //!   range at the TxRecordOrder lower_bound position. Same-hash records
+    //!   cluster naturally under that ordering, so a single beginInsertRows
+    //!   covers the whole tx.
     //!
     //! - TxRemoved payloads carry just the hash. The consumer locates the
-    //!   matching range in cachedWallet by binary search and removes it.
+    //!   matching range via hashIndex (O(1) average) and removes it as a
+    //!   single contiguous block.
     //!
     //! - TxUpdated payloads carry hash + status. No row mutation is needed:
     //!   per-row status (depth, Confirmed/Confirming/etc.) is refreshed
@@ -147,67 +207,109 @@ public:
         // Apply the consumer-side datetime filter. The producer has already
         // applied the wtx-level visibility checks (orphan coinstake/coinbase,
         // legacy OP_RETURN) under the locks it held at notification time.
-        QList<TransactionRecord> toInsert;
+        //
+        // All records in a payload share `time` and `hash`, so the datetime
+        // filter is all-or-nothing: either every record clears the cutoff
+        // or none do.
+        std::vector<TransactionRecord> toInsert;
         toInsert.reserve(payload.records.size());
         for (const TransactionRecord& rec : payload.records) {
             if (fLimitTxnDisplay && rec.time < limitTxnDateTime) {
                 continue;
             }
-            toInsert.append(rec);
+            toInsert.push_back(rec);
         }
-        if (toInsert.isEmpty()) {
+        if (toInsert.empty()) {
             return;
         }
 
-        // All records in a payload share the same hash, so they slot into
-        // cachedWallet as a single contiguous range at the lower_bound
-        // position for that hash.
+        // Sort the new records by TxRecordOrder. decomposeTransaction
+        // already produces them in idx order (which is the third-level
+        // tiebreaker, with same time + same hash), so this is normally
+        // a no-op — but enforce defensively against any future producer
+        // change.
+        std::sort(toInsert.begin(), toInsert.end(), TxRecordOrder());
+
+        // Skip duplicate insert: hashIndex.find() is O(1) average and
+        // tells us whether ANY record of this tx is already cached.
+        // Because the producer sends all records of a tx as one payload,
+        // a present hash means the full set is already there.
         const uint256& hash = toInsert.front().hash;
-        auto lower = std::lower_bound(cachedWallet.begin(), cachedWallet.end(), hash, TxLessThan());
-        auto upper = std::upper_bound(cachedWallet.begin(), cachedWallet.end(), hash, TxLessThan());
-        if (lower != upper) {
+        if (hashIndex.find(hash) != hashIndex.end()) {
             LogPrint(BCLog::LogFlags::VERBOSE,
                      "applyTxAdded: %s already in model — skipping duplicate insert", hash.GetHex());
             return;
         }
 
-        const int lowerIndex = static_cast<int>(lower - cachedWallet.begin());
+        // All records in toInsert share `time` and `hash` and differ only
+        // in `idx`. Under TxRecordOrder they sort to a contiguous range
+        // and slot into cachedWallet at the lower_bound position of the
+        // first record.
+        auto pos = std::lower_bound(cachedWallet.begin(), cachedWallet.end(),
+                                    toInsert.front(), TxRecordOrder());
+        const std::size_t insertIdx = static_cast<std::size_t>(pos - cachedWallet.begin());
+        const std::size_t insertCount = toInsert.size();
 
-        parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex + toInsert.size() - 1);
-        int insert_idx = lowerIndex;
-        for (const TransactionRecord& rec : std::as_const(toInsert)) {
-            cachedWallet.insert(insert_idx, rec);
-            insert_idx += 1;
+        parent->beginInsertRows(QModelIndex(),
+                                static_cast<int>(insertIdx),
+                                static_cast<int>(insertIdx + insertCount - 1));
+
+        // Order matters: shift the index BEFORE the vector insert (the
+        // shift uses logical positions, not iterators, so the vector's
+        // unshifted state doesn't matter), then do the insert, then add
+        // the new index entries for the inserted range. Doing it in this
+        // order keeps the index consistent at every observable point.
+        shiftHashIndex(insertIdx, static_cast<std::ptrdiff_t>(insertCount));
+        cachedWallet.insert(pos, toInsert.begin(), toInsert.end());
+        for (std::size_t k = 0; k < insertCount; ++k) {
+            hashIndex.emplace(hash, insertIdx + k);
         }
+
         parent->endInsertRows();
     }
 
     void applyTxRemoved(const GRC::TxRemovedPayload& payload)
     {
-        auto lower = std::lower_bound(cachedWallet.begin(), cachedWallet.end(), payload.hash, TxLessThan());
-        auto upper = std::upper_bound(cachedWallet.begin(), cachedWallet.end(), payload.hash, TxLessThan());
-        if (lower == upper) {
+        auto range = hashIndex.equal_range(payload.hash);
+        if (range.first == range.second) {
             // Not in cachedWallet — may have been filtered out at insert time,
             // or never inserted (e.g. an orphan caught by the producer-side
             // showTransaction check). No row work needed.
             return;
         }
 
-        const int lowerIndex = static_cast<int>(lower - cachedWallet.begin());
-        const int upperIndex = static_cast<int>(upper - cachedWallet.begin());
-        parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex - 1);
-        cachedWallet.erase(lower, upper);
+        // Collect the positions for this hash. Same-hash records are
+        // contiguous in the vector under TxRecordOrder (the second-level
+        // hash tiebreaker guarantees clustering), so the min and max
+        // bound a single range.
+        std::size_t minPos = std::numeric_limits<std::size_t>::max();
+        std::size_t maxPos = 0;
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second < minPos) minPos = it->second;
+            if (it->second > maxPos) maxPos = it->second;
+        }
+        const std::size_t removeCount = maxPos - minPos + 1;
+
+        parent->beginRemoveRows(QModelIndex(),
+                                static_cast<int>(minPos),
+                                static_cast<int>(maxPos));
+
+        cachedWallet.erase(cachedWallet.begin() + minPos,
+                           cachedWallet.begin() + maxPos + 1);
+        hashIndex.erase(payload.hash);
+        shiftHashIndex(maxPos + 1, -static_cast<std::ptrdiff_t>(removeCount));
+
         parent->endRemoveRows();
     }
 
     int size()
     {
-        return cachedWallet.size();
+        return static_cast<int>(cachedWallet.size());
     }
 
     TransactionRecord *index(int idx)
     {
-        if(idx >= 0 && idx < cachedWallet.size())
+        if(idx >= 0 && static_cast<std::size_t>(idx) < cachedWallet.size())
         {
             TransactionRecord *rec = &cachedWallet[idx];
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -7,6 +7,7 @@
 #include "optionsmodel.h"
 #include "addresstablemodel.h"
 #include "bitcoinunits.h"
+#include "main.h"
 #include "wallet/wallet.h"
 #include "node/ui_interface.h"
 #include "util.h"
@@ -16,10 +17,11 @@
 #include <QColor>
 #include <QIcon>
 #include <QDateTime>
-#include <QtAlgorithms>
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
+#include <iterator>
 #include <limits>
 #include <unordered_map>
 #include <vector>
@@ -90,7 +92,9 @@ public:
     void rebuildHashIndex()
     {
         hashIndex.clear();
-        hashIndex.reserve(cachedWallet.size());
+        // Reserve with headroom so the default max_load_factor=1.0 doesn't
+        // trigger an immediate rehash on the first emplace.
+        hashIndex.reserve(cachedWallet.size() * 2 + 1);
         for (std::size_t i = 0; i < cachedWallet.size(); ++i) {
             hashIndex.emplace(cachedWallet[i].hash, i);
         }
@@ -119,12 +123,18 @@ public:
     void loadWallet()
     {
         cachedWallet.clear();
-        hashIndex.clear();
+        // hashIndex is reset by rebuildHashIndex() below.
         {
             LOCK2(cs_main, wallet->cs_wallet);
 
             bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
             int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
+
+            // Reserve a reasonable upper bound up front to avoid the
+            // ~18 reallocations a 300k-tx wallet would otherwise pay.
+            // Each wtx typically decomposes to 1-3 records; double the
+            // wtx count as a safe lower estimate.
+            cachedWallet.reserve(wallet->mapWallet.size() * 2);
 
             for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
             {
@@ -132,9 +142,7 @@ public:
                 {
                     const QList<TransactionRecord> decomposed =
                         TransactionRecord::decomposeTransaction(wallet, it->second);
-                    for (const TransactionRecord& rec : decomposed) {
-                        cachedWallet.push_back(rec);
-                    }
+                    cachedWallet.insert(cachedWallet.end(), decomposed.begin(), decomposed.end());
                 }
             }
         }
@@ -289,6 +297,15 @@ public:
             if (it->second > maxPos) maxPos = it->second;
         }
         const std::size_t removeCount = maxPos - minPos + 1;
+
+        // Defensive checks for the contiguity invariant the erase relies
+        // on. If a future change ever lets same-hash records de-cluster
+        // (e.g. switching the comparator to (time, idx, hash), or a
+        // post-decomposition mutation of `time`), these asserts surface
+        // it before the erase silently drops unrelated rows.
+        assert(removeCount == static_cast<std::size_t>(std::distance(range.first, range.second)));
+        assert(cachedWallet[minPos].hash == payload.hash);
+        assert(cachedWallet[maxPos].hash == payload.hash);
 
         parent->beginRemoveRows(QModelIndex(),
                                 static_cast<int>(minPos),
@@ -765,7 +782,14 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
 {
     if(!index.isValid())
         return QVariant();
-    TransactionRecord *rec = static_cast<TransactionRecord*>(index.internalPointer());
+
+    // Resolve the row each call rather than trusting index.internalPointer().
+    // The pointer stored at createIndex() time can dangle: std::vector
+    // reallocation on insert (and element shifts on insert/erase past the
+    // held row) invalidate every TransactionRecord*. QSortFilterProxyModel
+    // and selection state hold persistent QModelIndexes across mutations.
+    TransactionRecord *rec = priv->index(index.row());
+    if (!rec) return QVariant();
 
     const auto column = static_cast<ColumnIndex>(index.column());
     switch (role) {
@@ -910,15 +934,13 @@ QVariant TransactionTableModel::headerData(int section, Qt::Orientation orientat
 QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    TransactionRecord *data = priv->index(row);
-    if(data)
-    {
-        return createIndex(row, column, priv->index(row));
-    }
-    else
-    {
+    if (row < 0 || row >= priv->size()) {
         return QModelIndex();
     }
+    // Pass no internalPointer / internalId — data() resolves the row each
+    // call (see comment there). Storing a TransactionRecord* would dangle
+    // across any vector insert/erase that shifts the row's storage.
+    return createIndex(row, column);
 }
 
 void TransactionTableModel::updateDisplayUnit()

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -314,6 +314,13 @@ public:
         // (e.g. switching the comparator to (time, idx, hash), or a
         // post-decomposition mutation of `time`), these asserts surface
         // it before the erase silently drops unrelated rows.
+        //
+        // Bounds checks come first so a corrupted hashIndex (positions
+        // past the end of cachedWallet) trips an assert rather than
+        // running the cachedWallet[minPos] / cachedWallet[maxPos]
+        // subscripts below into undefined behavior.
+        assert(minPos < cachedWallet.size());
+        assert(maxPos < cachedWallet.size());
         assert(removeCount == static_cast<std::size_t>(std::distance(range.first, range.second)));
         assert(cachedWallet[minPos].hash == payload.hash);
         assert(cachedWallet[maxPos].hash == payload.hash);
@@ -948,10 +955,14 @@ QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex 
     if (row < 0 || row >= priv->size()) {
         return QModelIndex();
     }
-    // Pass no internalPointer / internalId — data() resolves the row each
-    // call (see comment there). Storing a TransactionRecord* would dangle
-    // across any vector insert/erase that shifts the row's storage.
-    return createIndex(row, column);
+    // Pass an explicit nullptr internalPointer — data() resolves the row
+    // each call (see comment there). Storing a TransactionRecord* would
+    // dangle across any vector insert/erase that shifts the row's
+    // storage. The nullptr is explicit (rather than relying on the
+    // default-arg overload of createIndex) to match the third-arg
+    // convention used by the sibling table models and avoid any
+    // Qt-version-specific overload-resolution drift.
+    return createIndex(row, column, nullptr);
 }
 
 void TransactionTableModel::updateDisplayUnit()


### PR DESCRIPTION
## Summary

Phase 1 of a multi-phase redesign of the transaction-table model. Follow-up to PR #2944's wallet-event-queue producer/consumer boundary; foundation for the eventual viewport-scoped refresh (phase 2) and full windowed model with `canFetchMore`/`fetchMore` (phase 3). Self-contained — touches one file (`src/qt/transactiontablemodel.cpp`), no API change visible to other TUs.

### What changes

- Replace `QList<TransactionRecord> cachedWallet` with `std::vector<TransactionRecord>` + an `std::unordered_multimap<uint256, std::size_t, BlockHasher>` hash index.
- Introduce composite `TxRecordOrder` comparator over `(time DESC, hash ASC, idx ASC)`, replacing the hash-only `TxLessThan`.

The ordering choice matters for both clarity and code:

- **`time` descending** matches the user-facing display (most recent on top).
- **`hash` ascending at the second level** clusters all decomposed records of one tx into a contiguous range. With `(time, idx, hash)` instead, two txs sharing a wall-clock second AND overlapping `idx` values would interleave (A0, B0, A1, B1), forcing insert/remove to handle disjoint ranges. Hash at second level keeps each tx a coherent block — so `applyTxAdded` and `applyTxRemoved` each emit a single `beginInsertRows`/`beginRemoveRows`.
- **`idx` ascending at the third level** keeps records within one tx in the order `decomposeTransaction` produced them. `idx` is unique within a tx, so this is a true total order — no two records ever compare equal.

The companion `hashIndex` backs O(1)-average tx-hash lookup, replacing the prior `lower_bound`/`upper_bound` dance.

### Self-review findings already addressed in this PR

The second commit (`qt: review fixes`) addresses items caught during a multi-angle self-review of the first commit:

- **internalPointer UAF (Qt5 regression).** `TransactionTableModel::data()` cast `index.internalPointer()` back to `TransactionRecord*`, with the pointer stashed at `createIndex()` time. Under the old `QList<TransactionRecord>` (sizeof > sizeof void*), Qt5 stored elements indirectly via heap-allocated nodes, so element pointers were stable across container growth — even though `QList` reshuffles its internal pointer array. The new `std::vector` invalidates pointers on reallocation AND on element shifts past the held row. `QSortFilterProxyModel`'s `setDynamicSortFilter(true)` keeps persistent source indexes live across mutations, so a tx insert/erase mid-scroll could dereference freed memory. Fix: `data()` now resolves the row each call via `priv->index(row)`; `index()` drops the internalPointer payload entirely.
- **IWYU.** Added explicit `#include \"main.h\"` for `BlockHasher`, previously reaching this TU only via transitive include through `wallet/wallet.h`. `doc/developer-notes.md` mandates IWYU. Dropped the now-dead `<QtAlgorithms>` include.
- **Contiguity-invariant assert.** `applyTxRemoved` relies on same-hash records being contiguous in the vector. True today via two reinforcing properties (single `nTime` per decomposition + hash as the second-level tiebreaker), but enforced only socially. Added a debug assert that `[minPos, maxPos]` is bounded by same-hash records and that the count matches the multimap `equal_range`. The project explicitly `-UNDEBUG`s on every build (see top-level CMakeLists) so asserts are active in release.
- **Perf hygiene.** Pre-reserve `cachedWallet` in `loadWallet` to skip ~18 reallocations on a 300k-tx wallet; reserve `hashIndex` with headroom so the default `max_load_factor=1.0` doesn't trigger an immediate rehash; single range insert instead of per-record `push_back` loop; drop the redundant `hashIndex.clear()` (rebuild clears it too).

### Behavior change

`cachedWallet`'s internal order changes from hash-ASC to time-DESC. No external observer depends on the internal order (the visible table uses `QSortFilterProxyModel` which re-sorts independently), so the user-visible default sort is unaffected.

### Known follow-up (not in this PR)

`applyTxAdded`'s early return on `hashIndex.find(hash) != end()` (carried over from the pre-PR code's `lower_bound/upper_bound` dedup) drops legitimate updates when `CT_UPDATED` re-fires for an already-cached tx whose `decomposeTransaction` output has changed — e.g. after `importprivkey` flips `IsMine` on a previously-not-mine vout. Both pre-PR and post-PR code behave identically here, so this is not a regression of this PR; will be filed as a separate issue.

## Stacked PR series

This is Phase 1 of a three-phase stack:

- **Phase 1 (this PR)** — Container + ordering swap. Risk: low.
- **Phase 2** — Viewport-scoped refresh. Replaces `updateConfirmations()`'s table-wide `dataChanged` with viewport-scoped notifications.
- **Phase 3** — Full windowed model with `canFetchMore`/`fetchMore`, server-side sort/filter on the wallet event queue side, and a slice cache replacing `cachedWallet` on the GUI side. Phase 3 is what closes the 300k-tx-wallet GUI-startup and GUI-memory targets.

Each later phase rebases onto the prior one's branch, not onto development, to keep the diffs incremental and reviewable.

## Test plan

- [x] Clean build (RelWithDebInfo, Qt6 host build via build_targets.sh): pass.
- [x] Existing test suite (`test_gridcoin`): pass, no errors detected.
- [ ] Isolated-testnet smoke (inst 6 / inst 11 GUI): table populates, new tx insert at correct (time-DESC) position, reorg-driven remove disappears, scroll stable across active block delivery.
- [ ] CI matrix across all platform rows (Alpine / Arch / Debian / Fedora / OpenSUSE Leap / Tumbleweed / ARMhf / ARM64 / macOS Intel / macOS ARM64 / Static Depends / Mint / Windows / Flatpak / Native System Qt6): all green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)