### PR TITLE
qt: off-load WalletTxStore O(N) maintenance to a store-worker (windowed-model PR2.5)

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(test_gridcoin-qt
     bitcoinunitstests.cpp
     uritests.cpp
     wallet_event_queue_tests.cpp
+    wallettxstore_tests.cpp
 )
 
 set_target_properties(test_gridcoin-qt PROPERTIES

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -4,6 +4,7 @@
 #include "bitcoinunitstests.h"
 #include "uritests.h"
 #include "wallet_event_queue_tests.h"
+#include "wallettxstore_tests.h"
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -35,6 +36,10 @@ int main(int argc, char *argv[])
 
     WalletEventQueueTests test3;
     if (QTest::qExec(&test3) != 0)
+        fInvalid = true;
+
+    WalletTxStoreTests test4;
+    if (QTest::qExec(&test4) != 0)
         fInvalid = true;
 
     return fInvalid;

--- a/src/qt/test/wallettxstore_tests.cpp
+++ b/src/qt/test/wallettxstore_tests.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "wallettxstore_tests.h"
+
+#include "arith_uint256.h"
+#include "qt/transactionrecord.h"
+#include "qt/wallet_event_queue.h"
+#include "qt/wallettxstore.h"
+#include "uint256.h"
+
+#include <set>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using GRC::RowsInsertedPayload;
+using GRC::RowsRemovedPayload;
+using GRC::WalletEventQueue;
+using GRC::WalletTxStore;
+
+namespace {
+
+//! Distinct, deterministic hash per integer (locale-independent — no string
+//! conversion). n+1 avoids the zero hash.
+uint256 hashOf(int n)
+{
+    return ArithToUint256(arith_uint256(static_cast<uint64_t>(n) + 1));
+}
+
+//! A single-part TransactionRecord carrying just the ordering key fields the
+//! store uses (time/hash/idx); the rest default. The store's insert/remove
+//! never touch the wallet, so these synthetic records are sufficient.
+TransactionRecord makeRec(const uint256& hash, int64_t time, int idx)
+{
+    TransactionRecord r(hash, time);
+    r.idx = idx;
+    return r;
+}
+
+//! Poll the event queue (the worker drains asynchronously) until it holds at
+//! least `expected` events or a generous timeout elapses. qWait pumps the Qt
+//! loop and sleeps; ~1.5s ceiling is far above the worker's drain latency.
+void waitForQueue(WalletEventQueue& q, std::size_t expected)
+{
+    for (int i = 0; i < 300 && q.size() < expected; ++i) {
+        QTest::qWait(5);
+    }
+}
+
+} // anonymous namespace
+
+void WalletTxStoreTests::workerDrainsAllInsertsInOrder()
+{
+    WalletEventQueue q;
+    // reloadAndSnapshot (the only consumer of m_wallet) is not exercised here,
+    // so a null wallet is safe — the worker's insert/remove path is wallet-free.
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    constexpr int N = 50;
+    for (int i = 0; i < N; ++i) {
+        store.enqueueInsert(std::vector<TransactionRecord>{makeRec(hashOf(i), 1000 + i, 0)});
+    }
+    waitForQueue(q, static_cast<std::size_t>(N));
+
+    auto batch = q.drain();
+    QCOMPARE(batch.size(), static_cast<std::size_t>(N));
+    // Each distinct-hash insert yields exactly one RowsInserted; the single
+    // worker drains the intake FIFO in order, so seqnos are dense [0, N).
+    for (int i = 0; i < N; ++i) {
+        QVERIFY(std::holds_alternative<RowsInsertedPayload>(batch[i].payload));
+        QCOMPARE(batch[i].seqno, static_cast<uint64_t>(i));
+    }
+}
+
+void WalletTxStoreTests::workerHandlesInterleavedInsertRemove()
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    const uint256 h1 = hashOf(1);
+    const uint256 h2 = hashOf(2);
+    store.enqueueInsert(std::vector<TransactionRecord>{makeRec(h1, 2000, 0)});
+    store.enqueueInsert(std::vector<TransactionRecord>{makeRec(h2, 1000, 0)});
+    store.enqueueRemove(h1);
+    waitForQueue(q, 3);
+
+    auto batch = q.drain();
+    QCOMPARE(batch.size(), static_cast<std::size_t>(3));
+    // The worker dispatches both intake kinds, in enqueue order.
+    QVERIFY(std::holds_alternative<RowsInsertedPayload>(batch[0].payload));
+    QVERIFY(std::holds_alternative<RowsInsertedPayload>(batch[1].payload));
+    QVERIFY(std::holds_alternative<RowsRemovedPayload>(batch[2].payload));
+}
+
+void WalletTxStoreTests::workerPreservesAllUnderConcurrentProducers()
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    // Several producers enqueue concurrently (distinct hashes, so no dedup);
+    // the single worker serializes them. Confirms every item is applied exactly
+    // once — no loss, dup, or reorder across the MPSC intake.
+    constexpr int kProducers = 4;
+    constexpr int kPer       = 100;
+    constexpr int kTotal     = kProducers * kPer;
+
+    std::vector<std::thread> producers;
+    producers.reserve(kProducers);
+    for (int p = 0; p < kProducers; ++p) {
+        producers.emplace_back([&store, p]() {
+            for (int i = 0; i < kPer; ++i) {
+                store.enqueueInsert(
+                    std::vector<TransactionRecord>{makeRec(hashOf(p * 1000 + i), 1000 + i, 0)});
+            }
+        });
+    }
+    for (auto& t : producers) t.join();
+    waitForQueue(q, static_cast<std::size_t>(kTotal));
+
+    auto batch = q.drain();
+    QCOMPARE(batch.size(), static_cast<std::size_t>(kTotal));
+    std::set<uint64_t> seqnos;
+    for (const auto& ev : batch) {
+        QVERIFY(std::holds_alternative<RowsInsertedPayload>(ev.payload));
+        seqnos.insert(ev.seqno);
+    }
+    // Dense, unique seqnos == single-writer serialization of the concurrent intake.
+    QCOMPARE(seqnos.size(), static_cast<std::size_t>(kTotal));
+    QCOMPARE(*seqnos.begin(),  static_cast<uint64_t>(0));
+    QCOMPARE(*seqnos.rbegin(), static_cast<uint64_t>(kTotal - 1));
+}
+
+void WalletTxStoreTests::dtorWithPendingIntakeIsClean()
+{
+    WalletEventQueue q;
+    {
+        WalletTxStore store(nullptr, q);
+        store.start();
+        // Flood the intake, then destroy immediately — the worker is very likely
+        // still draining. The dtor must set m_stop and join cleanly without
+        // hanging, even with items still queued.
+        for (int i = 0; i < 500; ++i) {
+            store.enqueueInsert(std::vector<TransactionRecord>{makeRec(hashOf(i), 1000 + i, 0)});
+        }
+    } // store dtor here: stop + join. If it hung, this test would never return.
+    QVERIFY(true);
+}

