### PR TITLE
qt: windowed transaction-table model — per-view cursors + OverviewPage testbed (Phase 3)

### DIFF
--- a/doc/transaction_table_windowed_model.md
+++ b/doc/transaction_table_windowed_model.md
@@ -358,3 +358,135 @@ explicitly deferred to that work (tracked under the multiprocess RFC, #2937);
 this effort deliberately does not build the abstraction shell, because what
 matters for a clean split is the **shape of the calls underneath**, which this
 contract establishes.
+
+---
+
+## Addendum: the per-view cursor `view_index`-maintenance algorithm (PR3)
+
+This pins down the cursor arithmetic before any wiring (the PR1 risk-control move:
+get the trickiest logic into the GUI-OFF unit suite first). A cursor is a Qt-free
+object (`src/qt/cursor.{h,cpp}`) maintaining one filtered+sorted view over the
+producer's record table, using PR1's `GRC::Accepts` / `GRC::Less` / `SortKey` /
+`TxFilterFields` / `FilterSpec`. It never holds records; it is parameterized on two
+projector callables supplied by the caller (the store in production, a synthetic
+table in the unit tests):
+
+- `Fields(absidx) -> TxFilterFields` — the filter inputs for record `absidx`.
+- `Keys(absidx)   -> SortKey`        — the sort inputs for record `absidx`.
+
+### State + invariant
+
+```
+std::vector<std::size_t> view_index;   // accepted ABSOLUTE indices into the record
+                                       // table, kept sorted by Less(Keys(a),Keys(b),col,order)
+```
+
+**Invariant (I):** at every observable point, `view_index` contains *exactly* the
+absolute indices `i` with `Accepts(Fields(i), filter) == true`, in `Less`-sorted
+order for the current `(sort_column, sort_order)`, and every stored value equals the
+record's *current* absolute index in the table.
+
+The **served window** the consumer sees is `view_index[0 .. served)`, where
+`served = (limit < 0) ? view_index.size() : min(view_index.size(), limit)`. All
+emitted `CursorDelta`s are in **served-window-local** coordinates.
+
+```
+struct CursorDelta { enum {Reset, Insert, Remove, Change} type; int first; int count; };
+```
+
+### ⚠ Item 1 — locate existing rows by identity, never by sort-key
+
+To find an *existing* record's slot in `view_index` (for remove/update), search for
+its **absolute index value** (the `(hash,idx)` identity maps 1:1 to it), NOT a
+`lower_bound` over `Less`. Sort-keys are **not unique** — every Unconfirmed row
+shares the `INT_MAX`-height `status_sort_key`, so a `lower_bound` on a captured key
+lands anywhere in that band and can evict/reposition a *sibling*. Locating an
+existing row is therefore an identity scan (or a reverse map); `lower_bound`/`Less`
+is used **only** to choose the insertion slot for a row not currently present.
+
+### ⚠ Item 2 — reposition = erase, THEN lower_bound
+
+When a row that is present moves (its `SortKey` changed): **erase it from its old
+slot first, then compute the insert slot via `lower_bound` over the post-erase
+`view_index`.** A `new_pos` computed against the pre-erase vector is off-by-one
+whenever `old_pos <= new_pos`. Erase-then-`lower_bound` is exact by construction.
+
+### ⚠ Item 3 — off-window rows are still maintained; only emission is gated
+
+Membership/position changes update `view_index` for **all** rows, in-window or not
+(else an off-window row renders out of order when the window later grows/scrolls —
+Invariant I must always hold over the *whole* vector). Only the *delta emission* is
+gated by the served boundary (below). First confirmations on a Status-DESC Overview
+cross the served boundary constantly, so this path is hot.
+
+### ⚠ Item 4 — reindex/splice discipline (composes across a batch drain)
+
+The store-worker drains a batch of intake ops; each must leave Invariant I intact
+before the next:
+
+- `applyStoreInsert(P, count)`: the table inserted `count` records at absolute
+  `[P, P+count)`, shifting every later absolute index by `+count`. **(a)** for each
+  entry `e` in `view_index`, `if (e >= P) e += count` (fixes the stored absolute
+  indices); **(b)** for each new `i` in `[P, P+count)`, `if (Accepts(Fields(i)))`
+  insert `i` at its `lower_bound`-by-`Less` slot. Shift-before-insert so the new
+  entries are placed against an already-consistent vector.
+- `applyStoreRemove(P, count)`: the table removed absolute `[P, P+count)`, shifting
+  later indices by `-count`. **(a)** erase the entries whose value is in
+  `[P, P+count)` (located by identity, Item 1); **(b)** for each remaining entry
+  `e`, `if (e >= P+count) e -= count`. Remove-before-shift, mirror of insert.
+
+Both end with Invariant I, so a sequence of ops composes.
+
+### CT_UPDATED / applyStatusUpdate(P) — the membership/reposition cases
+
+Record `P`'s status (and thus `Accepts`/`SortKey`) changed. Let `old_in =` (P found
+in `view_index` at `old_pos`, Item 1), `new_in = Accepts(Fields(P))`:
+
+| old_in | new_in | action | emission |
+|--------|--------|--------|----------|
+| no  | no  | nothing | — |
+| no  | yes | `lower_bound`-insert P at `new_pos` | Insert (+ eviction) if `new_pos < served` |
+| yes | no  | erase P at `old_pos` | Remove (+ promotion) if `old_pos < served` |
+| yes | yes, slot unchanged | none (keys re-read) | Change at `old_pos` if `< served` |
+| yes | yes, slot moved | erase `old_pos`, then `lower_bound`-insert (Item 2) | translate (`old_pos`,`new_pos`) below |
+
+### Served-window translation (eviction / promotion at the boundary)
+
+With `served_old`/`served_new` computed before/after, and `cap = (limit<0)?∞:limit`:
+
+- **Insert at `view_index` slot `p`:**
+  - `p >= served_old` → off-window, no emission.
+  - `p < served_old` → emit `Insert(first=p, 1)`; **if the window was full**
+    (`view_index.size()-1 >= cap`, i.e. `served_old == cap`) the old last visible row
+    is pushed out → also emit `Remove(first=cap-1 [post-insert: served_new... =cap], 1)`
+    (eviction). Net visible count stays `cap`.
+- **Remove at slot `p`:**
+  - `p >= served_old` → off-window, no emission (served may shrink if unlimited).
+  - `p < served_old` → emit `Remove(first=p, 1)`; **if a row existed just past the
+    boundary** (`view_index.size() (pre-remove) > cap`, i.e. there was an off-window
+    row at `cap`) it promotes into view → also emit `Insert(first=served_new-1, 1)`
+    (promotion).
+- **Reposition (`old_pos`→`new_pos`, both relative to the same vector state):** apply
+  the Remove translation for `old_pos` then the Insert translation for `new_pos`
+  against the post-erase vector, collapsing a same-visible-slot move to a `Change`.
+
+### setLimit(new_limit)
+
+Recompute `served`. If it grows by `k`, emit `Insert(first=served_old, k)` (rows
+`view_index[served_old .. served_new)` promote in). If it shrinks by `k`, emit
+`Remove(first=served_new, k)`. `view_index` itself is untouched (Item 3) — only the
+window boundary moved. This is the cheap stairstep-resize op (decision 1).
+
+### setFilter / setSort
+
+A wholesale change to membership or order: rebuild `view_index` from scratch and emit
+a single `Reset(total = served_new)`; the consumer bulk-refills via `getRows`. (An
+incremental diff is possible but not worth the complexity for an interactive
+filter/sort change.)
+
+### Complexity
+
+Per store op / status update: O(N) over `view_index` (the absolute-index shift and/or
+the identity scan) — which is exactly why PR2.5 moved this onto the off-`cs_main`
+store-worker. An order-statistics structure to reach O(log N) is tracked separately;
+the contract here is correctness, not asymptotics.

--- a/doc/transaction_table_windowed_model.md
+++ b/doc/transaction_table_windowed_model.md
@@ -490,3 +490,59 @@ Per store op / status update: O(N) over `view_index` (the absolute-index shift a
 the identity scan) — which is exactly why PR2.5 moved this onto the off-`cs_main`
 store-worker. An order-statistics structure to reach O(log N) is tracked separately;
 the contract here is correctness, not asymptotics.
