### PR TITLE
rpc: add analyzepsgt command

### DIFF
--- a/src/psgt.cpp
+++ b/src/psgt.cpp
@@ -808,8 +808,11 @@ std::string PSGTRoleName(PSGTRole role)
 }
 
 // Maximum serialized scriptSig sizes used for final-size estimation.
-// A DER-encoded ECDSA signature plus sighash byte is at most 72 bytes,
-// 73 with its push opcode; a compressed pubkey is 33 bytes, 34 pushed.
+// A standard low-S DER-encoded ECDSA signature plus sighash byte is at most
+// 72 bytes, 73 with its push opcode (the consensus maximum is one byte more,
+// but SCRIPT_VERIFY_LOW_S is part of STANDARD_SCRIPT_VERIFY_FLAGS, so a
+// high-S signature would not relay and is the wrong bound for a broadcast
+// size estimate); a compressed pubkey is 33 bytes, 34 pushed.
 static constexpr unsigned int DUMMY_SIG_PUSH_SIZE = 73;
 static constexpr unsigned int DUMMY_PUBKEY_PUSH_SIZE = 34;
 
@@ -982,7 +985,8 @@ PSGTAnalysis AnalyzePSGT(const PartiallySignedTransaction& psgtx)
             out_amt += txout.nValue;
         }
         result.fee = in_amt - out_amt;
-        if (*result.fee < 0) {
+        if (*result.fee < 0 && result.error.empty()) {
+            // Don't overwrite a per-input error recorded above.
             result.error = "Transaction outputs exceed inputs";
         }
     }

--- a/src/psgt.cpp
+++ b/src/psgt.cpp
@@ -6,13 +6,18 @@
 
 #include <hash.h>
 #include <keystore.h>
+#include <policy/fees.h>
 #include <script/interpreter.h>
 #include <script/sign.h>
 #include <script/standard.h>
 #include <span.h>
 #include <streams.h>
+#include <tinyformat.h>
 #include <util/strencodings.h>
+#include <version.h>
 
+#include <algorithm>
+#include <cassert>
 #include <set>
 
 // Helper: extract a vector<unsigned char> from a CDataStream.
@@ -787,4 +792,208 @@ bool DecodeRawPSGT(PartiallySignedTransaction& psgt,
     }
 
     return true;