--- a/src/qt/test/wallettxstore_tests.h
+++ b/src/qt/test/wallettxstore_tests.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_WALLETTXSTORE_TESTS_H
+#define BITCOIN_QT_TEST_WALLETTXSTORE_TESTS_H
+
+#include <QObject>
+#include <QTest>
+
+//! Coverage for the PR2.5 store-worker / double-queue: producers enqueue
+//! (O(1)) and a single worker thread drains the intake queue and runs the O(N)
+//! store maintenance off the core locks, pushing the position-stamped events.
+//! These exercise the worker's drain/ordering/concurrency and clean shutdown.
+//! The rebuild barrier (reloadAndSnapshot quiescing the worker) needs a live
+//! CWallet, so it is covered by the ASan-GUI mesh soak + isolated-testnet
+//! validation, exactly as the PR2 store proper was.
+class WalletTxStoreTests : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void workerDrainsAllInsertsInOrder();
+    void workerHandlesInterleavedInsertRemove();
+    void workerPreservesAllUnderConcurrentProducers();
+    void dtorWithPendingIntakeIsClean();
+};
+
+#endif // BITCOIN_QT_TEST_WALLETTXSTORE_TESTS_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -52,6 +52,13 @@ WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* p
     connect(eventDrainTimer, &QTimer::timeout, this, &WalletModel::drainEventQueue);
     eventDrainTimer->start(MODEL_EVENT_DRAIN_INTERVAL);
 