+
+---
+
+## Addendum: scrollbar + resort contract for the detailed view (PR5)
+
+The detailed `TransactionView` is a scrolling `QTableView` over the full filtered
+list (up to ~300k rows). PR3 (OverviewPage) does not scroll — its `limit ≈ viewport`
+— so this contract lands with PR5's virtual model, but the primitives it relies on
+(epoch, identity-locate) are established by the PR3-A cursor core.
+
+### The model reports the TOTAL count, never the cached slice
+
+`rowCount()` returns the cursor's `totalAccepted()` — the whole filtered count — NOT
+the size of the materialized viewport slice. Consequences:
+
+- The scrollbar is sized for the full list (correct thumb size + position), and the
+  user can drag to **any** absolute position, including the middle and the end.
+- The viewport slice (~visible rows + a prefetch margin) is a **cache the view never
+  observes**. A `data(row)` for a row outside the slice returns a placeholder and
+  triggers an async `getRows(first,last)`; the returned slice is applied with a
+  `dataChanged`, and the placeholder rows fill in. A fast drag to an un-cached region
+  shows placeholders for a frame, then resolves — standard virtual-scroll behaviour.
+
+This is the **"full rowCount + placeholder-on-miss, NOT `canFetchMore`"** decision.
+`canFetchMore`/`fetchMore` is rejected precisely because it makes the scrollbar
+misbehave: the row count would grow as you scroll, the thumb would misreport the
+total, and you could not drag to the middle or end (append-only). The full-rowCount
+model is what makes random-access scrolling and a correctly-sized scrollbar possible
+— the slice underneath does NOT make the scrollbar act weird, because it is invisible
+to it.
+
+### Resort while scrolled into the middle — anchor on the SELECTED row
+
+A header-click resort is a cursor `setSort` → a `Reset` (the whole `view_index`
+reorders) that bumps the **epoch**. `rowCount` is unchanged, so the scrollbar does not
+resize or jump; only content reorders. The position policy (decided 2026-06-10):
+
+1. **Capture the anchor before the resort:** the `(hash,idx)` identity of the
+   currently **selected** row. If there is no selection, fall back to the identity of
+   the **topmost visible** row, so there is always a stable anchor.
+2. **Resort** (`setSort` → `Reset`, epoch bumped).
+3. **Scroll to the anchor's new position:** `cursor.findSlot(anchor_absidx)` (the
+   PR3-A identity-locate) gives the anchor's row index in the new order; scroll so it
+   is back in view (re-selected if it was the selection). The list reorders *around*
+   the user's anchor instead of throwing them to row 0 or to an unrelated row.
+
+The windowing interaction is only a **re-fetch**: after the `Reset` the cached slice
+holds the wrong transactions for those indices, so the model fetches the slice for the
+post-resort viewport. The **epoch** is the reconciliation token — any async
+`getRows` issued before the resort that arrives late carries the stale epoch and is
+discarded, so pre-resort rows are never painted into the post-resort window. No
+scrollbar weirdness, just a guarded re-fetch.
+
+Net: the scrollbar stays correctly sized and positioned across both fast scrolling and
+resort; the only moving parts are a transient placeholder fill and an anchor-preserving
+scroll, both supported by the cursor's `epoch` + identity-locate from PR3-A.

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(gridcoinqt STATIC
     optionsdialog.cpp
     optionsmodel.cpp
     overviewpage.cpp
+    overviewtxmodel.cpp
     peertablemodel.cpp
     qtipcserver.cpp
     qvalidatedlineedit.cpp

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(gridcoinqt STATIC
     transactionfilterproxy.cpp
     txfilter.cpp
     txorder.cpp
+    cursor.cpp
     transactionrecord.cpp
     transactiontablemodel.cpp
     transactionview.cpp

--- a/src/qt/cursor.cpp
+++ b/src/qt/cursor.cpp
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/cursor.h"
+
+#include <algorithm>
+#include <cstdint>
+
+namespace {
+constexpr std::size_t NPOS = static_cast<std::size_t>(-1);
+} // anonymous namespace
+
+namespace GRC {
+
+Cursor::Cursor(int view_id, FilterSpec filter, int sort_column, int sort_order,
+               FieldsFn fields, KeysFn keys)
+    : m_view_id(view_id)
+    , m_filter(std::move(filter))
+    , m_sort_column(sort_column)
+    , m_sort_order(sort_order)
+    , m_fields(std::move(fields))
+    , m_keys(std::move(keys))
+{
+}
+
+std::size_t Cursor::cap() const
+{
+    return m_filter.limit_rows < 0 ? NPOS : static_cast<std::size_t>(m_filter.limit_rows);
+}
+
+std::size_t Cursor::servedCount() const
+{
+    return std::min(m_view_index.size(), cap());
+}
+
+std::size_t Cursor::lowerBoundSlot(std::size_t absidx) const
+{
+    // Sorted insertion slot. Only valid for a row NOT currently present.
+    auto it = std::lower_bound(
+        m_view_index.begin(), m_view_index.end(), absidx,
+        [&](std::size_t a, std::size_t b) { return Less(m_keys(a), m_keys(b), m_sort_column, m_sort_order); });
+    return static_cast<std::size_t>(it - m_view_index.begin());
+}
+
+std::size_t Cursor::findSlot(std::size_t absidx) const
+{
+    // Identity locate (spec Item 1): never a sort-key binary search.
+    auto it = std::find(m_view_index.begin(), m_view_index.end(), absidx);
+    return it == m_view_index.end() ? NPOS : static_cast<std::size_t>(it - m_view_index.begin());
+}
+
+std::vector<CursorDelta> Cursor::rebuild(std::size_t n)
+{
+    m_view_index.clear();
+    for (std::size_t i = 0; i < n; ++i) {
+        if (Accepts(m_fields(i), m_filter)) m_view_index.push_back(i);
+    }
+    std::sort(m_view_index.begin(), m_view_index.end(),
+              [&](std::size_t a, std::size_t b) { return Less(m_keys(a), m_keys(b), m_sort_column, m_sort_order); });
+    ++m_epoch;
+    return {{CursorDelta::Reset, 0, static_cast<int>(servedCount())}};
+}
+
+// Served-window translation for a single-row INSERT that already happened at
+// `slot` (m_view_index has grown by 1). Eviction when the window was full.
+static void emitInsertAt(std::size_t slot, std::size_t size_after, std::size_t cap_v,
+                         std::vector<CursorDelta>& out)
+{
+    const std::size_t served_before = std::min(size_after - 1, cap_v);
+    const std::size_t served_after  = std::min(size_after, cap_v);
+    if (slot < served_after) {
+        out.push_back({CursorDelta::Insert, static_cast<int>(slot), 1});
+        if (served_before == cap_v) {  // window was full → last visible row evicted
+            out.push_back({CursorDelta::Remove, static_cast<int>(cap_v), 1});
+        }
+    }
+}
+
+// Served-window translation for a single-row REMOVE that already happened at
+// `pos` (size_before = size before the erase). Promotion when an off-window row exists.
+static void emitRemoveAt(std::size_t pos, std::size_t size_before, std::size_t cap_v,
+                         std::vector<CursorDelta>& out)
+{
+    const std::size_t served_before = std::min(size_before, cap_v);
+    if (pos < served_before) {
+        out.push_back({CursorDelta::Remove, static_cast<int>(pos), 1});
+        if (size_before > cap_v) {  // an off-window row promotes into the last visible slot
+            out.push_back({CursorDelta::Insert, static_cast<int>(cap_v - 1), 1});
+        }
+    }
+}
+
+std::vector<CursorDelta> Cursor::applyStoreInsert(std::size_t P, std::size_t count)
+{
+    std::vector<CursorDelta> out;
+    const std::size_t cap_v = cap();
+    // (a) the table grew at P → every later absolute index shifted +count.
+    for (auto& e : m_view_index) {
+        if (e >= P) e += count;
+    }
+    // (b) insert each newly-accepted record at its sorted slot.
+    for (std::size_t i = P; i < P + count; ++i) {
+        if (Accepts(m_fields(i), m_filter)) {
+            const std::size_t slot = lowerBoundSlot(i);
+            m_view_index.insert(m_view_index.begin() + slot, i);
+            emitInsertAt(slot, m_view_index.size(), cap_v, out);
+        }
+    }
+    return out;
+}
+
+std::vector<CursorDelta> Cursor::applyStoreRemove(std::size_t P, std::size_t count)
+{
+    std::vector<CursorDelta> out;
+    const std::size_t cap_v = cap();
+    // (a) erase the entries whose absolute value is in [P, P+count), by identity.
+    for (std::size_t v = P; v < P + count; ++v) {
+        const std::size_t pos = findSlot(v);
+        if (pos != NPOS) {
+            const std::size_t size_before = m_view_index.size();
+            m_view_index.erase(m_view_index.begin() + pos);
+            emitRemoveAt(pos, size_before, cap_v, out);
+        }
+    }
+    // (b) the table shrank by `count` at P → later survivors shift -count.
+    for (auto& e : m_view_index) {
+        if (e >= P + count) e -= count;
+    }
+    return out;
+}
+
+std::vector<CursorDelta> Cursor::applyStatusUpdate(std::size_t P)
+{
+    std::vector<CursorDelta> out;
+    const std::size_t cap_v = cap();
+    const std::size_t old_pos = findSlot(P);          // identity (Item 1)
+    const bool old_in = old_pos != NPOS;
+    const bool new_in = Accepts(m_fields(P), m_filter);
+
+    if (!old_in && !new_in) {
+        return out;                                   // not shown before or after
+    }
+    if (!old_in && new_in) {                          // membership flip-in
+        const std::size_t slot = lowerBoundSlot(P);
+        m_view_index.insert(m_view_index.begin() + slot, P);
+        emitInsertAt(slot, m_view_index.size(), cap_v, out);
+        return out;
+    }
+    if (old_in && !new_in) {                          // membership flip-out
+        const std::size_t size_before = m_view_index.size();
+        m_view_index.erase(m_view_index.begin() + old_pos);
+        emitRemoveAt(old_pos, size_before, cap_v, out);
+        return out;
+    }
+
+    // old_in && new_in: stays a member; may reposition. Erase-then-lower_bound
+    // (Item 2). Total size is unchanged, so no membership promote/evict — only a
+    // possible boundary CROSSING of the moved row itself.
+    const std::size_t size_full = m_view_index.size();
+    m_view_index.erase(m_view_index.begin() + old_pos);
+    const std::size_t new_slot = lowerBoundSlot(P);
+    m_view_index.insert(m_view_index.begin() + new_slot, P);
+
+    const std::size_t served_full = std::min(size_full, cap_v);
+    if (new_slot == old_pos) {                        // unchanged slot → just re-read
+        if (old_pos < served_full) out.push_back({CursorDelta::Change, static_cast<int>(old_pos), 1});
+        return out;
+    }
+    const bool old_vis = old_pos < served_full;
+    const bool new_vis = new_slot < served_full;
+    if (old_vis && new_vis) {                          // reorder within the window
+        out.push_back({CursorDelta::Remove, static_cast<int>(old_pos), 1});
+        out.push_back({CursorDelta::Insert, static_cast<int>(new_slot), 1});
+    } else if (old_vis && !new_vis) {                  // moved out of the window
+        out.push_back({CursorDelta::Remove, static_cast<int>(old_pos), 1});
+        if (size_full > cap_v) out.push_back({CursorDelta::Insert, static_cast<int>(served_full - 1), 1});
+    } else if (!old_vis && new_vis) {                  // moved into the window
+        out.push_back({CursorDelta::Insert, static_cast<int>(new_slot), 1});
+        if (size_full > cap_v) out.push_back({CursorDelta::Remove, static_cast<int>(served_full), 1});
+    }
+    // !old_vis && !new_vis: off-window move, no emission (view_index still maintained).
+    return out;
+}
+
+std::vector<CursorDelta> Cursor::setLimit(int new_limit)
+{
+    std::vector<CursorDelta> out;
+    const std::size_t served_old = servedCount();
+    m_filter.limit_rows = new_limit;
+    const std::size_t served_new = servedCount();
+    if (served_new > served_old) {
+        out.push_back({CursorDelta::Insert, static_cast<int>(served_old), static_cast<int>(served_new - served_old)});
+    } else if (served_new < served_old) {
+        out.push_back({CursorDelta::Remove, static_cast<int>(served_new), static_cast<int>(served_old - served_new)});
+    }
+    return out;
+}
+
+std::vector<CursorDelta> Cursor::setSort(int sort_column, int sort_order)
+{
+    m_sort_column = sort_column;
+    m_sort_order = sort_order;
+    std::sort(m_view_index.begin(), m_view_index.end(),
+              [&](std::size_t a, std::size_t b) { return Less(m_keys(a), m_keys(b), m_sort_column, m_sort_order); });
+    ++m_epoch;
+    return {{CursorDelta::Reset, 0, static_cast<int>(servedCount())}};
+}
+
+std::vector<CursorDelta> Cursor::setFilter(const FilterSpec& filter, std::size_t n)
+{
+    m_filter = filter;
+    return rebuild(n);
+}
+
+} // namespace GRC

--- a/src/qt/cursor.h
+++ b/src/qt/cursor.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_CURSOR_H
+#define GRIDCOIN_QT_CURSOR_H
+
+#include "qt/txfilter.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+//!
+//! \file cursor.h
+//!
+//! Qt-free per-view cursor for the windowed transaction-table model (PR3).
+//!
+//! A cursor maintains one filtered + sorted view over the producer's record
+//! table: an ordered `view_index` of the ABSOLUTE record indices that pass the
+//! view's GRC::FilterSpec, sorted by GRC::Less for the view's column/order. The
+//! store-worker (PR2.5) drives it from the off-cs_main worker thread; this core
+//! holds no records and no Qt types, so the same logic is unit-tested in the
+//! ENABLE_GUI=OFF configuration CI actually exercises (the PR1 risk-control
+//! move). See doc/transaction_table_windowed_model.md → "Addendum: the per-view
+//! cursor view_index-maintenance algorithm" for the spec this implements,
+//! including the four arithmetic hazards (identity-locate, erase-then-lower_bound,
+//! off-window maintenance, reindex/splice discipline) and the served-window
+//! translation (eviction/promotion at the boundary).
+//!
+//! The cursor is parameterized on two projector callables that read the backing
+//! table (the store's m_records in production, a synthetic table in the tests):
+//!   - FieldsFn(absidx) -> TxFilterFields  (filter inputs)
+//!   - KeysFn(absidx)   -> SortKey         (sort inputs)
+//! Callers MUST mutate the backing table BEFORE calling the corresponding
+//! apply* method, so the projectors observe the post-mutation table.
+//!
+
+namespace GRC {
+
+//!
+//! \brief One change to the served window, in served-window-local coordinates.
+//!
+//! The consumer applies these to its replica: Reset (bulk refill `count` rows
+//! via getRows), Insert/Remove `count` rows at `first`, or Change (re-read)
+//! `count` rows at `first`.
+//!
+struct CursorDelta {
+    enum Type { Reset, Insert, Remove, Change } type;
+    int first;
+    int count;
+};
+
+class Cursor
+{
+public:
+    using FieldsFn = std::function<TxFilterFields(std::size_t)>;
+    using KeysFn   = std::function<SortKey(std::size_t)>;
+
+    Cursor(int view_id, FilterSpec filter, int sort_column, int sort_order,
+           FieldsFn fields, KeysFn keys);
+
+    //! Rebuild from scratch over the `n` records [0, n). Returns one Reset.
+    std::vector<CursorDelta> rebuild(std::size_t n);
+
+    //! The table inserted `count` records at absolute [P, P+count) (later
+    //! absolute indices shifted +count). Shift-then-insert (spec Item 4).
+    std::vector<CursorDelta> applyStoreInsert(std::size_t P, std::size_t count);
+
+    //! The table removed absolute [P, P+count) (later absolute indices shifted
+    //! -count). Remove-then-shift (spec Item 4). No projector reads needed.
+    std::vector<CursorDelta> applyStoreRemove(std::size_t P, std::size_t count);
+
+    //! Record `P`'s status/fields changed: re-evaluate membership + sort slot,
+    //! maintaining view_index for ALL rows incl. off-window (spec Item 3),
+    //! locating by identity (Item 1) and repositioning erase-then-lower_bound
+    //! (Item 2).
+    std::vector<CursorDelta> applyStatusUpdate(std::size_t P);
+
+    //! Change the served-window cap (the stairstep resize). view_index is
+    //! untouched; only the boundary moves (promotion/eviction at the edge).
+    std::vector<CursorDelta> setLimit(int new_limit);
+
+    //! Change sort column/order. Wholesale re-sort → single Reset.
+    std::vector<CursorDelta> setSort(int sort_column, int sort_order);
+
+    //! Change the filter. Wholesale re-evaluate over [0, n) → single Reset.
+    std::vector<CursorDelta> setFilter(const FilterSpec& filter, std::size_t n);
+
+    int viewId() const { return m_view_id; }
+    uint64_t epoch() const { return m_epoch; }
+
+    //! Number of rows the consumer sees: min(accepted, cap).
+    std::size_t servedCount() const;
+    //! Total accepted rows (the full sorted index size).
+    std::size_t totalAccepted() const { return m_view_index.size(); }
+    //! Absolute record index at served position `served_pos` (for getRows).
+    std::size_t rowAt(std::size_t served_pos) const { return m_view_index[served_pos]; }
+
+    //! Test/inspection: the full sorted absolute-index vector.
+    const std::vector<std::size_t>& viewIndex() const { return m_view_index; }
+
+private:
+    //! Sorted insert slot for `absidx` via lower_bound over Less. Used ONLY for
+    //! a row not currently present (never to locate an existing row — Item 1).
+    std::size_t lowerBoundSlot(std::size_t absidx) const;
+    //! Identity locate: position of absolute index `absidx` in view_index, or
+    //! npos. Linear scan by value (Item 1).
+    std::size_t findSlot(std::size_t absidx) const;
+    //! Cap as a size_t (SIZE_MAX when unlimited).
+    std::size_t cap() const;
+
+    int m_view_id;
+    FilterSpec m_filter;
+    int m_sort_column;
+    int m_sort_order;
+    uint64_t m_epoch{0};
+
+    FieldsFn m_fields;
+    KeysFn m_keys;
+
+    //! Accepted absolute indices, sorted by Less(Keys(a), Keys(b), col, order).
+    std::vector<std::size_t> m_view_index;
+};
+
+} // namespace GRC
+
+#endif // GRIDCOIN_QT_CURSOR_H

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -446,7 +446,9 @@ void OverviewPage::setWalletModel(WalletModel *model)
                  __func__, num_transactions_for_view, m_overviewTxModel->limit());
 
         ui->listTransactions->setModel(m_overviewTxModel.get());
-        ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
+        // OverviewTxModel is a single-column list whose column already renders the
+        // ToAddress column's roles, so no setModelColumn is needed (the old proxy
+        // exposed all 5 columns and selected ToAddress here).
 
         // Keep up to date with wallet
         setBalance(model->getBalance(), model->getStake(), model->getUnconfirmedBalance(), model->getImmatureBalance());

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -15,7 +15,8 @@
 #include "bitcoinunits.h"
 #include "optionsmodel.h"
 #include "transactiontablemodel.h"
-#include "transactionfilterproxy.h"
+#include "overviewtxmodel.h"
+#include "uint256.h"
 #include "guiutil.h"
 #include "guiconstants.h"
 #include "gridcoin/voting/fwd.h"
@@ -207,8 +208,16 @@ OverviewPage::OverviewPage(QWidget *parent) :
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)
 {
-    if(filter)
-        emit transactionClicked(filter->mapToSource(index));
+    // Map the clicked served-window row to a TransactionTableModel index (via the
+    // tx identity) so the detailed view can select it — the windowed equivalent
+    // of the old proxy mapToSource().
+    if (m_overviewTxModel && walletModel && walletModel->getTransactionTableModel()) {
+        const uint256 txid = m_overviewTxModel->txidAt(index.row());
+        const QModelIndex source = walletModel->getTransactionTableModel()->indexForTxid(txid);
+        if (source.isValid()) {
+            emit transactionClicked(source);
+        }
+    }
 }
 
 void OverviewPage::handlePollLabelClicked()
