### PR TITLE
qt: extract Qt-free transaction filter/sort core (windowed-model step 1, #2944)

### DIFF
--- a/doc/transaction_table_windowed_model.md
+++ b/doc/transaction_table_windowed_model.md
@@ -1,0 +1,348 @@
+# Transaction Table Windowed Model — Design
+
+## Status
+
+In progress. This document describes the full scope of the transaction-table
+windowed-model rewrite and the sequence of pull requests that implement it. It
+is the design of record for the effort; individual PRs reference it.
+
+The work builds on two landed changes:
+
+- **PR #2944** — the wallet event queue: core threads push pre-decomposed
+  transaction events onto an MPSC queue; the Qt main thread drains it. This
+  established the producer/consumer split the windowed model formalizes.
+- **PR #3003** — the container/ordering swap: `TransactionTablePriv`'s cached
+  wallet became a `std::vector<TransactionRecord>` ordered by `TxRecordOrder`
+  (`time` DESC, `hash` ASC, `idx` ASC) plus an `unordered_multimap<uint256,
+  size_t>` hash index. This is the ordered store the windowed model promotes
+  to an authoritative producer-side object.
+
+## Motivation
+
+The transaction GUI inherited a "full replica + sledgehammer refresh" model
+from Bitcoin Core:
+
+- `TransactionTableModel` (a Qt-main-thread object) holds a **full** decomposed
+  replica of every wallet transaction row.
+- On every chain-tip advance, `updateConfirmations()` emits a `dataChanged`
+  signal spanning the **entire** model (rows `0 … N-1`) for two columns.
+- A client-side `QSortFilterProxyModel` (`TransactionFilterProxy`) with
+  `dynamicSortFilter=true` sits between the model and the view.
+
+The dominant cost is the proxy's reaction to the wide `dataChanged`: it re-runs
+`filterAcceptsRow()` for **all `N`** source rows, and because `filterAcceptsRow`
+reads several roles through `data()` → `TransactionTablePriv::index()`, that
+re-evaluation drags the per-row status recompute (`TRY_LOCK cs_main`/`cs_wallet`
++ `updateStatus`), the address-book label lookup, and string searches across
+the whole model on every block. On large or dense wallets (heavy stake
+accretion, dense sidestakes) this is a per-block hitch and a per-block
+accessibility-tree rebuild.
+
+It also forces O(N) decomposition on the Qt main thread at startup (the model
+constructor calls `loadWallet()` under `LOCK2(cs_main, cs_wallet)`), freezing
+the GUI for seconds on large wallets.
+
+### What this is and is not
+
+This effort delivers, **in-process**:
+
+- Startup freeze elimination — decomposition moves off the Qt main thread; the
+  table paints progressively.
+- Per-block confirmation refresh reduced from O(N) to O(viewport).
+- The Qt thread comes off `cs_main`/`cs_wallet` entirely on the render path.
+- The accessibility-tree churn of issue #2952 fixed (viewport-scoped refresh,
+  no full-table proxy remap).
+
+It does **not** deliver, in-process, the GUI memory-footprint reduction often
+associated with windowed models. The full decomposed record set stays resident
+in the one process. That footprint win materializes only at the multiprocess
+split (see [Phase 4](#phase-4--multiprocess-deferred)), when the store lives in
+the node process and each GUI process holds only a viewport-sized slice. We
+accept this trade deliberately: the in-process reshaping is the lowest-risk
+path that also yields a value-typed, pointer-free contract the multiprocess
+split marshals mechanically.
+
+## Endpoint architecture
+
+A producer-owned authoritative store, per-view server-side cursors, and thin
+windowed consumer models. The client `QSortFilterProxyModel` is retired; sort
+and filter become server-side operations.
+
+```
+   core threads (NotifyTransactionChanged, SetBestChain)
+        │  decompose + updateStatus under cs_main/cs_wallet
+        ▼
+   GRC::WalletTxStore          (authoritative; owns records[] + by_hash; cs_store leaf lock)
+        │   per-view Cursor { FilterSpec, SortSpec, view_index, viewport, epoch }
+        │
+   down-channel: Rows* payloads on the existing WalletEventQueue  ──▶  TransactionTableModel (thin, windowed slice cache)
+   up-channel:   setViewport / setSort / setFilter / getRows  ◀──        │
+                                                                          ▼
+                                                              TransactionView (QTableView)
+                                                              OverviewPage   (QListView)
+```
+
+### Authoritative store: full decomposed records
+
+`GRC::WalletTxStore` holds the **full** decomposed `std::vector<TransactionRecord>`
+in `TxRecordOrder`, the companion `unordered_multimap<uint256, size_t>` hash
+index, and a full `TransactionStatus` per record refreshed by calling the
+existing `updateStatus(wtx)` under `cs_main`+`cs_wallet`. It is guarded by a
+**leaf** mutex `cs_store` with the invariant that `cs_store` never nests
+`cs_main`/`cs_wallet` — producers do all wallet work (decompose, `updateStatus`)
+*before* taking `cs_store`; where both are needed the order is
+`cs_main → cs_wallet → cs_store`.
+
+Two alternatives were considered and rejected as the primary store:
+
+- **Reduced order-key store + lazy per-window decompose** would yield an
+  in-process memory win, but a reduced key set **cannot reproduce
+  `updateStatus()`'s branches**: the `Offline`/`Unconfirmed` split,
+  `OpenUntilBlock`/`OpenUntilDate` (needs `nLockTime`), `MaturesWarning` (needs
+  `GetRequestCount`), and `countsForBalance = IsTrusted` (depends on
+  `fConfChange`/`IsFromMe`/dependency confirmation) are **not** functions of
+  `(anchor, tip)`. A reduced store would have to re-lock the wallet for the
+  window anyway *and* maintain off-window confirmation flags perfectly for the
+  `Conflicted`/`NotAccepted` filter — reintroducing exactly the stale-status
+  bug class we have already paid to fix (the researcher-status `MarkDirty()` /
+  beacon `BeaconChanged()` fixes). Full records make that class structurally
+  impossible off-window.
+- **Hybrid sidecar** (full records for the window + compact filter fields for
+  all rows) shares the same status re-derivation hazard.
+
+Because the wallet stays in-node in both the in-process and multiprocess forms
+(per the multiprocess RFC, #2937), the store sits node-side regardless of its
+internal shape. The GUI-process footprint win at Phase 4 is therefore identical
+for all three store shapes — so choosing full-records forfeits nothing at the
+Phase-4 boundary while buying the lowest regression now. If an in-process RSS
+win is later judged worthwhile, the store internals can be swapped to a
+reduced-key representation behind the unchanged cursor/contract layer.
+
+### Server-side sort and filter
+
+Filter and sort run over `records[]` via a **Qt-free** evaluation core
+(`src/qt/txfilter.{h,cpp}`):
+
+- `GRC::Accepts(TxFilterFields, FilterSpec)` — the filter predicate, an exact
+  port of `TransactionFilterProxy::filterAcceptsRow`.
+- `GRC::Less(SortKey, SortKey, column, order)` — the sort comparison, an exact
+  port of the `Qt::EditRole` sort keys.
+
+A cursor's `setFilter` rebuilds its `view_index` (an `O(N)` walk + `O(F log F)`
+sort of the `F` accepted rows); `setSort` re-sorts the `view_index`
+(`O(F log F)`). Both run off the Qt thread, bump the cursor `epoch`, and emit a
+`RowsReset`. Because the core's natural order is already the default user sort
+(`time` DESC), most users never trigger a re-sort; the cost fires only on
+explicit sort-by-amount/type/address clicks, which are rare.
+
+### Anchor invariance bounds tip refresh
+
+The `Status` sort key is prefixed by the **confirmed block height**, which is
+invariant under a tip append. Therefore a plain tip-advance reorders **no**
+cursor's `view_index`. A tip-advance only recomputes status for the
+viewport-sized set of rows (via `updateStatus` under the locks) and emits one
+`RowsRangeChanged` per cursor — replacing the whole-model `dataChanged(0, N-1)`
+sledgehammer.
+
+Only two events require a row reposition: **first confirmation** (a row's
+height flips from the `INT_MAX` sentinel to a real height) and **reorg**. Both
+arrive via `CT_UPDATED` and must reposition the affected row in **every**
+cursor's `view_index` (including off-viewport) and flip its
+`Conflicted`/`NotAccepted` filter membership. This is the global-correctness
+obligation the windowed model must honor and the test plan exercises.
+
+### Consumer is a virtual model, not `canFetchMore`/`fetchMore`
+
+The consumer `TransactionTableModel` reports the **full** filtered row count
+from `rowCount()` (a stable accessibility-tree shape), holds only a
+viewport-sized slice cache, and on a cache miss in `data()` returns a
+placeholder and schedules a `setViewport` + `getRows` fetch; the reply emits
+`dataChanged` for the filled range.
+
+This is deliberately **not** the `canFetchMore`/`fetchMore` idiom the earlier
+sketch proposed: with a full `rowCount`, `canFetchMore` never fires, so that
+idiom is self-contradictory here. The virtual-model pattern (full count +
+placeholder-on-miss) is the correct Qt approach and is better for the
+accessibility tree (stable row count).
+
+Two consistency disciplines are baked into the contract:
+
+1. **`rowCount()` is event-driven only.** It is mutated solely inside
+   `beginInsertRows`/`endInsertRows`/`beginRemoveRows`/`endRemoveRows`/
+   `beginResetModel`/`endResetModel` as the model drains events. It never
+   forwards to a live store read. `getRows` is a pure data fetch; a reply whose
+   `epoch` does not match the model's current epoch is discarded and re-fetched
+   after pending events drain. This preserves Qt's "row count changes only
+   between begin/end" contract across the synchronous-down / asynchronous-up
+   boundary.
+2. **Identity is `(hash, idx)`, not `(txid, vout)`.** Selection and
+   `focusTransaction` re-resolution use the row's `(hash, idx)`; `internalPointer`
+   is never used to carry a `TransactionRecord*` (it dangles across vector
+   reallocation — established in PR #3003).
+
+## The contract (IPC-shaped, in-process)
+
+Value-typed and pointer-free across the view↔model boundary, so the
+multiprocess split is a mechanical transport swap. `TransactionRecord` is
+already marshalable (no `QString`/`QVariant` members); a `static_assert` guards
+that against a future Qt-typed field.
+
+### Down-channel (producer → consumer)
+
+Rides the existing `WalletEventQueue` unchanged in transport; only the payload
+variant grows. Every payload carries `viewId` + `epoch`:
+
+```cpp
+struct RowsResetPayload       { int viewId; int total_count; uint64_t epoch; };
+struct RowCountChangedPayload { int viewId; int total_count; uint64_t epoch; };
+struct RowsChangedPayload     { int viewId; int first; int last; uint64_t epoch;
+                                std::vector<TransactionRecord> records; };
+struct RowsInsertedPayload    { int viewId; int position; uint64_t epoch;
+                                std::vector<TransactionRecord> records; };
+struct RowsRemovedPayload     { int viewId; int position; int count; uint64_t epoch; };
+struct ChainTipChangedPayload { int height; int64_t best_time; };  // retained: balance hint only
+```
+
+`TxAddedPayload` / `TxRemovedPayload` (the PR #2944 payloads) are retired once
+both consumers are migrated.
+
+### Up-channel (consumer → producer)
+
+In-process: direct synchronous methods on `WalletTxStore`, taking `cs_store`,
+returning by value. At Phase 4 each becomes a Cap'n Proto request — a mechanical
+lift.
+
+```cpp
+RowsResult getRows(int viewId, int first, int last) const;   // slice cache fill
+RowsResult getAllRows(int viewId) const;                     // CSV export + select-all copy
+RowDetail  getRowDetail(int viewId, int row) const;          // replaces describe(); double-click only
+void       setViewport(int viewId, int first, int last);     // visible range + prefetch margin; no core locks
+void       setSort(int viewId, int column, int order);
+void       setFilter(int viewId, FilterSpec spec);
+int        rowForKey(int viewId, uint256 hash, int idx) const;  // selection / focus re-resolution
+```
+
+`FilterSpec` and the sort/field projections live in the Qt-free
+`src/qt/txfilter.h` (see step 1). Localization stays GUI-process-side: the
+cursor carries a GUI-supplied `type`/`address` sort string and `RowDetail` is
+rendered consumer-side, so the node never localizes — the one place
+"mechanical transport swap" carries an asterisk.
+
+## The PR ladder
+
+The windowed model is reached through a sequence of independently-correct,
+none-throwaway, reviewable pull requests. The phasing exists for **risk
+control** (reviewability and bisectability of battle-tested multithreaded GUI
+code), not for intermediate user-facing value — intermediate states are not
+expected to run for an appreciable time. Each step keeps the table fully
+working on its own.
+
+| PR | Scope | Risk |
+|----|-------|------|
+| **1** | Qt-free `txfilter.{h,cpp}` (`FilterSpec` / `Accepts` / `Less`, exact ports) + GUI-OFF unit suite; `TransactionFilterProxy` collapses its members into one `FilterSpec` and delegates `filterAcceptsRow` to `Accepts()`. Sort still via Qt `EditRole`. **Zero GUI behavior change.** | Low |
+| **2** | Relocate the cached wallet into a producer-owned `GRC::WalletTxStore` (`cs_store` leaf lock); `TransactionTableModel` becomes a thin full passthrough; the proxy is unchanged on top. The producer emits `RowsInserted`/`RowsRemoved` with producer-computed positions. `rowCount` becomes event-driven. | Med-high (new lock) |
+| **3** | Per-view `Cursor` infrastructure + `Rows*`/`RowsReset` events; producer-side O(viewport) status refresh on tip-advance and the `CT_UPDATED` reposition/membership-flip correctness. Migrate **OverviewPage** off its proxy to a cursor-bound model (the easy consumer — limit ≈ viewport, no scroll path). | Med |
+| **4** | Migrate **TransactionView** off its proxy to a cursor-bound model; **delete `TransactionFilterProxy`**; wire header-click sort → `setSort`, the filter widgets → `setFilter`, `focusTransaction` → `rowForKey`, CSV export + select-all → `getAllRows`, selection re-resolution by `(hash, idx)`. Remove the `updateConfirmations` sledgehammer. Still full-materialized. | Med-high |
+| **5** | Windowing: the model holds only a slice cache + margin; `data()` on a miss returns a placeholder and schedules `setViewport` + async `getRows`; status refresh moves fully producer-side; delete `index()`'s Qt-thread `TRY_LOCK`+`updateStatus` and `describe()`'s `LOCK2` (replaced by `getRowDetail`). | **High** (the irreducible multithreaded-GUI concentration) |
+| **6** | Off-Qt-thread progressive startup decompose: the `O(N)` decompose moves to a chunked background core task; the table opens at row count 0 and paints progressively. Order-flexible after PR 2. | Med |
+
+PR 2's full-passthrough model mode is the one mild staging artifact (a thin
+`rowCount`/`data` forwarding superseded by cursor binding in PR 4); it is
+justified to isolate the store relocation from the cursor change.
+
+## Deliberate divergences
+
+### Bitcoin Core as input, not default
+
+Bitcoin Core emits the same whole-model `dataChanged` sledgehammer in its
+`updateConfirmations` equivalent and has never viewport-scoped it; its scaling
+story for large wallets is "use the daemon." That does not fit Gridcoin's
+researcher-with-a-large-wallet GUI use case, so this windowed model is a
+deliberate, documented divergence rather than a port. Where the design keeps
+upstream patterns (the lazy `updateStatus` block-hash staleness check; the
+decomposition model), it is because they are sound, not by default.
+
+### ASCII case folding in filter and sort string comparison
+
+The Qt-free core compares strings using ASCII case folding rather than Qt's
+Unicode-aware `Qt::CaseInsensitive`, in two places:
+
+- `Accepts()` matches the address/label search substring (`IContains`).
+- `Less()` orders the string sort columns — `Status`, `Type`, `Address`
+  (`ICompare`).
+
+This is identical to Qt for base58 addresses, ASCII labels, and the ASCII
+`Status` sort key. It can differ only for case-insensitive handling of
+**non-ASCII** characters — i.e. a non-ASCII character in a label search
+(`Accepts`), or in the localized `Type` string when sorting by Type in a
+locale whose translated type names contain non-ASCII characters (`Less`). The
+`Address` column is base58 (ASCII) so its sort never diverges.
+
+The live exposure differs by step. In step 1 only `Accepts()` is wired, so the
+only live divergence is the label-search edge; sorting still goes through Qt's
+`EditRole` and remains Unicode-aware. `Less()` becomes the live comparator only
+when `TransactionView` is migrated off the proxy (step 4). At that point we
+revisit whether ASCII folding is acceptable for the `Type` column or whether
+the GUI — which already supplies the localized `type`/`address` sort strings,
+keeping localization GUI-process-side — should also supply a locale-aware
+collation key so the comparator stays Qt-faithful without the core gaining a
+Qt dependency. Until then the divergence is unit-test-only for `Less()`.
+
+Centralizing both predicates in one Qt-free, unit-tested module is worth this
+documented, sub-cosmetic edge.
+
+## Risks
+
+- **`cs_store` is a new leaf lock** on a path that is Qt-thread-exclusive today.
+  Producer mutations and one-time re-sorts under `setSort`/`setFilter` block the
+  Qt thread's `getRows` for the hold duration; mitigated by copy-out-only reads
+  and audited hold windows. The lock-order invariant
+  (`cs_main → cs_wallet → cs_store`, never nested the other way) is mandatory.
+- **`Status`-sort global correctness**: first-confirmation and reorg must
+  reposition the affected row in every cursor's `view_index` including
+  off-viewport and flip `Conflicted`/`NotAccepted` membership. OverviewPage
+  defaults to `Status` DESC, so this is exercised constantly.
+- **Windowing (PR 5)** concentrates the irreducible risk: precise
+  `begin`/`endInsertRows` across the viewport boundary for uncached rows, epoch
+  reconciliation between async `getRows` replies and up-channel events, and
+  prefetch-margin handling.
+- **GUI-OFF CI cannot exercise the model shell or event wiring** — the blind
+  spot that let PR #2944's heap corruption escape CI. Every model-touching PR
+  carries a mandatory ASan/UBSan-GUI + isolated-testnet validation burden that
+  decomposition does not reduce. PR 1 is structured specifically to land the
+  trickiest predicate logic in the GUI-OFF configuration CI *can* exercise.
+
+## Test strategy
+
+- **Unit (offline, GUI-OFF)** — the Qt-free core compiles into `test_gridcoin`
+  with `ENABLE_GUI=OFF`. PR 1 covers every `Accepts()` predicate and every
+  `Less()` column/order with boundary cases. Later PRs add Qt-free tests for
+  the cursor maintenance core: `view_index` splice on insert/remove,
+  first-confirmation/reorg reposition across cursors (including off-viewport
+  membership flips), and limit-row eviction.
+- **Isolated-testnet manual** — the heavy stake-accreted and deliberately
+  fragmented wallets are the only way to hit the real paths: scroll past the
+  prefetch margin, header-click sort on each column, every filter widget +
+  search, date-range + display-limit toggles, reorg during view, new-tx insert
+  above/below viewport, selection survival across sort/filter reset, CSV export
+  + select-all copy, and label edits.
+- **ASan/UBSan-GUI smoke** — mandatory because GUI-OFF CI cannot catch the model
+  shell. Each model-touching PR (store relocation, proxy removal, windowing) is
+  driven through a full scroll/sort/filter/reorg pass on a large wallet under
+  the sanitizer GUI build (`RelWithDebInfo`), watching for use-after-free across
+  vector reallocation and across the viewport-boundary row operations. Thread-
+  safety annotations on `cs_store` are verified under clang with
+  `HAVE_CLANG_THREAD_SAFETY=1` (GCC silently no-ops them).
+
+## Phase 4 — multiprocess (deferred)
+
+Not in scope for this effort. The contract above is built strictly IPC-shaped
+so the split is a transport swap, not a redesign: the down-channel payloads and
+up-channel methods become Cap'n Proto messages, `WalletTxStore` becomes the
+node-side service body behind an `interfaces::` abstraction, and each GUI
+process holds only its viewport slice — at which point the memory-footprint win
+materializes. The `interfaces::` abstract layer and the Cap'n Proto schema are
+explicitly deferred to that work (tracked under the multiprocess RFC, #2937);
+this effort deliberately does not build the abstraction shell, because what
+matters for a clean split is the **shape of the calls underneath**, which this
+contract establishes.

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(gridcoinqt STATIC
     transactiondesc.cpp
     transactiondescdialog.cpp
     transactionfilterproxy.cpp
+    txfilter.cpp
     transactionrecord.cpp
     transactiontablemodel.cpp
     transactionview.cpp

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -2,11 +2,24 @@
 
 #include "transactiontablemodel.h"
 #include "transactionrecord.h"
+#include "txfilter.h"
 #include "util/system.h"
 
 #include <QDateTime>
 
-#include <cstdlib>
+#include <algorithm>
+
+// Guard the standalone (Qt-free) mirrors in txfilter.h against the authoritative
+// Qt-side enums so they can never silently drift.
+static_assert(GRC::TXSTATUS_CONFLICTED  == TransactionStatus::Conflicted,
+              "TXSTATUS_CONFLICTED mirror out of sync with TransactionStatus::Conflicted");
+static_assert(GRC::TXSTATUS_NOTACCEPTED == TransactionStatus::NotAccepted,
+              "TXSTATUS_NOTACCEPTED mirror out of sync with TransactionStatus::NotAccepted");
+static_assert(static_cast<int>(GRC::TXCOL_STATUS)  == static_cast<int>(TransactionTableModel::Status),    "TXCOL_STATUS mirror drift");
+static_assert(static_cast<int>(GRC::TXCOL_DATE)    == static_cast<int>(TransactionTableModel::Date),      "TXCOL_DATE mirror drift");
+static_assert(static_cast<int>(GRC::TXCOL_TYPE)    == static_cast<int>(TransactionTableModel::Type),      "TXCOL_TYPE mirror drift");
+static_assert(static_cast<int>(GRC::TXCOL_ADDRESS) == static_cast<int>(TransactionTableModel::ToAddress), "TXCOL_ADDRESS mirror drift");
+static_assert(static_cast<int>(GRC::TXCOL_AMOUNT)  == static_cast<int>(TransactionTableModel::Amount),    "TXCOL_AMOUNT mirror drift");
 
 // Earliest date that can be represented (far in the past)
 const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromSecsSinceEpoch(0);
@@ -16,43 +29,35 @@ const QDateTime TransactionFilterProxy::MAX_DATE = QDateTime::fromSecsSinceEpoch
 //Halford 1-2-2015
 TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     QSortFilterProxyModel(parent),
-    dateFrom(MIN_DATE),
-    dateTo(MAX_DATE),
-    addrPrefix(),
-    typeFilter(ALL_TYPES),
-    minAmount(0),
-    limitRows(-1),
-    showInactive(true)
+    m_spec()
 {
+    // The spec defaults already reproduce the prior initial state (all dates,
+    // ALL_TYPES, no address filter, min_amount 0, unlimited, show_inactive
+    // true). The one runtime input is -showorphans, read once here. The
+    // original read it via gArgs on every filterAcceptsRow call; reading it
+    // once at construction is behavior-identical because -showorphans is a
+    // launch-time argument with no runtime mutation path (no GUI/RPC code
+    // calls ForceSetArg/SoftSetArg on it), so its value is fixed for the
+    // process lifetime.
+    m_spec.show_orphans = gArgs.GetBoolArg("-showorphans", false);
 }
 
 bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
 {
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
 
-    int type = index.data(TransactionTableModel::TypeRole).toInt();
-    QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
-    QString address = index.data(TransactionTableModel::AddressRole).toString();
-    QString label = index.data(TransactionTableModel::LabelRole).toString();
-    qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
-    int status = index.data(TransactionTableModel::StatusRole).toInt();
+    // Project the model roles into the Qt-free field set, then evaluate the
+    // shared predicate. AmountRole is the SIGNED net amount; Accepts() takes
+    // the absolute value itself.
+    GRC::TxFilterFields fields;
+    fields.type       = index.data(TransactionTableModel::TypeRole).toInt();
+    fields.time       = index.data(TransactionTableModel::DateRole).toDateTime().toSecsSinceEpoch();
+    fields.address    = index.data(TransactionTableModel::AddressRole).toString().toStdString();
+    fields.label      = index.data(TransactionTableModel::LabelRole).toString().toStdString();
+    fields.net_amount = index.data(TransactionTableModel::AmountRole).toLongLong();
+    fields.status     = index.data(TransactionTableModel::StatusRole).toInt();
 
-    if(!showInactive && (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted))
-        return false;
-    //1-2-2015 Halford - Mask Orphans from User View so they do not complain
-    if (!gArgs.GetBoolArg("-showorphans", false))
-        if (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted)
-            return false;
-    if(!(TYPE(type) & typeFilter))
-        return false;
-    if(datetime < dateFrom || datetime > dateTo)
-        return false;
-    if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
-        return false;
-    if(amount < minAmount)
-        return false;
-
-    return true;
+    return GRC::Accepts(fields, m_spec);
 }
 
 // Note that invalidateFilter() is just a deprecated alias for invalidate(), so these have been changed to invalidate()
@@ -61,51 +66,51 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
 
 void TransactionFilterProxy::setDateRange(const QDateTime &from, const QDateTime &to)
 {
-    this->dateFrom = from;
-    this->dateTo = to;
+    m_spec.date_from = from.toSecsSinceEpoch();
+    m_spec.date_to = to.toSecsSinceEpoch();
     invalidate();
 }
 
 void TransactionFilterProxy::setAddressPrefix(const QString &addrPrefix)
 {
-    this->addrPrefix = addrPrefix;
+    m_spec.address_substr = addrPrefix.toStdString();
     invalidate();
 }
 
 void TransactionFilterProxy::setTypeFilter(quint32 modes)
 {
-    this->typeFilter = modes;
+    m_spec.type_mask = modes;
     invalidate();
 }
 
 void TransactionFilterProxy::setMinAmount(qint64 minimum)
 {
-    this->minAmount = minimum;
+    m_spec.min_amount = minimum;
     invalidate();
 }
 
 void TransactionFilterProxy::setLimit(int limit)
 {
-    this->limitRows = limit;
+    m_spec.limit_rows = limit;
     invalidate();
 }
 
 int TransactionFilterProxy::getLimit()
 {
-    return this->limitRows;
+    return m_spec.limit_rows;
 }
 
 void TransactionFilterProxy::setShowInactive(bool showInactive)
 {
-    this->showInactive = showInactive;
+    m_spec.show_inactive = showInactive;
     invalidate();
 }
 
 int TransactionFilterProxy::rowCount(const QModelIndex &parent) const
 {
-    if(limitRows != -1)
+    if(m_spec.limit_rows != -1)
     {
-        return std::min(QSortFilterProxyModel::rowCount(parent), limitRows);
+        return std::min(QSortFilterProxyModel::rowCount(parent), static_cast<int>(m_spec.limit_rows));
     }
     else
     {

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -1,6 +1,8 @@
 #ifndef BITCOIN_QT_TRANSACTIONFILTERPROXY_H
 #define BITCOIN_QT_TRANSACTIONFILTERPROXY_H
 
+#include <qt/txfilter.h>
+
 #include <QSortFilterProxyModel>
 #include <QDateTime>
 
@@ -42,13 +44,14 @@ protected:
     bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const;
 
 private:
-    QDateTime dateFrom;
-    QDateTime dateTo;
-    QString addrPrefix;
-    quint32 typeFilter;
-    qint64 minAmount;
-    int limitRows;
-    bool showInactive;
+    // The scattered date/address/type/amount/limit/show-inactive members were
+    // collapsed into one value-typed GRC::FilterSpec, which is the parameter
+    // the view will push to the producer-side cursor in the windowed model.
+    // The setters below translate their Qt arguments into this spec; the
+    // per-row predicate is evaluated by the Qt-free GRC::Accepts(). show_orphans
+    // is read once from gArgs at construction (it is a launch arg, so this is
+    // equivalent to the original per-row read).
+    GRC::FilterSpec m_spec;
 
 signals:
 

--- a/src/qt/txfilter.cpp
+++ b/src/qt/txfilter.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "txfilter.h"
+
+#include <cstdlib>
+
+namespace {
+
+//! ASCII case fold. The original predicates use Qt::CaseInsensitive, which for
+//! the inputs that actually occur here — base58 addresses and ASCII labels —
+//! is exactly ASCII case folding. Non-ASCII bytes pass through unchanged; the
+//! only divergence from Qt's Unicode-aware folding is case-insensitive
+//! matching of non-ASCII characters in a label substring search, which is
+//! sub-cosmetic. (Sort comparison via Less() is not yet wired to the live
+//! sort in PR1 — the proxy still sorts via Qt EditRole — so any collation
+//! nuance there is exercised only by unit tests until a later PR.)
+std::string AsciiLower(const std::string& s)
+{
+    std::string out(s);
+    for (char& c : out) {
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    }
+    return out;
+}
+
+//! Case-insensitive substring test. Mirrors QString::contains(needle,
+//! Qt::CaseInsensitive): an empty needle matches everything.
+bool IContains(const std::string& haystack, const std::string& needle)
+{
+    if (needle.empty()) return true;
+    return AsciiLower(haystack).find(AsciiLower(needle)) != std::string::npos;
+}
+
+//! Case-insensitive lexicographic compare; sign matches std::string::compare.
+int ICompare(const std::string& a, const std::string& b)
+{
+    return AsciiLower(a).compare(AsciiLower(b));
+}
+
+} // anonymous namespace
+
+namespace GRC {
+
+bool Accepts(const TxFilterFields& f, const FilterSpec& s)
+{
+    // Mirrors TransactionFilterProxy::filterAcceptsRow (transactionfilterproxy.cpp).
+    // Two separate gates reject inactive rows, kept 1:1 with the original:
+    //   (1) the explicit show-inactive toggle, and
+    //   (2) the -showorphans launch-arg mask.
+    const bool inactive = (f.status == TXSTATUS_CONFLICTED || f.status == TXSTATUS_NOTACCEPTED);
+
+    if (!s.show_inactive && inactive) return false;
+    if (!s.show_orphans && inactive) return false;
+
+    if (!((1u << f.type) & s.type_mask)) return false;
+
+    if (f.time < s.date_from || f.time > s.date_to) return false;
+
+    if (!IContains(f.address, s.address_substr) && !IContains(f.label, s.address_substr)) {
+        return false;
+    }
+
+    if (std::llabs(f.net_amount) < s.min_amount) return false;
+
+    return true;
+}
+
+bool Less(const SortKey& a, const SortKey& b, int column, int order)
+{
+    // Three-way compare in ascending sense (<0 a before b, 0 equal, >0 after).
+    int cmp = 0;
+    switch (column) {
+    case TXCOL_DATE:
+        cmp = (a.time < b.time) ? -1 : (a.time > b.time ? 1 : 0);
+        break;
+    case TXCOL_AMOUNT:
+        cmp = (a.net_amount < b.net_amount) ? -1 : (a.net_amount > b.net_amount ? 1 : 0);
+        break;
+    case TXCOL_STATUS:
+        cmp = ICompare(a.status_sort_key, b.status_sort_key);
+        break;
+    case TXCOL_TYPE:
+        cmp = ICompare(a.type_string, b.type_string);
+        break;
+    case TXCOL_ADDRESS:
+        cmp = ICompare(a.address_string, b.address_string);
+        break;
+    default:
+        cmp = 0;
+        break;
+    }
+
+    // Strict-less in the requested order sense; equal keys -> false.
+    return (order == TXSORT_DESC) ? (cmp > 0) : (cmp < 0);
+}
+
+} // namespace GRC

--- a/src/qt/txfilter.h
+++ b/src/qt/txfilter.h
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_TXFILTER_H
+#define GRIDCOIN_QT_TXFILTER_H
+
+#include <cstdint>
+#include <string>
+
+//!
+//! \file txfilter.h
+//!
+//! Qt-free transaction-list filter/sort evaluation core.
+//!
+//! This is the first piece of the windowed transaction-table model (the
+//! design doc's "Phase 3"). It extracts the predicate logic that today lives
+//! inside TransactionFilterProxy::filterAcceptsRow() and the Qt::EditRole
+//! sort keys in TransactionTableModel::data() into a standalone, Qt-free
+//! module so that:
+//!
+//!   1. The trickiest logic gets unit-test coverage in the GUI-OFF build
+//!      configuration that CI actually exercises (the blind spot that hid
+//!      PR #2944's heap corruption).
+//!   2. The same evaluator is consumed by the producer-side per-view cursors
+//!      in later PRs (server-side filter/sort), once the client
+//!      QSortFilterProxyModel is retired.
+//!
+//! Deliberately contains NO Qt headers: it compiles into test_gridcoin with
+//! ENABLE_GUI=OFF. The FilterSpec value type is the parameter the GUI pushes
+//! down to the producer cursor (Phase 3) and that marshals over IPC unchanged
+//! (Phase 4) — value-typed, pointer-free, optimize-for-the-wire.
+//!
+
+namespace GRC {
+
+//!
+//! \brief Column indices, a standalone mirror of
+//! TransactionTableModel::ColumnIndex.
+//!
+//! Kept here (rather than including the Qt model header) so this translation
+//! unit stays Qt-free. transactionfilterproxy.cpp static_asserts these against
+//! the authoritative Qt-side enum so they cannot drift.
+//!
+enum TxSortColumn {
+    TXCOL_STATUS  = 0,
+    TXCOL_DATE    = 1,
+    TXCOL_TYPE    = 2,
+    TXCOL_ADDRESS = 3,
+    TXCOL_AMOUNT  = 4,
+};
+
+//!
+//! \brief The two TransactionStatus::Status values the filter treats as
+//! "inactive" (conflicted / not accepted).
+//!
+//! Mirror of the Qt-side enum; transactionfilterproxy.cpp static_asserts these
+//! against TransactionStatus::Conflicted / NotAccepted so they cannot drift.
+//!
+constexpr int TXSTATUS_CONFLICTED  = 6;
+constexpr int TXSTATUS_NOTACCEPTED = 9;
+
+//!
+//! \brief Sort order, a mirror of Qt::AscendingOrder (0) / Qt::DescendingOrder (1).
+//!
+enum TxSortOrder {
+    TXSORT_ASC  = 0,
+    TXSORT_DESC = 1,
+};
+
+//!
+//! \brief Serializable filter specification.
+//!
+//! The value-typed parameter the view pushes down to the producer-side cursor
+//! (Phase 3) and that marshals over IPC unchanged (Phase 4). Defaults reproduce
+//! TransactionFilterProxy's initial state: all dates, all types, no address
+//! filter, no minimum amount, unlimited rows, show everything including
+//! orphans-as-configured.
+//!
+struct FilterSpec {
+    //! Inclusive lower bound, seconds since epoch. Default 0 == MIN_DATE.
+    int64_t date_from = 0;
+    //! Inclusive upper bound, seconds since epoch. Default 0xFFFFFFFF == MAX_DATE.
+    int64_t date_to = 0xFFFFFFFF;
+    //! Bit field of (1u << TransactionRecord::Type). Default 0xFFFFFFFF == ALL_TYPES.
+    uint32_t type_mask = 0xFFFFFFFF;
+    //! Case-insensitive substring matched against the address OR the label.
+    //! Empty matches everything.
+    std::string address_substr;
+    //! Compared against llabs(net_amount): a row is rejected if its absolute
+    //! net amount is below this.
+    int64_t min_amount = 0;
+    //! Maximum rows the view exposes, -1 == unlimited. NOT a per-row predicate
+    //! (Accepts() ignores it); applied as a post-filter count cap by the
+    //! consumer (today TransactionFilterProxy::rowCount, later the cursor).
+    int32_t limit_rows = -1;
+    //! Show Conflicted / NotAccepted rows.
+    bool show_inactive = true;
+    //! The -showorphans launch arg. When false, Conflicted / NotAccepted rows
+    //! are masked regardless of show_inactive (mirrors the original two-gate
+    //! logic in filterAcceptsRow).
+    bool show_orphans = false;
+};
+
+//!
+//! \brief The per-row fields the filter predicate reads.
+//!
+//! The producer projects a TransactionRecord (+ address-book label) into this
+//! in later PRs; in PR1 TransactionFilterProxy builds it from the model roles
+//! it already reads.
+//!
+struct TxFilterFields {
+    //! rec.time, seconds since epoch.
+    int64_t time = 0;
+    //! rec.credit + rec.debit, SIGNED net amount (Accepts() takes the abs).
+    int64_t net_amount = 0;
+    //! TransactionRecord::Type.
+    int type = 0;
+    //! TransactionStatus::Status.
+    int status = 0;
+    //! rec.address.
+    std::string address;
+    //! Address-book label for rec.address (may be empty).
+    std::string label;
+};
+
+//!
+//! \brief The per-row keys the sort comparator reads.
+//!
+//! type_string / address_string are the localized, GUI-formatted strings
+//! (formatTxType / formatTxToAddress(..., /*tooltip=*/true)) supplied by the
+//! GUI, so this module never localizes — keeping localization GUI-process-side
+//! across the eventual multiprocess split. status_sort_key is rec.status.sortKey.
+//!
+struct SortKey {
+    int64_t time = 0;
+    int64_t net_amount = 0;
+    std::string status_sort_key;
+    std::string type_string;
+    std::string address_string;
+};
+
+//!
+//! \brief Exact port of TransactionFilterProxy::filterAcceptsRow.
+//!
+//! \return true if the row passes the filter and should be shown.
+//!
+bool Accepts(const TxFilterFields& fields, const FilterSpec& spec);
+
+//!
+//! \brief Exact port of the Qt::EditRole sort-key comparison.
+//!
+//! The proxy sorts on Qt::EditRole with case-insensitive string comparison.
+//! Returns true if \p a sorts strictly before \p b for the given \p column
+//! and \p order. Equal keys return false (a strict weak ordering).
+//!
+//! \param column One of TxSortColumn.
+//! \param order  One of TxSortOrder.
+//!
+bool Less(const SortKey& a, const SortKey& b, int column, int order);
+
+} // namespace GRC
+
+#endif // GRIDCOIN_QT_TXFILTER_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -47,6 +47,12 @@ add_executable(test_gridcoin
     net_tests.cpp
     orphan_block_tests.cpp
     psgt_tests.cpp
+    # Qt-free transaction filter/sort core (src/qt/txfilter.cpp) + its unit
+    # suite. The core has zero Qt dependencies, so it compiles into the
+    # GUI-OFF test binary directly — landing the GUI predicate logic in the
+    # one configuration CI exercises.
+    ${CMAKE_SOURCE_DIR}/src/qt/txfilter.cpp
+    qt_txfilter_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/qt_txfilter_tests.cpp
+++ b/src/test/qt_txfilter_tests.cpp
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF unit coverage for the Qt-free transaction filter/sort core
+// (src/qt/txfilter.{h,cpp}). This is the logic that today lives inside
+// TransactionFilterProxy::filterAcceptsRow() and the Qt::EditRole sort keys;
+// extracting and testing it here lands the trickiest GUI predicate logic in
+// the configuration CI actually exercises (ENABLE_GUI=OFF) — the blind spot
+// that hid PR #2944's heap corruption.
+
+#include <qt/txfilter.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+using namespace GRC;
+
+namespace {
+// A fields projection that PASSES the default (no-op) filter, so each test can
+// flip exactly one dimension and assert the consequence in isolation.
+TxFilterFields DefaultPassingRow()
+{
+    TxFilterFields f;
+    f.time = 1'600'000'000;   // mid-range timestamp
+    f.net_amount = 5 * 100000000LL;
+    f.type = 1;               // TransactionRecord::Generated (a normal, non-zero type)
+    f.status = 0;             // TransactionStatus::Confirmed (active)
+    f.address = "S1ExampleGridcoinAddress1111111111";
+    f.label = "Donations";
+    return f;
+}
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(qt_txfilter_tests)
+
+// ---- Accepts(): default spec passes a normal row -------------------------
+
+BOOST_AUTO_TEST_CASE(accepts_default_spec_passes)
+{
+    BOOST_CHECK(Accepts(DefaultPassingRow(), FilterSpec{}));
+}
+
+// ---- Accepts(): inactive (Conflicted / NotAccepted) gating ---------------
+
+BOOST_AUTO_TEST_CASE(accepts_inactive_gating)
+{
+    FilterSpec spec; // defaults: show_inactive=true, show_orphans=false
+
+    TxFilterFields conflicted = DefaultPassingRow();
+    conflicted.status = TXSTATUS_CONFLICTED;
+    TxFilterFields notaccepted = DefaultPassingRow();
+    notaccepted.status = TXSTATUS_NOTACCEPTED;
+
+    // Original logic rejects inactive rows when (!show_inactive || !show_orphans).
+    // Default spec has show_orphans=false, so inactive rows are masked even
+    // though show_inactive defaults true — mirroring the two-gate original.
+    BOOST_CHECK(!Accepts(conflicted, spec));
+    BOOST_CHECK(!Accepts(notaccepted, spec));
+
+    // Both gates open => inactive rows pass.
+    spec.show_orphans = true;
+    spec.show_inactive = true;
+    BOOST_CHECK(Accepts(conflicted, spec));
+    BOOST_CHECK(Accepts(notaccepted, spec));
+
+    // show_inactive closed masks them regardless of show_orphans.
+    spec.show_inactive = false;
+    BOOST_CHECK(!Accepts(conflicted, spec));
+    BOOST_CHECK(!Accepts(notaccepted, spec));
+
+    // show_orphans closed masks them regardless of show_inactive.
+    spec.show_inactive = true;
+    spec.show_orphans = false;
+    BOOST_CHECK(!Accepts(conflicted, spec));
+    BOOST_CHECK(!Accepts(notaccepted, spec));
+
+    // An ACTIVE status is never masked by either gate.
+    TxFilterFields active = DefaultPassingRow();
+    active.status = 0; // Confirmed
+    spec.show_inactive = false;
+    spec.show_orphans = false;
+    BOOST_CHECK(Accepts(active, spec));
+}
+
+// ---- Accepts(): type bit mask --------------------------------------------
+
+BOOST_AUTO_TEST_CASE(accepts_type_mask)
+{
+    TxFilterFields row = DefaultPassingRow();
+
+    for (int t = 0; t < 12; ++t) {
+        row.type = t;
+        FilterSpec only_this; only_this.type_mask = (1u << t);
+        FilterSpec all_but_this; all_but_this.type_mask = ~(1u << t);
+
+        BOOST_TEST_CONTEXT("type " << t) {
+            BOOST_CHECK(Accepts(row, only_this));
+            BOOST_CHECK(!Accepts(row, all_but_this));
+            BOOST_CHECK(Accepts(row, FilterSpec{})); // ALL_TYPES default
+        }
+    }
+}
+
+// ---- Accepts(): date range inclusivity -----------------------------------
+
+BOOST_AUTO_TEST_CASE(accepts_date_range_boundaries)
+{
+    TxFilterFields row = DefaultPassingRow();
+    row.time = 1000;
+
+    FilterSpec spec;
+    spec.date_from = 1000;
+    spec.date_to = 2000;
+
+    // Inclusive on both ends.
+    row.time = 1000; BOOST_CHECK(Accepts(row, spec));   // == from
+    row.time = 2000; BOOST_CHECK(Accepts(row, spec));   // == to
+    row.time = 1500; BOOST_CHECK(Accepts(row, spec));   // inside
+    row.time = 999;  BOOST_CHECK(!Accepts(row, spec));  // below from
+    row.time = 2001; BOOST_CHECK(!Accepts(row, spec));  // above to
+}
+
+// ---- Accepts(): address OR label substring, case-insensitive -------------
+
+BOOST_AUTO_TEST_CASE(accepts_address_or_label_substring)
+{
+    TxFilterFields row = DefaultPassingRow();
+    row.address = "S1AbCdEfGh";
+    row.label = "Coffee Fund";
+
+    auto with = [](const std::string& s){ FilterSpec f; f.address_substr = s; return f; };
+
+    // Address match (case-insensitive substring, not prefix).
+    BOOST_CHECK(Accepts(row, with("abcd")));
+    BOOST_CHECK(Accepts(row, with("CDEF")));
+    BOOST_CHECK(Accepts(row, with("S1ABCDEFGH")));
+    // Label match (case-insensitive substring).
+    BOOST_CHECK(Accepts(row, with("coffee")));
+    BOOST_CHECK(Accepts(row, with("FUND")));
+    BOOST_CHECK(Accepts(row, with("ee fu")));
+    // Neither matches.
+    BOOST_CHECK(!Accepts(row, with("zzz")));
+    // Empty substring matches everything (mirrors QString::contains("")).
+    BOOST_CHECK(Accepts(row, with("")));
+
+    // Match must be against address OR label independently.
+    TxFilterFields no_label = DefaultPassingRow();
+    no_label.address = "S1OnlyAddr";
+    no_label.label.clear();
+    BOOST_CHECK(Accepts(no_label, with("onlyaddr")));
+    BOOST_CHECK(!Accepts(no_label, with("nonexistent")));
+}
+
+// ---- Accepts(): min amount on absolute net value -------------------------
+
+BOOST_AUTO_TEST_CASE(accepts_min_amount_uses_abs)
+{
+    FilterSpec spec;
+    spec.min_amount = 3 * 100000000LL;
+
+    TxFilterFields pos = DefaultPassingRow();
+    pos.net_amount = 5 * 100000000LL;
+    BOOST_CHECK(Accepts(pos, spec));        // 5 >= 3
+
+    pos.net_amount = 2 * 100000000LL;
+    BOOST_CHECK(!Accepts(pos, spec));       // 2 < 3
+
+    // Negative net amounts are compared by absolute value (llabs), so a -5 GRC
+    // send passes a 3 GRC minimum just like a +5 GRC receive.
+    TxFilterFields neg = DefaultPassingRow();
+    neg.net_amount = -5 * 100000000LL;
+    BOOST_CHECK(Accepts(neg, spec));        // |-5| = 5 >= 3
+    neg.net_amount = -2 * 100000000LL;
+    BOOST_CHECK(!Accepts(neg, spec));       // |-2| = 2 < 3
+
+    // Boundary: exactly equal passes (>= not >).
+    TxFilterFields eq = DefaultPassingRow();
+    eq.net_amount = 3 * 100000000LL;
+    BOOST_CHECK(Accepts(eq, spec));
+}
+
+// ---- Accepts(): a non-trivial AND of several dimensions ------------------
+
+BOOST_AUTO_TEST_CASE(accepts_combined_predicates)
+{
+    TxFilterFields row = DefaultPassingRow();
+    row.type = 2;
+    row.time = 1500;
+    row.net_amount = 10 * 100000000LL;
+    row.address = "S1Combined";
+    row.label = "Rent";
+
+    FilterSpec spec;
+    spec.type_mask = (1u << 2);
+    spec.date_from = 1000; spec.date_to = 2000;
+    spec.min_amount = 1 * 100000000LL;
+    spec.address_substr = "rent";
+
+    BOOST_CHECK(Accepts(row, spec));
+
+    // Flip each dimension out of range; each alone must reject.
+    { auto s = spec; s.type_mask = (1u << 3); BOOST_CHECK(!Accepts(row, s)); }
+    { auto s = spec; s.date_to = 1400;        BOOST_CHECK(!Accepts(row, s)); }
+    { auto s = spec; s.min_amount = 100 * 100000000LL; BOOST_CHECK(!Accepts(row, s)); }
+    { auto s = spec; s.address_substr = "zzz"; BOOST_CHECK(!Accepts(row, s)); }
+}
+
+// ---- Less(): numeric columns (Date, Amount) ------------------------------
+
+BOOST_AUTO_TEST_CASE(less_numeric_columns)
+{
+    SortKey a; a.time = 100; a.net_amount = -50;
+    SortKey b; b.time = 200; b.net_amount = 50;
+
+    // Date ascending: a(100) < b(200)
+    BOOST_CHECK( Less(a, b, TXCOL_DATE, TXSORT_ASC));
+    BOOST_CHECK(!Less(b, a, TXCOL_DATE, TXSORT_ASC));
+    // Date descending inverts.
+    BOOST_CHECK(!Less(a, b, TXCOL_DATE, TXSORT_DESC));
+    BOOST_CHECK( Less(b, a, TXCOL_DATE, TXSORT_DESC));
+
+    // Amount is signed: -50 < 50 ascending.
+    BOOST_CHECK( Less(a, b, TXCOL_AMOUNT, TXSORT_ASC));
+    BOOST_CHECK( Less(b, a, TXCOL_AMOUNT, TXSORT_DESC));
+
+    // Equal keys -> false in both orders (strict weak ordering), for both
+    // numeric columns.
+    SortKey c; c.time = 100; c.net_amount = 42;
+    SortKey d; d.time = 100; d.net_amount = 42;
+    BOOST_CHECK(!Less(c, d, TXCOL_DATE, TXSORT_ASC));
+    BOOST_CHECK(!Less(c, d, TXCOL_DATE, TXSORT_DESC));
+    BOOST_CHECK(!Less(c, d, TXCOL_AMOUNT, TXSORT_ASC));
+    BOOST_CHECK(!Less(c, d, TXCOL_AMOUNT, TXSORT_DESC));
+}
+
+// ---- Less(): string columns (Status, Type, Address), case-insensitive ----
+
+BOOST_AUTO_TEST_CASE(less_string_columns_case_insensitive)
+{
+    SortKey a, b;
+    a.status_sort_key = "001"; b.status_sort_key = "002";
+    BOOST_CHECK( Less(a, b, TXCOL_STATUS, TXSORT_ASC));
+    BOOST_CHECK( Less(b, a, TXCOL_STATUS, TXSORT_DESC));
+    // Equal status key -> false in both orders (strict weak ordering).
+    SortKey sa, sb;
+    sa.status_sort_key = "007"; sb.status_sort_key = "007";
+    BOOST_CHECK(!Less(sa, sb, TXCOL_STATUS, TXSORT_ASC));
+    BOOST_CHECK(!Less(sa, sb, TXCOL_STATUS, TXSORT_DESC));
+
+    SortKey ta, tb;
+    ta.type_string = "apple"; tb.type_string = "Banana";
+    // Case-insensitive: "apple" < "banana" even though 'B' < 'a' in ASCII.
+    BOOST_CHECK( Less(ta, tb, TXCOL_TYPE, TXSORT_ASC));
+    BOOST_CHECK(!Less(tb, ta, TXCOL_TYPE, TXSORT_ASC));
+    // Case-insensitively equal type string -> false in both orders.
+    SortKey tc, td;
+    tc.type_string = "Mined - PoS"; td.type_string = "mined - pos";
+    BOOST_CHECK(!Less(tc, td, TXCOL_TYPE, TXSORT_ASC));
+    BOOST_CHECK(!Less(tc, td, TXCOL_TYPE, TXSORT_DESC));
+
+    SortKey aa, ab;
+    aa.address_string = "ABC"; ab.address_string = "abc";
+    // Case-insensitively equal -> false in both orders.
+    BOOST_CHECK(!Less(aa, ab, TXCOL_ADDRESS, TXSORT_ASC));
+    BOOST_CHECK(!Less(ab, aa, TXCOL_ADDRESS, TXSORT_ASC));
+    BOOST_CHECK(!Less(aa, ab, TXCOL_ADDRESS, TXSORT_DESC));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

First step of the windowed transaction-table model (the follow-on to PR #2944's event-queue work and the PR #3003 container/ordering swap). It extracts the filter predicate (`TransactionFilterProxy::filterAcceptsRow`) and the `Qt::EditRole` sort keys into a **standalone, Qt-free module** `src/qt/txfilter.{h,cpp}`:

- **`FilterSpec`** — serializable, value-typed filter parameters. This is the contract the view will push down to a producer-side cursor in a later step, and that marshals over IPC unchanged in the eventual multiprocess split (optimize-for-the-wire: value types, pointer-free).
- **`TxFilterFields`** / **`SortKey`** — the per-row fields the predicate / comparator read.
- **`Accepts()`** — exact port of `filterAcceptsRow`.
- **`Less()`** — exact port of the `EditRole` sort comparison.

`TransactionFilterProxy` collapses its seven scattered members (`dateFrom`/`dateTo`/`addrPrefix`/`typeFilter`/`minAmount`/`limitRows`/`showInactive`) into one `GRC::FilterSpec` and routes `filterAcceptsRow` through `Accepts()`. Its public setter/getter API and `rowCount` limit semantics are unchanged, so `TransactionView`/`OverviewPage` need no changes. Sorting still goes through Qt's `EditRole` this step — `Less()` is unit-tested but not yet wired to the live sort.

`static_assert`s in `transactionfilterproxy.cpp` guard the module's Qt-free enum mirrors (`TXSTATUS_CONFLICTED/NOTACCEPTED`, `TXCOL_*`) against the authoritative `TransactionStatus`/`TransactionTableModel::ColumnIndex` enums so they can never silently drift.

## Design of record

This PR also adds **`doc/transaction_table_windowed_model.md`**, the design of record for the entire windowed-model effort. It describes the endpoint architecture (producer-owned `WalletTxStore` + per-view server-side cursors + thin windowed consumer models, with the client `QSortFilterProxyModel` retired), the resolved design decisions (full-records authoritative store and why a reduced-key store is rejected on status-correctness grounds; the virtual-model pattern rather than `canFetchMore`/`fetchMore`; anchor-invariance bounding tip refresh to the viewport), the IPC-shaped value-typed contract, the **six-PR risk-bounded ladder** this PR is step 1 of, the deliberate divergences, the risk register, the test strategy, and the Phase-4 multiprocess deferral. Read it for the full scope; this PR implements only step 1.

## Why this is step 1

It is **behavior-preserving** (the running GUI is unchanged) and it lands the trickiest GUI predicate logic in the **`ENABLE_GUI=OFF`** configuration that CI actually exercises — directly addressing the GUI-off blind spot that let PR #2944's heap corruption escape CI. The module is the exact evaluator the producer-side cursors consume when sort/filter move server-side and the client proxy is retired in subsequent steps; nothing here is throwaway.

## Tests

New GUI-off Boost suite `src/test/qt_txfilter_tests.cpp` (compiled into `test_gridcoin`), 9 cases covering:
- both inactive gates independently (`show_inactive` vs `show_orphans`) + active-status-never-masked
- every type bit + the all-types default
- inclusive date range on both boundaries
- address-OR-label case-insensitive substring, empty-needle-matches-all
- `min_amount` on the absolute net value (incl. negative) + the `>=` boundary
- `Less()` for all five columns in both orders + equal-key strict-weak-ordering (Date, Amount, Status, Type, Address)

All pass; full `test_gridcoin` suite green; clean build with no new warnings (Qt6, RelWithDebInfo).

## One deliberate, documented divergence

The address/label substring match uses ASCII case folding rather than Qt's Unicode-aware `Qt::CaseInsensitive`. Identical for base58 addresses and ASCII labels; differs only for case-insensitive matching of **non-ASCII** characters within a label search — sub-cosmetic, and noted in `txfilter.cpp`.

## Review note

This was self-reviewed via a multi-agent adversarial port-fidelity pass (each of the 6 predicates + 5 sort keys checked 1:1 against the original lines). Verdict: behavior-preserving, no blockers; the surfaced items were unit-test coverage gaps (equal-key assertions, a missing `NotAccepted` case) which are folded into the suite above.

Part of the windowed-model effort tracked under #2944 / the tx-table redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
