### PR TITLE
qt: relocate cached-wallet ordering into a producer-owned WalletTxStore (windowed-model step 2, #2944)

### DIFF
--- a/doc/transaction_table_windowed_model.md
+++ b/doc/transaction_table_windowed_model.md
@@ -93,6 +93,16 @@ existing `updateStatus(wtx)` under `cs_main`+`cs_wallet`. It is guarded by a
 *before* taking `cs_store`; where both are needed the order is
 `cs_main → cs_wallet → cs_store`.
 
+This describes the store once it *serves reads*. In the relocation step (step 2
+below) the store does not yet serve reads — the consumer keeps its own full
+replica and the producer only stamps positions — so the store holds **ordering
+keys only** (`TxOrderKey` + the hash index), not full records; materializing
+records there would merely double resident memory. It grows to the full
+`records[]` + `TransactionStatus` form above in the windowing step (step 5),
+when the consumer drops its replica for a viewport slice and begins reading the
+store. The status-correctness rationale below is precisely what dictates *full
+records once the store serves reads*.
+
 Two alternatives were considered and rejected as the primary store:
 
 - **Reduced order-key store + lazy per-window decompose** would yield an
@@ -240,15 +250,17 @@ working on its own.
 | PR | Scope | Risk |
 |----|-------|------|
 | **1** | Qt-free `txfilter.{h,cpp}` (`FilterSpec` / `Accepts` / `Less`, exact ports) + GUI-OFF unit suite; `TransactionFilterProxy` collapses its members into one `FilterSpec` and delegates `filterAcceptsRow` to `Accepts()`. Sort still via Qt `EditRole`. **Zero GUI behavior change.** | Low |
-| **2** | Relocate the cached wallet into a producer-owned `GRC::WalletTxStore` (`cs_store` leaf lock); `TransactionTableModel` becomes a thin full passthrough; the proxy is unchanged on top. The producer emits `RowsInserted`/`RowsRemoved` with producer-computed positions. `rowCount` becomes event-driven. | Med-high (new lock) |
+| **2** | Relocate the cached-wallet **ordering** into a producer-owned `GRC::WalletTxStore` (key-only; `cs_store` leaf lock). The producer computes positions and emits `RowsInserted{position,records}`/`RowsRemoved{position,count}`; `TransactionTableModel` keeps its own Qt-thread-exclusive replica and applies the events at the stamped position in lockstep — it never reads the store on the render path, which keeps the unchanged proxy consistent across a multi-insert batch. `rowCount` is the replica's size (event-driven). | Med-high (new lock) |
 | **3** | Per-view `Cursor` infrastructure + `Rows*`/`RowsReset` events; producer-side O(viewport) status refresh on tip-advance and the `CT_UPDATED` reposition/membership-flip correctness. Migrate **OverviewPage** off its proxy to a cursor-bound model (the easy consumer — limit ≈ viewport, no scroll path). | Med |
 | **4** | Migrate **TransactionView** off its proxy to a cursor-bound model; **delete `TransactionFilterProxy`**; wire header-click sort → `setSort`, the filter widgets → `setFilter`, `focusTransaction` → `rowForKey`, CSV export + select-all → `getAllRows`, selection re-resolution by `(hash, idx)`. Remove the `updateConfirmations` sledgehammer. Still full-materialized. | Med-high |
 | **5** | Windowing: the model holds only a slice cache + margin; `data()` on a miss returns a placeholder and schedules `setViewport` + async `getRows`; status refresh moves fully producer-side; delete `index()`'s Qt-thread `TRY_LOCK`+`updateStatus` and `describe()`'s `LOCK2` (replaced by `getRowDetail`). | **High** (the irreducible multithreaded-GUI concentration) |
 | **6** | Off-Qt-thread progressive startup decompose: the `O(N)` decompose moves to a chunked background core task; the table opens at row count 0 and paints progressively. Order-flexible after PR 2. | Med |
 
-PR 2's full-passthrough model mode is the one mild staging artifact (a thin
-`rowCount`/`data` forwarding superseded by cursor binding in PR 4); it is
-justified to isolate the store relocation from the cursor change.
+PR 2's consumer-side replica is the one transient: a full replica fed by
+position-stamped events, kept (rather than reading the store directly) so the
+unchanged proxy stays consistent during a multi-insert drain. It shrinks to a
+viewport slice in the windowing step (PR 5); nothing is discarded, only
+narrowed.
 
 ## Deliberate divergences
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -88,10 +88,12 @@ add_library(gridcoinqt STATIC
     transactiondescdialog.cpp
     transactionfilterproxy.cpp
     txfilter.cpp
+    txorder.cpp
     transactionrecord.cpp
     transactiontablemodel.cpp
     transactionview.cpp
     wallet_event_queue.cpp
+    wallettxstore.cpp
     updatedialog.cpp
     upgradeqt.cpp
     voting/additionalfieldstableview.cpp

--- a/src/qt/test/wallet_event_queue_tests.cpp
+++ b/src/qt/test/wallet_event_queue_tests.cpp
@@ -11,8 +11,8 @@
 #include <vector>
 
 using GRC::ChainTipChangedPayload;
-using GRC::TxAddedPayload;
-using GRC::TxRemovedPayload;
+using GRC::RowsInsertedPayload;
+using GRC::RowsRemovedPayload;
 using GRC::WalletEvent;
 using GRC::WalletEventPayload;
 using GRC::WalletEventQueue;
@@ -31,13 +31,13 @@ void WalletEventQueueTests::singlePushDrainsOne()
 {
     WalletEventQueue q;
 
-    q.push(TxRemovedPayload{uint256()});
+    q.push(RowsRemovedPayload{0, 1});
     QCOMPARE(q.size(), static_cast<std::size_t>(1));
 
     auto batch = q.drain();
     QCOMPARE(batch.size(), static_cast<std::size_t>(1));
     QCOMPARE(batch[0].seqno, static_cast<uint64_t>(0));
-    QVERIFY(std::holds_alternative<TxRemovedPayload>(batch[0].payload));
+    QVERIFY(std::holds_alternative<RowsRemovedPayload>(batch[0].payload));
 
     // Queue is now empty.
     QCOMPARE(q.size(), static_cast<std::size_t>(0));
@@ -49,7 +49,7 @@ void WalletEventQueueTests::seqnoMonotonicWithinSingleProducer()
 
     constexpr int N = 100;
     for (int i = 0; i < N; ++i) {
-        q.push(TxRemovedPayload{uint256()});
+        q.push(RowsRemovedPayload{0, 1});
     }
 
     auto batch = q.drain();
@@ -63,15 +63,15 @@ void WalletEventQueueTests::allPayloadVariantsRoundTrip()
 {
     WalletEventQueue q;
 
-    q.push(TxAddedPayload{}); // empty record list is enough — testing the variant lane.
-    q.push(TxRemovedPayload{uint256()});
+    q.push(RowsInsertedPayload{}); // empty record list is enough — testing the variant lane.
+    q.push(RowsRemovedPayload{0, 1});
     q.push(ChainTipChangedPayload{2771000, 1779000000});
 
     auto batch = q.drain();
     QCOMPARE(batch.size(), static_cast<std::size_t>(3));
 
-    QVERIFY(std::holds_alternative<TxAddedPayload>(batch[0].payload));
-    QVERIFY(std::holds_alternative<TxRemovedPayload>(batch[1].payload));
+    QVERIFY(std::holds_alternative<RowsInsertedPayload>(batch[0].payload));
+    QVERIFY(std::holds_alternative<RowsRemovedPayload>(batch[1].payload));
     QVERIFY(std::holds_alternative<ChainTipChangedPayload>(batch[2].payload));
 
     const auto& tip = std::get<ChainTipChangedPayload>(batch[2].payload);
@@ -84,7 +84,7 @@ void WalletEventQueueTests::drainPartialBatch()
     WalletEventQueue q;
 
     for (int i = 0; i < 10; ++i) {
-        q.push(TxRemovedPayload{uint256()});
+        q.push(RowsRemovedPayload{0, 1});
     }
     QCOMPARE(q.size(), static_cast<std::size_t>(10));
 
@@ -119,7 +119,7 @@ void WalletEventQueueTests::multiProducerSeqnosAreUniqueAndDense()
     for (int p = 0; p < kProducers; ++p) {
         producers.emplace_back([&q]() {
             for (int i = 0; i < kPerProducer; ++i) {
-                q.push(TxRemovedPayload{uint256()});
+                q.push(RowsRemovedPayload{0, 1});
             }
         });
     }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -18,12 +18,8 @@
 #include <QIcon>
 #include <QDateTime>
 
-#include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <iterator>
-#include <limits>
-#include <unordered_map>
 #include <vector>
 
 // Amount column is right-aligned it contains numbers
@@ -35,28 +31,12 @@ static int column_alignments[] = {
         Qt::AlignRight|Qt::AlignVCenter
     };
 
-// Composite-key ordering for the cached transaction list. Three-level key:
-//
-//   1. time DESCENDING — newest first; matches the default user-facing
-//      ordering for the table.
-//   2. hash ASCENDING  — clusters all decomposed records of one tx into a
-//      contiguous range. Without this, two txs that share a wall-clock
-//      second AND have overlapping decomposition indices would interleave
-//      (A0, B0, A1, B1), forcing insert/remove to handle disjoint ranges.
-//      With hash at second level, each tx is always a coherent block.
-//   3. idx ASCENDING   — within a single tx (same time, same hash), preserves
-//      the order produced by TransactionRecord::decomposeTransaction. idx
-//      values are unique within a tx, so this is a true total order: no two
-//      records ever compare equal.
-struct TxRecordOrder
-{
-    bool operator()(const TransactionRecord &a, const TransactionRecord &b) const
-    {
-        if (a.time != b.time) return a.time > b.time;
-        if (a.hash != b.hash) return a.hash < b.hash;
-        return a.idx < b.idx;
-    }
-};
+// The cached-wallet ORDERING (time DESC, hash ASC, idx ASC) and the position /
+// contiguous-range computation now live producer-side in GRC::WalletTxStore
+// (src/qt/wallettxstore.{h,cpp}), built on the Qt-free GRC::TxOrderLess
+// (src/qt/txorder.h). This model is a thin consumer: it keeps a replica that
+// it mutates in lockstep from the producer's position-stamped RowsInserted /
+// RowsRemoved events — it never computes positions itself.
 
 // Private implementation
 class TransactionTablePriv
@@ -73,92 +53,28 @@ public:
     TransactionTableModel *parent;
 
     //!
-    //! \brief Local cache of wallet transactions, sorted by TxRecordOrder
-    //! (time DESC, hash ASC, idx ASC). Each entry is one row of the table.
-    //!
-    //! Companion `hashIndex` maps tx-hash → vector positions for O(1)
-    //! lookup. Records with the same hash are always contiguous in the
-    //! vector (the second-level hash tiebreaker in TxRecordOrder
-    //! guarantees this).
+    //! \brief Consumer-side replica of the ordered wallet view, kept in
+    //! lockstep with the producer-owned GRC::WalletTxStore by replaying its
+    //! position-stamped RowsInserted / RowsRemoved events. Each entry is one
+    //! row of the table. This is Qt-thread-exclusive (only data(),
+    //! applyEventBatch, and loadWallet touch it, all on the Qt main thread),
+    //! so it needs no lock. The producer's authoritative ordering store is a
+    //! separate object guarded by cs_store; the consumer never reads it on the
+    //! render path. (The replica shrinks to a viewport slice in the windowing
+    //! step, PR5.)
     //!
     std::vector<TransactionRecord> cachedWallet;
-    std::unordered_multimap<uint256, std::size_t, BlockHasher> hashIndex;
 
-    //!
-    //! \brief Rebuild hashIndex from cachedWallet from scratch. Used after
-    //! loadWallet() and any bulk operation where it's cheaper to rebuild
-    //! than to maintain incrementally.
-    //!
-    void rebuildHashIndex()
-    {
-        hashIndex.clear();
-        // Reserve with headroom so the default max_load_factor=1.0 doesn't
-        // trigger an immediate rehash on the first emplace.
-        hashIndex.reserve(cachedWallet.size() * 2 + 1);
-        for (std::size_t i = 0; i < cachedWallet.size(); ++i) {
-            hashIndex.emplace(cachedWallet[i].hash, i);
-        }
-    }
-
-    //!
-    //! \brief Bump every hashIndex value whose position is >= `from` by
-    //! `delta`. Used to maintain the index after a vector insert (positive
-    //! delta) or erase (negative delta).
-    //!
-    //! O(M) where M = total hashIndex entries. Acceptable per design
-    //! (the typical insert/remove is rare and pays this only once).
-    //!
-    void shiftHashIndex(std::size_t from, std::ptrdiff_t delta)
-    {
-        for (auto& kv : hashIndex) {
-            if (kv.second >= from) {
-                kv.second = static_cast<std::size_t>(
-                    static_cast<std::ptrdiff_t>(kv.second) + delta);
-            }
-        }
-    }
-
-    /* Query entire wallet anew from core.
-     */
+    /* Query entire wallet anew from core, via the producer store. */
     void loadWallet()
     {
-        cachedWallet.clear();
-        // hashIndex is reset by rebuildHashIndex() below.
-        {
-            LOCK2(cs_main, wallet->cs_wallet);
-
-            const bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
-            const int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
-
-            // Reserve a reasonable upper bound up front to avoid the
-            // ~18 reallocations a 300k-tx wallet would otherwise pay.
-            // Each wtx typically decomposes to 1-3 records; double the
-            // wtx count as a safe lower estimate.
-            cachedWallet.reserve(wallet->mapWallet.size() * 2);
-
-            for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
-            {
-                if (!TransactionRecord::showTransaction(it->second)) continue;
-
-                const QList<TransactionRecord> decomposed =
-                    TransactionRecord::decomposeTransaction(wallet, it->second);
-
-                // Apply the datetime-limit filter at the RECORD level on
-                // rec.time (= CWalletTx::GetTxTime), matching the Date
-                // column shown in the GUI and the cutoff applied in
-                // applyTxAdded. showTransaction's wtx-level cutoff
-                // compares wtx.nTime (signing time), which can drift
-                // from GetTxTime for confirmed txs and produces a
-                // visibly inconsistent filter on initial load vs
-                // incremental adds.
-                for (const TransactionRecord& rec : decomposed) {
-                    if (fLimitTxnDisplay && rec.time < limitTxnDateTime) continue;
-                    cachedWallet.push_back(rec);
-                }
-            }
-        }
-        std::sort(cachedWallet.begin(), cachedWallet.end(), TxRecordOrder());
-        rebuildHashIndex();
+        // reloadAndSnapshot rebuilds the producer-side ordering store (under
+        // cs_main + cs_wallet, blocking producers and discarding any stale
+        // queued events) and returns a fresh, fully decomposed, sorted snapshot
+        // for this replica. The datetime-display cutoff is applied store-side.
+        const bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
+        const int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
+        cachedWallet = walletModel->getTxStore().reloadAndSnapshot(fLimitTxnDisplay, limitTxnDateTime);
     }
 
 
@@ -180,160 +96,94 @@ public:
     //! queue. This is the new incremental update path; it runs on the Qt
     //! main thread and does NOT take cs_main or cs_wallet.
     //!
-    //! - TxAdded payloads carry records that were already decomposed at the
-    //!   producer side, so no wallet lookup is needed. The consumer applies
-    //!   the user's datetime-limit filter (a record-level predicate on
-    //!   record.time) and inserts the surviving records as a contiguous
-    //!   range at the TxRecordOrder lower_bound position. Same-hash records
-    //!   cluster naturally under that ordering, so a single beginInsertRows
-    //!   covers the whole tx.
+    //! - RowsInserted payloads carry a producer-computed position and the
+    //!   decomposed records (already datetime-filtered and de-duped store-side).
+    //!   The consumer splices them into its replica at exactly that position
+    //!   inside one beginInsertRows/endInsertRows bracket. It reads ONLY the
+    //!   payload, never the producer store, so the replica tracks the begin/end
+    //!   replay even when a drain batch contains several inserts that reorder
+    //!   rows — which keeps the QSortFilterProxyModel on top consistent.
     //!
-    //! - TxRemoved payloads carry just the hash. The consumer locates the
-    //!   matching range via hashIndex (O(1) average) and removes it as a
-    //!   single contiguous block.
+    //! - RowsRemoved payloads carry a producer-computed position + count for a
+    //!   contiguous run; the consumer erases that range in one
+    //!   beginRemoveRows/endRemoveRows bracket.
     //!
-    //! - TxUpdated payloads carry hash + status. No row mutation is needed:
-    //!   per-row status (depth, Confirmed/Confirming/etc.) is refreshed
-    //!   lazily on read inside index(), and updateConfirmations() drives
-    //!   a per-block table-wide dataChanged that refreshes the visible
-    //!   rows. The event is acknowledged via verbose logging only.
+    //! - ChainTipChanged: no row mutation. Per-row status (confirmations) is
+    //!   refreshed lazily on read in index(), driven once per batch by
+    //!   updateConfirmations() at the WalletModel drain level.
     //!
     void applyEventBatch(const std::vector<GRC::WalletEvent>& events)
     {
-        const bool fLimitTxnDisplay = walletModel->getOptionsModel()->getLimitTxnDisplay();
-        const int64_t limitTxnDateTime = walletModel->getOptionsModel()->getLimitTxnDateTime();
-
         for (const auto& ev : events) {
             std::visit([&](auto&& payload) {
                 using P = std::decay_t<decltype(payload)>;
-                if constexpr (std::is_same_v<P, GRC::TxAddedPayload>) {
-                    applyTxAdded(payload, fLimitTxnDisplay, limitTxnDateTime);
-                } else if constexpr (std::is_same_v<P, GRC::TxRemovedPayload>) {
-                    applyTxRemoved(payload);
+                if constexpr (std::is_same_v<P, GRC::RowsInsertedPayload>) {
+                    applyRowsInserted(payload);
+                } else if constexpr (std::is_same_v<P, GRC::RowsRemovedPayload>) {
+                    applyRowsRemoved(payload);
                 } else if constexpr (std::is_same_v<P, GRC::ChainTipChangedPayload>) {
-                    // ChainTipChanged is handled at the WalletModel drain
-                    // level (triggers updateConfirmations + checkBalanceChanged
-                    // once per batch). No per-event row mutation here.
+                    // Handled at the WalletModel drain level (updateConfirmations
+                    // + checkBalanceChanged once per batch). No row mutation.
                 }
             }, ev.payload);
         }
     }
 
-    void applyTxAdded(const GRC::TxAddedPayload& payload,
-                      bool fLimitTxnDisplay,
-                      int64_t limitTxnDateTime)
+    void applyRowsInserted(const GRC::RowsInsertedPayload& payload)
     {
-        // Apply the consumer-side datetime filter. The producer has already
-        // applied the wtx-level visibility checks (orphan coinstake/coinbase,
-        // legacy OP_RETURN) under the locks it held at notification time.
-        //
-        // All records in a payload share `time` and `hash`, so the datetime
-        // filter is all-or-nothing: either every record clears the cutoff
-        // or none do.
-        std::vector<TransactionRecord> toInsert;
-        toInsert.reserve(payload.records.size());
-        for (const TransactionRecord& rec : payload.records) {
-            if (fLimitTxnDisplay && rec.time < limitTxnDateTime) {
-                continue;
-            }
-            toInsert.push_back(rec);
-        }
-        if (toInsert.empty()) {
+        if (payload.records.empty()) {
             return;
         }
 
-        // Sort the new records by TxRecordOrder. decomposeTransaction
-        // already produces them in idx order (which is the third-level
-        // tiebreaker, with same time + same hash), so this is normally
-        // a no-op — but enforce defensively against any future producer
-        // change.
-        std::sort(toInsert.begin(), toInsert.end(), TxRecordOrder());
-
-        // Skip duplicate insert: hashIndex.find() is O(1) average and
-        // tells us whether ANY record of this tx is already cached.
-        // Because the producer sends all records of a tx as one payload,
-        // a present hash means the full set is already there.
-        const uint256& hash = toInsert.front().hash;
-        if (hashIndex.find(hash) != hashIndex.end()) {
-            LogPrint(BCLog::LogFlags::VERBOSE,
-                     "applyTxAdded: %s already in model — skipping duplicate insert", hash.GetHex());
+        // The store computes `position` against an ordering that mirrors this
+        // replica (both start identical and replay the same position-stamped
+        // events in seqno order), so position is provably in range for the
+        // current producer. Validate it explicitly anyway: the DEPLOYED build
+        // is -DNDEBUG, so an assert here would vanish and a bad position would
+        // become a huge size_t -> out-of-bounds insert (heap corruption). If a
+        // future producer regression ever emits a bad position, degrade safely
+        // — log and skip — rather than corrupt the heap.
+        if (payload.position < 0
+                || static_cast<std::size_t>(payload.position) > cachedWallet.size()) {
+            LogPrintf("ERROR: %s: RowsInserted position %d out of range [0, %u] — skipping",
+                      __func__, payload.position,
+                      static_cast<unsigned int>(cachedWallet.size()));
             return;
         }
-
-        // All records in toInsert share `time` and `hash` and differ only
-        // in `idx`. Under TxRecordOrder they sort to a contiguous range
-        // and slot into cachedWallet at the lower_bound position of the
-        // first record.
-        auto pos = std::lower_bound(cachedWallet.begin(), cachedWallet.end(),
-                                    toInsert.front(), TxRecordOrder());
-        const std::size_t insertIdx = static_cast<std::size_t>(pos - cachedWallet.begin());
-        const std::size_t insertCount = toInsert.size();
+        const std::size_t insertIdx = static_cast<std::size_t>(payload.position);
+        const std::size_t insertCount = payload.records.size();
 
         parent->beginInsertRows(QModelIndex(),
                                 static_cast<int>(insertIdx),
                                 static_cast<int>(insertIdx + insertCount - 1));
-
-        // Order matters: shift the index BEFORE the vector insert (the
-        // shift uses logical positions, not iterators, so the vector's
-        // unshifted state doesn't matter), then do the insert, then add
-        // the new index entries for the inserted range. Doing it in this
-        // order keeps the index consistent at every observable point.
-        shiftHashIndex(insertIdx, static_cast<std::ptrdiff_t>(insertCount));
-        cachedWallet.insert(pos, toInsert.begin(), toInsert.end());
-        for (std::size_t k = 0; k < insertCount; ++k) {
-            hashIndex.emplace(hash, insertIdx + k);
-        }
-
+        cachedWallet.insert(cachedWallet.begin() + insertIdx,
+                            payload.records.begin(), payload.records.end());
         parent->endInsertRows();
     }
 
-    void applyTxRemoved(const GRC::TxRemovedPayload& payload)
+    void applyRowsRemoved(const GRC::RowsRemovedPayload& payload)
     {
-        auto range = hashIndex.equal_range(payload.hash);
-        if (range.first == range.second) {
-            // Not in cachedWallet — may have been filtered out at insert time,
-            // or never inserted (e.g. an orphan caught by the producer-side
-            // showTransaction check). No row work needed.
+        // A RowsRemoved is emitted only for a real, non-empty erase the store
+        // located, so the range is provably in this replica. Validate anyway —
+        // the deployed -DNDEBUG build drops asserts, and a bad position/count
+        // would become a huge size_t -> out-of-bounds erase (heap corruption).
+        // Degrade safely on a future producer regression.
+        if (payload.position < 0 || payload.count <= 0
+                || static_cast<std::size_t>(payload.position)
+                       + static_cast<std::size_t>(payload.count) > cachedWallet.size()) {
+            LogPrintf("ERROR: %s: RowsRemoved range [%d, +%d) out of bounds for %u rows — skipping",
+                      __func__, payload.position, payload.count,
+                      static_cast<unsigned int>(cachedWallet.size()));
             return;
         }
-
-        // Collect the positions for this hash. Same-hash records are
-        // contiguous in the vector under TxRecordOrder (the second-level
-        // hash tiebreaker guarantees clustering), so the min and max
-        // bound a single range.
-        std::size_t minPos = std::numeric_limits<std::size_t>::max();
-        std::size_t maxPos = 0;
-        for (auto it = range.first; it != range.second; ++it) {
-            if (it->second < minPos) minPos = it->second;
-            if (it->second > maxPos) maxPos = it->second;
-        }
-        const std::size_t removeCount = maxPos - minPos + 1;
-
-        // Defensive checks for the contiguity invariant the erase relies
-        // on. If a future change ever lets same-hash records de-cluster
-        // (e.g. switching the comparator to (time, idx, hash), or a
-        // post-decomposition mutation of `time`), these asserts surface
-        // it before the erase silently drops unrelated rows.
-        //
-        // Bounds checks come first so a corrupted hashIndex (positions
-        // past the end of cachedWallet) trips an assert rather than
-        // running the cachedWallet[minPos] / cachedWallet[maxPos]
-        // subscripts below into undefined behavior.
-        assert(minPos < cachedWallet.size());
-        assert(maxPos < cachedWallet.size());
-        assert(removeCount == static_cast<std::size_t>(std::distance(range.first, range.second)));
-        assert(cachedWallet[minPos].hash == payload.hash);
-        assert(cachedWallet[maxPos].hash == payload.hash);
+        const std::size_t pos = static_cast<std::size_t>(payload.position);
+        const std::size_t count = static_cast<std::size_t>(payload.count);
 
         parent->beginRemoveRows(QModelIndex(),
-                                static_cast<int>(minPos),
-                                static_cast<int>(maxPos));
-
-        cachedWallet.erase(cachedWallet.begin() + minPos,
-                           cachedWallet.begin() + maxPos + 1);
-        hashIndex.erase(payload.hash);
-        shiftHashIndex(maxPos + 1, -static_cast<std::ptrdiff_t>(removeCount));
-
+                                static_cast<int>(pos),
+                                static_cast<int>(pos + count - 1));
+        cachedWallet.erase(cachedWallet.begin() + pos,
+                           cachedWallet.begin() + pos + count);
         parent->endRemoveRows();
     }
 

--- a/src/qt/txorder.cpp
+++ b/src/qt/txorder.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "txorder.h"
+
+namespace GRC {
+
+bool TxOrderLess(const TxOrderKey& a, const TxOrderKey& b)
+{
+    if (a.time != b.time) return a.time > b.time;   // time DESCENDING
+    if (a.hash != b.hash) return a.hash < b.hash;   // hash ASCENDING
+    return a.idx < b.idx;                           // idx ASCENDING
+}
+
+} // namespace GRC

--- a/src/qt/txorder.h
+++ b/src/qt/txorder.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TXORDER_H
+#define BITCOIN_QT_TXORDER_H
+
+#include "uint256.h"
+
+#include <cstdint>
+
+//!
+//! \file txorder.h
+//!
+//! Qt-free transaction ordering key + comparator for the windowed
+//! transaction-table model's producer-side store.
+//!
+//! This is the single source of truth for the cached-wallet ordering that was
+//! introduced in PR #3003 as `TxRecordOrder` (time DESC, hash ASC, idx ASC).
+//! It is extracted here, operating on a minimal Qt-free key, so that:
+//!
+//!   1. The producer-side `GRC::WalletTxStore` (which is Qt-coupled, because
+//!      `TransactionRecord` pulls in `<QList>`/`qint64`) can compute insert
+//!      positions and contiguous removal ranges through this one comparator.
+//!   2. The position/clustering logic gets unit-test coverage in the GUI-OFF
+//!      build configuration that CI exercises — the blind spot that hid
+//!      PR #2944's heap corruption — since `uint256` is Qt-free.
+//!
+//! `WalletTxStore::TxRecordOrder` projects a `TransactionRecord` into a
+//! `TxOrderKey` and defers to `TxOrderLess`, so there is exactly one ordering
+//! definition.
+//!
+
+namespace GRC {
+
+//!
+//! \brief The three fields that define a transaction row's position in the
+//! cached, ordered wallet view: receive time, tx hash, and the decomposition
+//! sub-index.
+//!
+struct TxOrderKey {
+    //! TransactionRecord::time (CWalletTx::GetTxTime), seconds since epoch.
+    int64_t time = 0;
+    //! TransactionRecord::hash.
+    uint256 hash;
+    //! TransactionRecord::idx — the decomposeTransaction sub-index, unique
+    //! within a single tx, making the order a true total order.
+    int idx = 0;
+};
+
+//!
+//! \brief Strict weak ordering: (time DESC, hash ASC, idx ASC).
+//!
+//! - time DESCENDING — newest first, the default user-facing order.
+//! - hash ASCENDING  — clusters all decomposed records of one tx into a
+//!   contiguous range (the removal path relies on this clustering).
+//! - idx ASCENDING   — within one tx, preserves decompose order; idx is unique
+//!   within a tx, so no two keys ever compare equal.
+//!
+//! \return true if \p a sorts strictly before \p b.
+//!
+bool TxOrderLess(const TxOrderKey& a, const TxOrderKey& b);
+
+} // namespace GRC
+
+#endif // BITCOIN_QT_TXORDER_H

--- a/src/qt/wallet_event_queue.h
+++ b/src/qt/wallet_event_queue.h
@@ -20,28 +20,39 @@
 namespace GRC {
 
 //!
-//! \brief Producer-side payload: a transaction was added to the wallet, with its
-//! pre-decomposed display records.
+//! \brief Producer-side payload: rows were inserted into the ordered wallet
+//! view at a producer-computed position.
 //!
-//! The producer thread (the one firing CWallet::NotifyTransactionChanged) runs
-//! TransactionRecord::decomposeTransaction under the cs_wallet lock it already
-//! holds and ships the resulting list of records to the consumer. The consumer
-//! never touches the wallet.
+//! Windowed-model PR2 moved the ORDERING to the producer-side GRC::WalletTxStore:
+//! the producer runs TransactionRecord::decomposeTransaction under the locks it
+//! already holds, the store computes the TxOrderLess insert position, and this
+//! payload carries that position plus the records. The consumer inserts the
+//! records into its replica at exactly \p position inside a single
+//! beginInsertRows/endInsertRows bracket — it reads ONLY this payload, never the
+//! live store, so its replica tracks the begin/end replay even when a drain
+//! batch contains several inserts that reorder rows.
 //!
-struct TxAddedPayload
+//! \p records are all the decomposed parts of one transaction; under TxOrderLess
+//! they occupy a contiguous range, so one payload == one bracket.
+//!
+struct RowsInsertedPayload
 {
-    QList<TransactionRecord> records;
+    int position;
+    std::vector<TransactionRecord> records;
 };
 
 //!
-//! \brief Producer-side payload: an existing transaction was removed from the
-//! wallet, or is no longer visible (e.g. an orphaned coinstake). The consumer
-//! drops the matching rows from its model; it is a no-op if the tx isn't
-//! currently in the cached list.
+//! \brief Producer-side payload: a contiguous run of rows was removed at a
+//! producer-computed position. Carries position + count (resolved from the tx
+//! hash by the store, where same-hash rows are guaranteed contiguous). The
+//! consumer erases [position, position + count) inside one
+//! beginRemoveRows/endRemoveRows bracket. A removal that matched nothing emits
+//! no event at all, so this payload always denotes a real, non-empty erase.
 //!
-struct TxRemovedPayload
+struct RowsRemovedPayload
 {
-    uint256 hash;
+    int position;
+    int count;
 };
 
 //!
@@ -68,8 +79,8 @@ struct ChainTipChangedPayload
 };
 
 using WalletEventPayload = std::variant<
-    TxAddedPayload,
-    TxRemovedPayload,
+    RowsInsertedPayload,
+    RowsRemovedPayload,
     ChainTipChangedPayload>;
 
 //!

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -31,8 +31,13 @@ WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* p
          , cachedNumTransactions(0)
          , cachedEncryptionStatus(Unencrypted)
          , cachedNumBlocks(0)
+         , m_txStore(wallet, m_event_queue)
 {
     addressTableModel = new AddressTableModel(wallet, this);
+    // TransactionTableModel's ctor performs the initial load via
+    // m_txStore.reloadAndSnapshot(); m_txStore is already constructed (init
+    // list) and no producer can run yet — subscribeToCoreSignals() is called
+    // below, after the model exists.
     transactionTableModel = new TransactionTableModel(wallet, this);
 
     // Drain the producer→GUI event queue at a steady cadence. 500ms is
@@ -721,9 +726,9 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
             // in sync.
             LogPrint(BCLog::LogFlags::VERBOSE,
                      "NotifyTransactionChanged: %s status=%d but tx not in mapWallet "
-                     "— pushing TxRemoved",
+                     "— removing from store",
                      hash.GetHex(), status);
-            walletmodel->getEventQueue().push(GRC::TxRemovedPayload{hash});
+            walletmodel->getTxStore().removeTransaction(hash);
             break;
         }
         const CWalletTx& wtx = it->second;
@@ -759,22 +764,25 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
         }
 
         if (visible) {
-            GRC::TxAddedPayload payload;
-            payload.records = TransactionRecord::decomposeTransaction(wallet, wtx);
-            if (!payload.records.isEmpty()) {
-                walletmodel->getEventQueue().push(std::move(payload));
+            // Decompose under the locks already held, then hand the records to
+            // the producer-side store, which applies the datetime cutoff,
+            // de-dupes, computes the insert position, and emits RowsInserted.
+            const QList<TransactionRecord> decomposed =
+                TransactionRecord::decomposeTransaction(wallet, wtx);
+            if (!decomposed.isEmpty()) {
+                walletmodel->getTxStore().insertTransaction(
+                    std::vector<TransactionRecord>(decomposed.begin(), decomposed.end()));
             }
         } else {
             // Tx is genuinely filtered out (a real orphan coinstake, or a
-            // legacy non-IsFromMe OP_RETURN). Ensure the consumer removes the
-            // row if it was previously visible — TxRemoved is a no-op if the
-            // tx isn't in cachedWallet.
-            walletmodel->getEventQueue().push(GRC::TxRemovedPayload{hash});
+            // legacy non-IsFromMe OP_RETURN). Ensure the store removes the rows
+            // if they were previously visible — a no-op if absent.
+            walletmodel->getTxStore().removeTransaction(hash);
         }
         break;
     }
     case CT_DELETED:
-        walletmodel->getEventQueue().push(GRC::TxRemovedPayload{hash});
+        walletmodel->getTxStore().removeTransaction(hash);
         break;
     }
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -6,6 +6,7 @@
 #include <map>
 
 #include "qt/wallet_event_queue.h"
+#include "qt/wallettxstore.h"
 #include "support/allocators/secure.h" /* for SecureString */
 #include "wallet/ismine.h"
 
@@ -142,6 +143,13 @@ public:
     //!
     GRC::WalletEventQueue& getEventQueue() { return m_event_queue; }
 
+    //!
+    //! \brief Accessor for the producer-owned transaction ordering store. The
+    //! producer (NotifyTransactionChanged) mutates it; TransactionTableModel
+    //! reads it only at reset time (reloadAndSnapshot).
+    //!
+    GRC::WalletTxStore& getTxStore() { return m_txStore; }
+
 private:
     CWallet *wallet;
 
@@ -171,6 +179,13 @@ private:
     //! drainEventQueue(), fired by eventDrainTimer every 500ms.
     //!
     GRC::WalletEventQueue m_event_queue;
+
+    //!
+    //! \brief Producer-owned transaction ordering store. Declared AFTER
+    //! m_event_queue so the WalletEventQueue& it holds is bound to a fully
+    //! constructed object (member init order == declaration order).
+    //!
+    GRC::WalletTxStore m_txStore;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/wallettxstore.h"
+
+#include "main.h"
+#include "wallet/wallet.h"
+
+#include <algorithm>
+#include <iterator>
+#include <limits>
+
+namespace {
+
+//! Order a TransactionRecord by projecting it to a TxOrderKey and deferring to
+//! the single Qt-free ordering definition. There is exactly one ordering: the
+//! GUI-OFF-testable GRC::TxOrderLess.
+struct RecordOrder {
+    bool operator()(const TransactionRecord& a, const TransactionRecord& b) const
+    {
+        return GRC::TxOrderLess({a.time, a.hash, a.idx}, {b.time, b.hash, b.idx});
+    }
+};
+
+} // anonymous namespace
+
+namespace GRC {
+
+WalletTxStore::WalletTxStore(CWallet* wallet, GRC::WalletEventQueue& queue)
+    : m_wallet(wallet)
+    , m_queue(queue)
+{
+}
+
+void WalletTxStore::shiftIndex(std::size_t from, std::ptrdiff_t delta)
+{
+    // Bump every index entry at or after `from` by `delta`. Logical positions,
+    // not iterators, so this is order-independent w.r.t. the vector splice.
+    for (auto& kv : m_by_hash) {
+        if (kv.second >= from) {
+            kv.second = static_cast<std::size_t>(
+                static_cast<std::ptrdiff_t>(kv.second) + delta);
+        }
+    }
+}
+
+void WalletTxStore::rebuildIndex()
+{
+    m_by_hash.clear();
+    m_by_hash.reserve(m_keys.size() * 2 + 1);
+    for (std::size_t i = 0; i < m_keys.size(); ++i) {
+        m_by_hash.emplace(m_keys[i].hash, i);
+    }
+}
+
+void WalletTxStore::insertTransaction(std::vector<TransactionRecord> records)
+{
+    LOCK(cs_store);
+
+    // Datetime-display cutoff (cached from the last reloadAndSnapshot). All
+    // records of one tx share `time`, so this is all-or-nothing.
+    if (m_limit_enabled) {
+        records.erase(std::remove_if(records.begin(), records.end(),
+                          [&](const TransactionRecord& r) { return r.time < m_limit_time; }),
+                      records.end());
+    }
+    if (records.empty()) {
+        return;
+    }
+
+    // Sort defensively by the ordering key. decomposeTransaction already
+    // produces idx order (the third-level tiebreaker for same time+hash), so
+    // this is normally a no-op.
+    std::sort(records.begin(), records.end(), RecordOrder());
+
+    const uint256 hash = records.front().hash;
+
+    // Dedup: a present hash means the full record set of this tx is already in
+    // the store (all parts arrive in one call), so skip — no event.
+    if (m_by_hash.find(hash) != m_by_hash.end()) {
+        return;
+    }
+
+    // All records share `time` and `hash` and differ only in `idx`; under
+    // TxOrderLess they form a contiguous range slotting in at the lower_bound
+    // of the first key.
+    const TxOrderKey first_key{records.front().time, hash, records.front().idx};
+    const auto pos = std::lower_bound(m_keys.begin(), m_keys.end(), first_key, GRC::TxOrderLess);
+    const std::size_t insertIdx = static_cast<std::size_t>(pos - m_keys.begin());
+    const std::size_t count = records.size();
+
+    std::vector<TxOrderKey> new_keys;
+    new_keys.reserve(count);
+    for (const TransactionRecord& r : records) {
+        new_keys.push_back({r.time, r.hash, r.idx});
+    }
+
+    // Shift the index BEFORE splicing the vector (the shift uses logical
+    // positions), then splice, then add the new index entries — keeping the
+    // index consistent at every observable point.
+    shiftIndex(insertIdx, static_cast<std::ptrdiff_t>(count));
+    m_keys.insert(m_keys.begin() + insertIdx, new_keys.begin(), new_keys.end());
+    for (std::size_t k = 0; k < count; ++k) {
+        m_by_hash.emplace(hash, insertIdx + k);
+    }
+
+    // Push the position-stamped event WHILE cs_store is held so that queue
+    // seqno-order equals store-mutation-order across all producer threads.
+    m_queue.push(GRC::RowsInsertedPayload{static_cast<int>(insertIdx), std::move(records)});
+}
+
+void WalletTxStore::removeTransaction(const uint256& hash)
+{
+    LOCK(cs_store);
+
+    auto range = m_by_hash.equal_range(hash);
+    if (range.first == range.second) {
+        // Not present — filtered out at insert time, or never inserted. No-op,
+        // no event.
+        return;
+    }
+
+    // Same-hash keys are contiguous under TxOrderLess (the hash tiebreaker
+    // clusters them), so min/max bound a single range.
+    std::size_t minPos = std::numeric_limits<std::size_t>::max();
+    std::size_t maxPos = 0;
+    for (auto it = range.first; it != range.second; ++it) {
+        if (it->second < minPos) minPos = it->second;
+        if (it->second > maxPos) maxPos = it->second;
+    }
+    const std::size_t count = maxPos - minPos + 1;
+    const std::size_t distance = static_cast<std::size_t>(std::distance(range.first, range.second));
+
+    // The erase below relies on same-hash keys being a single contiguous run
+    // (guaranteed by TxOrderLess's hash tiebreaker). Validate at runtime, not
+    // via assert: the deployed build is -DNDEBUG, so an assert would vanish and
+    // a de-clustered index would erase a wider [minPos, maxPos] range that
+    // swallows foreign rows (heap/structure corruption). The bounds check is
+    // ordered first and short-circuits, so the m_keys[] subscripts below it
+    // never run out of range. If the invariant is ever violated, bail without
+    // erasing or emitting — a stale row is a safe degradation; a wrong erase is
+    // not.
+    if (maxPos >= m_keys.size()
+            || count != distance
+            || m_keys[minPos].hash != hash
+            || m_keys[maxPos].hash != hash) {
+        LogPrintf("ERROR: %s: hash %s index non-contiguous/out-of-range "
+                  "(minPos=%u maxPos=%u count=%u distance=%u keys=%u) — skipping remove",
+                  __func__, hash.GetHex(),
+                  static_cast<unsigned int>(minPos), static_cast<unsigned int>(maxPos),
+                  static_cast<unsigned int>(count), static_cast<unsigned int>(distance),
+                  static_cast<unsigned int>(m_keys.size()));
+        return;
+    }
+
+    m_keys.erase(m_keys.begin() + minPos, m_keys.begin() + maxPos + 1);
+    m_by_hash.erase(hash);
+    shiftIndex(maxPos + 1, -static_cast<std::ptrdiff_t>(count));
+
+    m_queue.push(GRC::RowsRemovedPayload{static_cast<int>(minPos), static_cast<int>(count)});
+}
+
+std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabled, int64_t limit_time)
+{
+    std::vector<TransactionRecord> built;
+
+    // Hold cs_main + cs_wallet across the whole rebuild AND the queue drain,
+    // exactly as the old loadWallet held them for its scan. cs_main is the
+    // load-bearing exclusion lock here: EVERY producer of insert/remove holds
+    // cs_main — CT_NEW/CT_UPDATED under cs_main+cs_wallet, and BOTH CT_DELETED
+    // sites (ReorganizeChain in main.cpp, ResendWalletTransactions in
+    // wallet.cpp) under cs_main even though they do NOT hold cs_wallet at the
+    // fire site. So holding cs_main across both the index rebuild and the
+    // queue drain fully excludes producers: no event can be queued between the
+    // two, which makes the returned snapshot, the rebuilt index, and the
+    // emptied queue mutually consistent.
+    LOCK2(cs_main, m_wallet->cs_wallet);
+
+    built.reserve(m_wallet->mapWallet.size() * 2);
+    for (auto it = m_wallet->mapWallet.begin(); it != m_wallet->mapWallet.end(); ++it) {
+        if (!TransactionRecord::showTransaction(it->second)) {
+            continue;
+        }
+        const QList<TransactionRecord> decomposed =
+            TransactionRecord::decomposeTransaction(m_wallet, it->second);
+        for (const TransactionRecord& rec : decomposed) {
+            if (limit_enabled && rec.time < limit_time) {
+                continue;
+            }
+            built.push_back(rec);
+        }
+    }
+    std::sort(built.begin(), built.end(), RecordOrder());
+
+    {
+        LOCK(cs_store);
+        m_limit_enabled = limit_enabled;
+        m_limit_time = limit_time;
+        m_keys.clear();
+        m_keys.reserve(built.size());
+        for (const TransactionRecord& r : built) {
+            m_keys.push_back({r.time, r.hash, r.idx});
+        }
+        rebuildIndex();
+    }
+
+    // Discard any events queued before this rebuild: they were computed against
+    // the old index and are superseded by `built`. Producers are still blocked
+    // on cs_wallet, so nothing new can be queued until we return; the returned
+    // snapshot, the rebuilt index, and the now-empty queue are consistent.
+    m_queue.drain();
+
+    return built;
+}
+
+} // namespace GRC

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -61,8 +61,13 @@ void WalletTxStore::insertTransaction(std::vector<TransactionRecord> records)
     // Datetime-display cutoff (cached from the last reloadAndSnapshot). All
     // records of one tx share `time`, so this is all-or-nothing.
     if (m_limit_enabled) {
+        // Hoist the guarded member into a local read under cs_store: the Clang
+        // thread-safety analyzer does not propagate held-lock state into the
+        // lambda body, so capture the value rather than read m_limit_time inside
+        // the predicate.
+        const int64_t limit_time = m_limit_time;
         records.erase(std::remove_if(records.begin(), records.end(),
-                          [&](const TransactionRecord& r) { return r.time < m_limit_time; }),
+                          [limit_time](const TransactionRecord& r) { return r.time < limit_time; }),
                       records.end());
     }
     if (records.empty()) {

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_WALLETTXSTORE_H
+#define BITCOIN_QT_WALLETTXSTORE_H
+
+#include "qt/txorder.h"
+#include "qt/transactionrecord.h"
+#include "qt/wallet_event_queue.h"
+#include "sync.h"
+#include "uint256.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+class CWallet;
+
+namespace GRC {
+
+//!
+//! \brief Qt-free hasher for the tx-hash index. A correct internal hash over
+//! uint256 (any well-distributed hash works for a private multimap); kept
+//! header-light so wallettxstore.h need not pull in main.h's BlockHasher.
+//!
+struct TxHashHasher {
+    std::size_t operator()(const uint256& h) const { return static_cast<std::size_t>(h.GetUint64(0)); }
+};
+
+//!
+//! \brief Producer-owned authoritative ordering store for the windowed
+//! transaction-table model (windowed-model PR2).
+//!
+//! Step 2 of the windowed-model rewrite relocates the cached-wallet ORDERING
+//! out of the Qt-thread-exclusive TransactionTablePriv into this object, which
+//! the producer (core threads, in WalletModel's NotifyTransactionChanged
+//! handler) mutates. The store computes each new transaction's insert position
+//! and each removal's contiguous range, then pushes a position-stamped
+//! RowsInserted / RowsRemoved event onto the WalletEventQueue. The consumer
+//! (TransactionTableModel) applies those events to its own replica in lockstep
+//! — it never reads this store on the render path — which is what keeps the
+//! still-present QSortFilterProxyModel consistent across a multi-insert drain
+//! batch (a pure-passthrough-reading-the-eager-store consumer would mis-map
+//! rows mid-replay).
+//!
+//! In PR2 the store holds ORDERING KEYS ONLY (not full TransactionRecords): it
+//! does not yet serve reads, so materializing full records here would only
+//! double resident memory. It grows to the full-records authoritative store in
+//! the windowing step (PR5), when the consumer drops its full replica for a
+//! viewport slice and begins reading the store.
+//!
+//! Threading: m_keys / m_by_hash are guarded by the leaf mutex cs_store. The
+//! canonical lock order is cs_main -> cs_wallet -> cs_store; cs_store is NEVER
+//! held while acquiring cs_main / cs_wallet. Producers finish all wallet work
+//! (decompose under the locks they already hold) BEFORE calling into the store,
+//! which takes cs_store last and for a microsecond-bounded window. The Rows*
+//! event is pushed WHILE cs_store is held, so queue seqno-order is identical to
+//! store-mutation-order across all producer threads.
+//!
+class WalletTxStore
+{
+public:
+    WalletTxStore(CWallet* wallet, GRC::WalletEventQueue& queue);
+
+    WalletTxStore(const WalletTxStore&) = delete;
+    WalletTxStore& operator=(const WalletTxStore&) = delete;
+
+    //!
+    //! \brief Producer: a transaction became visible. Applies the cached
+    //! datetime-display cutoff, de-duplicates, computes the TxOrderLess insert
+    //! position, updates the index, and pushes one RowsInserted carrying the
+    //! surviving records. A no-op (no event) if the tx is already present or
+    //! every record is filtered out.
+    //!
+    //! Called from core threads. Takes cs_store internally; the caller must NOT
+    //! hold cs_store. (Callers that produced \p records via decomposeTransaction
+    //! already released nothing — they still hold cs_main/cs_wallet, which is
+    //! fine: cs_store is the innermost leaf.)
+    //!
+    void insertTransaction(std::vector<TransactionRecord> records);
+
+    //!
+    //! \brief Producer: a transaction is no longer visible / was deleted.
+    //! Locates its contiguous range via the hash index and pushes one
+    //! RowsRemoved. A no-op (no event) if the tx is not present. Touches only
+    //! the store (cs_store) — never the wallet — so it is safe to call from the
+    //! CT_DELETED path which holds no wallet locks.
+    //!
+    void removeTransaction(const uint256& hash);
+
+    //!
+    //! \brief Qt thread: rebuild the store from the wallet and return a full
+    //! decomposed snapshot for the consumer's replica.
+    //!
+    //! Holds cs_main + cs_wallet across the whole rebuild (blocking producers,
+    //! exactly as the old loadWallet did), swaps the index under cs_store, and
+    //! drains+discards any pending queue events while producers are still
+    //! blocked — so the returned snapshot, the rebuilt index, and the (now
+    //! empty) queue are mutually consistent. Any producer event after this
+    //! returns is computed against the rebuilt index and applied by the next
+    //! drain. \p limit_enabled / \p limit_time are the OptionsModel
+    //! datetime-display cutoff (read on the Qt thread by the caller); the store
+    //! caches them and applies them to subsequent insertTransaction calls.
+    //!
+    std::vector<TransactionRecord> reloadAndSnapshot(bool limit_enabled, int64_t limit_time);
+
+private:
+    void shiftIndex(std::size_t from, std::ptrdiff_t delta) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+    void rebuildIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    CWallet* const m_wallet;
+    GRC::WalletEventQueue& m_queue;
+
+    mutable Mutex cs_store;
+
+    //! Ordering keys, sorted by TxOrderLess. Authoritative position oracle.
+    std::vector<TxOrderKey> m_keys GUARDED_BY(cs_store);
+    //! tx hash -> positions in m_keys. Same-hash keys are contiguous.
+    std::unordered_multimap<uint256, std::size_t, TxHashHasher> m_by_hash GUARDED_BY(cs_store);
+
+    //! Cached OptionsModel datetime-display cutoff, set by reloadAndSnapshot.
+    bool m_limit_enabled GUARDED_BY(cs_store){false};
+    int64_t m_limit_time GUARDED_BY(cs_store){0};
+};
+
+} // namespace GRC
+
+#endif // BITCOIN_QT_WALLETTXSTORE_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -53,6 +53,11 @@ add_executable(test_gridcoin
     # one configuration CI exercises.
     ${CMAKE_SOURCE_DIR}/src/qt/txfilter.cpp
     qt_txfilter_tests.cpp
+    # Qt-free transaction ordering core (src/qt/txorder.cpp) + its unit suite:
+    # the position/clustering logic the producer-side WalletTxStore relies on,
+    # tested in the GUI-OFF configuration CI exercises.
+    ${CMAKE_SOURCE_DIR}/src/qt/txorder.cpp
+    qt_txorder_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/qt_txorder_tests.cpp
+++ b/src/test/qt_txorder_tests.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF unit coverage for the Qt-free transaction ordering core
+// (src/qt/txorder.{h,cpp}). This is the (time DESC, hash ASC, idx ASC)
+// ordering — and the lower_bound insert-position and same-hash contiguity it
+// guarantees — that the producer-side GRC::WalletTxStore relies on to compute
+// the position-stamped RowsInserted / RowsRemoved events. Testing it here keeps
+// the position/clustering logic covered in the ENABLE_GUI=OFF configuration CI
+// exercises (TransactionRecord itself is Qt-coupled, so the store proper is
+// covered by ASan-GUI + isolated-testnet validation instead).
+
+#include <qt/txorder.h>
+
+#include "uint256.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <vector>
+
+using namespace GRC;
+
+namespace {
+TxOrderKey K(int64_t time, const char* hash_hex, int idx)
+{
+    return TxOrderKey{time, uint256S(hash_hex), idx};
+}
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(qt_txorder_tests)
+
+// ---- TxOrderLess: the three ordering levels --------------------------------
+
+BOOST_AUTO_TEST_CASE(txorder_time_descending_primary)
+{
+    // Newer time sorts FIRST, so a newer key is "less than" an older one.
+    TxOrderKey newer = K(300, "01", 0);
+    TxOrderKey older = K(200, "01", 0);
+    BOOST_CHECK( TxOrderLess(newer, older));
+    BOOST_CHECK(!TxOrderLess(older, newer));
+}
+
+BOOST_AUTO_TEST_CASE(txorder_hash_ascending_tiebreak)
+{
+    // Same time -> lower hash sorts first (ascending).
+    TxOrderKey a = K(100, "01", 0);
+    TxOrderKey b = K(100, "02", 0);
+    BOOST_CHECK( TxOrderLess(a, b));
+    BOOST_CHECK(!TxOrderLess(b, a));
+}
+
+BOOST_AUTO_TEST_CASE(txorder_idx_ascending_tiebreak)
+{
+    // Same time + same hash -> lower idx sorts first (ascending).
+    TxOrderKey a = K(100, "0a", 0);
+    TxOrderKey b = K(100, "0a", 1);
+    BOOST_CHECK( TxOrderLess(a, b));
+    BOOST_CHECK(!TxOrderLess(b, a));
+}
+
+BOOST_AUTO_TEST_CASE(txorder_strict_weak_equal_is_false)
+{
+    // A true total order: equal keys are never less than each other.
+    TxOrderKey a = K(100, "0a", 3);
+    BOOST_CHECK(!TxOrderLess(a, a));
+}
+
+// ---- lower_bound insert position (mirrors WalletTxStore::insertTransaction) -
+
+BOOST_AUTO_TEST_CASE(txorder_lower_bound_insert_positions)
+{
+    // A descending-by-time sorted view: 300, 200, 100 (all distinct hashes,
+    // single idx). This is the cachedWallet/keys order.
+    std::vector<TxOrderKey> keys = { K(300, "01", 0), K(200, "02", 0), K(100, "03", 0) };
+    BOOST_REQUIRE(std::is_sorted(keys.begin(), keys.end(), TxOrderLess));
+
+    auto pos = [&](const TxOrderKey& k) {
+        return std::lower_bound(keys.begin(), keys.end(), k, TxOrderLess) - keys.begin();
+    };
+
+    // Newest of all -> front.
+    BOOST_CHECK_EQUAL(pos(K(400, "00", 0)), 0);
+    // Between 300 and 200 -> index 1.
+    BOOST_CHECK_EQUAL(pos(K(250, "00", 0)), 1);
+    // Between 200 and 100 -> index 2.
+    BOOST_CHECK_EQUAL(pos(K(150, "00", 0)), 2);
+    // Oldest of all -> end.
+    BOOST_CHECK_EQUAL(pos(K(50, "00", 0)), 3);
+}
+
+// ---- same-hash clustering (the removal path's contiguity invariant) --------
+
+BOOST_AUTO_TEST_CASE(txorder_same_hash_records_cluster_contiguously)
+{
+    // Two txs sharing a wall-clock time, each decomposed into 2 records. Under
+    // (time, hash, idx) the parts of one tx must occupy a contiguous run, so
+    // the store's equal_range min/max bound a single erase range.
+    std::vector<TxOrderKey> keys = {
+        K(100, "aa", 0), K(100, "aa", 1),   // tx aa, parts 0,1
+        K(100, "bb", 0), K(100, "bb", 1),   // tx bb, parts 0,1
+    };
+    // Deliberately scramble then sort by the comparator.
+    std::vector<TxOrderKey> scrambled = { keys[3], keys[0], keys[2], keys[1] };
+    std::sort(scrambled.begin(), scrambled.end(), TxOrderLess);
+
+    // aa < bb (hash ascending), idx ascending within each.
+    BOOST_CHECK(scrambled[0].hash == uint256S("aa") && scrambled[0].idx == 0);
+    BOOST_CHECK(scrambled[1].hash == uint256S("aa") && scrambled[1].idx == 1);
+    BOOST_CHECK(scrambled[2].hash == uint256S("bb") && scrambled[2].idx == 0);
+    BOOST_CHECK(scrambled[3].hash == uint256S("bb") && scrambled[3].idx == 1);
+
+    // Each hash occupies a single contiguous [min,max] run.
+    auto run = [&](const uint256& h) {
+        int lo = -1, hi = -1;
+        for (int i = 0; i < (int)scrambled.size(); ++i) {
+            if (scrambled[i].hash == h) { if (lo < 0) lo = i; hi = i; }
+        }
+        return std::make_pair(lo, hi);
+    };
+    auto aa = run(uint256S("aa"));
+    auto bb = run(uint256S("bb"));
+    BOOST_CHECK_EQUAL(aa.first, 0); BOOST_CHECK_EQUAL(aa.second, 1);
+    BOOST_CHECK_EQUAL(bb.first, 2); BOOST_CHECK_EQUAL(bb.second, 3);
+    // Contiguity: run length == number of parts (no foreign row interleaved).
+    BOOST_CHECK_EQUAL(aa.second - aa.first + 1, 2);
+    BOOST_CHECK_EQUAL(bb.second - bb.first + 1, 2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Step 2 of the windowed transaction-table model (design of record: [`doc/transaction_table_windowed_model.md`](doc/transaction_table_windowed_model.md), landed in #3010). It relocates the cached-wallet **ordering** out of the Qt-thread-exclusive `TransactionTablePriv` into a producer-owned `GRC::WalletTxStore`, and converts the producer→consumer contract to **position-stamped events**.

### New
- **`src/qt/txorder.{h,cpp}`** — Qt-free ordering key + comparator (`TxOrderKey`, `TxOrderLess`: time DESC, hash ASC, idx ASC), the single source of truth for the order. GUI-OFF unit-tested in `qt_txorder_tests.cpp` (comparator levels, `lower_bound` insert positions, same-hash contiguity).
- **`src/qt/wallettxstore.{h,cpp}`** — `GRC::WalletTxStore`, owned by `WalletModel`, guarded by a new **leaf** mutex `cs_store`. `insertTransaction`/`removeTransaction` compute the position and push `RowsInserted{position,records}` / `RowsRemoved{position,count}` **while `cs_store` is held** (so queue seqno-order == store-mutation-order). `reloadAndSnapshot` rebuilds the store and discards stale queued events under `cs_main`+`cs_wallet`, returning a snapshot for the consumer replica.

### Changed
- **`wallet_event_queue.h`** — variant gains `RowsInserted`/`RowsRemoved`; the legacy `TxAdded`/`TxRemoved` payloads are retired (and the GUI `wallet_event_queue_tests.cpp` ported accordingly).
- **`walletmodel.{h,cpp}`** — `m_txStore` member + `getTxStore()`; `NotifyTransactionChanged` routes its four push sites through the store. The `showTransaction` gate and the transient-orphan override are preserved verbatim. Datetime-display cutoff moved store-side.
- **`transactiontablemodel.cpp`** — the model becomes a thin **lockstep consumer**: it keeps its own Qt-thread-exclusive replica (`cachedWallet`) and applies events at the producer-stamped position inside `begin/end{Insert,Remove}Rows`; it **never reads the store on the render path**, which keeps the still-present `QSortFilterProxyModel` consistent across a multi-insert drain batch. The ordering machinery (`hashIndex`, `shiftHashIndex`, `rebuildHashIndex`, `TxRecordOrder`, `lower_bound`) is removed. Lazy per-row status refresh (`index()` TRY_LOCK) is unchanged.

## Design notes

- **Key-only store (in this step).** The store holds ordering keys only — it does not serve reads yet, so materializing full records would only *double* resident memory. It grows to the full-records authoritative store in the windowing step, when the consumer drops its full replica for a viewport slice. Same endpoint, no transient memory doubling.
- **Lock order** is `cs_main → cs_wallet → cs_store`; `cs_store` is a leaf never held while acquiring the wallet locks, and the `Rows*` push happens under it. `cs_main` is the load-bearing producer-exclusion lock for `reloadAndSnapshot` (both `CT_DELETED` sites hold `cs_main` but not `cs_wallet`).
- **NDEBUG hardening.** The consumer bounds checks and the store contiguity invariant are enforced by explicit **runtime guards that log-and-skip**, not `assert`s: the deployed RelWithDebInfo build is `-DNDEBUG`, so an assert would vanish and a bad position/count would become an out-of-bounds vector op. No live path emits a bad position (producer positions come from `lower_bound`/`equal_range` and are provably in range) — this is defensive hardening so a future producer regression degrades safely.

## Tests

- `qt_txorder_tests` (GUI-OFF) — 6 cases; `wallet_event_queue_tests` (GUI) — 8 cases ported to the new payloads; full `test_gridcoin` suite — green.
- Clean build of `test_gridcoin`, `gridcoinresearch`, **and `test_gridcoin-qt`** (no warnings, Qt6, RelWithDebInfo).

## ⚠ Validation status — NOT yet exercised on the model shell

GUI-off CI **cannot** build or run the `wallettxstore`/event-queue/`transactiontablemodel` shell (the `test_gridcoin-qt` GUI target is GUI-only and CI is GUI-off — the exact #2944 escape class). This PR will be validated under an **ASan/UBSan-GUI build on the isolated testnet** against the pathological wallets before merge: multi-insert block bursts, reorg/`CT_DELETED` flood concurrent with a `LimitTxnDisplay`-toggle `reloadAndSnapshot`, sort/filter, selection-on-reset, CSV/copy. Reviewers: please treat green CI as necessary-but-not-sufficient here.

This was self-reviewed via a multi-agent adversarial pass (threading/lock discipline, option-(a) replay consistency, the reload/queue-discard race, payload conversion). Verdict: `cs_store` is a sound deadlock-free leaf lock, no UAF/replay-divergence found; the one blocker it caught — the GUI `wallet_event_queue_tests.cpp` still referencing the retired payloads — is fixed in this PR.

Part of the windowed-model effort (#2944 / the tx-table redesign). Step 1 was #3010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)