@@ -251,40 +260,37 @@ int OverviewPage::getNumTransactionsForView()
 
 void OverviewPage::updateTransactions()
 {
-    if (filter)
+    if (m_overviewTxModel)
     {
         int numItems = getNumTransactionsForView();
 
-        LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(): numItems = %d, getLimit() = %d",
-                 numItems, filter->getLimit());
+        LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(): numItems = %d, limit = %d",
+                 numItems, m_overviewTxModel->limit());
 
-        // This is a "stairstep" approach, using x3 to x6 factors to size the setLimit.
-        // Based on testing with a wallet with a large number of transactions (40k+)
-        // Using a factor of three is a good balance between the setRowHidden loop
-        // and the very high expense of the getLimit call, which invalidates the filter
-        // and sort, and implicitly redoes the sort, which can take seconds for a large
-        // wallet.
-
-        // Most main window resizes will be done without an actual call to setLimit.
-        if (filter->getLimit() < numItems)
+        // "Stairstep" the served-window cap with x3..x6 factors so most window
+        // resizes do not change the limit at all. The cap is now a cheap
+        // setViewLimit on the producer cursor (boundary Insert/Remove events,
+        // applied on the next drain) rather than the old proxy's full re-sort,
+        // but the stairstep still avoids needless churn.
+        if (m_overviewTxModel->limit() < numItems)
         {
-            filter->setLimit(numItems * 3);
+            m_overviewTxModel->setLimit(numItems * 3);
             LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(), setLimit(%d)", numItems * 3);
         }
-        else if (filter->getLimit() > numItems * 6)
+        else if (m_overviewTxModel->limit() > numItems * 6)
         {
-            filter->setLimit(numItems * 3);
+            m_overviewTxModel->setLimit(numItems * 3);
             LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(), setLimit(%d)", numItems * 3);
         }
 
-        for (int i = 0; i <= filter->getLimit(); ++i)
+        for (int i = 0; i <= m_overviewTxModel->limit(); ++i)
         {
             ui->listTransactions->setRowHidden(i, i >= numItems);
         }
 
         ui->listTransactions->update();
 
-        int transaction_count = filter->rowCount();
+        int transaction_count = m_overviewTxModel->rowCount();
 
         // This needs to be both here and in SetPrivacy because the trigger could come from either.
         ui->recentTransactionsNoResult->setVisible(m_privacy || !transaction_count);
@@ -365,7 +371,7 @@ void OverviewPage::setCurrentPollTitle(const QString& title)
 void OverviewPage::setPrivacy(bool privacy)
 {
     m_privacy = privacy;
-    int transaction_count = filter->rowCount();
+    int transaction_count = m_overviewTxModel ? m_overviewTxModel->rowCount() : 0;
 
     if (currentBalance != -1) {
         setBalance(currentBalance, currentStake, currentUnconfirmedBalance, currentImmatureBalance);
@@ -429,21 +435,17 @@ void OverviewPage::setWalletModel(WalletModel *model)
     this->walletModel = model;
     if(model && model->getOptionsModel())
     {
-        // Set up transaction list
-        filter.reset(new TransactionFilterProxy());
-        filter->setSourceModel(model->getTransactionTableModel());
-        filter->setDynamicSortFilter(true);
-        filter->setSortRole(Qt::EditRole);
-        filter->setShowInactive(false);
-
+        // Set up the recent-transactions list as a mini windowed model (PR3):
+        // a VIEW_OVERVIEW cursor (Status DESC, inactive masked) maintained in the
+        // producer WalletTxStore backs it, instead of a client-side
+        // QSortFilterProxyModel over the full TransactionTableModel replica.
         int num_transactions_for_view = getNumTransactionsForView();
-        filter->setLimit(num_transactions_for_view);
+        m_overviewTxModel.reset(new OverviewTxModel(model, num_transactions_for_view));
 
-        LogPrint(BCLog::LogFlags::QT, "INFO: %s: num_transactions_for_view = %i, getLimit() = %i",
-                 __func__, num_transactions_for_view, filter->getLimit());
+        LogPrint(BCLog::LogFlags::QT, "INFO: %s: num_transactions_for_view = %i, limit = %i",
+                 __func__, num_transactions_for_view, m_overviewTxModel->limit());
 
-        filter->sort(TransactionTableModel::Status, Qt::DescendingOrder);
-        ui->listTransactions->setModel(filter.get());
+        ui->listTransactions->setModel(m_overviewTxModel.get());
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
 
         // Keep up to date with wallet

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -15,7 +15,7 @@ class ResearcherModel;
 class MRCModel;
 class WalletModel;
 class TxViewDelegate;
-class TransactionFilterProxy;
+class OverviewTxModel;
 
 /** Overview ("home") page widget */
 class OverviewPage : public QWidget
@@ -63,7 +63,9 @@ private:
     bool m_privacy = false;
 
     TxViewDelegate *txdelegate;
-    std::unique_ptr<TransactionFilterProxy> filter;
+    //! Windowed-model recent-transactions list (PR3): a VIEW_OVERVIEW cursor in
+    //! the producer store backs this instead of a client-side QSortFilterProxy.
+    std::unique_ptr<OverviewTxModel> m_overviewTxModel;
 
 private slots:
     void updateDisplayUnit();

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -89,6 +89,7 @@ void OverviewTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 endResetModel();
             } else if constexpr (std::is_same_v<P, GRC::RowsInsertedPayload>) {
                 if (payload.viewId != GRC::VIEW_OVERVIEW) return;
+                if (payload.records.empty()) return;  // empty insert → invalid beginInsertRows range
                 const int pos = payload.position;
                 if (pos < 0 || static_cast<std::size_t>(pos) > m_rows.size()) return;
                 beginInsertRows(QModelIndex(), pos,

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -47,11 +47,14 @@ QVariant OverviewTxModel::data(const QModelIndex& index, int role) const
             || static_cast<std::size_t>(index.row()) >= m_rows.size()) {
         return QVariant();
     }
-    // Render the Status column (the list's single visual column), reusing the
-    // TransactionTableModel formatters. const_cast: formatRole takes a non-const
-    // record (legacy getTxID()/describe() are non-const) but does not mutate it.
+    // Render the ToAddress column's roles — the single visual column the recent-tx
+    // delegate composes (its DecorationRole is the transaction-TYPE icon
+    // txAddressDecoration, and its DisplayRole is the address), matching the old
+    // proxy list which set modelColumn = ToAddress. Reuse the TransactionTableModel
+    // formatters. const_cast: formatRole takes a non-const record (legacy
+    // getTxID()/describe() are non-const) but does not mutate it.
     return m_ttm->formatRole(const_cast<TransactionRecord*>(&m_rows[index.row()]),
-                             TransactionTableModel::Status, role);
+                             TransactionTableModel::ToAddress, role);
 }
 
 void OverviewTxModel::setLimit(int limit)

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/overviewtxmodel.h"
+
+#include "qt/txfilter.h"
+#include "qt/transactiontablemodel.h"
+#include "qt/walletmodel.h"
+#include "qt/wallettxstore.h"
+
+#include <type_traits>
+#include <variant>
+
+OverviewTxModel::OverviewTxModel(WalletModel* walletModel, int initialLimit, QObject* parent)
+    : QAbstractListModel(parent)
+    , m_walletModel(walletModel)
+    , m_ttm(walletModel->getTransactionTableModel())
+    , m_limit(initialLimit)
+{
+    // Register the server-side view: recent transactions sorted by Status DESC,
+    // inactive (Conflicted/NotAccepted) masked, capped at the resize-derived
+    // limit — matching the old TransactionFilterProxy configuration in
+    // OverviewPage::setWalletModel.
+    GRC::FilterSpec spec;
+    spec.show_inactive = false;
+    spec.limit_rows = m_limit;
+    GRC::WalletTxStore& store = m_walletModel->getTxStore();
+    store.registerView(GRC::VIEW_OVERVIEW, spec, GRC::TXCOL_STATUS, GRC::TXSORT_DESC);
+
+    // registerView pushed a RowsReset that the next drain will deliver, but also
+    // seed synchronously so the list is populated before the first drain tick.
+    m_rows = store.getRows(GRC::VIEW_OVERVIEW, 0, m_limit);
+
+    connect(m_walletModel, &WalletModel::walletEventsDrained,
+            this, &OverviewTxModel::applyEventBatch);
+}
+
+int OverviewTxModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+}
+
+QVariant OverviewTxModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || index.row() < 0
+            || static_cast<std::size_t>(index.row()) >= m_rows.size()) {
+        return QVariant();
+    }
+    // Render the Status column (the list's single visual column), reusing the
+    // TransactionTableModel formatters. const_cast: formatRole takes a non-const
+    // record (legacy getTxID()/describe() are non-const) but does not mutate it.
+    return m_ttm->formatRole(const_cast<TransactionRecord*>(&m_rows[index.row()]),
+                             TransactionTableModel::Status, role);
+}
+
+void OverviewTxModel::setLimit(int limit)
+{
+    if (limit == m_limit) {
+        return;
+    }
+    m_limit = limit;
+    // The cursor recomputes its served window and emits the boundary Insert/Remove
+    // events, which arrive on the next drain.
+    m_walletModel->getTxStore().setViewLimit(GRC::VIEW_OVERVIEW, limit);
+}
+
+uint256 OverviewTxModel::txidAt(int row) const
+{
+    if (row < 0 || static_cast<std::size_t>(row) >= m_rows.size()) {
+        return uint256();
+    }
+    return m_rows[row].hash;
+}
+
+void OverviewTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& events)
+{
+    GRC::WalletTxStore& store = m_walletModel->getTxStore();
+    for (const GRC::WalletEvent& ev : events) {
+        std::visit([&](auto&& payload) {
+            using P = std::decay_t<decltype(payload)>;
+            if constexpr (std::is_same_v<P, GRC::RowsResetPayload>) {
+                if (payload.viewId != GRC::VIEW_OVERVIEW) return;
+                beginResetModel();
+                m_rows = store.getRows(GRC::VIEW_OVERVIEW, 0, payload.total);
+                endResetModel();
+            } else if constexpr (std::is_same_v<P, GRC::RowsInsertedPayload>) {
+                if (payload.viewId != GRC::VIEW_OVERVIEW) return;
+                const int pos = payload.position;
+                if (pos < 0 || static_cast<std::size_t>(pos) > m_rows.size()) return;
+                beginInsertRows(QModelIndex(), pos,
+                                pos + static_cast<int>(payload.records.size()) - 1);
+                m_rows.insert(m_rows.begin() + pos,
+                              payload.records.begin(), payload.records.end());
+                endInsertRows();
+            } else if constexpr (std::is_same_v<P, GRC::RowsRemovedPayload>) {
+                if (payload.viewId != GRC::VIEW_OVERVIEW) return;
+                const int pos = payload.position;
+                if (pos < 0 || payload.count <= 0
+                        || static_cast<std::size_t>(pos) + static_cast<std::size_t>(payload.count)
+                               > m_rows.size()) return;
+                beginRemoveRows(QModelIndex(), pos, pos + payload.count - 1);
+                m_rows.erase(m_rows.begin() + pos, m_rows.begin() + pos + payload.count);
+                endRemoveRows();
+            } else if constexpr (std::is_same_v<P, GRC::RowsChangedPayload>) {
+                if (payload.viewId != GRC::VIEW_OVERVIEW) return;
+                // The payload carries no records (a Change does not move the row),
+                // so re-fetch the changed slice from the cursor and refresh.
+                const std::vector<TransactionRecord> fresh =
+                    store.getRows(GRC::VIEW_OVERVIEW, payload.first, payload.count);
+                for (std::size_t i = 0; i < fresh.size()
+                        && static_cast<std::size_t>(payload.first) + i < m_rows.size(); ++i) {
+                    m_rows[static_cast<std::size_t>(payload.first) + i] = fresh[i];
+                }
+                if (!fresh.empty()) {
+                    emit dataChanged(index(payload.first, 0),
+                                     index(payload.first + static_cast<int>(fresh.size()) - 1, 0));
+                }
+            }
+            // VIEW_FULL Rows* events, RowCountChanged, and ChainTipChanged are
+            // not consumed here (RowCountChanged is for the scrolled detailed
+            // view; the Overview list shows only its served window).
+        }, ev.payload);
+    }
+}