+    // Launch the store-worker now — before producers can fire (subscribe is
+    // below) — so it is ready to drain the intake queue off the core locks
+    // (PR2.5). The initial reloadAndSnapshot in the TransactionTableModel ctor
+    // above ran with no worker yet; that is fine, it skips the worker barrier
+    // when the worker has not started.
+    m_txStore.start();
+
     subscribeToCoreSignals();
 }
 
@@ -728,7 +735,7 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
                      "NotifyTransactionChanged: %s status=%d but tx not in mapWallet "
                      "— removing from store",
                      hash.GetHex(), status);
-            walletmodel->getTxStore().removeTransaction(hash);
+            walletmodel->getTxStore().enqueueRemove(hash);
             break;
         }
         const CWalletTx& wtx = it->second;
@@ -764,25 +771,27 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
         }
 
         if (visible) {
-            // Decompose under the locks already held, then hand the records to
-            // the producer-side store, which applies the datetime cutoff,
-            // de-dupes, computes the insert position, and emits RowsInserted.
+            // Decompose under the locks already held, then ENQUEUE the records
+            // to the store-worker (PR2.5). The worker applies the datetime
+            // cutoff, de-dupes, computes the insert position, and emits
+            // RowsInserted off the core locks; the enqueue itself is O(1), so
+            // this handler no longer does O(N) ordering work under cs_main.
             const QList<TransactionRecord> decomposed =
                 TransactionRecord::decomposeTransaction(wallet, wtx);
             if (!decomposed.isEmpty()) {
-                walletmodel->getTxStore().insertTransaction(
+                walletmodel->getTxStore().enqueueInsert(
                     std::vector<TransactionRecord>(decomposed.begin(), decomposed.end()));
             }
         } else {
             // Tx is genuinely filtered out (a real orphan coinstake, or a
             // legacy non-IsFromMe OP_RETURN). Ensure the store removes the rows
             // if they were previously visible — a no-op if absent.
-            walletmodel->getTxStore().removeTransaction(hash);
+            walletmodel->getTxStore().enqueueRemove(hash);
         }
         break;
     }
     case CT_DELETED:
-        walletmodel->getTxStore().removeTransaction(hash);
+        walletmodel->getTxStore().enqueueRemove(hash);
         break;
     }
 }

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -33,6 +33,95 @@ WalletTxStore::WalletTxStore(CWallet* wallet, GRC::WalletEventQueue& queue)
 {
 }
 