+}
+
+std::string PSGTRoleName(PSGTRole role)
+{
+    switch (role) {
+    case PSGTRole::CREATOR: return "creator";
+    case PSGTRole::UPDATER: return "updater";
+    case PSGTRole::SIGNER: return "signer";
+    case PSGTRole::FINALIZER: return "finalizer";
+    case PSGTRole::EXTRACTOR: return "extractor";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+    return "";
+}
+
+// Maximum serialized scriptSig sizes used for final-size estimation.
+// A DER-encoded ECDSA signature plus sighash byte is at most 72 bytes,
+// 73 with its push opcode; a compressed pubkey is 33 bytes, 34 pushed.
+static constexpr unsigned int DUMMY_SIG_PUSH_SIZE = 73;
+static constexpr unsigned int DUMMY_PUBKEY_PUSH_SIZE = 34;
+
+/** Serialized size of pushing a redeem script onto a scriptSig. */
+static unsigned int RedeemScriptPushSize(const CScript& redeem_script)
+{
+    const size_t n = redeem_script.size();
+    return n + (n < OP_PUSHDATA1 ? 1 : n <= 0xff ? 2 : 3);
+}
+
+PSGTAnalysis AnalyzePSGT(const PartiallySignedTransaction& psgtx)
+{
+    PSGTAnalysis result;
+
+    if (psgtx.tx.vin.empty()) {
+        result.next = PSGTRole::CREATOR;
+        return result;
+    }
+
+    if (psgtx.inputs.size() != psgtx.tx.vin.size()) {
+        result.error = "PSGT input count does not match unsigned transaction input count";
+        result.next = PSGTRole::CREATOR;
+        return result;
+    }
+
+    bool all_have_utxo = true;
+    bool all_sizable = true;
+    CAmount in_amt = 0;
+
+    // Copy of the unsigned tx whose scriptSigs are filled with dummies of the
+    // expected final length, so one GetSerializeSize call yields the estimate.
+    CMutableTransaction est_tx = psgtx.tx;
+
+    result.inputs.resize(psgtx.inputs.size());
+
+    for (unsigned int i = 0; i < psgtx.inputs.size(); ++i) {
+        const PSGTInput& input = psgtx.inputs[i];
+        PSGTInputAnalysis& ia = result.inputs[i];
+
+        ia.is_final = PSGTInputSigned(input);
+
+        // Unlike SignPSGTInput/FinalizePSGT, also require the provided
+        // previous transaction to actually match prevout.hash — a mismatched
+        // utxo would yield a bogus amount and scriptPubKey for analysis.
+        const COutPoint& prevout = psgtx.tx.vin[i].prevout;
+        ia.has_utxo = !input.non_witness_utxo.IsNull()
+            && prevout.n < input.non_witness_utxo.vout.size()
+            && input.non_witness_utxo.GetHash() == prevout.hash;
+
+        if (ia.has_utxo) {
+            in_amt += input.non_witness_utxo.vout[prevout.n].nValue;
+        } else {
+            all_have_utxo = false;
+        }
+
+        if (ia.is_final) {
+            ia.next = PSGTRole::EXTRACTOR;
+            est_tx.vin[i].scriptSig = input.final_script_sig;
+            continue;
+        }
+
+        if (!ia.has_utxo) {
+            ia.next = PSGTRole::UPDATER;
+            all_sizable = false;
+            continue;
+        }
+
+        const CScript& scriptPubKey = input.non_witness_utxo.vout[prevout.n].scriptPubKey;
+        CScript signScript = scriptPubKey;
+        bool is_p2sh = scriptPubKey.IsPayToScriptHash();
+
+        if (is_p2sh) {
+            CScriptID expected(uint160(std::vector<unsigned char>(
+                scriptPubKey.begin() + 2, scriptPubKey.begin() + 22)));
+            if (input.redeem_script.empty() || CScriptID(input.redeem_script) != expected) {
+                ia.missing_redeem_script = true;
+                ia.next = PSGTRole::UPDATER;
+                all_sizable = false;
+                continue;
+            }
+            signScript = input.redeem_script;
+        }
+
+        txnouttype scriptType;
+        std::vector<std::vector<unsigned char>> vSolutions;
+        Solver(signScript, scriptType, vSolutions);
+
+        unsigned int script_sig_size = 0;
+
+        switch (scriptType) {
+        case TX_PUBKEY:
+        {
+            ia.missing_sigs.push_back(CPubKey(vSolutions[0]).GetID());
+            ia.next = PSGTRole::SIGNER;
+            script_sig_size = DUMMY_SIG_PUSH_SIZE;
+            break;
+        }
+        case TX_PUBKEYHASH:
+        {
+            const CKeyID keyid = CKeyID(uint160(vSolutions[0]));
+            ia.missing_sigs.push_back(keyid);
+            // The signer also needs the full pubkey; report it missing unless
+            // the PSGT carries it in hd_keypaths (a wallet signer will have
+            // its own copy, but an offline analyzer cannot know that).
+            bool have_pubkey = false;
+            for (const auto& kp : input.hd_keypaths) {
+                if (kp.first.GetID() == keyid) {
+                    have_pubkey = true;
+                    break;
+                }
+            }
+            if (!have_pubkey) ia.missing_pubkeys.push_back(keyid);
+            ia.next = PSGTRole::SIGNER;
+            script_sig_size = DUMMY_SIG_PUSH_SIZE + DUMMY_PUBKEY_PUSH_SIZE;
+            break;
+        }
+        case TX_MULTISIG:
+        {
+            // vSolutions[0][0] = required count, [1..N] = pubkeys, [N+1][0] = key count
+            const unsigned int required = vSolutions.front()[0];
+            unsigned int have = 0;
+            for (unsigned int k = 1; k + 1 < vSolutions.size(); ++k) {
+                CKeyID keyid = CPubKey(vSolutions[k]).GetID();
+                if (input.partial_sigs.count(keyid)) {
+                    ++have;
+                } else {
+                    ia.missing_sigs.push_back(keyid);
+                }
+            }
+            if (have >= required) {
+                // Enough signatures to assemble; the remaining keys are optional.
+                ia.missing_sigs.clear();
+                ia.next = PSGTRole::FINALIZER;
+            } else {
+                ia.next = PSGTRole::SIGNER;
+            }
+            script_sig_size = 1 /* OP_0 */ + required * DUMMY_SIG_PUSH_SIZE;
+            break;
+        }
+        default:
+            result.error = strprintf("Input %u spends a non-standard or unspendable output", i);
+            ia.next = PSGTRole::UPDATER;
+            all_sizable = false;
+            continue;
+        }
+
+        if (is_p2sh) {
+            script_sig_size += RedeemScriptPushSize(input.redeem_script);
+        }
+
+        // Raw filler bytes (not a push) so the dummy scriptSig serializes to
+        // exactly script_sig_size bytes of script body.
+        CScript dummy;
+        dummy.insert(dummy.end(), script_sig_size, 0x00);
+        est_tx.vin[i].scriptSig = dummy;
+    }
+
+    // Note: unlike Bitcoin, a non-final single-sig (P2PK/P2PKH) input is
+    // always the signer's job, never the finalizer's — SignPSGTInput writes
+    // final_script_sig directly and FinalizeInput cannot assemble single-sig
+    // inputs from partial_sigs (the full pubkey is not stored there).
+    result.next = PSGTRole::EXTRACTOR;
+    for (const PSGTInputAnalysis& ia : result.inputs) {
+        result.next = std::min(result.next, ia.next);
+    }
+
+    if (all_have_utxo) {
+        CAmount out_amt = 0;
+        for (const CTxOut& txout : psgtx.tx.vout) {
+            out_amt += txout.nValue;
+        }
+        result.fee = in_amt - out_amt;
+        if (*result.fee < 0) {
+            result.error = "Transaction outputs exceed inputs";
+        }
+    }
+
+    if (all_sizable) {
+        const unsigned int est_size =
+            ::GetSerializeSize(CTransaction(est_tx), SER_NETWORK, PROTOCOL_VERSION);
+        result.estimated_final_size = est_size;
+        result.min_required_fee =
+            GetMinFee(CTransaction(psgtx.tx), 1000, GMF_SEND, est_size);
+    }
+
+    return result;
 }

--- a/src/psgt.h
+++ b/src/psgt.h
@@ -10,6 +10,8 @@
 #include <pubkey.h>
 
 #include <map>
+#include <optional>
+#include <string>
 #include <vector>
 
 // BIP 174-style key types for PSGT serialization.
@@ -126,5 +128,48 @@ std::vector<unsigned char> SerializePSGT(const PartiallySignedTransaction& psgt)
 void UpdatePSGTOutput(const SigningProvider& provider,
                        PartiallySignedTransaction& psgt,
                        unsigned int index);
+
+/** Roles in the PSGT workflow, in pipeline order. */
+enum class PSGTRole {
+    CREATOR,
+    UPDATER,
+    SIGNER,
+    FINALIZER,
+    EXTRACTOR,
+};
+
+/** Lowercase display name of a PSGT role ("creator", "updater", ...). */
+std::string PSGTRoleName(PSGTRole role);
+
+/** Analysis result for a single PSGT input. */
+struct PSGTInputAnalysis
+{
+    bool has_utxo = false;  //!< non_witness_utxo present, prevout.n in range, hash matches
+    bool is_final = false;  //!< final_script_sig present
+    PSGTRole next = PSGTRole::UPDATER; //!< Next role needed to make progress on this input
+
+    std::vector<CKeyID> missing_pubkeys; //!< Keys whose full pubkey is not in the PSGT
+    std::vector<CKeyID> missing_sigs;    //!< Keys whose signature is still required
+    bool missing_redeem_script = false;  //!< P2SH input whose redeem script is unknown
+};
+
+/** Whole-PSGT analysis result (Bitcoin Core analyzepsbt equivalent). */
+struct PSGTAnalysis
+{
+    std::optional<CAmount> fee;                       //!< Inputs minus outputs; set iff all input UTXOs are known
+    std::optional<unsigned int> estimated_final_size; //!< Bytes of the fully-signed tx; set iff every input's final size can be estimated
+    std::optional<CAmount> min_required_fee;          //!< GetMinFee at the estimated final size
+    std::vector<PSGTInputAnalysis> inputs;
+    PSGTRole next = PSGTRole::EXTRACTOR; //!< Earliest-stage role needed across all inputs
+    std::string error;                   //!< Non-empty if a problem was detected
+};
+
+/**
+ * Analyze a PSGT: per-input UTXO/finality status, missing material
+ * (pubkeys, signatures, redeem scripts), the next role required per input
+ * and globally, plus fee and estimated final size when computable.
+ * Pure function of the PSGT; does not consult the wallet or mutate anything.
+ */
+PSGTAnalysis AnalyzePSGT(const PartiallySignedTransaction& psgtx);
 
 #endif // GRIDCOIN_PSGT_H

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -343,6 +343,115 @@ UniValue decodepsgt(const UniValue& params)
     return result;
 }
 