--- a/src/qt/overviewtxmodel.h
+++ b/src/qt/overviewtxmodel.h
@@ -27,10 +27,11 @@ class TransactionTableModel;
 //! RowsInserted/Removed/Changed — so the count/limit/resize mechanics are proven
 //! here before the detailed transaction table migrates to the same path (PR5).
 //!
-//! It is a single-column list (the recent-tx delegate composes several roles for
-//! the Status column, exactly as the old proxy did). Role values are produced by
-//! TransactionTableModel::formatRole, so the formatters live in one place and the
-//! delegate reads identical data.
+//! It is a single-column list whose column renders the ToAddress column's roles
+//! (the recent-tx delegate composes several of them — the type icon, address,
+//! amount, date — exactly as the old proxy did with modelColumn = ToAddress).
+//! Role values are produced by TransactionTableModel::formatRole, so the
+//! formatters live in one place and the delegate reads identical data.
 //!
 class OverviewTxModel : public QAbstractListModel
 {

--- a/src/qt/overviewtxmodel.h
+++ b/src/qt/overviewtxmodel.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_OVERVIEWTXMODEL_H
+#define BITCOIN_QT_OVERVIEWTXMODEL_H
+
+#include "qt/transactionrecord.h"
+#include "qt/wallet_event_queue.h"
+#include "uint256.h"
+
+#include <QAbstractListModel>
+
+#include <vector>
+
+class WalletModel;
+class TransactionTableModel;
+
+//!
+//! \brief Mini windowed-model consumer for OverviewPage's recent-transactions list.
+//!
+//! The windowed-model PR3 testbed. Instead of a client-side QSortFilterProxyModel
+//! over the full TransactionTableModel replica, OverviewPage drives a VIEW_OVERVIEW
+//! cursor in the producer GRC::WalletTxStore (server-side filter+sort, maintained
+//! off cs_main/cs_wallet on the store-worker). This model holds ONLY the cursor's
+//! served-window slice of records — refilled on RowsReset, patched on
+//! RowsInserted/Removed/Changed — so the count/limit/resize mechanics are proven
+//! here before the detailed transaction table migrates to the same path (PR5).
+//!
+//! It is a single-column list (the recent-tx delegate composes several roles for
+//! the Status column, exactly as the old proxy did). Role values are produced by
+//! TransactionTableModel::formatRole, so the formatters live in one place and the
+//! delegate reads identical data.
+//!
+class OverviewTxModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    explicit OverviewTxModel(WalletModel* walletModel, int initialLimit, QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+
+    //! Set the served-row cap (OverviewPage's stairstep resize); forwards to the
+    //! producer cursor. The resulting Insert/Remove events arrive via the drain.
+    void setLimit(int limit);
+    int limit() const { return m_limit; }
+
+    //! The tx hash at served row \p row (for click-through to the detailed view),
+    //! or a null hash if out of range.
+    uint256 txidAt(int row) const;
+
+private slots:
+    //! Apply a drained batch of wallet events; ignores everything not VIEW_OVERVIEW.
+    void applyEventBatch(const std::vector<GRC::WalletEvent>& events);
+
+private:
+    WalletModel* m_walletModel;
+    TransactionTableModel* m_ttm;            //!< formatter source (formatRole)
+    int m_limit;
+    std::vector<TransactionRecord> m_rows;   //!< served-window replica (VIEW_OVERVIEW)
+};
+
+#endif // BITCOIN_QT_OVERVIEWTXMODEL_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -131,6 +131,11 @@ public:
 
     void applyRowsInserted(const GRC::RowsInsertedPayload& payload)
     {
+        // This consumer owns only the native, unfiltered VIEW_FULL stream;
+        // per-view cursor events (OverviewPage etc.) belong to other consumers.
+        if (payload.viewId != GRC::VIEW_FULL) {
+            return;
+        }
         if (payload.records.empty()) {
             return;
         }
@@ -163,6 +168,9 @@ public:
 
     void applyRowsRemoved(const GRC::RowsRemovedPayload& payload)
     {
+        if (payload.viewId != GRC::VIEW_FULL) {
+            return;  // per-view cursor event — not this consumer's
+        }
         // A RowsRemoved is emitted only for a real, non-empty erase the store
         // located, so the range is provably in this replica. Validate anyway —
         // the deployed -DNDEBUG build drops asserts, and a bad position/count
@@ -659,7 +667,17 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     TransactionRecord *rec = priv->index(index.row());
     if (!rec) return QVariant();
 
-    const auto column = static_cast<ColumnIndex>(index.column());
+    return formatRole(rec, index.column(), role);
+}
+
+// Role-formatting core, factored out of data() so the per-view consumers
+// (OverviewPage's OverviewTxModel — windowed-model PR3) render their own served
+// records through the identical formatters instead of duplicating them. `rec`
+// is any record (this model's replica row or a cursor's served row); `columnInt`
+// is a TransactionTableModel::ColumnIndex.
+QVariant TransactionTableModel::formatRole(TransactionRecord *rec, int columnInt, int role) const
+{
+    const auto column = static_cast<ColumnIndex>(columnInt);
     switch (role) {
     case Qt::DecorationRole:
         switch (column) {
@@ -728,18 +746,18 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     case Qt::TextAlignmentRole:
-        return column_alignments[index.column()];
+        return column_alignments[columnInt];
     case Qt::ForegroundRole:
         // Non-confirmed (but not immature) as transactions are grey
         if(!rec->status.countsForBalance && rec->status.status != TransactionStatus::Immature)
         {
             return COLOR_UNCONFIRMED;
         }
-        if(index.column() == Amount && (rec->credit+rec->debit) < 0)
+        if(columnInt == Amount && (rec->credit+rec->debit) < 0)
         {
             return COLOR_NEGATIVE;
         }
-        if(index.column() == ToAddress)
+        if(columnInt == ToAddress)
         {
             return addressColor(rec);
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -692,6 +692,12 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
 // is a TransactionTableModel::ColumnIndex.
 QVariant TransactionTableModel::formatRole(TransactionRecord *rec, int columnInt, int role) const
 {
+    // Public helper (per-view consumers call it too): validate the column so an
+    // out-of-range value cannot index column_alignments[] out of bounds or land in
+    // an undefined ColumnIndex (asserts are compiled out in release builds).
+    if (!rec || columnInt < Status || columnInt > Amount) {
+        return QVariant();
+    }
     const auto column = static_cast<ColumnIndex>(columnInt);
     switch (role) {
     case Qt::DecorationRole:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -302,6 +302,21 @@ int TransactionTableModel::rowCount(const QModelIndex &parent) const
     return priv->size();
 }
 
+QModelIndex TransactionTableModel::indexForTxid(const uint256& hash) const
+{
+    // First replica row whose tx hash matches (same-hash parts are contiguous;
+    // the first is a fine click-through anchor). Linear scan — off the hot path
+    // (runs only on a recent-transaction click).
+    const int rows = priv->size();
+    for (int row = 0; row < rows; ++row) {
+        TransactionRecord* rec = priv->index(row);
+        if (rec && rec->hash == hash) {
+            return index(row, 0);
+        }
+    }
+    return QModelIndex();
+}
+
 int TransactionTableModel::columnCount(const QModelIndex &parent) const
 {
     if (parent.isValid()) {

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -61,6 +61,12 @@ public:
     int rowCount(const QModelIndex &parent) const;
     int columnCount(const QModelIndex &parent) const;
     QVariant data(const QModelIndex &index, int role) const;
+    //! Role-formatting core (factored out of data()): render \p role for an
+    //! arbitrary \p rec at \p column (a ColumnIndex). data() calls it for this
+    //! model's rows; the per-view windowed consumers (OverviewTxModel, PR3) call
+    //! it for their own served records, so the formatters live in exactly one
+    //! place. \p rec may be any record, not necessarily in this model's replica.
+    QVariant formatRole(TransactionRecord *rec, int column, int role) const;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
     QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
 

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -70,6 +70,11 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
     QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
 
+    //! First replica row matching tx \p hash, as a model index, or an invalid
+    //! index. Maps a per-view consumer's clicked row (OverviewTxModel, PR3) back
+    //! to a TransactionTableModel index for the detailed-view click-through.
+    QModelIndex indexForTxid(const uint256& hash) const;
+
     //!
     //! \brief Consume a batch of producer-side wallet events drained from
     //! WalletModel's WalletEventQueue. Inserts/removes rows from the cached

--- a/src/qt/wallet_event_queue.h
+++ b/src/qt/wallet_event_queue.h
@@ -20,6 +20,17 @@
 namespace GRC {
 
 //!
+//! \brief View identifiers stamped on per-view events (PR3).
+//!
+//! VIEW_FULL is the native unfiltered/unsorted stream the TransactionTableModel
+//! consumes today (PR2/PR2.5 behaviour, epoch 0). Registered cursors (server-side
+//! filter/sort) use VIEW_OVERVIEW and up. The consumer ignores events whose viewId
+//! it does not own.
+//!
+constexpr int VIEW_FULL = 0;
+constexpr int VIEW_OVERVIEW = 1;
+
+//!
 //! \brief Producer-side payload: rows were inserted into the ordered wallet
 //! view at a producer-computed position.
 //!
@@ -39,6 +50,8 @@ struct RowsInsertedPayload
 {
     int position;
     std::vector<TransactionRecord> records;
+    int viewId = VIEW_FULL;   //!< which view this insert belongs to (PR3)
+    uint64_t epoch = 0;       //!< source cursor epoch, for stale-fetch reconciliation (PR3)
 };
 
 //!
@@ -52,6 +65,48 @@ struct RowsInsertedPayload
 struct RowsRemovedPayload
 {
     int position;
+    int count;
+    int viewId = VIEW_FULL;   //!< which view this removal belongs to (PR3)
+    uint64_t epoch = 0;       //!< source cursor epoch, for stale-fetch reconciliation (PR3)
+};
+
+//!
+//! \brief Producer-side payload (PR3): a per-view cursor was rebuilt wholesale
+//! (filter or sort change) — the consumer must drop its replica for \p viewId
+//! and bulk-refill \p total served rows via the store's getRows. Carries the
+//! new \p epoch so any in-flight pre-rebuild fetch can be discarded on arrival.
+//!
+struct RowsResetPayload
+{
+    int viewId;
+    uint64_t epoch;
+    int total;       //!< served-window row count after the rebuild
+};
+
+//!
+//! \brief Producer-side payload (PR3): the TOTAL accepted row count for a view
+//! changed (e.g. a row entered/left the filter off-window, so the scrollbar
+//! extent moves but no served row was inserted/removed). The consumer resizes
+//! its virtual rowCount to \p total_accepted without touching cached rows.
+//! Decision 4 (RowCountChanged not deferred — OverviewPage is the windowed testbed).
+//!
+struct RowCountChangedPayload
+{
+    int viewId;
+    uint64_t epoch;
+    int total_accepted;
+};
+
+//!
+//! \brief Producer-side payload (PR3): rows [first, first+count) of \p viewId
+//! changed in place (a status/field update that did NOT move them) — the
+//! consumer re-reads them (dataChanged), re-fetching from the store if windowed.
+//!
+struct RowsChangedPayload
+{
+    int viewId;
+    uint64_t epoch;
+    int first;
     int count;
 };
 
@@ -81,7 +136,10 @@ struct ChainTipChangedPayload
 using WalletEventPayload = std::variant<
     RowsInsertedPayload,
     RowsRemovedPayload,
-    ChainTipChangedPayload>;
+    ChainTipChangedPayload,
+    RowsResetPayload,
+    RowCountChangedPayload,
+    RowsChangedPayload>;
 
 //!
 //! \brief A single event in the wallet→GUI event channel.

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -211,6 +211,10 @@ void WalletModel::drainEventQueue()
         }
     }
 
+    // Fan the same batch out to the per-view windowed consumers (OverviewTxModel),
+    // which filter to their own viewId. The queue is drained exactly once, here.
+    emit walletEventsDrained(events);
+
     // Balance and number of transactions might have changed.
     checkBalanceChanged();
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -771,16 +771,28 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
         }
 
         if (visible) {
-            // Decompose under the locks already held, then ENQUEUE the records
-            // to the store-worker (PR2.5). The worker applies the datetime
-            // cutoff, de-dupes, computes the insert position, and emits
-            // RowsInserted off the core locks; the enqueue itself is O(1), so
-            // this handler no longer does O(N) ordering work under cs_main.
+            // Decompose under the locks already held, compute per-row status
+            // producer-side (updateStatus requires cs_main, held here), then
+            // ENQUEUE to the store-worker (PR2.5). The worker applies the datetime
+            // cutoff, de-dupes, computes positions, maintains the per-view cursors
+            // and emits events off the core locks; the enqueue itself is O(1).
+            // Status is computed here so the off-lock cursors can filter/sort by
+            // it without re-touching the wallet.
             const QList<TransactionRecord> decomposed =
                 TransactionRecord::decomposeTransaction(wallet, wtx);
             if (!decomposed.isEmpty()) {
-                walletmodel->getTxStore().enqueueInsert(
-                    std::vector<TransactionRecord>(decomposed.begin(), decomposed.end()));
+                std::vector<TransactionRecord> recs(decomposed.begin(), decomposed.end());
+                for (TransactionRecord& rec : recs) {
+                    rec.updateStatus(wtx);
+                }
+                // CT_NEW is a fresh insert; CT_UPDATED / CT_UPDATING is an upsert
+                // of an existing tx (e.g. a confirmation) — the store updates it in
+                // place and repositions it in any status-sorted cursor.
+                if (status == CT_NEW) {
+                    walletmodel->getTxStore().enqueueInsert(std::move(recs));
+                } else {
+                    walletmodel->getTxStore().enqueueUpsert(std::move(recs));
+                }
             }
         } else {
             // Tx is genuinely filtered out (a real orphan coinstake, or a

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -213,6 +213,13 @@ signals:
     // needs this signal instead.
     void transactionUpdated();
 
+    //! Fan-out of a drained wallet-event batch to per-view windowed consumers
+    //! (PR3: OverviewTxModel). WalletModel drains the queue once and applies the
+    //! VIEW_FULL stream to its TransactionTableModel; this delivers the same batch
+    //! to the per-view consumers, which filter to their own viewId. Same-thread
+    //! (DirectConnection), so the const-ref is passed without a copy.
+    void walletEventsDrained(const std::vector<GRC::WalletEvent>& events);
+
     // Signal that balance in wallet changed
     void balanceChanged(qint64 balance, qint64 stake, qint64 unconfirmedBalance, qint64 immatureBalance);
 

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -23,6 +23,27 @@ struct RecordOrder {
     }
 };
 
+//! Project a stored record to the Qt-free filter inputs. `label` is left empty:
+//! the Overview view (PR3) does not filter by address substring, and the
+//! address-book label needs cs_wallet, which the worker does not hold. The
+//! detailed table's address filter populates it in PR4.
+GRC::TxFilterFields projectFields(const TransactionRecord& r)
+{
+    return GRC::TxFilterFields{
+        r.time, r.credit + r.debit, static_cast<int>(r.type),
+        static_cast<int>(r.status.status), r.address, std::string()};
+}
+
+//! Project a stored record to the Qt-free sort inputs. type_string /
+//! address_string are left empty: those are the localized Qt formatter strings,
+//! used only when sorting by Type/Address — which the Overview view does not (it
+//! sorts by date/status). PR4 supplies them when the detailed table migrates.
+GRC::SortKey projectKeys(const TransactionRecord& r)
+{
+    return GRC::SortKey{
+        r.time, r.credit + r.debit, r.status.sortKey, std::string(), std::string()};
+}
+
 } // anonymous namespace
 
 namespace GRC {
@@ -74,6 +95,19 @@ void WalletTxStore::enqueueRemove(const uint256& hash)
     m_intake_cv.notify_one();
 }
 
+void WalletTxStore::enqueueUpsert(std::vector<TransactionRecord> records)
+{
+    if (records.empty()) {
+        return;
+    }
+    const uint256 hash = records.front().hash;
+    {
+        LOCK(cs_intake);
+        m_intake.push_back(IntakeItem{IntakeItem::Update, std::move(records), hash});
+    }
+    m_intake_cv.notify_one();
+}
+
 void WalletTxStore::workerLoop()
 {
     WAIT_LOCK(cs_intake, lock);
@@ -114,9 +148,11 @@ void WalletTxStore::workerLoop()
 
 void WalletTxStore::applyIntake(IntakeItem item)
 {
-    // No lock held here; insert/removeTransaction take cs_store internally.
+    // No lock held here; insert/remove/updateTransaction take cs_store internally.
     if (item.kind == IntakeItem::Insert) {
         insertTransaction(std::move(item.records));
+    } else if (item.kind == IntakeItem::Update) {
+        updateTransaction(std::move(item.records));
     } else {
         removeTransaction(item.hash);
     }
@@ -146,7 +182,11 @@ void WalletTxStore::rebuildIndex()
 void WalletTxStore::insertTransaction(std::vector<TransactionRecord> records)
 {
     LOCK(cs_store);
+    insertLocked(std::move(records));
+}
 
+void WalletTxStore::insertLocked(std::vector<TransactionRecord> records)
+{
     // Datetime-display cutoff (cached from the last reloadAndSnapshot). All
     // records of one tx share `time`, so this is all-or-nothing.
     if (m_limit_enabled) {
@@ -196,12 +236,22 @@ void WalletTxStore::insertTransaction(std::vector<TransactionRecord> records)
     // Push the position-stamped event WHILE cs_store is held so that queue
     // seqno-order equals store-mutation-order across all producer threads.
     m_queue.push(GRC::RowsInsertedPayload{static_cast<int>(insertIdx), std::move(records)});
+
+    // Drive each registered cursor: the new records now occupy
+    // [insertIdx, insertIdx+count) in m_records (cursors index into m_records).
+    for (auto& [viewId, cursor] : m_cursors) {
+        emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStoreInsert(insertIdx, count));
+    }
 }
 
 void WalletTxStore::removeTransaction(const uint256& hash)
 {
     LOCK(cs_store);
+    removeLocked(hash);
+}
 
+void WalletTxStore::removeLocked(const uint256& hash)
+{
     auto range = m_by_hash.equal_range(hash);
     if (range.first == range.second) {
         // Not present — filtered out at insert time, or never inserted. No-op,
@@ -247,6 +297,12 @@ void WalletTxStore::removeTransaction(const uint256& hash)
     shiftIndex(maxPos + 1, -static_cast<std::ptrdiff_t>(count));
 
     m_queue.push(GRC::RowsRemovedPayload{static_cast<int>(minPos), static_cast<int>(count)});
+
+    // Drive each registered cursor: [minPos, minPos+count) were erased from
+    // m_records and later positions shifted down by count.
+    for (auto& [viewId, cursor] : m_cursors) {
+        emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStoreRemove(minPos, count));
+    }
 }
 
 std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabled, int64_t limit_time)
@@ -297,12 +353,21 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
     }
     std::sort(built.begin(), built.end(), RecordOrder());
 
+    std::vector<GRC::RowsResetPayload> cursor_resets;
     {
         LOCK(cs_store);
         m_limit_enabled = limit_enabled;
         m_limit_time = limit_time;
         m_records = built;
         rebuildIndex();
+        // Rebuild each registered cursor over the new m_records. Their Reset
+        // events are pushed AFTER the drain below (which discards pre-rebuild
+        // events), so the windowed consumers refill against the new snapshot.
+        for (auto& [viewId, cursor] : m_cursors) {
+            cursor.rebuild(m_records.size());
+            cursor_resets.push_back(GRC::RowsResetPayload{
+                viewId, cursor.epoch(), static_cast<int>(cursor.servedCount())});
+        }
     }
 
     // Discard any events queued before this rebuild: they were computed against
@@ -310,6 +375,14 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
     // on cs_wallet, so nothing new can be queued until we return; the returned
     // snapshot, the rebuilt index, and the now-empty queue are consistent.
     m_queue.drain();
+
+    // Re-publish the per-view cursor Resets AFTER the drain so they survive it;
+    // the windowed consumers (e.g. OverviewTxModel) refill via getRows. Producers
+    // are still blocked on cs_wallet, so these are the only queued events until
+    // we return.
+    for (const GRC::RowsResetPayload& reset : cursor_resets) {
+        m_queue.push(reset);
+    }
 
     // Release the store-worker (PR2.5): the rebuilt index is live, so resume
     // draining. Producers remain blocked on cs_wallet until we return, so the
@@ -322,6 +395,180 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
     }
 
     return built;
+}
+
+void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)
+{
+    LOCK(cs_store);
+
+    if (m_limit_enabled) {
+        const int64_t limit_time = m_limit_time;
+        records.erase(std::remove_if(records.begin(), records.end(),
+                          [limit_time](const TransactionRecord& r) { return r.time < limit_time; }),
+                      records.end());
+    }
+    if (records.empty()) {
+        // The whole tx fell outside the datetime cutoff. If it was present, it
+        // must go (its parts are now hidden); a bare hash remove handles that.
+        return;
+    }
+    std::sort(records.begin(), records.end(), RecordOrder());
+    const uint256 hash = records.front().hash;
+
+    auto range = m_by_hash.equal_range(hash);
+    if (range.first == range.second) {
+        // Not present (previously filtered, or just became visible) -> insert.
+        insertLocked(std::move(records));
+        return;
+    }
+
+    std::size_t minPos = std::numeric_limits<std::size_t>::max();
+    std::size_t maxPos = 0;
+    for (auto it = range.first; it != range.second; ++it) {
+        if (it->second < minPos) minPos = it->second;
+        if (it->second > maxPos) maxPos = it->second;
+    }
+    const std::size_t stored = maxPos - minPos + 1;
+
+    // Structural guard (mirrors removeLocked): same-hash records must be one
+    // contiguous run AND the part count must be unchanged for an in-place
+    // overwrite. If the part count changed or the run is broken, fall back to
+    // remove+insert rather than overwrite mismatched slots.
+    if (maxPos >= m_records.size()
+            || stored != records.size()
+            || static_cast<std::size_t>(std::distance(range.first, range.second)) != stored
+            || m_records[minPos].hash != hash
+            || m_records[maxPos].hash != hash) {
+        removeLocked(hash);
+        insertLocked(std::move(records));
+        return;
+    }
+
+    // In-place overwrite: the status changed but the ordering key (time,hash,idx)
+    // did not, so positions are unchanged. No VIEW_FULL event is emitted — the
+    // detailed table refreshes confirmation status lazily on read (unchanged
+    // behaviour). Re-evaluate each cursor per affected row: under a status sort a
+    // first confirmation repositions the row.
+    for (std::size_t k = 0; k < records.size(); ++k) {
+        m_records[minPos + k] = records[k];
+    }
+    for (auto& [viewId, cursor] : m_cursors) {
+        for (std::size_t p = minPos; p <= maxPos; ++p) {
+            emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStatusUpdate(p));
+        }
+    }
+}
+
+TxFilterFields WalletTxStore::projectFieldsAt(std::size_t i) const
+{
+    return projectFields(m_records[i]);
+}
+
+SortKey WalletTxStore::projectKeysAt(std::size_t i) const
+{
+    return projectKeys(m_records[i]);
+}
+
+void WalletTxStore::makeCursorProjectors(Cursor::FieldsFn& fields, Cursor::KeysFn& keys)
+{
+    fields = [this](std::size_t i) { return projectFieldsAt(i); };
+    keys = [this](std::size_t i) { return projectKeysAt(i); };
+}
+
+void WalletTxStore::registerView(int viewId, FilterSpec filter, int sort_column, int sort_order)
+{
+    LOCK(cs_store);
+    Cursor::FieldsFn fields;
+    Cursor::KeysFn keys;
+    makeCursorProjectors(fields, keys);
+    Cursor cursor(viewId, std::move(filter), sort_column, sort_order,
+                  std::move(fields), std::move(keys));
+    const auto deltas = cursor.rebuild(m_records.size());
+    const uint64_t epoch = cursor.epoch();
+    m_cursors.insert_or_assign(viewId, std::move(cursor));
+    emitCursorDeltas(viewId, epoch, deltas);
+}
+
+void WalletTxStore::setViewSort(int viewId, int sort_column, int sort_order)
+{
+    LOCK(cs_store);
+    auto it = m_cursors.find(viewId);
+    if (it == m_cursors.end()) return;
+    emitCursorDeltas(viewId, it->second.epoch(), it->second.setSort(sort_column, sort_order));
+}
+
+void WalletTxStore::setViewFilter(int viewId, FilterSpec filter)
+{
+    LOCK(cs_store);
+    auto it = m_cursors.find(viewId);
+    if (it == m_cursors.end()) return;
+    emitCursorDeltas(viewId, it->second.epoch(), it->second.setFilter(filter, m_records.size()));
+}
+
+void WalletTxStore::setViewLimit(int viewId, int limit)
+{
+    LOCK(cs_store);
+    auto it = m_cursors.find(viewId);
+    if (it == m_cursors.end()) return;
+    emitCursorDeltas(viewId, it->second.epoch(), it->second.setLimit(limit));
+}
+
+std::vector<TransactionRecord> WalletTxStore::getRows(int viewId, int first, int count)
+{
+    LOCK(cs_store);
+    std::vector<TransactionRecord> out;
+    auto it = m_cursors.find(viewId);
+    if (it == m_cursors.end() || first < 0 || count <= 0) {
+        return out;
+    }
+    const std::size_t served = it->second.servedCount();
+    const std::size_t begin = static_cast<std::size_t>(first);
+    if (begin >= served) {
+        return out;
+    }
+    const std::size_t end = std::min(served, begin + static_cast<std::size_t>(count));
+    out.reserve(end - begin);
+    for (std::size_t i = begin; i < end; ++i) {
+        out.push_back(m_records[it->second.rowAt(i)]);
+    }
+    return out;
+}
+
+int WalletTxStore::totalAccepted(int viewId)
+{
+    LOCK(cs_store);
+    auto it = m_cursors.find(viewId);
+    return it == m_cursors.end() ? 0 : static_cast<int>(it->second.totalAccepted());
+}
+
+void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,
+                                     const std::vector<CursorDelta>& deltas)
+{
+    auto it = m_cursors.find(viewId);
+    for (const CursorDelta& d : deltas) {
+        switch (d.type) {
+        case CursorDelta::Reset:
+            m_queue.push(GRC::RowsResetPayload{viewId, epoch, d.count});
+            break;
+        case CursorDelta::Insert: {
+            std::vector<TransactionRecord> recs;
+            if (it != m_cursors.end()) {
+                recs.reserve(static_cast<std::size_t>(d.count));
+                for (int j = 0; j < d.count; ++j) {
+                    recs.push_back(m_records[it->second.rowAt(static_cast<std::size_t>(d.first + j))]);
+                }
+            }
+            m_queue.push(GRC::RowsInsertedPayload{d.first, std::move(recs), viewId, epoch});
+            break;
+        }
+        case CursorDelta::Remove:
+            m_queue.push(GRC::RowsRemovedPayload{d.first, d.count, viewId, epoch});
+            break;
+        case CursorDelta::Change:
+            m_queue.push(GRC::RowsChangedPayload{viewId, epoch, d.first, d.count});
+            break;
+        }
+    }
 }
 
 } // namespace GRC

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -348,7 +348,12 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
             if (limit_enabled && rec.time < limit_time) {
                 continue;
             }