+WalletTxStore::~WalletTxStore()
+{
+    {
+        LOCK(cs_intake);
+        m_stop = true;
+    }
+    m_intake_cv.notify_all();
+    if (m_worker.joinable()) {
+        m_worker.join();
+    }
+}
+
+void WalletTxStore::start()
+{
+    // Qt thread, once. Launch the worker that drains the intake queue off the
+    // core locks. Idempotent so a double-call (e.g. re-init) is harmless.
+    if (m_started) {
+        return;
+    }
+    m_started = true;
+    m_worker = std::thread([this] { workerLoop(); });
+}
+
+void WalletTxStore::enqueueInsert(std::vector<TransactionRecord> records)
+{
+    {
+        LOCK(cs_intake);
+        m_intake.push_back(IntakeItem{IntakeItem::Insert, std::move(records), uint256()});
+    }
+    m_intake_cv.notify_one();
+}
+
+void WalletTxStore::enqueueRemove(const uint256& hash)
+{
+    {
+        LOCK(cs_intake);
+        m_intake.push_back(IntakeItem{IntakeItem::Remove, {}, hash});
+    }
+    m_intake_cv.notify_one();
+}
+
+void WalletTxStore::workerLoop()
+{
+    WAIT_LOCK(cs_intake, lock);
+    while (true) {
+        // Wait for work, a stop request, or a rebuild pause. Use the explicit
+        // while-condition form (NOT a wait() predicate lambda): the Clang
+        // thread-safety analyzer does not propagate the held lock into a lambda
+        // body, but it does into this loop, so the guarded reads stay verified.
+        while (!m_stop && (m_rebuilding || m_intake.empty())) {
+            // While a rebuild is pending, park and tell reloadAndSnapshot we are
+            // idle so it can clear the intake queue and rebuild the index with no
+            // concurrent worker mutation.
+            if (m_rebuilding && !m_worker_parked) {
+                m_worker_parked = true;
+                m_idle_cv.notify_all();
+            }
+            m_intake_cv.wait(lock);
+        }
+        if (m_stop) {
+            return;
+        }
+        // We have work and are not rebuilding.
+        m_worker_parked = false;
+
+        IntakeItem item = std::move(m_intake.front());
+        m_intake.pop_front();
+
+        // Drop cs_intake while doing the O(N) store maintenance (which takes
+        // cs_store). cs_intake and cs_store are NEVER held simultaneously, so the
+        // two leaves cannot invert. The lock re-acquires at the end of this scope
+        // before the loop re-evaluates its wait condition.
+        {
+            REVERSE_LOCK(lock);
+            applyIntake(std::move(item));
+        }
+    }
+}
+
+void WalletTxStore::applyIntake(IntakeItem item)
+{
+    // No lock held here; insert/removeTransaction take cs_store internally.
+    if (item.kind == IntakeItem::Insert) {
+        insertTransaction(std::move(item.records));
+    } else {
+        removeTransaction(item.hash);
+    }
+}
+
 void WalletTxStore::shiftIndex(std::size_t from, std::ptrdiff_t delta)
 {
     // Bump every index entry at or after `from` by `delta`. Logical positions,
@@ -182,6 +271,22 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
     // emptied queue mutually consistent.
     LOCK2(cs_main, m_wallet->cs_wallet);
 
+    // Quiesce the store-worker (PR2.5) before clearing/rebuilding. The worker is
+    // an independent store mutator that cs_main/cs_wallet does NOT exclude, so
+    // signal a rebuild and wait for it to park. It never needs cs_main/cs_wallet
+    // (insert/removeTransaction take only cs_store), so waiting for it here while
+    // we hold both cannot deadlock. m_started guards the pre-start() first reload
+    // (no worker yet → nothing to wait for).
+    {
+        WAIT_LOCK(cs_intake, ilock);
+        m_rebuilding = true;
+        m_intake_cv.notify_all();   // wake the worker so it observes m_rebuilding
+        while (m_started && !m_worker_parked) {
+            m_idle_cv.wait(ilock);  // wait until the worker confirms it has parked
+        }
+        m_intake.clear();           // pre-rebuild intake is superseded by the scan below
+    }
+
     built.reserve(m_wallet->mapWallet.size() * 2);
     for (auto it = m_wallet->mapWallet.begin(); it != m_wallet->mapWallet.end(); ++it) {
         if (!TransactionRecord::showTransaction(it->second)) {
@@ -215,6 +320,16 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
     // on cs_wallet, so nothing new can be queued until we return; the returned
     // snapshot, the rebuilt index, and the now-empty queue are consistent.
     m_queue.drain();
+
+    // Release the store-worker (PR2.5): the rebuilt index is live, so resume
+    // draining. Producers remain blocked on cs_wallet until we return, so the
+    // worker has nothing to apply until the snapshot is installed.
+    {
+        LOCK(cs_intake);
+        m_rebuilding = false;
+        m_worker_parked = false;
+        m_intake_cv.notify_all();
+    }
 
     return built;
 }

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -11,7 +11,6 @@
 #include "sync.h"
 #include "uint256.h"
 
-#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <deque>

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -11,8 +11,11 @@
 #include "sync.h"
 #include "uint256.h"
 
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -63,32 +66,35 @@ class WalletTxStore
 {
 public:
     WalletTxStore(CWallet* wallet, GRC::WalletEventQueue& queue);
+    ~WalletTxStore();
 
     WalletTxStore(const WalletTxStore&) = delete;
     WalletTxStore& operator=(const WalletTxStore&) = delete;
 
     //!
-    //! \brief Producer: a transaction became visible. Applies the cached
-    //! datetime-display cutoff, de-duplicates, computes the TxOrderLess insert
-    //! position, updates the index, and pushes one RowsInserted carrying the
-    //! surviving records. A no-op (no event) if the tx is already present or
-    //! every record is filtered out.
+    //! \brief Start the store-worker thread. Called once by WalletModel after
+    //! construction, before the first reloadAndSnapshot. Idempotent.
     //!
-    //! Called from core threads. Takes cs_store internally; the caller must NOT
-    //! hold cs_store. (Callers that produced \p records via decomposeTransaction
-    //! already released nothing — they still hold cs_main/cs_wallet, which is
-    //! fine: cs_store is the innermost leaf.)
+    void start();
+
     //!
-    void insertTransaction(std::vector<TransactionRecord> records);
+    //! \brief Producer: a transaction became visible. Enqueues the
+    //! already-decomposed \p records onto the intake queue and returns
+    //! immediately (O(1), no store mutation on the caller's thread); the worker
+    //! applies the datetime cutoff, dedup, ordering, and the RowsInserted event
+    //! off-lock. Called from core threads under cs_main/cs_wallet — takes only
+    //! the leaf cs_intake, never cs_store, so it never waits on the O(N)
+    //! ordering maintenance (PR2.5 double-queue).
+    //!
+    void enqueueInsert(std::vector<TransactionRecord> records);
 
     //!
     //! \brief Producer: a transaction is no longer visible / was deleted.
-    //! Locates its contiguous range via the hash index and pushes one
-    //! RowsRemoved. A no-op (no event) if the tx is not present. Touches only
-    //! the store (cs_store) — never the wallet — so it is safe to call from the
-    //! CT_DELETED path which holds no wallet locks.
+    //! Enqueues a removal by \p hash for the worker (O(1), same threading
+    //! contract as enqueueInsert). Safe from the CT_DELETED path (no wallet
+    //! locks held).
     //!
-    void removeTransaction(const uint256& hash);
+    void enqueueRemove(const uint256& hash);
 
     //!
     //! \brief Qt thread: rebuild the store from the wallet and return a full
@@ -107,6 +113,26 @@ public:
     std::vector<TransactionRecord> reloadAndSnapshot(bool limit_enabled, int64_t limit_time);
 
 private:
+    //! One unit of deferred store maintenance handed from a producer to the worker.
+    struct IntakeItem {
+        enum Kind { Insert, Remove } kind;
+        std::vector<TransactionRecord> records; //!< Insert: the decomposed parts.
+        uint256 hash;                           //!< Remove: the tx hash.
+    };
+
+    //! Worker entry point: drain the intake queue and apply each item. Parks
+    //! while m_rebuilding is set (acknowledging via m_worker_parked); exits on
+    //! m_stop. Holds cs_intake only while waiting/dequeuing — never with cs_store.
+    void workerLoop();
+    //! Worker: apply one intake item (the O(N) store maintenance). Must be called
+    //! with NO lock held; insert/removeTransaction take cs_store internally.
+    void applyIntake(IntakeItem item);
+
+    //! The O(N) ordering maintenance, now worker-private (was the public PR2 API;
+    //! producers call enqueue* instead). Each takes cs_store and pushes one event.
+    void insertTransaction(std::vector<TransactionRecord> records);
+    void removeTransaction(const uint256& hash);
+
     void shiftIndex(std::size_t from, std::ptrdiff_t delta) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
     void rebuildIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_store);
 
@@ -123,6 +149,20 @@ private:
     //! Cached OptionsModel datetime-display cutoff, set by reloadAndSnapshot.
     bool m_limit_enabled GUARDED_BY(cs_store){false};
     int64_t m_limit_time GUARDED_BY(cs_store){0};
+
+    //! Intake queue (PR2.5). Producers enqueue here; the store-worker drains it
+    //! and performs the O(N) maintenance off the core locks. cs_intake is an
+    //! independent leaf — it is NEVER held while taking cs_store (and vice
+    //! versa), so the two never invert.
+    mutable Mutex cs_intake;
+    std::deque<IntakeItem> m_intake GUARDED_BY(cs_intake);
+    bool m_stop GUARDED_BY(cs_intake){false};          //!< shutdown request (dtor)
+    bool m_rebuilding GUARDED_BY(cs_intake){false};    //!< reloadAndSnapshot wants the worker parked
+    bool m_worker_parked GUARDED_BY(cs_intake){false}; //!< worker has acknowledged the pause
+    CConditionVariable m_intake_cv;  //!< worker waits for work / stop / resume
+    CConditionVariable m_idle_cv;    //!< reloadAndSnapshot waits for m_worker_parked
+    std::thread m_worker;
+    bool m_started{false};           //!< Qt-thread only: start() idempotency guard
 };
 
 } // namespace GRC


