### PR TITLE
scraper: fix AutoGreylist GetWAS zero-denominator crash (5.5.1.0 mandatory hotfix)

### DIFF
--- a/.github/workflows/cmake_distros.yml
+++ b/.github/workflows/cmake_distros.yml
@@ -27,8 +27,8 @@ jobs:
             prep_cmd: "dnf install -y which sudo git"
             build_args: ""
 
-          - distro: OpenSUSE Leap 15.6
-            image: opensuse/leap:15.6
+          - distro: OpenSUSE Leap 16.0
+            image: opensuse/leap:16.0
             prep_cmd: "zypper refresh && zypper install -y sudo which git"
             build_args: "CC=gcc-13 CXX=g++-13"
 

--- a/.github/workflows/cmake_distros.yml
+++ b/.github/workflows/cmake_distros.yml
@@ -34,7 +34,12 @@ jobs:
 
           - distro: OpenSUSE Tumbleweed
             image: opensuse/tumbleweed
-            prep_cmd: "zypper refresh && zypper install -y sudo which git"
+            # Rolling distro: dist-upgrade to align the container's snapshot
+            # with the current repo head before installing patterns/packages.
+            # Without this, pattern installs (e.g. devel_basis) can fail when
+            # the pattern was rebuilt against newer libs than the image ships
+            # — a recurring CI drift caused by Tumbleweed's release cadence.
+            prep_cmd: "zypper --non-interactive --gpg-auto-import-keys ref && zypper --non-interactive dup --auto-agree-with-licenses --allow-vendor-change && zypper install -y sudo which git"
             build_args: ""
 
           - distro: Arch Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ HunterGate(
 # =====================
 
 project("Gridcoin"
-    VERSION 5.5.0.0
+    VERSION 5.5.1.0
     DESCRIPTION "POS-based cryptocurrency that rewards BOINC computation"
     HOMEPAGE_URL "https://gridcoin.us"
     LANGUAGES C CXX

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -92,6 +92,16 @@ install_deps() {
             ;;
 
         debian|ubuntu|linuxmint)
+            # Refresh the apt package index BEFORE we probe for renamed
+            # Qt6 packages below. On a fresh debian:sid / ubuntu:noble
+            # container the baseline image may ship with stale or empty
+            # /var/lib/apt/lists; without an update here the apt-cache
+            # probes would miss the new package names and fall back to
+            # the legacy names that no longer exist, reintroducing the
+            # original Sid CI failure. The subsequent `apt-get install`
+            # at the bottom of this case relies on the same fresh index.
+            sudo apt-get update
+
             # Base Build Tools
             append_base build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 cmake git curl ccache doxygen graphviz bison xxd libxkbcommon-dev
 
@@ -113,14 +123,13 @@ install_deps() {
             #   - Ubuntu Jammy (22.04):           old names only
             #
             # `prefer_new_qt_package` picks the new name when apt-cache
-            # knows about it, otherwise falls back to the old name. Apt-
-            # cache is already populated by this point in the CI runners
-            # (the OS-detect block above triggered an `apt update`
-            # transitively); on bare-metal dev systems each call falls
-            # through to whichever name resolves. `-q -q` keeps the
-            # detection quiet on the success path. Future renames of
-            # other modules in this family only need another one-line
-            # call to this helper.
+            # knows about it, otherwise falls back to the old name. The
+            # apt index was refreshed just above so the probe sees the
+            # current package set on any environment (CI image, bare-
+            # metal dev, fresh container). `-q -q` keeps the detection
+            # quiet on the success path. Future renames of other modules
+            # in this family only need another one-line call to this
+            # helper.
             prefer_new_qt_package() {
                 local new=$1 old=$2
                 if apt-cache -q -q show "$new" >/dev/null 2>&1; then
@@ -450,7 +459,9 @@ install_deps() {
             brew install $PKGS_TO_INSTALL
             ;;
         debian|ubuntu|linuxmint)
-            sudo apt-get update
+            # apt-get update was run earlier in the debian/ubuntu/linuxmint
+            # branch above (before the Qt6 rename-detection probes), so the
+            # index is already fresh here.
             sudo apt-get install -y --no-install-recommends $PKGS_TO_INSTALL
 
             # MinGW Threading Fix (Linux Only)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -209,18 +209,34 @@ install_deps() {
                     local url="$1"
                     local name="$2"
                     local desc="$3"
-                    # Match on the OBS project base path (.../windows:/mingw:/winNN/)
-                    # rather than the full URL or our own alias. The
-                    # openSUSE-shipped Cross-toolchain repos provide exactly
-                    # these MinGW packages, but carry a human-readable alias
-                    # and a distribution-specific URL suffix that neither a
-                    # full-URL nor an alias match would recognise. Matching the
-                    # base path identifies them and avoids adding a duplicate
-                    # repo (which is how the dead-URL duplicates were created
-                    # in the first place).
+                    # Detection is done on the OBS project base path
+                    # (.../windows:/mingw:/winNN/) rather than the full URL or
+                    # our own alias, because the openSUSE-shipped Cross-toolchain
+                    # repos provide exactly these MinGW packages but carry a
+                    # human-readable alias and a URL whose trailing distro
+                    # segment may differ from ours (e.g. no trailing slash).
+                    #
+                    # A repo only actually satisfies the dependency if its URL
+                    # carries BOTH the base path AND the current distro segment
+                    # ($DISTRO_PATH). A repo with the base path but a different
+                    # distro segment — a stale dead-URL duplicate from the
+                    # pre-fix script, or a Leap/Tumbleweed mismatch — does NOT
+                    # satisfy it and must not be silently treated as if it did.
                     local base="${url%"$DISTRO_PATH"/}"
-                    if sudo zypper lr -u | grep -Fq "$base"; then
-                        echo "Repository for $desc already provided by an existing repo ($base) - skipping."
+                    if sudo zypper lr -u | grep -F "$base" | grep -Fq "$DISTRO_PATH"; then
+                        echo "Repository for $desc already provided by an existing repo - skipping."
+                    elif sudo zypper lr -u | grep -Fq "$base"; then
+                        # Base path present but wrong distro segment: a stale or
+                        # mismatched MinGW repo is in the way. It will not
+                        # provide $desc packages for this system and will fail
+                        # to refresh. Warn with cleanup instructions rather than
+                        # adding a second repo for the same OBS project.
+                        echo "Warning: a MinGW cross-toolchain repo for a different distribution"
+                        echo "         is present under ${base} (expected distro segment"
+                        echo "         '$DISTRO_PATH'). It will not provide $desc packages for"
+                        echo "         this system and will fail on refresh. Remove the stale"
+                        echo "         repo — 'sudo zypper lr' to find its alias, then"
+                        echo "         'sudo zypper rr <alias>' — and re-run."
                     elif sudo zypper lr | grep -Fq "$name"; then
                         echo "Warning: Repository alias '$name' exists but URL mismatch - leaving as-is."
                     else

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -187,7 +187,12 @@ install_deps() {
                 DISTRO_PATH="openSUSE_Tumbleweed"
                 IS_TUMBLEWEED="true"
             elif [[ "$PRETTY_NAME" == *"Leap"* ]]; then
-                DISTRO_PATH="15.6"
+                # The openSUSE Build Service distribution directory for Leap is
+                # openSUSE_Leap_<version> (e.g. openSUSE_Leap_16.0). VERSION_ID
+                # is sourced from /etc/os-release during OS detection above.
+                # Hardcoding a fixed version here produced dead repo URLs on
+                # every Leap release other than the hardcoded one.
+                DISTRO_PATH="openSUSE_Leap_${VERSION_ID}"
             else
                  echo "Error: Unknown openSUSE version."
                  return 1
@@ -204,15 +209,23 @@ install_deps() {
                     local url="$1"
                     local name="$2"
                     local desc="$3"
-                    if sudo zypper lr -u | grep -Fq "$url"; then
-                        echo "Repository for $desc already exists (URL match)."
+                    # Match on the OBS project base path (.../windows:/mingw:/winNN/)
+                    # rather than the full URL or our own alias. The
+                    # openSUSE-shipped Cross-toolchain repos provide exactly
+                    # these MinGW packages, but carry a human-readable alias
+                    # and a distribution-specific URL suffix that neither a
+                    # full-URL nor an alias match would recognise. Matching the
+                    # base path identifies them and avoids adding a duplicate
+                    # repo (which is how the dead-URL duplicates were created
+                    # in the first place).
+                    local base="${url%"$DISTRO_PATH"/}"
+                    if sudo zypper lr -u | grep -Fq "$base"; then
+                        echo "Repository for $desc already provided by an existing repo ($base) - skipping."
+                    elif sudo zypper lr | grep -Fq "$name"; then
+                        echo "Warning: Repository alias '$name' exists but URL mismatch - leaving as-is."
                     else
-                        if sudo zypper lr | grep -q "$name"; then
-                            echo "Warning: Repository alias '$name' exists but URL mismatch."
-                        else
-                            echo "Adding $desc repository: $url"
-                            sudo zypper ar -f "$url" "$name"
-                        fi
+                        echo "Adding $desc repository: $url"
+                        sudo zypper ar -f "$url" "$name"
                     fi
                 }
                 add_repo_if_missing "$REPO_64_URL" "$REPO_64_NAME" "MinGW Win64"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -99,26 +99,39 @@ install_deps() {
             append_base libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libqrencode-dev libzip-dev libcurl4-openssl-dev zipcmp zipmerge ziptool
 
             # Qt6 Packages (Qt5 names are not defined here as most are EOL)
-            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev
+            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools
 
-            # The Qt6Core5Compat dev package was renamed across the Debian/Ubuntu
-            # family in mid-2026:
-            #   - Debian Sid (and forky/trixie) ship only `qt6-5compat-dev`;
-            #     the older `libqt6core5compat6-dev` was dropped.
-            #   - Ubuntu Noble (24.04) ships both -- `libqt6core5compat6-dev` is
-            #     a transitional that pulls in `qt6-5compat-dev`.
-            #   - Ubuntu Jammy (22.04) ships only `libqt6core5compat6-dev`.
-            # Detect which name is available in the current apt cache and use
-            # that. Apt-cache is already populated by this point in the CI
-            # runners (the OS-detect block above triggered an `apt update`
-            # transitively) and on bare-metal dev systems this falls through
-            # to whichever name resolves. `-q -q` keeps the detection quiet on
-            # the success path.
-            if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
-                append_qt qt6-5compat-dev
-            else
-                append_qt libqt6core5compat6-dev
-            fi
+            # Several Qt6 module -dev packages were renamed across the
+            # Debian/Ubuntu family between 2024 and 2026, moving from the
+            # legacy `libqt6<module>6-dev` naming to the upstream-aligned
+            # `qt6-<module>-dev` naming. The transitional metapackages have
+            # been dropped at different points per distro:
+            #
+            #   - Debian Sid / forky / trixie:    new names only
+            #   - Debian Bookworm (12):           new names only
+            #   - Ubuntu Noble (24.04):           new names only
+            #   - Ubuntu Jammy (22.04):           old names only
+            #
+            # `prefer_new_qt_package` picks the new name when apt-cache
+            # knows about it, otherwise falls back to the old name. Apt-
+            # cache is already populated by this point in the CI runners
+            # (the OS-detect block above triggered an `apt update`
+            # transitively); on bare-metal dev systems each call falls
+            # through to whichever name resolves. `-q -q` keeps the
+            # detection quiet on the success path. Future renames of
+            # other modules in this family only need another one-line
+            # call to this helper.
+            prefer_new_qt_package() {
+                local new=$1 old=$2
+                if apt-cache -q -q show "$new" >/dev/null 2>&1; then
+                    append_qt "$new"
+                else
+                    append_qt "$old"
+                fi
+            }
+            prefer_new_qt_package qt6-charts-dev   libqt6charts6-dev
+            prefer_new_qt_package qt6-svg-dev      libqt6svg6-dev
+            prefer_new_qt_package qt6-5compat-dev  libqt6core5compat6-dev
 
             # Windows Cross-Compile Tools
             # NOTE: We only append NSIS here. The MinGW compiler (g++-mingw-w64-x86-64)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -250,6 +250,32 @@ install_deps() {
             fi
 
             # Pattern Install
+            #
+            # On Tumbleweed (rolling release), the base image as of
+            # snapshot ~20260523 ships busybox-gawk (and busybox-less),
+            # both of which `provide` the generic `gawk` / `less` capability.
+            # `patterns-devel-base-devel_basis` requires the canonical GNU
+            # gawk; zypper refuses the install with "not installable
+            # providers" because busybox-gawk already owns the `gawk`
+            # provider slot. Remove the busybox shims first so the devel
+            # pattern can pull in the real GNU tools.
+            #
+            # Safe for non-CI / bare-metal developer use too: on a system
+            # that's about to install patterns-devel-base-devel_basis, the
+            # canonical GNU gawk/less are what's actually wanted -- the
+            # busybox-* variants are minimal alternates the pattern will
+            # replace anyway. The `|| true` keeps this idempotent: if the
+            # busybox packages aren't installed (e.g. an existing fully
+            # provisioned dev box) the rm is a no-op.
+            #
+            # Leap and other openSUSE flavours don't hit this in their
+            # current snapshots, so the workaround is gated on Tumbleweed
+            # only.
+            if [[ "$IS_TUMBLEWEED" == "true" ]]; then
+                echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less, if present)..."
+                sudo zypper rm -y busybox-gawk busybox-less 2>/dev/null || true
+            fi
+
             echo "Installing devel_basis pattern..."
             sudo zypper install -y -t pattern devel_basis
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -264,16 +264,21 @@ install_deps() {
             # that's about to install patterns-devel-base-devel_basis, the
             # canonical GNU gawk/less are what's actually wanted -- the
             # busybox-* variants are minimal alternates the pattern will
-            # replace anyway. The `|| true` keeps this idempotent: if the
-            # busybox packages aren't installed (e.g. an existing fully
-            # provisioned dev box) the rm is a no-op.
+            # replace anyway.
             #
             # Leap and other openSUSE flavours don't hit this in their
-            # current snapshots, so the workaround is gated on Tumbleweed
-            # only.
-            if [[ "$IS_TUMBLEWEED" == "true" ]]; then
-                echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less, if present)..."
-                sudo zypper rm -y busybox-gawk busybox-less 2>/dev/null || true
+            # current snapshots, so the workaround is gated on Tumbleweed.
+            # The `rpm -q --quiet` guard skips the rm entirely on systems
+            # where neither shim is installed (e.g. an already-provisioned
+            # dev box) -- no zypper noise and no exit-code dance. When the
+            # rm does run, stderr stays visible so a real removal failure
+            # (repo lock, network, solver problem) surfaces in the CI /
+            # shell log rather than masquerading as the downstream
+            # devel_basis install failure.
+            if [[ "$IS_TUMBLEWEED" == "true" ]] \
+                && { rpm -q --quiet busybox-gawk || rpm -q --quiet busybox-less; }; then
+                echo "Removing busybox shims that conflict with devel_basis (busybox-gawk, busybox-less)..."
+                sudo zypper rm -y busybox-gawk busybox-less
             fi
 
             echo "Installing devel_basis pattern..."

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -99,7 +99,26 @@ install_deps() {
             append_base libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libqrencode-dev libzip-dev libcurl4-openssl-dev zipcmp zipmerge ziptool
 
             # Qt6 Packages (Qt5 names are not defined here as most are EOL)
-            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev libqt6core5compat6-dev
+            append_qt qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-tools-dev-tools libqt6charts6-dev libqt6svg6-dev
+
+            # The Qt6Core5Compat dev package was renamed across the Debian/Ubuntu
+            # family in mid-2026:
+            #   - Debian Sid (and forky/trixie) ship only `qt6-5compat-dev`;
+            #     the older `libqt6core5compat6-dev` was dropped.
+            #   - Ubuntu Noble (24.04) ships both -- `libqt6core5compat6-dev` is
+            #     a transitional that pulls in `qt6-5compat-dev`.
+            #   - Ubuntu Jammy (22.04) ships only `libqt6core5compat6-dev`.
+            # Detect which name is available in the current apt cache and use
+            # that. Apt-cache is already populated by this point in the CI
+            # runners (the OS-detect block above triggered an `apt update`
+            # transitively) and on bare-metal dev systems this falls through
+            # to whichever name resolves. `-q -q` keeps the detection quiet on
+            # the success path.
+            if apt-cache -q -q show qt6-5compat-dev >/dev/null 2>&1; then
+                append_qt qt6-5compat-dev
+            else
+                append_qt libqt6core5compat6-dev
+            fi
 
             # Windows Cross-Compile Tools
             # NOTE: We only append NSIS here. The MinGW compiler (g++-mingw-w64-x86-64)

--- a/src/gridcoin/project.h
+++ b/src/gridcoin/project.h
@@ -635,11 +635,22 @@ public:
                 TC_40_SB_avg /= 2;
             }
 
-            if (TC_7_SB_avg == 0 && TC_40_SB_avg == 0) {
+            // The denominator of the WAS fraction is TC_40_SB_avg, so guard on
+            // THAT alone, not on both averages being zero. A zero 40-SB average
+            // — including the integer-division-truncation case where a small
+            // 40-SB total-credit delta divided by up to 40 rounds down to 0
+            // while TC_7_SB_avg is still non-zero — means there is negligible
+            // long-term work availability, so the WAS is 0.0 (exactly the
+            // no-statistics value this method documents above). The previous
+            // "TC_7_SB_avg == 0 && TC_40_SB_avg == 0" guard let TC_40_SB_avg == 0
+            // with TC_7_SB_avg != 0 fall through to Fraction(x, 0), which throws
+            // std::out_of_range("denominator specified is zero") and aborts
+            // ThreadScraperSubscriber on every node processing that superblock.
+            if (TC_40_SB_avg == 0) {
                 return Fraction(0);
-            } else {
-                return Fraction(TC_7_SB_avg, TC_40_SB_avg);
             }
+
+            return Fraction(TC_7_SB_avg, TC_40_SB_avg);
         }
 
         //!

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1532,4 +1532,33 @@ BOOST_AUTO_TEST_CASE(it_applies_benefit_of_doubt_correctly)
     delete whitelist_index_entry;
 }
 
+BOOST_AUTO_TEST_CASE(it_does_not_throw_when_the_40SB_average_truncates_to_zero)
+{
+    // Regression test for the GetWAS() divide-by-zero that crashed mainnet nodes in
+    // ThreadScraperSubscriber (St12out_of_range "denominator specified is zero").
+    //
+    // GetWAS() returns Fraction(TC_7_SB_avg, TC_40_SB_avg), where both averages are
+    // integer divisions (sum / min(processed, 7|40)). A low-activity project whose
+    // 40-SB total-credit delta is small enough that m_TC_40_SB_sum / 40 truncates to 0,
+    // while m_TC_7_SB_sum / 7 is still non-zero, used to fall through the old
+    // "TC_7_SB_avg == 0 && TC_40_SB_avg == 0" guard to Fraction(non-zero, 0), which
+    // throws. The fix guards on the denominator (TC_40_SB_avg) alone and returns WAS = 0.
+    //
+    // Drive the candidate through the public UpdateGreylistCandidateEntry path (which
+    // itself calls GetWAS() internally) so this reproduces the exact production code path.
+    GRC::AutoGreylist::GreylistCandidateEntry candidate("TestProject", std::optional<uint64_t>(1000));
+
+    // sb_from_baseline = 7, total credit 990: 7-SB delta = 1000 - 990 = 10 -> m_TC_7_SB_sum = 10.
+    candidate.UpdateGreylistCandidateEntry(990, 7, false);
+
+    // sb_from_baseline = 40, total credit 970: 40-SB delta = 1000 - 970 = 30 -> m_TC_40_SB_sum = 30,
+    // m_sb_from_baseline_processed = 40. GetWAS() (called inside UpdateGreylistCandidateEntry) then
+    // computes TC_7_SB_avg = 10 / min(40,7) = 10/7 = 1 (non-zero) and
+    // TC_40_SB_avg = 30 / min(40,40) = 30/40 = 0 (integer truncation) -- the crash trigger.
+    BOOST_REQUIRE_NO_THROW(candidate.UpdateGreylistCandidateEntry(970, 40, false));
+
+    // A zero 40-SB average means negligible long-term work availability, so WAS = 0.0.
+    BOOST_CHECK(candidate.GetWAS() == Fraction(0));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Mandatory hotfix — 5.5.1.0

Fixes a network-wide node crash first observed on mainnet on 2026-06-08. Subscriber nodes abort in `ThreadScraperSubscriber()` with:

```
EXCEPTION: St12out_of_range
denominator specified is zero
gridcoin in ThreadScraperSubscriber()
terminate called after throwing an instance of 'std::out_of_range'
  what():  denominator specified is zero
```

This is a hard abort (SIGABRT), not a graceful exit: the exception propagates out of `ScraperConstructConvergedManifestByProject` / the AutoGreylist refresh, `PrintException` re-throws it past the thread's `catch`, and it reaches `std::terminate`. Because every node computes the same AutoGreylist over the same superblock data, all subscriber nodes hit it simultaneously.

## Root cause

`Project::GreylistCandidateEntry::GetWAS()` (`src/gridcoin/project.h`) computes the Work Availability Score as `Fraction(TC_7_SB_avg, TC_40_SB_avg)`. The denominator is `TC_40_SB_avg`, but the divide-by-zero guard keyed on **both** averages being zero:

```cpp
uint64_t TC_7_SB_avg  = m_TC_7_SB_sum  / std::min<uint64_t>(m_sb_from_baseline_processed, 7);
uint64_t TC_40_SB_avg = m_TC_40_SB_sum / std::min<uint64_t>(m_sb_from_baseline_processed, 40);
...
if (TC_7_SB_avg == 0 && TC_40_SB_avg == 0) {   // <-- wrong condition
    return Fraction(0);
} else {
    return Fraction(TC_7_SB_avg, TC_40_SB_avg); // <-- throws when TC_40_SB_avg == 0, TC_7_SB_avg != 0
}
```

Both averages are **integer** divisions. A low-activity project whose 40-SB total-credit delta is small enough that `m_TC_40_SB_sum / 40` truncates to `0`, while `m_TC_7_SB_sum / 7` is still non-zero, falls through the `&&` guard to `Fraction(non-zero, 0)`. The `Fraction` constructor throws `std::out_of_range("denominator specified is zero")`. On mainnet this was triggered by a project at exactly that truncation edge (logged immediately before the crash as `Project … was excluded because there was no convergence … at the project level`).

## Fix

Guard on the denominator (`TC_40_SB_avg`) alone:

```cpp
if (TC_40_SB_avg == 0) {
    return Fraction(0);
}
return Fraction(TC_7_SB_avg, TC_40_SB_avg);
```

A zero 40-SB average means negligible long-term work availability, so the WAS is `0.0` — exactly the no-statistics value `GetWAS()` already documents. This is the value the original guard plainly intended to return; the `&&` was the defect. The change is consensus-relevant (WAS feeds greylisting → magnitude → superblock), but the prior behavior was a universal abort — no node completed the superblock through this path — so coordinated deployment of this fix lets all nodes compute the intended `WAS = 0` and agree.

## Verification

Validated **live on mainnet**: with the hotfix deployed, the node re-hit the identical convergence-exclusion trigger that aborted it twice before (06:11, 06:16) and **kept running** — no exception, chain syncing forward through the AutoGreylist refresh path.

## Full Fraction zero-denominator audit

Because this class of bug aborts a consensus thread, every use of `GRC::Fraction` (`src/util.h`) in consensus code was traced to confirm `GetWAS()` was the only unguarded zero-denominator site. It was.

**Two existing invariants** keep the rest safe:
1. The `Fraction` **constructor** rejects `denominator == 0` (and `INT64_MIN`) — so any `Fraction` that exists has a non-zero denominator, and every `… / x.GetDenominator()` division is safe by construction.
2. The `Fraction` **deserializer** (`SerializationOp`, `src/util.h`) re-checks on read and throws `std::ios_base::failure` — the malformed-contract-**rejection** path, *not* a crash. So a crafted/corrupt SideStake/Allocation contract carrying a zero (or `INT64_MIN`) denominator is rejected as invalid, not network-fatal. This closes the obvious crafted-contract DoS vector.

Every site, classified:

| Site | Verdict | Why |
|---|---|---|
| `project.h` `GetWAS()` — `Fraction(TC_7_SB_avg, TC_40_SB_avg)` | **FIXED** | the bug; now guarded on `TC_40_SB_avg == 0` |
| `chainparams.cpp` (all), `project.h` `Fraction(1, 10)`, `validation.cpp` `Fraction(4, 5)`, `poll.cpp` `Fraction(100, 567)` | SAFE | literal non-zero denominators |
| single-arg `Fraction(x)` and default `Fraction()` (`project.h`, `poll.cpp`, `registry.cpp`, `sidestake.cpp`) | SAFE | denominator defaults to `1` |
| `Fraction` / `Allocation` **deserialize** (`SerializationOp`) | SAFE | guards `denom == 0` + `INT64_MIN` → `ios_base::failure` (reject, not crash) |
| `Allocation(numerator, denominator)` ctors (`sidestake.cpp`) | SAFE | only reached via the guarded deserialize, or `Allocation(double / 100.0)` |
| `Fraction::operator/` / `operator/=` — inverts the divisor (`a / b → a * Fraction(b.denom, b.numer)`), so a **zero-valued** divisor would throw | SAFE | no consensus caller divides by a possibly-zero `Fraction`; the only division-by-variable is `double / 100.0` |
| reward math: `… / GetMagnitudeUnit().GetDenominator()` (`accrual/snapshot.h`), `… / foundation_fee_fraction.GetDenominator()` (`miner.cpp`), `… / fee_fraction.GetDenominator()` (`mrc.cpp`) | SAFE | denominator-never-zero invariant (#1) |
| `mrc.cpp` `… / mrc_payment_interval` (a **non-`Fraction`** integer divisor) | SAFE | guarded by the `mrc_payment_interval < zero_payout_interval` early `return`; `zero_payout_interval` is a positive consensus constant ⇒ divisor `≥ 1` at the division |

**Durable takeaway:** the `Fraction` *constructor* throws `std::out_of_range` (the crash class that `PrintException` + `terminate` made fatal here), whereas the *deserializer* throws `std::ios_base::failure` (handled). So the risk is specifically **new code that builds a `Fraction` from a *computed* denominator** — `GetWAS()` was the only such site, and it is now guarded.

## Changes

- `scraper: fix divide-by-zero abort in AutoGreylist GetWAS (denominator-only guard)`
- `test: regression test for AutoGreylist GetWAS zero-denominator crash` — drives the public `UpdateGreylistCandidateEntry` → `GetWAS` path to the truncation edge; throws pre-fix, returns `Fraction(0)` post-fix.
- `build: bump version to 5.5.1.0 for the hotfix release`

CI-only commits cherry-picked from `development` so this PR's checks pass on the `master` base (which predates them): OpenSUSE Leap 16.0 image bump, OpenSUSE Tumbleweed `zypper dup` + busybox-gawk/-less removal, and the Debian-family new-vs-legacy Qt6 `-dev` package-name detection. No production-code effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