-            built.push_back(rec);
+            // Compute status producer-side (cs_main held here) so the cursors
+            // rebuilt over m_records can filter/sort by it. The VIEW_FULL consumer
+            // still refreshes status lazily on read; this is a harmless head-start.
+            TransactionRecord r = rec;
+            r.updateStatus(it->second);
+            built.push_back(std::move(r));
         }
     }
     std::sort(built.begin(), built.end(), RecordOrder());

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -137,9 +137,9 @@ void WalletTxStore::shiftIndex(std::size_t from, std::ptrdiff_t delta)
 void WalletTxStore::rebuildIndex()
 {
     m_by_hash.clear();
-    m_by_hash.reserve(m_keys.size() * 2 + 1);
-    for (std::size_t i = 0; i < m_keys.size(); ++i) {
-        m_by_hash.emplace(m_keys[i].hash, i);
+    m_by_hash.reserve(m_records.size() * 2 + 1);
+    for (std::size_t i = 0; i < m_records.size(); ++i) {
+        m_by_hash.emplace(m_records[i].hash, i);
     }
 }
 
@@ -178,23 +178,17 @@ void WalletTxStore::insertTransaction(std::vector<TransactionRecord> records)
 
     // All records share `time` and `hash` and differ only in `idx`; under
     // TxOrderLess they form a contiguous range slotting in at the lower_bound
-    // of the first key.
-    const TxOrderKey first_key{records.front().time, hash, records.front().idx};
-    const auto pos = std::lower_bound(m_keys.begin(), m_keys.end(), first_key, GRC::TxOrderLess);
-    const std::size_t insertIdx = static_cast<std::size_t>(pos - m_keys.begin());
+    // of the first record.
+    const auto pos = std::lower_bound(m_records.begin(), m_records.end(), records.front(), RecordOrder());
+    const std::size_t insertIdx = static_cast<std::size_t>(pos - m_records.begin());
     const std::size_t count = records.size();
-
-    std::vector<TxOrderKey> new_keys;
-    new_keys.reserve(count);
-    for (const TransactionRecord& r : records) {
-        new_keys.push_back({r.time, r.hash, r.idx});
-    }
 
     // Shift the index BEFORE splicing the vector (the shift uses logical
     // positions), then splice, then add the new index entries — keeping the
-    // index consistent at every observable point.
+    // index consistent at every observable point. The records are copied into the
+    // store (the authoritative full-records table) and then moved into the event.
     shiftIndex(insertIdx, static_cast<std::ptrdiff_t>(count));
-    m_keys.insert(m_keys.begin() + insertIdx, new_keys.begin(), new_keys.end());
+    m_records.insert(m_records.begin() + insertIdx, records.begin(), records.end());
     for (std::size_t k = 0; k < count; ++k) {
         m_by_hash.emplace(hash, insertIdx + k);
     }
@@ -231,24 +225,24 @@ void WalletTxStore::removeTransaction(const uint256& hash)
     // via assert: the deployed build is -DNDEBUG, so an assert would vanish and
     // a de-clustered index would erase a wider [minPos, maxPos] range that
     // swallows foreign rows (heap/structure corruption). The bounds check is
-    // ordered first and short-circuits, so the m_keys[] subscripts below it
+    // ordered first and short-circuits, so the m_records[] subscripts below it
     // never run out of range. If the invariant is ever violated, bail without
     // erasing or emitting — a stale row is a safe degradation; a wrong erase is
     // not.
-    if (maxPos >= m_keys.size()
+    if (maxPos >= m_records.size()
             || count != distance
-            || m_keys[minPos].hash != hash
-            || m_keys[maxPos].hash != hash) {
+            || m_records[minPos].hash != hash
+            || m_records[maxPos].hash != hash) {
         LogPrintf("ERROR: %s: hash %s index non-contiguous/out-of-range "
                   "(minPos=%u maxPos=%u count=%u distance=%u keys=%u) — skipping remove",
                   __func__, hash.GetHex(),
                   static_cast<unsigned int>(minPos), static_cast<unsigned int>(maxPos),
                   static_cast<unsigned int>(count), static_cast<unsigned int>(distance),
-                  static_cast<unsigned int>(m_keys.size()));
+                  static_cast<unsigned int>(m_records.size()));
         return;
     }
 
-    m_keys.erase(m_keys.begin() + minPos, m_keys.begin() + maxPos + 1);
+    m_records.erase(m_records.begin() + minPos, m_records.begin() + maxPos + 1);
     m_by_hash.erase(hash);
     shiftIndex(maxPos + 1, -static_cast<std::ptrdiff_t>(count));
 
@@ -307,11 +301,7 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
         LOCK(cs_store);
         m_limit_enabled = limit_enabled;
         m_limit_time = limit_time;
-        m_keys.clear();
-        m_keys.reserve(built.size());
-        for (const TransactionRecord& r : built) {
-            m_keys.push_back({r.time, r.hash, r.idx});
-        }
+        m_records = built;
         rebuildIndex();
     }
 

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -406,6 +406,14 @@ void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)
 {
     LOCK(cs_store);
 
+    if (records.empty()) {
+        return;
+    }
+    // Capture the hash BEFORE the datetime-cutoff erase below: all parts of a tx
+    // share `time`, so the cutoff is all-or-nothing, and on an empty result we
+    // still need the hash to evict any rows the tx previously had.
+    const uint256 hash = records.front().hash;
+
     if (m_limit_enabled) {
         const int64_t limit_time = m_limit_time;
         records.erase(std::remove_if(records.begin(), records.end(),
@@ -413,12 +421,13 @@ void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)
                       records.end());
     }
     if (records.empty()) {
-        // The whole tx fell outside the datetime cutoff. If it was present, it
-        // must go (its parts are now hidden); a bare hash remove handles that.
+        // The whole tx fell behind the datetime cutoff: if it was present it must
+        // go (its parts are now hidden). removeLocked is a no-op if absent, and
+        // drives the cursors + emits the removal events.
+        removeLocked(hash);
         return;
     }
     std::sort(records.begin(), records.end(), RecordOrder());
-    const uint256 hash = records.front().hash;
 
     auto range = m_by_hash.equal_range(hash);
     if (range.first == range.second) {
@@ -499,7 +508,11 @@ void WalletTxStore::setViewSort(int viewId, int sort_column, int sort_order)
     LOCK(cs_store);
     auto it = m_cursors.find(viewId);
     if (it == m_cursors.end()) return;
-    emitCursorDeltas(viewId, it->second.epoch(), it->second.setSort(sort_column, sort_order));
+    // Sequence the mutation before reading epoch(): setSort() bumps the cursor
+    // epoch, and C++ leaves function-argument evaluation order unspecified, so
+    // computing the deltas first guarantees the emitted events carry the NEW epoch.
+    const auto deltas = it->second.setSort(sort_column, sort_order);
+    emitCursorDeltas(viewId, it->second.epoch(), deltas);
 }
 
 void WalletTxStore::setViewFilter(int viewId, FilterSpec filter)
@@ -507,7 +520,9 @@ void WalletTxStore::setViewFilter(int viewId, FilterSpec filter)
     LOCK(cs_store);
     auto it = m_cursors.find(viewId);
     if (it == m_cursors.end()) return;
-    emitCursorDeltas(viewId, it->second.epoch(), it->second.setFilter(filter, m_records.size()));
+    // setFilter() bumps the epoch (Reset); sequence before reading epoch().
+    const auto deltas = it->second.setFilter(filter, m_records.size());
+    emitCursorDeltas(viewId, it->second.epoch(), deltas);
 }
 
 void WalletTxStore::setViewLimit(int viewId, int limit)
