### PR TITLE
refactor: drop std-equivalent Boost usage (replace_all, split, unused includes)

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -3,10 +3,9 @@
 //
 
 #include <algorithm>
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 #include <map>
+#include <util/string.h>
 
 #include "alert.h"
 #include "chainparams.h"
@@ -276,7 +275,7 @@ bool CAlert::ProcessAlert(bool fThread)
                         safeStatus.push_back(strStatusBar[i]);
                 }
                 safeStatus = singleQuote+safeStatus+singleQuote;
-                boost::replace_all(strCmd, "%s", safeStatus);
+                ReplaceAll(strCmd, "%s", safeStatus);
 
                 if (fThread)
                     boost::thread t(runCommand, strCmd); // thread runs free

--- a/src/gridcoin/backup.cpp
+++ b/src/gridcoin/backup.cpp
@@ -10,7 +10,7 @@
 #include "util/time.h"
 #include <filesystem>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/version.hpp>
 
 #include <string>
 

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -22,8 +22,8 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <optional>
+#include <util/string.h>
 #include <set>
 #include <univalue.h>
 
@@ -94,7 +94,7 @@ bool UpdateRWSettingsForMode(const ResearcherMode mode, const std::string& email
 std::string LowerUnderscore(std::string data)
 {
     data = ToLower(data);
-    boost::replace_all(data, "_", " ");
+    ReplaceAll(data, "_", " ");
 
     return data;
 }

--- a/src/gridcoin/voting/registry.cpp
+++ b/src/gridcoin/voting/registry.cpp
@@ -18,6 +18,7 @@
 #include "txdb.h"
 #include "node/ui_interface.h"
 #include "validation.h"
+#include <util/string.h>
 
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
@@ -833,8 +834,8 @@ std::string PollReference::Notify(const PollNotificationType& notify_type) const
     if (!Expired(GetAdjustedTime())) {
         if (!strCmd.empty()) {
             // The placeholders %s1 and %s2 are replaced with the txid and the notification type.
-            boost::replace_all(strCmd, "%s1", m_txid.ToString());
-            boost::replace_all(strCmd, "%s2", NotifyTypeToString(notify_type));
+            ReplaceAll(strCmd, "%s1", m_txid.ToString());
+            ReplaceAll(strCmd, "%s2", NotifyTypeToString(notify_type));
             boost::thread t(runCommand, strCmd); // thread runs free
 
             LogPrint(BCLog::LogFlags::MISC, "INFO: %s: poll notify command: %s", __func__, strCmd);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -26,10 +26,7 @@
 #include "node/coherence.h"
 #include <util/syserror.h>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <openssl/crypto.h>
-
-#include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 
 static boost::thread_group threadGroup;
 static CScheduler scheduler;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,11 +44,11 @@
 #include "random.h"
 #include "validation.h"
 
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <ctime>
 #include <math.h>
+#include <util/string.h>
 
 extern bool AskForOutstandingBlocks(uint256 hashStart);
 extern bool GridcoinServices();
@@ -1396,7 +1396,7 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     std::string strCmd = gArgs.GetArg("-blocknotify", "");
     if (!fIsInitialDownload && !strCmd.empty())
     {
-        boost::replace_all(strCmd, "%s", hashBestChain.GetHex());
+        ReplaceAll(strCmd, "%s", hashBestChain.GetHex());
         boost::thread t(runCommand, strCmd); // thread runs free
     }
     #endif

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -2,9 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <boost/algorithm/string.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 #include "diagnosticsdialog.h"
 #include "qt/forms/ui_diagnosticsdialog.h"
 #include "qt/decoration.h"

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -10,13 +10,13 @@
 #include <key_io.h>
 #include "wallet/db.h"
 #include <util.h>
+#include <util/string.h>
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/shared_ptr.hpp>
 #include <list>
@@ -131,7 +131,7 @@ bool ReadHTTPRequestLine(std::basic_istream<char>& stream, int &proto,
 
     // HTTP request line is space-delimited
     std::vector<std::string> vWords;
-    boost::split(vWords, str, boost::is_any_of(" "));
+    vWords = SplitString(str, ' ');
     if (vWords.size() < 2)
         return false;
 
@@ -172,7 +172,7 @@ int ReadHTTPStatus(std::basic_istream<char>& stream, int &proto)
     std::string str;
     std::getline(stream, str);
     std::vector<std::string> vWords;
-    boost::split(vWords, str, boost::is_any_of(" "));
+    vWords = SplitString(str, ' ');
     if (vWords.size() < 2)
         return HTTP_INTERNAL_SERVER_ERROR;
     str.pop_back();

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -12,6 +12,7 @@
 #include <util.h>
 //#include <util/system.h>
 #include <util/settings.h>
+#include <util/string.h>
 
 #include <cstdint>
 
@@ -1806,6 +1807,22 @@ BOOST_AUTO_TEST_CASE(util_Fraction_FromString)
     }
 
     BOOST_CHECK_EQUAL(err, valid_err_message);
+}
+
+BOOST_AUTO_TEST_CASE(util_ReplaceAll)
+{
+    const std::string original("A test \"%s\" string '%s'.");
+    auto test_replaceall = [&original](const std::string& search, const std::string& substitute, const std::string& expected) {
+        auto test = original;
+        ReplaceAll(test, search, substitute);
+        BOOST_CHECK_EQUAL(test, expected);
+    };
+
+    test_replaceall("", "foo", original);                  // empty search is a no-op
+    test_replaceall(original, "", "");                     // whole-string search, empty substitute
+    test_replaceall("%s", "foo", "A test \"foo\" string 'foo'.");
+    test_replaceall("\"", "foo", "A test foo%sfoo string '%s'.");
+    test_replaceall("'", "foo", "A test \"%s\" string foo%sfoo.");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1823,6 +1823,19 @@ BOOST_AUTO_TEST_CASE(util_ReplaceAll)
     test_replaceall("%s", "foo", "A test \"foo\" string 'foo'.");
     test_replaceall("\"", "foo", "A test foo%sfoo string '%s'.");
     test_replaceall("'", "foo", "A test \"%s\" string foo%sfoo.");
+
+    // Termination/overlap invariants of the pos += substitute.length() loop:
+    std::string grow("a");
+    ReplaceAll(grow, "a", "aa");     // substitute contains search: no re-processing
+    BOOST_CHECK_EQUAL(grow, "aa");
+
+    std::string overlap("aaaa");
+    ReplaceAll(overlap, "aa", "x");  // matches consumed non-overlapping, left-to-right
+    BOOST_CHECK_EQUAL(overlap, "xx");
+
+    std::string shrink("aaa");
+    ReplaceAll(shrink, "a", "");     // empty substitute with consecutive matches terminates
+    BOOST_CHECK_EQUAL(shrink, "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -102,6 +102,20 @@ std::vector<T> Split(const Span<const char>& sp, char sep, bool include_sep = fa
 }
 
 /**
+ * Replace all (non-overlapping) occurrences of @a search in @a in_out with
+ * @a substitute, in place. Equivalent to boost::replace_all.
+ */
+inline void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute)
+{
+    if (search.empty()) return;
+    std::string::size_type pos = 0;
+    while ((pos = in_out.find(search, pos)) != std::string::npos) {
+        in_out.replace(pos, search.length(), substitute);
+        pos += substitute.length();
+    }
+}
+
+/**
  * Join a list of items
  *
  * @param list       The list to join

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -20,6 +20,7 @@
 #include <locale>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 void ParseString(const std::string& str, char c, std::vector<std::string>& v);
@@ -105,7 +106,7 @@ std::vector<T> Split(const Span<const char>& sp, char sep, bool include_sep = fa
  * Replace all (non-overlapping) occurrences of @a search in @a in_out with
  * @a substitute, in place. Equivalent to boost::replace_all.
  */
-inline void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute)
+inline void ReplaceAll(std::string& in_out, std::string_view search, std::string_view substitute)
 {
     if (search.empty()) return;
     std::string::size_type pos = 0;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -13,7 +13,6 @@
 
 #include <chainparamsbase.h>
 
-#include <boost/algorithm/string/replace.hpp>
 #include <stdexcept>
 #include <thread>
 #include <typeinfo>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/algorithm/string.hpp>
+#include <util/string.h>
 
 using namespace std;
 
@@ -218,7 +219,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
             continue;
 
         std::vector<std::string> vstr;
-        boost::split(vstr, line, boost::is_any_of(" "));
+        vstr = SplitString(line, ' ');
         if (vstr.size() < 2)
             continue;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,7 +11,6 @@
 #include "crypter.h"
 #include "node/ui_interface.h"
 #include "wallet/coincontrol.h"
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 #include "random.h"
 #include "rpc/server.h"
@@ -887,7 +886,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb) EXCLUSIV
         std::string strCmd = gArgs.GetArg("-walletnotify", "");
         if (!strCmd.empty())
         {
-            boost::replace_all(strCmd, "%s", hash.GetHex());
+            ReplaceAll(strCmd, "%s", hash.GetHex());
             boost::thread t(runCommand, strCmd); // thread runs free
         }
         #endif

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -55,7 +55,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/algorithm/string/classification.hpp
     boost/algorithm/string/join.hpp
     boost/algorithm/string/predicate.hpp
-    boost/algorithm/string/replace.hpp
     boost/algorithm/string/split.hpp
     boost/array.hpp
     boost/asio.hpp


### PR DESCRIPTION
Part of the Group 1 (std-equivalent) Boost hygiene discussed in #2124. Three small, independent clean-ups, kept as separate commits for review:

**1. `boost::replace_all` → in-tree `ReplaceAll`**
Adds a small `ReplaceAll()` to `util/string.h` (matching upstream Core's `util::ReplaceAll` behaviour) and converts the six call sites (`alert.cpp`, `main.cpp`, `wallet/wallet.cpp`, `gridcoin/voting/registry.cpp` ×2, `gridcoin/researcher.cpp`). Removes `boost/algorithm/string/replace.hpp` from the tree entirely (plus two now-dead includes: `classification.hpp` in `alert.cpp`, a stale `replace.hpp` in `util/system.cpp`) and updates `EXPECTED_BOOST_INCLUDES`. Adds a `util_ReplaceAll` unit test.

**2. `boost::split` → in-tree `SplitString`**
Replaces `boost::split` + `is_any_of` in the HTTP line parsers (`rpc/protocol.cpp`) and the wallet key-import parser (`wallet/rpcdump.cpp`). All used the default (non-compressing) split, which `SplitString` matches, so behaviour is unchanged. Removes `boost/algorithm/string.hpp` from `protocol.cpp`; `rpcdump.cpp` keeps it for `boost::algorithm::starts_with` (`std::string::starts_with` is C++20, project is C++17). The scraper's `token_compress_on` split is intentionally left as-is.

**3. Drop unused Boost includes**
`init.cpp` (two vestigial `predicate.hpp` includes), `qt/diagnosticsdialog.cpp` (`algorithm/string.hpp` + `date_time/posix_time.hpp`), and `gridcoin/backup.cpp` (swap the unused `date_time/posix_time` include for `<boost/version.hpp>`, which actually provides `BOOST_VERSION`).

All three swaps mirror changes upstream Core already made, so this reduces future merge friction. **Not** a dependency removal — Boost stays linked while thread/asio/iostreams/filesystem remain; this is purely hygiene. Each Boost header that is fully removed is dropped from the include lint; the rest remain used elsewhere.