+static const RPCHelpMan analyzepsgt_help{
+    "analyzepsgt",
+    "Analyzes and provides information about the current status of a PSGT and its inputs.",
+    {
+        {"psgt", RPCArg::Type::STR, RPCArg::Optional::NO,
+            "A base64-encoded PSGT."},
+    },
+    RPCResult{RPCResult::Type::OBJ, "", "",
+        {
+            {RPCResult::Type::ARR, "inputs", "Per-input analysis.",
+                {
+                    {RPCResult::Type::OBJ, "", "",
+                        {
+                            {RPCResult::Type::BOOL, "has_utxo",
+                                "Whether a matching non_witness_utxo is provided for this input."},
+                            {RPCResult::Type::BOOL, "is_final",
+                                "Whether the input has a final scriptSig."},
+                            {RPCResult::Type::OBJ, "missing", /*optional=*/true,
+                                "Material still required to complete this input (only present when something is missing).",
+                                {
+                                    {RPCResult::Type::ARR, "pubkeys", /*optional=*/true,
+                                        "Key hashes whose full public key is not in the PSGT.",
+                                        {{RPCResult::Type::STR_HEX, "keyid", "Hash160 of the public key."}}},
+                                    {RPCResult::Type::ARR, "signatures", /*optional=*/true,
+                                        "Key hashes whose signature is still required.",
+                                        {{RPCResult::Type::STR_HEX, "keyid", "Hash160 of the public key."}}},
+                                    {RPCResult::Type::BOOL, "redeemscript", /*optional=*/true,
+                                        "Whether the P2SH redeem script is missing."},
+                                }},
+                            {RPCResult::Type::STR, "next",
+                                "Role of the next person this input needs to go to."},
+                        }},
+                }},
+            {RPCResult::Type::NUM, "estimated_final_size", /*optional=*/true,
+                "Estimated size of the fully-signed transaction in bytes "
+                "(only present when every input's final size can be estimated)."},
+            {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true,
+                "Transaction fee in GRC (only present when all input UTXOs are known)."},
+            {RPCResult::Type::STR_AMOUNT, "min_required_fee", /*optional=*/true,
+                "Minimum fee in GRC required by network policy at the estimated final size."},
+            {RPCResult::Type::STR, "next",
+                "Role of the next person this PSGT needs to go to."},
+            {RPCResult::Type::STR, "error", /*optional=*/true,
+                "Error message (only present when there is an error)."},
+        }},
+    RPCExamples{
+        HelpExampleCli("analyzepsgt", "\"cHNndP8B...\"") +
+        HelpExampleRpc("analyzepsgt", "\"cHNndP8B...\"")},
+};
+const RPCHelpMan& analyzepsgt_helpman() { return analyzepsgt_help; }
+
+UniValue analyzepsgt(const UniValue& params)
+{
+    PartiallySignedTransaction psgt;
+    string error;
+    if (!DecodeRawPSGT(psgt, params[0].get_str(), error))
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, error);
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    UniValue result(UniValue::VOBJ);
+
+    UniValue inputs_arr(UniValue::VARR);
+    for (const PSGTInputAnalysis& ia : analysis.inputs)
+    {
+        UniValue in_obj(UniValue::VOBJ);
+        in_obj.pushKV("has_utxo", ia.has_utxo);
+        in_obj.pushKV("is_final", ia.is_final);
+
+        if (!ia.missing_pubkeys.empty() || !ia.missing_sigs.empty() || ia.missing_redeem_script)
+        {
+            UniValue missing(UniValue::VOBJ);
+            if (!ia.missing_pubkeys.empty())
+            {
+                UniValue arr(UniValue::VARR);
+                for (const CKeyID& keyid : ia.missing_pubkeys)
+                    arr.push_back(keyid.GetHex());
+                missing.pushKV("pubkeys", arr);
+            }
+            if (!ia.missing_sigs.empty())
+            {
+                UniValue arr(UniValue::VARR);
+                for (const CKeyID& keyid : ia.missing_sigs)
+                    arr.push_back(keyid.GetHex());
+                missing.pushKV("signatures", arr);
+            }
+            if (ia.missing_redeem_script)
+                missing.pushKV("redeemscript", true);
+            in_obj.pushKV("missing", missing);
+        }
+
+        in_obj.pushKV("next", PSGTRoleName(ia.next));
+        inputs_arr.push_back(in_obj);
+    }
+    result.pushKV("inputs", inputs_arr);
+
+    if (analysis.estimated_final_size)
+        result.pushKV("estimated_final_size", (int)*analysis.estimated_final_size);
+    if (analysis.fee)
+        result.pushKV("fee", ValueFromAmount(*analysis.fee));
+    if (analysis.min_required_fee)
+        result.pushKV("min_required_fee", ValueFromAmount(*analysis.min_required_fee));
+    result.pushKV("next", PSGTRoleName(analysis.next));
+    if (!analysis.error.empty())
+        result.pushKV("error", analysis.error);
+
+    return result;
+}
+
 static const RPCHelpMan combinepsgt_help{
     "combinepsgt",
     "Combine multiple PSGTs for the same transaction into one merged PSGT.",

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -440,7 +440,7 @@ UniValue analyzepsgt(const UniValue& params)
     result.pushKV("inputs", inputs_arr);
 
     if (analysis.estimated_final_size)
-        result.pushKV("estimated_final_size", (int)*analysis.estimated_final_size);
+        result.pushKV("estimated_final_size", (int64_t)*analysis.estimated_final_size);
     if (analysis.fee)
         result.pushKV("fee", ValueFromAmount(*analysis.fee));
     if (analysis.min_required_fee)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -384,6 +384,7 @@ static const CRPCCommand vRPCCommands[] =
     { "walletdiagnose",          &walletdiagnose,          cat_wallet, &walletdiagnose_helpman        },
 
   // PSGT commands
+    { "analyzepsgt",             &analyzepsgt,             cat_wallet, &analyzepsgt_helpman        },
     { "createpsgt",              &createpsgt,              cat_wallet, &createpsgt_helpman        },
     { "decodepsgt",              &decodepsgt,              cat_wallet, &decodepsgt_helpman        },
     { "combinepsgt",             &combinepsgt,             cat_wallet, &combinepsgt_helpman        },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -193,6 +193,7 @@ extern UniValue walletpassphrasechange(const UniValue& params);
 extern UniValue walletdiagnose(const UniValue& params);
 
 // PSGT (Partially Signed Gridcoin Transactions)
+extern UniValue analyzepsgt(const UniValue& params);
 extern UniValue createpsgt(const UniValue& params);
 extern UniValue decodepsgt(const UniValue& params);
 extern UniValue combinepsgt(const UniValue& params);
@@ -355,6 +356,7 @@ extern const RPCHelpMan& createhtlc_helpman();
 extern const RPCHelpMan& createmrcrequest_helpman();
 extern const RPCHelpMan& createrawtransaction_helpman();
 extern const RPCHelpMan& currentcontractaverage_helpman();
+extern const RPCHelpMan& analyzepsgt_helpman();
 extern const RPCHelpMan& combinepsgt_helpman();
 extern const RPCHelpMan& converttopsgt_helpman();
 extern const RPCHelpMan& createpsgt_helpman();

--- a/src/test/psgt_tests.cpp
+++ b/src/test/psgt_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <key.h>
 #include <keystore.h>
+#include <policy/fees.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <psgt.h>
@@ -14,6 +15,7 @@
 #include <script/standard.h>
 #include <streams.h>
 #include <util/strencodings.h>
+#include <version.h>
 
 BOOST_AUTO_TEST_SUITE(psgt_tests)
 
@@ -640,6 +642,250 @@ BOOST_AUTO_TEST_CASE(hd_keypaths_roundtrip)
     BOOST_CHECK(it2 != psgt2.outputs[0].hd_keypaths.end());
     BOOST_CHECK_EQUAL(it2->second.fingerprint[0], 0xCA);
     BOOST_CHECK_EQUAL(it2->second.path[2], 0x8000002Au);
+}
+
+// ---------------------------------------------------------------------------
+// AnalyzePSGT tests.
+// ---------------------------------------------------------------------------
+
+static CScript P2SH(const CScriptID& id)
+{
+    CScript s;
+    s << OP_HASH160 << id << OP_EQUAL;
+    return s;
+}
+
+static CScript Multisig1of2(const CKey& key1, const CKey& key2)
+{
+    CScript s;
+    s << OP_1 << key1.GetPubKey() << key2.GetPubKey() << OP_2 << OP_CHECKMULTISIG;
+    return s;
+}
+
+// Build a fake previous transaction with an arbitrary scriptPubKey.
+static CTransaction MakePrevTxScript(const CScript& scriptPubKey, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.nTime = 1700000000;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout.SetNull();
+    mtx.vin[0].scriptSig = CScript() << 0;
+    mtx.vout.push_back(CTxOut(amount, scriptPubKey));
+    return CTransaction(mtx);
+}
+
+// Build an unsigned one-input spend of prevTx:0 paying amount to a fresh key.
+static PartiallySignedTransaction MakeSpendPSGT(const CTransaction& prevTx, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.nTime = 1700002000;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(prevTx.GetHash(), 0);
+    mtx.vout.push_back(CTxOut(amount, P2PKH(MakeKey().GetPubKey().GetID())));
+
+    PartiallySignedTransaction psgt(mtx);
+    psgt.inputs[0].non_witness_utxo = prevTx;
+    return psgt;
+}
+
+// Test: unsigned P2PKH input — signer's turn, missing sig and pubkey,
+// fee/size/min-fee all computable.
+BOOST_AUTO_TEST_CASE(analyze_p2pkh_unsigned)
+{
+    CKey key = MakeKey();
+    CKeyID keyid = key.GetPubKey().GetID();
+    CTransaction prevTx = MakePrevTx(key, 10 * COIN);
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    const PSGTInputAnalysis& ia = analysis.inputs[0];
+    BOOST_CHECK(ia.has_utxo);
+    BOOST_CHECK(!ia.is_final);
+    BOOST_CHECK(ia.next == PSGTRole::SIGNER);
+    BOOST_REQUIRE_EQUAL(ia.missing_sigs.size(), 1u);
+    BOOST_CHECK(ia.missing_sigs[0] == keyid);
+    // No hd_keypaths entry, so the full pubkey is unknown to the PSGT.
+    BOOST_REQUIRE_EQUAL(ia.missing_pubkeys.size(), 1u);
+    BOOST_CHECK(ia.missing_pubkeys[0] == keyid);
+    BOOST_CHECK(!ia.missing_redeem_script);
+
+    BOOST_CHECK(analysis.next == PSGTRole::SIGNER);
+    BOOST_CHECK(analysis.error.empty());
+
+    BOOST_REQUIRE(analysis.fee.has_value());
+    BOOST_CHECK_EQUAL(*analysis.fee, 1 * COIN);
+
+    // Estimated size = unsigned size + dummy P2PKH scriptSig (107 bytes).
+    BOOST_REQUIRE(analysis.estimated_final_size.has_value());
+    const unsigned int unsigned_size =
+        ::GetSerializeSize(CTransaction(psgt.tx), SER_NETWORK, PROTOCOL_VERSION);
+    BOOST_CHECK_EQUAL(*analysis.estimated_final_size, unsigned_size + 107);
+
+    BOOST_REQUIRE(analysis.min_required_fee.has_value());
+    BOOST_CHECK_EQUAL(*analysis.min_required_fee,
+        GetMinFee(CTransaction(psgt.tx), 1000, GMF_SEND, *analysis.estimated_final_size));
+
+    // With a pubkey present in hd_keypaths, only the signature is missing.
+    psgt.inputs[0].hd_keypaths[key.GetPubKey()] = KeyOriginInfo();
+    analysis = AnalyzePSGT(psgt);
+    BOOST_CHECK(analysis.inputs[0].missing_pubkeys.empty());
+    BOOST_CHECK_EQUAL(analysis.inputs[0].missing_sigs.size(), 1u);
+}
+
+// Test: input without UTXO data — updater's turn, no fee or size estimate.
+BOOST_AUTO_TEST_CASE(analyze_no_utxo)
+{
+    CKey key = MakeKey();
+    CTransaction prevTx = MakePrevTx(key, 10 * COIN);
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+    psgt.inputs[0].non_witness_utxo = CTransaction();
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    BOOST_CHECK(!analysis.inputs[0].has_utxo);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::UPDATER);
+    BOOST_CHECK(analysis.next == PSGTRole::UPDATER);
+    BOOST_CHECK(!analysis.fee.has_value());
+    BOOST_CHECK(!analysis.estimated_final_size.has_value());
+    BOOST_CHECK(!analysis.min_required_fee.has_value());
+}
+
+// Test: provided UTXO does not match the input's prevout hash — treated as
+// missing (stricter than SignPSGTInput, which skips the hash check).
+BOOST_AUTO_TEST_CASE(analyze_wrong_utxo_hash)
+{
+    CKey key = MakeKey();
+    CTransaction prevTx = MakePrevTx(key, 10 * COIN);
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+    // Substitute a different transaction as the claimed UTXO.
+    psgt.inputs[0].non_witness_utxo = MakePrevTx(MakeKey(), 10 * COIN);
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    BOOST_CHECK(!analysis.inputs[0].has_utxo);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::UPDATER);
+    BOOST_CHECK(!analysis.fee.has_value());
+}
+
+// Test: P2SH 1-of-2 multisig — signer's turn until enough partial sigs,
+// then finalizer's turn.
+BOOST_AUTO_TEST_CASE(analyze_multisig_partial)
+{
+    CKey key1 = MakeKey();
+    CKey key2 = MakeKey();
+    CScript redeem = Multisig1of2(key1, key2);
+    CTransaction prevTx = MakePrevTxScript(P2SH(CScriptID(redeem)), 10 * COIN);
+
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+    psgt.inputs[0].redeem_script = redeem;
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    BOOST_CHECK(analysis.inputs[0].has_utxo);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::SIGNER);
+    BOOST_CHECK_EQUAL(analysis.inputs[0].missing_sigs.size(), 2u);
+    BOOST_CHECK(analysis.next == PSGTRole::SIGNER);
+
+    // Estimated scriptSig: OP_0 + 1 dummy sig + redeem script push.
+    BOOST_REQUIRE(analysis.estimated_final_size.has_value());
+    const unsigned int unsigned_size =
+        ::GetSerializeSize(CTransaction(psgt.tx), SER_NETWORK, PROTOCOL_VERSION);
+    BOOST_CHECK_EQUAL(*analysis.estimated_final_size,
+        unsigned_size + 1 + 73 + redeem.size() + 1);
+
+    // Sign with one key — 1-of-2 is now satisfiable: finalizer's turn.
+    CBasicKeyStore keystore;
+    keystore.AddKey(key1);
+    keystore.AddCScript(redeem);
+    BOOST_REQUIRE(SignPSGTInput(keystore, psgt, 0));
+    BOOST_REQUIRE_EQUAL(psgt.inputs[0].partial_sigs.size(), 1u);
+
+    analysis = AnalyzePSGT(psgt);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::FINALIZER);
+    BOOST_CHECK(analysis.inputs[0].missing_sigs.empty());
+    BOOST_CHECK(analysis.next == PSGTRole::FINALIZER);
+}
+
+// Test: P2SH input with unknown redeem script — updater's turn; fee is still
+// known (the UTXO is present) but the final size is not estimable.
+BOOST_AUTO_TEST_CASE(analyze_p2sh_missing_redeem)
+{
+    CKey key1 = MakeKey();
+    CKey key2 = MakeKey();
+    CScript redeem = Multisig1of2(key1, key2);
+    CTransaction prevTx = MakePrevTxScript(P2SH(CScriptID(redeem)), 10 * COIN);
+
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    BOOST_CHECK(analysis.inputs[0].has_utxo);
+    BOOST_CHECK(analysis.inputs[0].missing_redeem_script);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::UPDATER);
+    BOOST_CHECK(analysis.next == PSGTRole::UPDATER);
+    BOOST_REQUIRE(analysis.fee.has_value());
+    BOOST_CHECK_EQUAL(*analysis.fee, 1 * COIN);
+    BOOST_CHECK(!analysis.estimated_final_size.has_value());
+}
+
+// Test: fully signed input — extractor's turn; the actual final scriptSig is
+// used for the size estimate.
+BOOST_AUTO_TEST_CASE(analyze_final_extractor)
+{
+    CKey key = MakeKey();
+    CTransaction prevTx = MakePrevTx(key, 10 * COIN);
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+
+    CBasicKeyStore keystore;
+    keystore.AddKey(key);
+    BOOST_REQUIRE(SignPSGTInput(keystore, psgt, 0));
+    BOOST_REQUIRE(PSGTInputSigned(psgt.inputs[0]));
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    BOOST_CHECK(analysis.inputs[0].is_final);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::EXTRACTOR);
+    BOOST_CHECK(analysis.inputs[0].missing_sigs.empty());
+    BOOST_CHECK(analysis.next == PSGTRole::EXTRACTOR);
+
+    // The estimate uses the actual final scriptSig, so it must equal the
+    // size of the extracted, fully-signed transaction.
+    CMutableTransaction final_tx = psgt.tx;
+    final_tx.vin[0].scriptSig = psgt.inputs[0].final_script_sig;
+    BOOST_REQUIRE(analysis.estimated_final_size.has_value());
+    BOOST_CHECK_EQUAL(*analysis.estimated_final_size,
+        ::GetSerializeSize(CTransaction(final_tx), SER_NETWORK, PROTOCOL_VERSION));
+}
+
+// Test: outputs exceed inputs — error reported with a negative fee; and a
+// PSGT with no inputs is the creator's problem.
+BOOST_AUTO_TEST_CASE(analyze_negative_fee_and_empty)
+{
+    CKey key = MakeKey();
+    CTransaction prevTx = MakePrevTx(key, 10 * COIN);
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 11 * COIN);
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_CHECK(!analysis.error.empty());
+    BOOST_REQUIRE(analysis.fee.has_value());
+    BOOST_CHECK_EQUAL(*analysis.fee, -1 * COIN);
+
+    // Empty PSGT: nothing to analyze, back to the creator.
+    PartiallySignedTransaction empty;
+    analysis = AnalyzePSGT(empty);
+    BOOST_CHECK(analysis.inputs.empty());
+    BOOST_CHECK(analysis.next == PSGTRole::CREATOR);
+    BOOST_CHECK(analysis.error.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/psgt_tests.cpp
+++ b/src/test/psgt_tests.cpp
@@ -888,4 +888,28 @@ BOOST_AUTO_TEST_CASE(analyze_negative_fee_and_empty)
     BOOST_CHECK(analysis.error.empty());
 }
 