@@ -515,7 +530,9 @@ void WalletTxStore::setViewLimit(int viewId, int limit)
     LOCK(cs_store);
     auto it = m_cursors.find(viewId);
     if (it == m_cursors.end()) return;
-    emitCursorDeltas(viewId, it->second.epoch(), it->second.setLimit(limit));
+    // setLimit() does not bump the epoch, but sequence for consistency/safety.
+    const auto deltas = it->second.setLimit(limit);
+    emitCursorDeltas(viewId, it->second.epoch(), deltas);
 }
 
 std::vector<TransactionRecord> WalletTxStore::getRows(int viewId, int first, int count)

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_QT_WALLETTXSTORE_H
 #define BITCOIN_QT_WALLETTXSTORE_H
 
+#include "qt/cursor.h"
 #include "qt/txorder.h"
 #include "qt/transactionrecord.h"
 #include "qt/wallet_event_queue.h"
@@ -14,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <map>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -95,6 +97,39 @@ public:
     void enqueueRemove(const uint256& hash);
 
     //!
+    //! \brief Producer: a transaction already in the store changed (CT_UPDATED —
+    //! e.g. first confirmation). Enqueues the freshly re-decomposed \p records
+    //! (with producer-computed status) for the worker, which replaces the stored
+    //! records in place and re-evaluates each cursor's membership/sort slot
+    //! (applyStatusUpdate). Same O(1) threading contract as enqueueInsert.
+    //!
+    void enqueueUpsert(std::vector<TransactionRecord> records);
+
+    //!
+    //! \brief Qt thread: register a per-view cursor (server-side filter+sort).
+    //! Builds the cursor over the current m_records and pushes a RowsReset so the
+    //! consumer bulk-refills via getRows. Re-registering an existing viewId
+    //! replaces it. \p viewId is one of the GRC::VIEW_* identifiers.
+    //!
+    void registerView(int viewId, FilterSpec filter, int sort_column, int sort_order);
+
+    //! Qt thread: change a registered view's sort / filter / served-row cap.
+    //! Each pushes the cursor's resulting events (Reset for sort/filter,
+    //! Insert/Remove at the boundary for a limit change).
+    void setViewSort(int viewId, int sort_column, int sort_order);
+    void setViewFilter(int viewId, FilterSpec filter);
+    void setViewLimit(int viewId, int limit);
+
+    //! Qt thread: read [first, first+count) served rows of \p viewId as records
+    //! (a copy of the slice). Clamps to the served window; returns fewer rows if
+    //! the window is shorter. Unknown viewId -> empty.
+    std::vector<TransactionRecord> getRows(int viewId, int first, int count);
+
+    //! Qt thread: total accepted rows for \p viewId (the virtual rowCount), or 0
+    //! if the view is not registered.
+    int totalAccepted(int viewId);
+
+    //!
     //! \brief Qt thread: rebuild the store from the wallet and return a full
     //! decomposed snapshot for the consumer's replica.
     //!
@@ -113,8 +148,8 @@ public:
 private:
     //! One unit of deferred store maintenance handed from a producer to the worker.
     struct IntakeItem {
-        enum Kind { Insert, Remove } kind;
-        std::vector<TransactionRecord> records; //!< Insert: the decomposed parts.
+        enum Kind { Insert, Remove, Update } kind;
+        std::vector<TransactionRecord> records; //!< Insert/Update: the decomposed parts.
         uint256 hash;                           //!< Remove: the tx hash.
     };
 
@@ -127,12 +162,38 @@ private:
     void applyIntake(IntakeItem item);
 
     //! The O(N) ordering maintenance, now worker-private (was the public PR2 API;