### PR DESCRIPTION
## Windowed-model PR2.5 — off-load the store's O(N) maintenance to a worker

Follow-up to #3011 (windowed-model PR2). Addresses the Copilot review point on that PR:
`NotifyTransactionChanged` called `insertTransaction`/`removeTransaction` **synchronously**, doing
the O(N) `m_keys` vector splice + `shiftIndex` reindex under `cs_main`+`cs_wallet`. That moved onto
the validation/msghand critical path the O(N) ordering work which — pre-refactor — ran on the Qt
consumer thread, off the core locks. On a large wallet a reorg `CT_DELETED` flood could stall
validation.

### The double-queue
- Producers now call **`enqueueInsert`/`enqueueRemove`** — an O(1) push onto an intake queue under
  the leaf `cs_intake` (never `cs_store`) — and return immediately.
- A single **store-worker thread** drains the intake FIFO and performs the O(N) maintenance holding
  **only `cs_store`**, then pushes the position-stamped `RowsInserted`/`RowsRemoved` onto the
  existing event queue for the unchanged thin GUI apply.
- Single writer ⇒ event-queue order still equals mutation order end-to-end.

Producer under-lock cost drops to **O(parts) decompose + O(1) enqueue**; the reorg flood becomes N
cheap enqueues, not N O(N) shifts under `cs_main`.

