### PR TITLE
test: close help-rendering coverage gap for 6 pre-#2922 / late-add RPCs (#2922)

### DIFF
--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -840,4 +840,21 @@ BOOST_AUTO_TEST_CASE(psgt_commands_help_renders)
     });
 }
 
+// Pre-#2922 commands that were converted to RPCHelpMan before the tier-coverage
+// push started and therefore weren't included in any of the tier-N test cases
+// above, plus `getrawprojectstatus` (added to dev between PR M and PR M3, and
+// missed during the M3 rebase). All are in the dispatch table with a non-null
+// helpman accessor, so this is a pure test-coverage gap, not a wiring gap.
+BOOST_AUTO_TEST_CASE(pre_2922_and_late_adds_help_renders)
+{
+    check_help_renders({
+        {"addkey",                 &addkey_helpman},
+        {"getrawprojectstatus",    &getrawprojectstatus_helpman},
+        {"maintainbackups",        &maintainbackups_helpman},
+        {"walletlock",             &walletlock_helpman},
+        {"walletpassphrase",       &walletpassphrase_helpman},
+        {"walletpassphrasechange", &walletpassphrasechange_helpman},
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Structural audit of the post-#2977 dispatch table found six dispatched RPCs without a corresponding \`*_help_renders\` test case:

- \`addkey\`
- \`getrawprojectstatus\`
- \`maintainbackups\`
- \`walletlock\`
- \`walletpassphrase\`
- \`walletpassphrasechange\`

All six are properly converted to the M3 surface (file-scope \`RPCHelpMan\` + helpman accessor + dispatch entry with non-null \`_helpman\` pointer); the dispatcher path renders their help correctly. This is a **pure test-coverage gap**, not a wiring gap.

## Why these six were missed

- Three wallet-auth commands (\`walletlock\`, \`walletpassphrase\`, \`walletpassphrasechange\`) were converted to RPCHelpMan **before** the #2922 umbrella issue existed; the tier-level test sweeps under #2922 never picked them up because they weren't tagged as tier work.
- \`maintainbackups\` and \`addkey\` were converted pre-#2922 for similar reasons. \`addkey\` is also in the special body-guard group that PR M kept on the legacy path until M3 — the test surface never had a \"M3-style helpman accessor exists for these\" check.
- \`getrawprojectstatus\` landed on dev between PR M (#2973) and PR M3 (#2977) via the project-status RPC work; it was missed during the M3 rebase that wired the file-scope accessor.

## Wiring confirmation

Audit of the four M3 invariants (run on current dev, post-#2977):

| Invariant | Result |
|---|---|
| Every dispatch entry has a non-null \`_helpman\` pointer | 177/177 ✅ |
| No \`bool fHelp\` stragglers in RPC bodies | 0 ✅ |
| No \`bool fHelp\` stragglers in \`server.h\` forward decls | 0 ✅ |
| Every dispatched helpman is forward-declared in \`server.h\` | 0 missing ✅ |
| No orphan helpman forward decls | 0 unused ✅ |

So this PR is the last piece needed to declare the #2922 umbrella structurally complete.

## Test plan

- [x] \`test_gridcoin --run_test=rpchelpman_tests/pre_2922_and_late_adds_help_renders\` passes
- [x] Full \`rpchelpman_tests\` suite passes
- [x] Full \`test_gridcoin\` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)