-    //! producers call enqueue* instead). Each takes cs_store and pushes one event.
+    //! producers call enqueue* instead). Each takes cs_store and pushes the native
+    //! VIEW_FULL event AND drives the registered cursors.
     void insertTransaction(std::vector<TransactionRecord> records);
     void removeTransaction(const uint256& hash);
+    //! Worker: a present tx's records changed in place (CT_UPDATED). Replaces the
+    //! stored records and re-evaluates each cursor (applyStatusUpdate). Takes cs_store.
+    void updateTransaction(std::vector<TransactionRecord> records);
+    //! Lock-free cores (caller already holds cs_store): the actual O(N) maintenance
+    //! + cursor drive. insert/removeTransaction are thin lock-taking wrappers;
+    //! updateTransaction composes these directly for its not-present /
+    //! part-count-changed fallback without re-entering the non-recursive cs_store.
+    void insertLocked(std::vector<TransactionRecord> records) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+    void removeLocked(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
 
     void shiftIndex(std::size_t from, std::ptrdiff_t delta) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
     void rebuildIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! Translate one cursor's served-window CursorDeltas into WalletEvents for
+    //! \p viewId (Reset/Insert/Remove/Change), fetching records from m_records for
+    //! the inserted/changed served rows. Caller holds cs_store.
+    void emitCursorDeltas(int viewId, uint64_t epoch,
+                          const std::vector<CursorDelta>& deltas) EXCLUSIVE_LOCKS_REQUIRED(cs_store);
+
+    //! Cursor projectors over m_records[i]. Read m_records while the caller holds
+    //! cs_store, but they are invoked through the cursor's std::function
+    //! indirection, which the Clang thread-safety analyzer cannot see the lock
+    //! through — hence NO_THREAD_SAFETY_ANALYSIS. Every call path holds cs_store
+    //! (the worker's apply* and the Qt-thread register/getRows all take it).
+    TxFilterFields projectFieldsAt(std::size_t i) const NO_THREAD_SAFETY_ANALYSIS;
+    SortKey projectKeysAt(std::size_t i) const NO_THREAD_SAFETY_ANALYSIS;
+    //! Build the (Fields, Keys) projector pair bound to this store for a cursor.
+    void makeCursorProjectors(Cursor::FieldsFn& fields, Cursor::KeysFn& keys);
 
     CWallet* const m_wallet;
     GRC::WalletEventQueue& m_queue;
@@ -145,6 +206,12 @@ private:
     std::vector<TransactionRecord> m_records GUARDED_BY(cs_store);
     //! tx hash -> positions in m_records. Same-hash records are contiguous.
     std::unordered_multimap<uint256, std::size_t, TxHashHasher> m_by_hash GUARDED_BY(cs_store);
+
+    //! Registered per-view cursors (server-side filter+sort), keyed by VIEW_*.
+    //! Each indexes into m_records; maintained on the worker thread (insert/
+    //! remove/update) and on the Qt thread (register/setView*/getRows), all under
+    //! cs_store. std::map for stable references across insertion.
+    std::map<int, Cursor> m_cursors GUARDED_BY(cs_store);
 
     //! Cached OptionsModel datetime-display cutoff, set by reloadAndSnapshot.
     bool m_limit_enabled GUARDED_BY(cs_store){false};

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -47,13 +47,12 @@ struct TxHashHasher {
 //! batch (a pure-passthrough-reading-the-eager-store consumer would mis-map
 //! rows mid-replay).
 //!
-//! In PR2 the store holds ORDERING KEYS ONLY (not full TransactionRecords): it
-//! does not yet serve reads, so materializing full records here would only
-//! double resident memory. It grows to the full-records authoritative store in
-//! the windowing step (PR5), when the consumer drops its full replica for a
-//! viewport slice and begins reading the store.
+//! As of PR3 the store holds the FULL authoritative TransactionRecords (not just
+//! ordering keys): the per-view cursors filter/sort over them and the store
+//! serves reads (getRows) for the windowed consumers. The detailed-table consumer
+//! still keeps its own full replica until it migrates to a viewport slice (PR5).
 //!
-//! Threading: m_keys / m_by_hash are guarded by the leaf mutex cs_store. The
+//! Threading: m_records / m_by_hash are guarded by the leaf mutex cs_store. The
 //! canonical lock order is cs_main -> cs_wallet -> cs_store; cs_store is NEVER
 //! held while acquiring cs_main / cs_wallet. Producers finish all wallet work
 //! (decompose under the locks they already hold) BEFORE calling into the store,
@@ -140,9 +139,11 @@ private:
 
     mutable Mutex cs_store;
 
-    //! Ordering keys, sorted by TxOrderLess. Authoritative position oracle.
-    std::vector<TxOrderKey> m_keys GUARDED_BY(cs_store);
-    //! tx hash -> positions in m_keys. Same-hash keys are contiguous.
+    //! Full authoritative records, sorted by TxOrderLess (RecordOrder). Position
+    //! oracle for the native VIEW_FULL stream and the backing table the per-view
+    //! cursors index into.
+    std::vector<TransactionRecord> m_records GUARDED_BY(cs_store);
+    //! tx hash -> positions in m_records. Same-hash records are contiguous.
     std::unordered_multimap<uint256, std::size_t, TxHashHasher> m_by_hash GUARDED_BY(cs_store);
 
     //! Cached OptionsModel datetime-display cutoff, set by reloadAndSnapshot.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -58,6 +58,10 @@ add_executable(test_gridcoin
     # tested in the GUI-OFF configuration CI exercises.
     ${CMAKE_SOURCE_DIR}/src/qt/txorder.cpp
     qt_txorder_tests.cpp
+    # Qt-free per-view cursor (src/qt/cursor.cpp) + its unit suite: the
+    # view_index-maintenance arithmetic (windowed-model PR3), tested GUI-OFF.
+    ${CMAKE_SOURCE_DIR}/src/qt/cursor.cpp
+    qt_cursor_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/qt_cursor_tests.cpp
+++ b/src/test/qt_cursor_tests.cpp
@@ -1,0 +1,339 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF unit coverage for the Qt-free per-view cursor (src/qt/cursor.{h,cpp}),
+// the windowed-model PR3 core. Exercises the view_index-maintenance algorithm
+// (doc/transaction_table_windowed_model.md addendum), in particular the four
+// arithmetic hazards: identity-locate (not sort-key), erase-then-lower_bound
+// reposition, off-window maintenance with gated emission, and the store
+// reindex/splice — plus the served-window eviction/promotion boundary. The
+// cursor itself is Qt-free, so it compiles into test_gridcoin with ENABLE_GUI=OFF
+// where CI actually runs (the blind spot that hid #2944).
+
+#include <qt/cursor.h>
+#include <qt/txfilter.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace GRC;
+
+namespace {
+
+//! A synthetic record carrying both the filter inputs and the sort inputs, so
+//! the projectors index a plain vector (no wallet, no Qt) — the cursor never
+//! sees this type.
+struct Rec {
+    int64_t time = 0;
+    int64_t amount = 0;
+    int type = 0;
+    int status = 0;             // 0 = active; 6/9 = Conflicted/NotAccepted (inactive)
+    std::string addr;
+    std::string label;
+    std::string status_sort;    // sort key for TXCOL_STATUS
+};
+
+//! A backing table + the two projectors bound to it. apply* must be called only
+//! after the table is mutated (the production contract).
+struct Table {
+    std::vector<Rec> rows;
+    Cursor::FieldsFn fields() {
+        return [this](std::size_t i) {
+            const Rec& r = rows[i];
+            return TxFilterFields{r.time, r.amount, r.type, r.status, r.addr, r.label};
+        };
+    }
+    Cursor::KeysFn keys() {
+        return [this](std::size_t i) {
+            const Rec& r = rows[i];
+            return SortKey{r.time, r.amount, r.status_sort, "", ""};
+        };
+    }
+};
+
+Rec active(int64_t time, const std::string& ssort = "") { Rec r; r.time = time; r.status = 0; r.status_sort = ssort; return r; }
+
+// Count deltas of a given type.
+int countType(const std::vector<CursorDelta>& d, CursorDelta::Type t) {
+    int n = 0; for (const auto& x : d) if (x.type == t) ++n; return n;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(qt_cursor_tests)
+
+// ---- rebuild: filter membership + sort order --------------------------------
+
+BOOST_AUTO_TEST_CASE(rebuild_filters_inactive_and_sorts_date_desc)
+{
+    Table t;
+    t.rows = { active(100), active(300), /*inactive*/ Rec{200,0,0,6,"","",""}, active(150) };
+    Cursor c(1, FilterSpec{}, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    auto d = c.rebuild(t.rows.size());
+
+    // Default spec masks inactive (show_orphans=false): row 2 (status 6) excluded.
+    // Sorted time-DESC: 300(idx1), 150(idx3), 100(idx0).
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 3u);
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 3u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 1u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[1], 3u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[2], 0u);
+    BOOST_CHECK_EQUAL(d.size(), 1u);
+    BOOST_CHECK_EQUAL(d[0].type, CursorDelta::Reset);
+    BOOST_CHECK_EQUAL(d[0].count, 3);
+}
+
+// ---- store insert: absolute-index shift + sorted placement (Item 4) ---------
+
+BOOST_AUTO_TEST_CASE(store_insert_shifts_absidx_and_places_in_sort_order)
+{
+    Table t;
+    t.rows = { active(100), active(300), active(150) };  // view_index DESC: [1,2,0]
+    Cursor c(1, FilterSpec{}, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());
+
+    // Insert a record at absolute position 0 (everything shifts +1). New row time=200.
+    t.rows.insert(t.rows.begin(), active(200));
+    auto d = c.applyStoreInsert(0, 1);
+
+    // Old indices 1,2,0 became 2,3,1; new row at absidx 0 (time 200) slots between
+    // 300 and 150 -> view_index DESC by time: 300(2),200(0),150(3),100(1).
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 4u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 2u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[1], 0u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[2], 3u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[3], 1u);
+    BOOST_CHECK_EQUAL(countType(d, CursorDelta::Insert), 1);
+    BOOST_CHECK_EQUAL(d[0].first, 1);  // inserted at served slot 1
+}
+
+// ---- store remove: identity erase + shift (Item 4) --------------------------
+
+BOOST_AUTO_TEST_CASE(store_remove_erases_by_identity_and_shifts)
+{
+    Table t;
+    t.rows = { active(100), active(300), active(150) };  // DESC: [1,2,0]
+    Cursor c(1, FilterSpec{}, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());
+
+    // Remove absolute index 1 (time 300). Survivors 0,2 -> 2 stays >1 so shifts to 1.
+    t.rows.erase(t.rows.begin() + 1);
+    auto d = c.applyStoreRemove(1, 1);
+
+    // Remaining: 100(was 0, still 0), 150(was 2, now 1). DESC: 150(1),100(0).
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 2u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 1u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[1], 0u);
+    BOOST_CHECK_EQUAL(countType(d, CursorDelta::Remove), 1);
+    BOOST_CHECK_EQUAL(d[0].first, 0);  // 300 was the first served row
+}
+
+// ---- status update: membership flip in / out --------------------------------
+
+BOOST_AUTO_TEST_CASE(status_update_flip_out_then_in)
+{
+    Table t;
+    t.rows = { active(100), active(200), active(300) };
+    Cursor c(1, FilterSpec{}, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());                 // [2,1,0]
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 3u);
+
+    // Row 1 goes Conflicted -> masked (default show_orphans=false) -> flip-out.
+    t.rows[1].status = TXSTATUS_CONFLICTED;
+    auto d1 = c.applyStatusUpdate(1);
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 2u);
+    BOOST_CHECK_EQUAL(countType(d1, CursorDelta::Remove), 1);
+    BOOST_CHECK_EQUAL(d1[0].first, 1);        // 200 was served slot 1
+
+    // Row 1 goes active again -> flip-in, re-slots by time (200 -> slot 1).
+    t.rows[1].status = 0;
+    auto d2 = c.applyStatusUpdate(1);
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 3u);
+    BOOST_CHECK_EQUAL(countType(d2, CursorDelta::Insert), 1);
+    BOOST_CHECK_EQUAL(d2[0].first, 1);
+    BOOST_CHECK_EQUAL(c.viewIndex()[1], 1u);
+}
+
+// ---- ⚠ Item 1: locate by identity when sort-keys collide --------------------
+
+BOOST_AUTO_TEST_CASE(identity_locate_with_equal_sort_keys)
+{
+    // Three rows sharing the SAME status_sort ("u") — all equal under TXCOL_STATUS
+    // Less. A sort-key lower_bound to locate would hit the band's start (a sibling);
+    // identity-locate must hit the exact row.
+    Table t;
+    t.rows = { active(10, "u"), active(20, "u"), active(30, "u") };  // all "u"
+    Cursor c(1, FilterSpec{}, TXCOL_STATUS, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 3u);
+
+    // Flip-out the MIDDLE record by absolute identity (idx 1). The siblings (0,2)
+    // must remain; the survivor that stays must be 0 and 2, not a mis-located one.
+    t.rows[1].status = TXSTATUS_CONFLICTED;
+    c.applyStatusUpdate(1);
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 2u);
+    std::vector<std::size_t> remaining(c.viewIndex().begin(), c.viewIndex().end());
+    std::sort(remaining.begin(), remaining.end());
+    BOOST_CHECK_EQUAL(remaining[0], 0u);
+    BOOST_CHECK_EQUAL(remaining[1], 2u);   // idx 1 removed, NOT a sibling
+}
+
+// ---- ⚠ Item 2: reposition recomputes insert slot AFTER erase ----------------
+
+BOOST_AUTO_TEST_CASE(reposition_moves_down_no_off_by_one)
+{
+    // Sort by TXCOL_STATUS DESC over distinct keys d>c>b>a. view_index: [d,c,b,a].
+    Table t;
+    t.rows = { active(0,"d"), active(0,"c"), active(0,"b"), active(0,"a") };
+    Cursor c(1, FilterSpec{}, TXCOL_STATUS, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());               // [0,1,2,3]  (d,c,b,a)
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 0u);
+
+    // Row 0's key drops "d" -> "a.5" (between b and a). old_pos 0 < new_pos 3:
+    // a pre-erase new_pos would be off-by-one. Final order must be c,b,a.5,a.
+    t.rows[0].status_sort = "a5";           // "a5" sorts after "a", before "b"
+    c.applyStatusUpdate(0);
+    // DESC: c(1) > b(2) > a5(0) > a(3)
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 4u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 1u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[1], 2u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[2], 0u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[3], 3u);
+}
+
+// ---- served-window: eviction on insert into a full window -------------------
+
+BOOST_AUTO_TEST_CASE(served_window_eviction_on_insert_when_full)
+{
+    Table t;
+    t.rows = { active(100), active(200), active(300) };
+    FilterSpec spec; spec.limit_rows = 2;                 // cap 2
+    Cursor c(1, spec, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());                              // accepted [2,1,0], served [2,1]
+    BOOST_CHECK_EQUAL(c.servedCount(), 2u);
+
+    // Insert time=250 at absidx 3 -> slots between 300 and 200 (served slot 1).
+    t.rows.push_back(active(250));
+    auto d = c.applyStoreInsert(3, 1);
+    // Visible: Insert at 1, then evict the row pushed off the bottom (Remove at cap=2).
+    BOOST_CHECK_EQUAL(c.servedCount(), 2u);
+    BOOST_CHECK_EQUAL(c.totalAccepted(), 4u);
+    BOOST_REQUIRE_EQUAL(d.size(), 2u);
+    BOOST_CHECK_EQUAL(d[0].type, CursorDelta::Insert);
+    BOOST_CHECK_EQUAL(d[0].first, 1);
+    BOOST_CHECK_EQUAL(d[1].type, CursorDelta::Remove);
+    BOOST_CHECK_EQUAL(d[1].first, 2);
+}
+
+// ---- served-window: promotion on remove with overflow -----------------------
+
+BOOST_AUTO_TEST_CASE(served_window_promotion_on_remove_with_overflow)
+{
+    Table t;
+    t.rows = { active(100), active(200), active(300), active(400) };
+    FilterSpec spec; spec.limit_rows = 2;
+    Cursor c(1, spec, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());                  // accepted [3,2,1,0], served [400,300]
+    BOOST_CHECK_EQUAL(c.servedCount(), 2u);
+
+    // Remove the top visible row (400, absidx 3). 200 should promote into view.
+    t.rows.erase(t.rows.begin() + 3);
+    auto d = c.applyStoreRemove(3, 1);
+    BOOST_CHECK_EQUAL(c.servedCount(), 2u);
+    BOOST_REQUIRE_EQUAL(d.size(), 2u);
+    BOOST_CHECK_EQUAL(d[0].type, CursorDelta::Remove);
+    BOOST_CHECK_EQUAL(d[0].first, 0);
+    BOOST_CHECK_EQUAL(d[1].type, CursorDelta::Insert);
+    BOOST_CHECK_EQUAL(d[1].first, 1);          // promoted into the last visible slot
+}
+
+// ---- ⚠ Item 3: off-window change maintains view_index, emits nothing --------
+
+BOOST_AUTO_TEST_CASE(off_window_update_maintained_without_emission)
+{
+    Table t;
+    t.rows = { active(100,"a"), active(200,"b"), active(300,"c"), active(400,"d") };
+    FilterSpec spec; spec.limit_rows = 2;
+    Cursor c(1, spec, TXCOL_STATUS, TXSORT_DESC, t.fields(), t.keys());  // DESC: d,c,b,a = [3,2,1,0]
+    c.rebuild(t.rows.size());                  // served = [3,2]
+
+    // Change an OFF-window row (idx 0, "a", at view slot 3) to "bb" (sorts between
+    // c and b, i.e. to view slot 2 — still off-window). It repositions among the
+    // off-window rows: no emission (both old slot 3 and new slot 2 are >= served),
+    // but view_index must still reflect the new order (Item 3).
+    t.rows[0].status_sort = "bb";
+    auto d = c.applyStatusUpdate(0);
+    BOOST_CHECK_EQUAL(d.size(), 0u);           // off-window move: silent
+    // New DESC order: d(3) > c(2) > bb(0) > b(1).
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 3u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[1], 2u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[2], 0u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[3], 1u);
+
+    // Growing the window now reveals the off-window rows in the correct order.
+    auto g = c.setLimit(4);
+    BOOST_CHECK_EQUAL(countType(g, CursorDelta::Insert), 1);
+    BOOST_CHECK_EQUAL(g[0].first, 2);          // promoted rows start at old served=2
+    BOOST_CHECK_EQUAL(g[0].count, 2);
+}
+
+// ---- setLimit grow / shrink -------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(setlimit_grow_then_shrink)
+{
+    Table t;
+    t.rows = { active(100), active(200), active(300), active(400), active(500) };
+    FilterSpec spec; spec.limit_rows = 2;
+    Cursor c(1, spec, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());
+    BOOST_CHECK_EQUAL(c.servedCount(), 2u);
+
+    auto grow = c.setLimit(4);
+    BOOST_CHECK_EQUAL(c.servedCount(), 4u);
+    BOOST_REQUIRE_EQUAL(grow.size(), 1u);
+    BOOST_CHECK_EQUAL(grow[0].type, CursorDelta::Insert);
+    BOOST_CHECK_EQUAL(grow[0].first, 2);
+    BOOST_CHECK_EQUAL(grow[0].count, 2);
+
+    auto shrink = c.setLimit(1);
+    BOOST_CHECK_EQUAL(c.servedCount(), 1u);
+    BOOST_REQUIRE_EQUAL(shrink.size(), 1u);
+    BOOST_CHECK_EQUAL(shrink[0].type, CursorDelta::Remove);
+    BOOST_CHECK_EQUAL(shrink[0].first, 1);
+    BOOST_CHECK_EQUAL(shrink[0].count, 3);
+}
+
+// ---- CT_UPDATED first-confirmation repositions across the served boundary ----
+
+BOOST_AUTO_TEST_CASE(ct_updated_first_confirmation_moves_out_of_window)
+{
+    // Status-DESC like OverviewPage. Unconfirmed sorts FIRST ("z..." high key).
+    // A first confirmation drops the key so the row falls past the served window;
+    // an off-window row promotes. This path runs constantly on a live Overview.
+    Table t;
+    t.rows = { active(0,"z_unconf"), active(0,"m_conf"), active(0,"l_conf"), active(0,"k_conf") };
+    FilterSpec spec; spec.limit_rows = 2;
+    Cursor c(1, spec, TXCOL_STATUS, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());                  // DESC: z(0),m(1),l(2),k(3); served [0,1]
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 0u);
+
+    // Row 0 confirms: key z_unconf -> "a_conf" (now sorts LAST). Moves out of window.
+    t.rows[0].status_sort = "a_conf";
+    auto d = c.applyStatusUpdate(0);
+    // Moved out of the served window (was slot 0, now last) -> Remove(0) + promote l(2) into slot 1.
+    BOOST_REQUIRE_EQUAL(d.size(), 2u);
+    BOOST_CHECK_EQUAL(d[0].type, CursorDelta::Remove);
+    BOOST_CHECK_EQUAL(d[0].first, 0);
+    BOOST_CHECK_EQUAL(d[1].type, CursorDelta::Insert);
+    BOOST_CHECK_EQUAL(d[1].first, 1);
+    // Full order DESC: m(1),l(2),k(3),a_conf(0).
+    BOOST_CHECK_EQUAL(c.viewIndex()[0], 1u);
+    BOOST_CHECK_EQUAL(c.viewIndex()[3], 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Phase 3 of the windowed transaction-table model (follow-up to PR #2944's event-queue work; continues #3010 / #3011 / #3015). It introduces **producer-side per-view cursors** — server-side filter + sort, maintained off `cs_main`/`cs_wallet` on the PR2.5 store-worker — and migrates **OverviewPage's recent-transactions list** to consume one as a "mini windowed model", proving the count / limit / resize mechanics before the detailed `TransactionView` migrates (PR5).

The native, unfiltered **VIEW_FULL** stream that `TransactionTableModel` (the detailed history table) consumes is untouched and guarded by `viewId`, so the detailed table behaves exactly as before — with no view registered, the cursor code paths are inert.

## What's in it

**PR3-A — Qt-free cursor core** (`src/qt/cursor.{h,cpp}`, `src/test/qt_cursor_tests.cpp`)
- `GRC::Cursor` maintains one ordered `view_index` of the accepted record indices over PR1's `GRC::Accepts` / `GRC::Less` evaluator. It holds no records and no Qt types; it is parameterized on two projector callables (`Fields`/`Keys`) so the same logic is unit-tested in the `ENABLE_GUI=OFF` configuration CI exercises.
- 12 GUI-OFF unit tests covering the four arithmetic hazards — identity-locate (not a sort-key `lower_bound`, since sort-keys collide), erase-then-`lower_bound` reposition, off-window maintenance with gated emission, and the store reindex/splice discipline — plus the served-window eviction/promotion boundary and the CT_UPDATED-crosses-the-boundary case.
- The `view_index`-maintenance algorithm and the scrollbar/resort contract are documented in `doc/transaction_table_windowed_model.md`.

**PR3-B — wiring**
- `WalletTxStore` now holds the full authoritative `TransactionRecord`s (not just ordering keys) and owns a `map<viewId, Cursor>` maintained by the store-worker. insert/remove/`updateTransaction` drive each cursor (`applyStoreInsert`/`Remove`/`StatusUpdate`) and translate the resulting served-window deltas into per-view `Rows*` events.
- CT_UPDATED becomes a real **in-place upsert** (it repositions a row under a status sort) instead of the old dedup-skip no-op; per-row status is computed producer-side via `TransactionRecord::updateStatus()` under the `cs_main` already held, so the off-lock cursors can filter/sort by it.
- New per-view event payloads: `viewId` + `epoch` on `RowsInserted`/`RowsRemoved`, plus `RowsReset` / `RowCountChanged` / `RowsChanged`. `WalletModel` drains the queue once and fans the batch out (`walletEventsDrained`) to per-view consumers, which filter to their own `viewId`.
- `OverviewTxModel` — the mini windowed consumer: holds only the cursor's served-window slice, refilled on `RowsReset` and patched on the others, rendering through the shared `TransactionTableModel::formatRole`. OverviewPage is migrated off `TransactionFilterProxy`; the stairstep resize forwards to the cursor's `setViewLimit`, and recent-tx click-through maps the served row back to a detailed-view index via `indexForTxid`.

## Key design decisions
- **In-place CT_UPDATED upsert**, not remove+insert, so the detailed table does not flicker a row on every confirmation; lock-free cores (`insertLocked`/`removeLocked`) let `updateTransaction` compose the not-present / part-count-changed fallback under the already-held `cs_store`.
- **OverviewPage sorts by date/status only** in PR3 (both producer-available); sorting by Type/Address needs the localized Qt formatter strings in `SortKey`, deferred to PR4.
- **Formatters reused, not duplicated**: the `data()` role switch is extracted into a public `formatRole(rec, column, role)`, called by both `TransactionTableModel` and `OverviewTxModel`.
- **Scrollbar contract for PR5** (documented now): full `rowCount` + placeholder-on-miss (NOT `canFetchMore`), so the scrollbar is sized for the whole list and supports random access; a resort anchors on the currently selected row.

## Validation
- Clang `WERROR_THREAD_SAFETY` GUI build clean. The cursor reads `m_records` through `this`-capturing `std::function`s, so reads are routed via `projectFieldsAt`/`projectKeysAt` marked `NO_THREAD_SAFETY_ANALYSIS` (the analyzer cannot see `cs_store` through the indirection; every call path holds it).
- Unit suites green: `qt_cursor_tests`, `wallettxstore_tests` (the PR2.5 store tests pass unchanged through the `m_records` refactor), `qt_txfilter_tests`, `qt_txorder_tests`.
- GUI-verified on the isolated testnet: the recent-transactions list renders the correct transaction-type icon + address.
- **~10h ASan mesh soak, clean** — a GUI ASan build under live staking churn on the isolated testnet, zero sanitizer hits and no abort.

## Scope / follow-ups
The detailed `TransactionView` still uses the VIEW_FULL stream (unchanged in this PR).
- **PR4**: migrate `TransactionView` off the proxy, delete `TransactionFilterProxy`, factor formatters into a shared Qt helper, add localized Type/Address sort.
- **PR5**: windowing / virtual model for the detailed table — reuses these count/limit mechanics and the scrollbar contract.
- **PR6**: off-Qt-thread startup decompose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