### Rebuild barrier
`reloadAndSnapshot` now quiesces the worker (it is a store mutator that `cs_main`/`cs_wallet` does
not exclude): set `m_rebuilding`, wait for the worker to park, clear the intake queue, rebuild the
index, drain the event queue, then release. The worker never needs `cs_main`/`cs_wallet`
(`insert`/`remove` take only `cs_store`), so waiting for it while holding both cannot deadlock. The
wait loops use the explicit `while`-condition form (not a `wait()` predicate lambda) so the Clang
thread-safety analyzer keeps the `cs_intake`-guarded reads verified.

This is also the in-process precursor to the Phase-4 node/GUI (multiprocess) split: the worker is the
node-side store maintainer; the event queue is the wire.

### Verification
- Builds clean under **clang `-DWERROR_THREAD_SAFETY=ON`** (the new worker, `cs_intake`, the
  explicit-`while` waits, and the barrier).
- New **`WalletTxStoreTests`** (Qt test binary), all passing: drain-all-in-order, interleaved
  insert/remove, concurrent-producer serialization (4×100, dense seqnos), clean dtor with pending
  intake. (`insert`/`remove` never touch `m_wallet`, so synthetic records suffice.)
- **Pending pre-merge:** ASan/UBSan-GUI mesh soak (burst + reorg + reload races) on the isolated
  testnet — the rebuild-barrier + `reloadAndSnapshot` integration needs a live wallet, exactly as
  the PR2 store proper was validated.

Part of the windowed transaction-table model (#2944); stacks on #3011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