+// Test: when an input error and the negative-fee condition hold at once, the
+// per-input message recorded first is not overwritten by the fee check.
+BOOST_AUTO_TEST_CASE(analyze_error_precedence)
+{
+    // A bare OP_TRUE matches no script template: non-standard. The UTXO
+    // itself is still known, so the fee gets computed -- and is negative,
+    // since the spend pays out more than the input carries.
+    CTransaction prevTx = MakePrevTxScript(CScript() << OP_TRUE, 1 * COIN);
+    PartiallySignedTransaction psgt = MakeSpendPSGT(prevTx, 2 * COIN);
+
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+
+    BOOST_REQUIRE_EQUAL(analysis.inputs.size(), 1u);
+    BOOST_CHECK(analysis.inputs[0].has_utxo);
+    BOOST_CHECK(analysis.inputs[0].next == PSGTRole::UPDATER);
+    BOOST_CHECK(!analysis.estimated_final_size.has_value());
+
+    BOOST_REQUIRE(analysis.fee.has_value());
+    BOOST_CHECK_EQUAL(*analysis.fee, -1 * COIN);
+
+    BOOST_CHECK_EQUAL(analysis.error,
+        "Input 0 spends a non-standard or unspendable output");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -829,6 +829,7 @@ BOOST_AUTO_TEST_CASE(wallet_tx_state_debug_help_renders)
 BOOST_AUTO_TEST_CASE(psgt_commands_help_renders)
 {
     check_help_renders({
+        {"analyzepsgt",            &analyzepsgt_helpman},
         {"createpsgt",             &createpsgt_helpman},
         {"decodepsgt",             &decodepsgt_helpman},
         {"combinepsgt",            &combinepsgt_helpman},


### PR DESCRIPTION
Implements Task 10a of #3006: an `analyzepsgt` RPC, modeled on Bitcoin Core's `analyzepsbt`, that reports the current status of a PSGT and what is needed to move it forward.

For each input it reports:
- `has_utxo` — whether a matching `non_witness_utxo` is present (also verifies the provided transaction's hash matches `prevout.hash`, which the signing path does not check)
- `is_final` — whether the input has a final scriptSig
- `missing.pubkeys` / `missing.signatures` / `missing.redeemscript` — material still required
- `next` — the role (creator/updater/signer/finalizer/extractor) that needs to act

Globally it reports the earliest-stage `next` role across inputs, plus fee information when computable.

### Design notes

**Analysis lives in `psgt.{h,cpp}`, not the RPC layer.** `AnalyzePSGT()` is a pure function returning a plain `PSGTAnalysis` struct; the RPC is a thin JSON wrapper. This lets the parked Qt load/inspect/sign dialog (Task 10b) reuse the analysis directly once the #2944 transaction-model rework settles.

**No changes to `script/sign.{h,cpp}`.** Bitcoin detects missing material by extending the signing engine (`SignatureData.missing_*` + `DummySignatureCreator`, PR 13425) and running a dummy sign pass. With only four spendable script types (P2PK, P2PKH, multisig, P2SH) and no witness machinery, missing material is enumerated directly via `Solver()` classification instead, keeping consensus-adjacent signing code untouched.

**Gridcoin-native fee reporting instead of a feerate.** Gridcoin's fee policy is a step function — `(1 + bytes/1000) × base fee`, 10× for v2 transactions — so a Bitcoin-style smooth `estimated_feerate` would be misleading. The RPC instead reports `fee` (inputs minus outputs, when all UTXOs are known), `estimated_final_size` (exact serialized size with dummy scriptSigs of the expected final length; final inputs use their actual scriptSig), and `min_required_fee` (`GetMinFee` at that size, the same call shape the wallet uses in `CreateTransaction`).

**Single-sig inputs are always the signer's job.** Unlike Bitcoin, a non-final P2PK/P2PKH input is never reported as `finalizer`: `SignPSGTInput` writes `final_script_sig` directly for single-sig inputs, and `FinalizeInput` cannot assemble them from `partial_sigs` (the full pubkey is not stored there). Only multisig inputs can be in the "enough signatures, awaiting finalizer" state.

### Testing

- 7 new unit tests in `psgt_tests` covering: unsigned P2PKH (signer; missing sig + pubkey; exact size estimate; min-fee cross-check), missing UTXO (updater), mismatched UTXO hash (updater), P2SH 1-of-2 multisig before/after one signature (signer → finalizer), P2SH with unknown redeem script (updater; fee still reported), fully-signed input (extractor; estimate equals actual final size), outputs-exceed-inputs error, and the zero-input creator case.
- `analyzepsgt` added to the `psgt_commands_help_renders` case in `rpchelpman_tests`.
- Full test suite passes locally; whitespace lint clean. All four CI workflows green on the fork branch.

RPC follows the post-#2977 convention (file-scope `RPCHelpMan` + helpman accessor, actor without `fHelp`). No consensus, P2P, or on-disk format changes; no wallet access or locks in the new RPC.
