### PR TITLE
ci: set CCACHE_DIR so cmake_compatibility caches actually get populated

### DIFF
--- a/.github/workflows/cmake_compatibility.yml
+++ b/.github/workflows/cmake_compatibility.yml
@@ -18,6 +18,11 @@ env:
   # Global settings for all jobs
   BUILD_TYPE: RelWithDebInfo
   USE_CCACHE: true
+  # Match the `path: ~/.ccache` declared by each job's actions/cache step.
+  # ccache 4.x defaults to ~/.cache/ccache, so without this override the
+  # builds write to a directory the cache action never sees and no caching
+  # actually happens.
+  CCACHE_DIR: /home/runner/.ccache
 
 jobs:
   # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Every job in \`.github/workflows/cmake_compatibility.yml\` declares an \`actions/cache@v5\` step with \`path: \~/.ccache\`, but the workflow never sets \`CCACHE_DIR\`. On ubuntu-24.04 ccache 4.x defaults to \`~/.cache/ccache\`, so each build writes to one directory while the cache action saves a different (empty) one. Restore-keys then find nothing useful and the cache provides zero benefit — ARM cross-builds take the full wall-clock time on every run instead of hitting cached objects.

## Fix

One-line addition to the workflow-level env block:

\`\`\`yaml
env:
  BUILD_TYPE: RelWithDebInfo
  USE_CCACHE: true
  CCACHE_DIR: /home/runner/.ccache   # added
\`\`\`

This is inherited by all three jobs (Linux Native, Linux ARM64, Linux ARMhf) and matches the \`~/.ccache\` path each cache step already declares.

## Reference

This mirrors the working setup in the sibling workflow \`.github/workflows/cmake_quality.yml\` (lines 21-23), which has had \`CCACHE_DIR: /home/runner/.ccache\` at the workflow-level env block since it was introduced — and where ccache stats consistently show non-zero hit rates run-over-run.

## Verification

After this lands, the next CI run on this workflow should show:
- Build step: ccache stats reporting non-zero misses (the first run still misses because the cache is now correctly empty), then on subsequent runs against the same branch (or via restore-keys) increasing hit rates.
- Cache step "Post Restore Ccache": non-trivial size saved instead of ~0 bytes.

Visible improvement: ARM64 and ARMhf cross-build wall-clock should drop from full-rebuild (~25 min) toward cached-rebuild (~5-10 min) on iterative PR pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)