### PR TITLE
qt: windowed-table read APIs + Qt-free WindowCache core (windowed-model PR5-A)

### DIFF
--- a/src/qt/cursor.h
+++ b/src/qt/cursor.h
@@ -103,6 +103,14 @@ public:
     //! Absolute record index at served position `served_pos` (for getRows).
     std::size_t rowAt(std::size_t served_pos) const { return m_view_index[served_pos]; }
 
+    //! Accepted-row position of absolute record index `absidx` in the sorted
+    //! view, or npos (== static_cast<std::size_t>(-1)) if `absidx` is not
+    //! accepted. The public face of the private identity-locate (findSlot): the
+    //! store's rowForKey maps a (hash, idx) → absolute index → this accepted row
+    //! for click-through to a row and anchor-on-resort (PR5). O(N) linear scan,
+    //! matching findSlot — a discrete user action, not a hot path.
+    std::size_t positionOf(std::size_t absidx) const { return findSlot(absidx); }
+
     //! Test/inspection: the full sorted absolute-index vector.
     const std::vector<std::size_t>& viewIndex() const { return m_view_index; }
 

--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -49,10 +49,13 @@ DetailedTxModel::DetailedTxModel(WalletModel* walletModel, QObject* parent)
     // seed synchronously so the table is populated before the first drain tick.
     // Capture the high-water (PR4-fix B): the registration Reset that arrives on
     // the first drain carries this same seqno and is skipped as already reflected.
-    // count = -1 ("all served") reads the rows, the served count AND the high-water
-    // in one cs_store hold — atomic, so a concurrent worker insert can't drop a row
-    // that the seqno skip would then suppress.
-    m_rows = store.getRows(GRC::VIEW_DETAILED, 0, -1, &m_applied_seqno);
+    // count = -1 ("all served") reads the rows + the high-water (RowsResult) in
+    // one cs_store hold — atomic, so a concurrent worker insert can't drop a row
+    // that the seqno skip would then suppress. (PR4 holds the full replica; the
+    // viewport slice + RowsResult.total_accepted/epoch are PR5-B.)
+    GRC::RowsResult seed = store.getRows(GRC::VIEW_DETAILED, 0, -1);
+    m_rows = std::move(seed.records);
+    m_applied_seqno = seed.high_water;
 
     connect(m_walletModel, &WalletModel::walletEventsDrained,
             this, &DetailedTxModel::applyEventBatch);
@@ -125,19 +128,19 @@ void DetailedTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
             if constexpr (std::is_same_v<P, GRC::RowsResetPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
                 if (seqno <= m_applied_seqno) return;   // already reflected (PR4-fix B)
-                // Refetch the FULL current served set and the store's high-water in
-                // one cs_store hold. Using the live totalAccepted (not the possibly
-                // stale payload.total) plus the high-water means any worker insert/
-                // remove that landed after this Reset was emitted is captured here
-                // exactly once and will be skipped when its own event arrives.
+                // Refetch the FULL current served set together with the store's
+                // high-water in one cs_store hold (RowsResult): the slice and the
+                // high-water are mutually consistent, so any worker insert/remove
+                // that landed after this Reset was emitted is captured here exactly
+                // once and is skipped when its own event arrives.
                 beginResetModel();
-                uint64_t hw = m_applied_seqno;
-                // count = -1: rows + served count + high-water in ONE cs_store hold
-                // (atomic — a separate totalAccepted() could under-fetch a row the
+                // count = -1: rows + high-water in ONE cs_store hold (RowsResult,
+                // atomic — a separately-locked count could under-fetch a row the
                 // high-water already covered, dropping it permanently). (PR4-fix B)
-                m_rows = store.getRows(GRC::VIEW_DETAILED, 0, -1, &hw);
+                GRC::RowsResult r = store.getRows(GRC::VIEW_DETAILED, 0, -1);
+                m_rows = std::move(r.records);
                 endResetModel();
-                m_applied_seqno = std::max(hw, seqno);
+                m_applied_seqno = std::max(r.high_water, seqno);
             } else if constexpr (std::is_same_v<P, GRC::RowsInsertedPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
                 if (seqno <= m_applied_seqno) return;   // already reflected in a refetch
@@ -168,7 +171,7 @@ void DetailedTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 // so re-fetch the changed slice from the cursor and refresh. A
                 // row spans every column, so the dataChanged span is full-width.
                 const std::vector<TransactionRecord> fresh =
-                    store.getRows(GRC::VIEW_DETAILED, payload.first, payload.count);
+                    store.getRows(GRC::VIEW_DETAILED, payload.first, payload.count).records;
                 for (std::size_t i = 0; i < fresh.size()
                         && static_cast<std::size_t>(payload.first) + i < m_rows.size(); ++i) {
                     m_rows[static_cast<std::size_t>(payload.first) + i] = fresh[i];

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -33,9 +33,11 @@ OverviewTxModel::OverviewTxModel(WalletModel* walletModel, int initialLimit, QOb
     // seed synchronously so the list is populated before the first drain tick.
     // Capture the high-water (PR4-fix B): the registration Reset arriving on the
     // first drain carries this seqno and is skipped as already reflected. count = -1
-    // ("all served") reads rows + served count + high-water in one cs_store hold —
+    // ("all served") reads rows + high-water (RowsResult) in one cs_store hold —
     // atomic, so a concurrent worker insert can't drop a row the skip would suppress.
-    m_rows = store.getRows(GRC::VIEW_OVERVIEW, 0, -1, &m_applied_seqno);
+    GRC::RowsResult seed = store.getRows(GRC::VIEW_OVERVIEW, 0, -1);
+    m_rows = std::move(seed.records);
+    m_applied_seqno = seed.high_water;
 
     connect(m_walletModel, &WalletModel::walletEventsDrained,
             this, &OverviewTxModel::applyEventBatch);
@@ -96,14 +98,14 @@ void OverviewTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 // worker delta that landed after this Reset was emitted is captured
                 // here exactly once and skipped when its own event arrives.
                 beginResetModel();
-                uint64_t hw = m_applied_seqno;
-                // count = -1: rows + served count + high-water in ONE cs_store hold
-                // (atomic — getRows clamps to the live served window, capped). A
-                // separate totalAccepted() could under-fetch a row the high-water
-                // already covered, dropping it permanently below cap. (PR4-fix B)
-                m_rows = store.getRows(GRC::VIEW_OVERVIEW, 0, -1, &hw);
+                // count = -1: rows + high-water in ONE cs_store hold (RowsResult,
+                // atomic — getRows clamps to the live served window, capped; a
+                // separately-locked count could under-fetch a row the high-water
+                // already covered, dropping it permanently below cap). (PR4-fix B)
+                GRC::RowsResult r = store.getRows(GRC::VIEW_OVERVIEW, 0, -1);
+                m_rows = std::move(r.records);
                 endResetModel();
-                m_applied_seqno = std::max(hw, seqno);
+                m_applied_seqno = std::max(r.high_water, seqno);
             } else if constexpr (std::is_same_v<P, GRC::RowsInsertedPayload>) {
                 if (payload.viewId != GRC::VIEW_OVERVIEW) return;
                 if (seqno <= m_applied_seqno) return;   // already reflected in a refetch
@@ -133,7 +135,7 @@ void OverviewTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& event
                 // The payload carries no records (a Change does not move the row),
                 // so re-fetch the changed slice from the cursor and refresh.
                 const std::vector<TransactionRecord> fresh =
-                    store.getRows(GRC::VIEW_OVERVIEW, payload.first, payload.count);
+                    store.getRows(GRC::VIEW_OVERVIEW, payload.first, payload.count).records;
                 for (std::size_t i = 0; i < fresh.size()
                         && static_cast<std::size_t>(payload.first) + i < m_rows.size(); ++i) {
                     m_rows[static_cast<std::size_t>(payload.first) + i] = fresh[i];

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -742,7 +742,12 @@ RowsResult WalletTxStore::getRows(int viewId, int first, int count)
     // via a separate locked call, or a worker insert/remove landing between the
     // two locks could misalign the slice and drop or double-count a row that the
     // seqno skip would then make permanent (PR4-fix B, generalized to PR5 scroll).
-    res.total_accepted = static_cast<int>(cur.totalAccepted());
+    // Clamp to INT_MAX: total_accepted feeds Qt's int-based rowCount downstream. A
+    // wallet can never hold 2^31 rows, but the saturating cast keeps the count
+    // well-defined rather than wrapping negative if it ever did (Copilot PR5-A).
+    res.total_accepted = static_cast<int>(
+        std::min<std::size_t>(cur.totalAccepted(),
+                              static_cast<std::size_t>(std::numeric_limits<int>::max())));
     res.epoch = cur.epoch();
     auto sit = m_view_seqno.find(viewId);
     res.high_water = (sit == m_view_seqno.end()) ? 0 : sit->second;

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -726,48 +726,44 @@ void WalletTxStore::setViewLimit(int viewId, int limit)
     emitCursorDeltas(viewId, it->second.epoch(), deltas);
 }
 
-std::vector<TransactionRecord> WalletTxStore::getRows(int viewId, int first, int count,
-                                                      uint64_t* out_high_water)
+RowsResult WalletTxStore::getRows(int viewId, int first, int count)
 {
     LOCK(cs_store);
-    // Report the view's high-water under the SAME lock as the row read, so the two
-    // are mutually consistent: the returned rows reflect exactly the events up to
-    // and including this seqno (PR4-fix B).
-    if (out_high_water) {
-        auto sit = m_view_seqno.find(viewId);
-        *out_high_water = (sit == m_view_seqno.end()) ? 0 : sit->second;
-    }
-    std::vector<TransactionRecord> out;
+    RowsResult res;
     auto it = m_cursors.find(viewId);
-    if (it == m_cursors.end() || first < 0 || count == 0) {
-        return out;
+    if (it == m_cursors.end()) {
+        return res;   // unknown view: empty slice, zero metadata
     }
-    const std::size_t served = it->second.servedCount();
+    const Cursor& cur = it->second;
+    // Sample ALL of the view's metadata under THIS single cs_store hold, together
+    // with the row copy below — total_accepted (virtual rowCount), epoch (sort/
+    // filter generation) and high_water (last emitted seqno) are mutually
+    // consistent with the returned rows. A caller must NOT re-sample any of these
+    // via a separate locked call, or a worker insert/remove landing between the
+    // two locks could misalign the slice and drop or double-count a row that the
+    // seqno skip would then make permanent (PR4-fix B, generalized to PR5 scroll).
+    res.total_accepted = static_cast<int>(cur.totalAccepted());
+    res.epoch = cur.epoch();
+    auto sit = m_view_seqno.find(viewId);
+    res.high_water = (sit == m_view_seqno.end()) ? 0 : sit->second;
+
+    if (first < 0 || count == 0) {
+        return res;   // metadata valid, slice empty by request
+    }
+    const std::size_t served = cur.servedCount();
     const std::size_t begin = static_cast<std::size_t>(first);
     if (begin >= served) {
-        return out;
+        return res;   // off the served window: metadata valid, slice empty
     }
-    // count < 0 means "all served rows from `first`". Reading servedCount HERE,
-    // under this single cs_store hold (together with the rows and the high-water
-    // above), is what makes a Reset refetch atomic: a caller must NOT sample the
-    // count via a separate totalAccepted() call, or a worker insert landing between
-    // the two locks would under-fetch a row while the high-water already covered it
-    // — and the seqno skip would then drop that row permanently (PR4-fix B).
+    // count < 0 means "all served rows from `first`".
     const std::size_t end = (count < 0)
         ? served
         : std::min(served, begin + static_cast<std::size_t>(count));
-    out.reserve(end - begin);
+    res.records.reserve(end - begin);
     for (std::size_t i = begin; i < end; ++i) {
-        out.push_back(m_records[it->second.rowAt(i)]);
+        res.records.push_back(m_records[cur.rowAt(i)]);
     }
-    return out;
-}
-
-int WalletTxStore::totalAccepted(int viewId)
-{
-    LOCK(cs_store);
-    auto it = m_cursors.find(viewId);
-    return it == m_cursors.end() ? 0 : static_cast<int>(it->second.totalAccepted());
+    return res;
 }
 
 void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -42,6 +42,30 @@ struct TxHashHasher {
 };
 
 //!
+//! \brief Atomic result of a windowed read (getRows): the requested row slice
+//! plus the view's metadata, all sampled under the SAME cs_store hold.
+//!
+//! Returning the four together is the generalization of PR4-fix B to the PR5
+//! scroll path. A windowed consumer keeps two reconciliation channels: a
+//! STRUCTURAL channel (the virtual rowCount + the ordered Insert/Remove/Change/
+//! Reset delta stream) and a CONTENT channel (the scroll-driven slice fetch).
+//! The content fetch must observe the rowCount (\ref total_accepted), the
+//! cursor's sort/filter generation (\ref epoch) and the view's event high-water
+//! (\ref high_water) at the EXACT instant the rows were copied — a second,
+//! separately-locked call (the removed totalAccepted(viewId)) could observe a
+//! different store state and misalign the slice against the structural channel,
+//! dropping or double-counting a row (the PR4-fix B bug class). The consumer
+//! adopts a content fetch only when its \ref epoch and \ref high_water match the
+//! structural channel's, and NEVER advances the structural seqno from it.
+//!
+struct RowsResult {
+    std::vector<TransactionRecord> records; //!< the [first, first+count) slice (a copy)
+    int total_accepted = 0;                 //!< the view's full accepted count (virtual rowCount)
+    uint64_t epoch = 0;                      //!< cursor sort/filter generation at the read instant
+    uint64_t high_water = 0;                 //!< seqno of the last event emitted for the view at the read
+};
+
+//!
 //! \brief Producer-owned authoritative ordering store for the windowed
 //! transaction-table model (windowed-model PR2).
 //!
@@ -153,22 +177,17 @@ public:
     void setViewFilter(int viewId, FilterSpec filter);
     void setViewLimit(int viewId, int limit);
 
-    //! Qt thread: read [first, first+count) served rows of \p viewId as records
-    //! (a copy of the slice). Clamps to the served window; returns fewer rows if
-    //! the window is shorter. \p count < 0 means "all served rows from \p first"
-    //! (the served count is read under THIS call's single cs_store hold) — a Reset
-    //! refetch MUST use it rather than a separately-locked totalAccepted(), else a
-    //! worker insert between the two locks drops a row that the seqno skip then
-    //! suppresses permanently (PR4-fix B). Unknown viewId -> empty. If
-    //! \p out_high_water is non-null, it receives the seqno of the last event
-    //! emitted for \p viewId at the moment of the read (same cs_store hold) — the
-    //! consumer uses it to discard events already reflected in this snapshot.
-    std::vector<TransactionRecord> getRows(int viewId, int first, int count,
-                                           uint64_t* out_high_water = nullptr);
-
-    //! Qt thread: total accepted rows for \p viewId (the virtual rowCount), or 0
-    //! if the view is not registered.
-    int totalAccepted(int viewId);
+    //! Qt thread: read [first, first+count) served rows of \p viewId, plus the
+    //! view's total_accepted / epoch / high_water, ALL under one cs_store hold
+    //! (\ref RowsResult). Clamps the slice to the served window; returns fewer
+    //! rows if it is shorter. \p count < 0 means "all served rows from \p first".
+    //! Unknown viewId / first < 0 / count == 0 -> empty slice, but the metadata
+    //! fields are still valid for a registered view (total_accepted/epoch/
+    //! high_water reflect the current cursor) so a caller can refresh its
+    //! reconciliation baseline without a slice copy. Returning the metadata
+    //! WITH the slice atomically is what closes the PR4-fix B race for both the
+    //! Reset refetch and the PR5 scroll fetch — see \ref RowsResult.
+    RowsResult getRows(int viewId, int first, int count);
 
     //!
     //! \brief Qt thread: rebuild the store from the wallet and return a full

--- a/src/qt/windowcache.h
+++ b/src/qt/windowcache.h
@@ -186,7 +186,9 @@ public:
     bool applyRemove(WindowCacheSink& sink, uint64_t seqno, int pos, int count)
     {
         if (seqno <= m_structural_seqno) return false;   // already reflected
-        if (count <= 0 || pos < 0 || pos + count > m_total) return false;
+        // Subtraction form, not pos+count > m_total: avoids int wrap on pathological
+        // input (count > 0 holds by short-circuit when the comparison is reached).
+        if (count <= 0 || pos < 0 || pos > m_total - count) return false;
 
         const int base = m_cache_first;
         const int len = static_cast<int>(m_rows.size());
@@ -224,7 +226,9 @@ public:
                      const std::vector<Record>& fresh)
     {
         if (seqno <= m_structural_seqno) return false;   // already reflected
-        if (count <= 0 || pos < 0 || pos + count > m_total) return false;
+        // Subtraction form, not pos+count > m_total: avoids int wrap on pathological
+        // input (count > 0 holds by short-circuit when the comparison is reached).
+        if (count <= 0 || pos < 0 || pos > m_total - count) return false;
 
         const int base = m_cache_first;
         const int len = static_cast<int>(m_rows.size());
@@ -271,8 +275,9 @@ public:
         // <= m_total always holds for a well-formed fetch. A malformed one must not
         // set the slice past the table end, or has()/at() would report rows
         // >= m_total as present, corrupting the [cacheFirst, cacheFirst+cacheSize)
-        // invariant (PR5-A review finding).
-        if (first < 0 || first + count > m_total) return false;
+        // invariant (PR5-A review finding). Subtraction form (count >= 0) avoids the
+        // int wrap a first+count comparison would have on pathological input.
+        if (first < 0 || first > m_total - count) return false;
         m_cache_first = first;
         m_rows = std::move(rows);
         if (count > 0) sink.dataChanged(first, count);

--- a/src/qt/windowcache.h
+++ b/src/qt/windowcache.h
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_WINDOWCACHE_H
+#define GRIDCOIN_QT_WINDOWCACHE_H
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+//!
+//! \file windowcache.h
+//!
+//! Qt-free consumer-side reconciliation core for the windowed detailed
+//! transaction table (windowed-model PR5).
+//!
+//! PR4's DetailedTxModel holds the FULL filtered+sorted replica (the cursor cap
+//! is unlimited, so servedCount == totalAccepted). PR5 keeps the producer's
+//! cursor cap unlimited — so the store read path is unchanged and getRows(first)
+//! is an absolute accepted index — and moves the sliding window entirely into
+//! the consumer: this object caches only a contiguous slice [cacheFirst,
+//! cacheFirst + cacheSize) of the records and reports the full row count to the
+//! view so the scrollbar spans the whole history. Rows outside the slice render
+//! as placeholders until a scroll-driven fetch fills them.
+//!
+//! Correctness rests on a strict TWO-CHANNEL split, which is the central hazard
+//! this class encapsulates (and the reason it is a Qt-free, unit-tested core):
+//!
+//!   - STRUCTURAL channel: the ordered Reset / Insert / Remove / Change delta
+//!     stream drained from the WalletEventQueue. It is the SOLE owner of the
+//!     virtual row count (m_total) and of the model's begin/endInsertRows /
+//!     begin/endRemoveRows brackets. Each delta carries a seqno; applying one
+//!     advances m_structural_seqno. A delta whose seqno is <= the high-water is
+//!     already reflected and is skipped (the PR4-fix B gate).
+//!
+//!   - CONTENT channel: the scroll-driven getRows(first, count) slice fetch. It
+//!     fills row CONTENT for a newly-visible region. It NEVER changes m_total and
+//!     NEVER advances m_structural_seqno. A fetched slice is adopted ONLY when its
+//!     epoch matches the cache's (no intervening sort/filter — those bump the
+//!     cursor epoch and arrive as a structural Reset) AND its high_water EXACTLY
+//!     equals m_structural_seqno (the fetch reflects precisely the structural
+//!     state the consumer has applied — no more, no less). A mismatch means the
+//!     fetch raced an insert/remove in either direction; it is discarded and the
+//!     consumer re-requests after the next drain settles the seqno. This is the
+//!     PR4-fix B race generalized to the scroll path: the content channel may
+//!     never silently shift the structural coordinate system.
+//!
+//! The class is templated on the record type so the reconciliation arithmetic is
+//! exercised in the ENABLE_GUI=OFF unit suite with a synthetic record (the same
+//! risk-control discipline as the Qt-free Cursor): TransactionRecord pulls in Qt
+//! (QList/QString) and cannot compile GUI-OFF, but this logic must.
+//!
+//! Threading: Qt-thread-only, like the model it backs. No internal locking.
+//!
+
+namespace GRC {
+
+//!
+//! \brief Sink the WindowCache drives to translate structural changes into the
+//! host model's row-mutation signals.
+//!
+//! The cache owns the begin/end bracketing: it calls beginInsert BEFORE it grows
+//! m_total and endInsert AFTER, so the host (a QAbstractItemModel) can forward
+//! beginInsert(first,count) -> beginInsertRows(parent, first, first+count-1) and
+//! the framework observes a consistent old-count/new-count transition. The
+//! GUI-OFF unit suite implements a recording sink that asserts the bracket order
+//! and the pre-mutation row count.
+//!
+struct WindowCacheSink {
+    virtual ~WindowCacheSink() = default;
+    virtual void beginReset() = 0;
+    virtual void endReset() = 0;
+    virtual void beginInsert(int first, int count) = 0;
+    virtual void endInsert() = 0;
+    virtual void beginRemove(int first, int count) = 0;
+    virtual void endRemove() = 0;
+    //! `count` rows starting at absolute `first` should be re-queried (a Change
+    //! delta refreshed them in place, or a content fetch made them available).
+    virtual void dataChanged(int first, int count) = 0;
+};
+
+template <class Record>
+class WindowCache
+{
+public:
+    WindowCache() = default;
+
+    // ---- queries -----------------------------------------------------------
+
+    //! The virtual row count (full accepted set), owned by the structural channel.
+    int total() const { return m_total; }
+    //! Absolute index of the first cached row.
+    int cacheFirst() const { return m_cache_first; }
+    //! Number of contiguous cached rows: the slice is [cacheFirst, cacheFirst+cacheSize).
+    int cacheSize() const { return static_cast<int>(m_rows.size()); }
+    //! Structural high-water: the seqno of the last applied structural delta.
+    uint64_t structuralSeqno() const { return m_structural_seqno; }
+    //! The cursor sort/filter generation this cache is coherent with.
+    uint64_t epoch() const { return m_epoch; }
+
+    //! True if absolute `row` is currently in the cached slice.
+    bool has(int row) const
+    {
+        return row >= m_cache_first
+            && row < m_cache_first + static_cast<int>(m_rows.size());
+    }
+
+    //! Pointer to the cached record at absolute `row`, or nullptr (placeholder)
+    //! if `row` is outside the slice. Valid until the next mutating call.
+    const Record* at(int row) const
+    {
+        if (!has(row)) return nullptr;
+        return &m_rows[static_cast<std::size_t>(row - m_cache_first)];
+    }
+
+    // ---- structural channel ------------------------------------------------
+
+    //! Constructor-time / re-attach seed: set the whole cache with NO sink
+    //! signals (the host model is being (re)built; it issues its own reset). Sets
+    //! the structural baseline to max(high_water, 0) == high_water.
+    void seedInitial(std::vector<Record> rows, int cache_first, int total,
+                     uint64_t epoch, uint64_t high_water)
+    {
+        m_rows = std::move(rows);
+        m_cache_first = cache_first;
+        m_total = total;
+        m_epoch = epoch;
+        m_structural_seqno = high_water;
+    }
+
+    //! Structural Reset (sort/filter change, or a coalesced refill): replace the
+    //! whole cache from a fresh fetch. Skipped if already reflected. The new
+    //! structural baseline is max(high_water, seqno) — the fetch's high-water if
+    //! it is ahead of the Reset event's own seqno (PR4-fix B). Brackets the swap
+    //! in beginReset/endReset.
+    bool applyReset(WindowCacheSink& sink, uint64_t seqno, std::vector<Record> rows,
+                    int cache_first, int total, uint64_t epoch, uint64_t high_water)
+    {
+        if (seqno <= m_structural_seqno) return false;   // already reflected
+        sink.beginReset();
+        m_rows = std::move(rows);
+        m_cache_first = cache_first;
+        m_total = total;
+        m_epoch = epoch;
+        sink.endReset();
+        m_structural_seqno = high_water > seqno ? high_water : seqno;
+        return true;
+    }
+
+    //! Structural Insert of `records.size()` rows at absolute `pos`. Shifts the
+    //! cache base or splices into the slice as the position dictates (see below),
+    //! grows m_total inside the begin/endInsert bracket, and advances the seqno.
+    bool applyInsert(WindowCacheSink& sink, uint64_t seqno, int pos,
+                     const std::vector<Record>& records)
+    {
+        if (seqno <= m_structural_seqno) return false;   // already reflected
+        const int count = static_cast<int>(records.size());
+        if (count <= 0) return false;                    // empty insert: nothing to do
+        if (pos < 0 || pos > m_total) return false;      // out of range: drop defensively
+
+        const int base = m_cache_first;
+        const int len = static_cast<int>(m_rows.size());
+
+        sink.beginInsert(pos, count);
+        m_total += count;
+        if (pos < base) {
+            // Entirely before the window: the cached rows keep their content but
+            // their absolute positions all shift up by `count`.
+            m_cache_first = base + count;
+        } else if (pos <= base + len) {
+            // Inside the slice (incl. either edge): splice the new rows in so they
+            // render immediately (no placeholder flash for a top-of-window insert).
+            m_rows.insert(m_rows.begin() + static_cast<std::size_t>(pos - base),
+                          records.begin(), records.end());
+        }
+        // pos > base + len: entirely after the window; only m_total changed.
+        sink.endInsert();
+        m_structural_seqno = seqno;
+        return true;
+    }
+
+    //! Structural Remove of `count` rows at absolute `pos`. Erases the overlap
+    //! with the slice and shifts the cache base down by however many removed rows
+    //! were strictly before it; shrinks m_total inside the begin/endRemove bracket.
+    bool applyRemove(WindowCacheSink& sink, uint64_t seqno, int pos, int count)
+    {
+        if (seqno <= m_structural_seqno) return false;   // already reflected
+        if (count <= 0 || pos < 0 || pos + count > m_total) return false;
+
+        const int base = m_cache_first;
+        const int len = static_cast<int>(m_rows.size());
+        const int cs = base, ce = base + len;            // cache abs range [cs, ce)
+        const int rs = pos, re = pos + count;            // removal abs range [rs, re)
+        const int olo = cs > rs ? cs : rs;               // overlap = [max(cs,rs),
+        const int ohi = ce < re ? ce : re;               //           min(ce,re))
+
+        sink.beginRemove(pos, count);
+        m_total -= count;
+        if (olo < ohi) {
+            m_rows.erase(m_rows.begin() + static_cast<std::size_t>(olo - base),
+                         m_rows.begin() + static_cast<std::size_t>(ohi - base));
+        }
+        // Rows removed strictly before the cache start pull the base down.
+        const int min_re_cs = re < cs ? re : cs;
+        const int removed_before_cache = (min_re_cs - rs) > 0 ? (min_re_cs - rs) : 0;
+        m_cache_first = base - removed_before_cache;
+        sink.endRemove();
+        m_structural_seqno = seqno;
+        return true;
+    }
+
+    //! Structural Change: `count` rows at absolute `pos` were refreshed in place
+    //! (no reorder). `fresh` holds the new records for [pos, pos+count) — the caller
+    //! fetches exactly `count` rows via getRows, so fresh.size() == count in
+    //! practice. The in-cache overlap is updated from `fresh` and dataChanged is
+    //! emitted for the rows actually refreshed. No size change. The seqno is advanced
+    //! UNCONDITIONALLY: a Change does not move rows, so the structural state
+    //! (positions + count) is already correct and the event must be consumed exactly
+    //! once. If `fresh` is shorter than `count` (a contract violation), the uncovered
+    //! rows keep their cached values rather than reading out of bounds; the content
+    //! channel refreshes them on the next fetch.
+    bool applyChange(WindowCacheSink& sink, uint64_t seqno, int pos, int count,
+                     const std::vector<Record>& fresh)
+    {
+        if (seqno <= m_structural_seqno) return false;   // already reflected
+        if (count <= 0 || pos < 0 || pos + count > m_total) return false;
+
+        const int base = m_cache_first;
+        const int len = static_cast<int>(m_rows.size());
+        const int cs = base, ce = base + len;
+        const int rs = pos, re = pos + count;
+        const int olo = cs > rs ? cs : rs;
+        const int ohi = ce < re ? ce : re;
+        // Update only the overlap we have records for.
+        int updated_lo = -1, updated_hi = -1;
+        for (int abs = olo; abs < ohi; ++abs) {
+            const int fresh_idx = abs - pos;
+            if (fresh_idx < 0 || fresh_idx >= static_cast<int>(fresh.size())) continue;
+            m_rows[static_cast<std::size_t>(abs - base)] = fresh[static_cast<std::size_t>(fresh_idx)];
+            if (updated_lo < 0) updated_lo = abs;
+            updated_hi = abs;
+        }
+        m_structural_seqno = seqno;
+        if (updated_lo >= 0) {
+            sink.dataChanged(updated_lo, updated_hi - updated_lo + 1);
+        }
+        return true;
+    }
+
+    // ---- content channel ---------------------------------------------------
+
+    //! Adopt a scroll-driven slice fetch for [first, first+rows.size()). Adopted
+    //! ONLY when the fetch reflects exactly the consumer's structural state:
+    //! epoch == this cache's epoch (no intervening resort/refilter) AND
+    //! high_water == m_structural_seqno (no intervening insert/remove in either
+    //! direction). Otherwise the fetch is discarded (returns false) — the consumer
+    //! re-requests after the next drain settles the seqno. NEVER touches m_total
+    //! or m_structural_seqno. Emits dataChanged over the adopted slice so the view
+    //! re-queries the rows that just became available (placeholder -> data).
+    bool fillContent(WindowCacheSink& sink, int first, std::vector<Record> rows,
+                     uint64_t epoch, uint64_t high_water)
+    {
+        if (epoch != m_epoch) return false;                 // raced a resort/refilter
+        if (high_water != m_structural_seqno) return false; // raced an insert/remove
+        const int count = static_cast<int>(rows.size());
+        // Reject a slice that would fall outside the virtual table [0, m_total).
+        // Defensive, and consistent with applyInsert/applyRemove: a legitimate
+        // fetch is clamped by getRows to the served window, and the matched-seqno
+        // gate above guarantees the fetch's total equals m_total, so first+count
+        // <= m_total always holds for a well-formed fetch. A malformed one must not
+        // set the slice past the table end, or has()/at() would report rows
+        // >= m_total as present, corrupting the [cacheFirst, cacheFirst+cacheSize)
+        // invariant (PR5-A review finding).
+        if (first < 0 || first + count > m_total) return false;
+        m_cache_first = first;
+        m_rows = std::move(rows);
+        if (count > 0) sink.dataChanged(first, count);
+        return true;
+    }
+
+private:
+    int m_total = 0;                  //!< virtual row count (structural channel owns it)
+    int m_cache_first = 0;            //!< absolute index of m_rows[0]
+    std::vector<Record> m_rows;       //!< the cached contiguous slice
+    uint64_t m_structural_seqno = 0;  //!< high-water of applied structural deltas
+    uint64_t m_epoch = 0;             //!< cursor sort/filter generation the cache matches
+};
+
+} // namespace GRC
+
+#endif // GRIDCOIN_QT_WINDOWCACHE_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -62,6 +62,11 @@ add_executable(test_gridcoin
     # view_index-maintenance arithmetic (windowed-model PR3), tested GUI-OFF.
     ${CMAKE_SOURCE_DIR}/src/qt/cursor.cpp
     qt_cursor_tests.cpp
+    # Qt-free windowed-table reconciliation core (src/qt/windowcache.h, a
+    # header-only template — no .cpp) + its unit suite: the consumer-side
+    # two-channel split (structural deltas vs scroll-driven content fetch) and the
+    # cache-base arithmetic (windowed-model PR5), tested GUI-OFF.
+    qt_windowcache_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/qt_cursor_tests.cpp
+++ b/src/test/qt_cursor_tests.cpp
@@ -414,4 +414,28 @@ BOOST_AUTO_TEST_CASE(interleaved_reposition_to_equal_keys)
     BOOST_CHECK_EQUAL(c.viewIndex()[3], 2u);
 }
 
+// ---- positionOf: public identity-locate (PR5 rowForKey backing) -------------
+
+BOOST_AUTO_TEST_CASE(position_of_maps_absidx_to_accepted_row_or_npos)
+{
+    // The store's rowForKey resolves a (hash, idx) to an absolute record index,
+    // then asks the cursor for its accepted row via positionOf — for click-through
+    // to a row and anchor-on-resort (PR5). It must report the sorted accepted
+    // position, and npos for a row the filter excludes or that is absent.
+    constexpr std::size_t NPOS = static_cast<std::size_t>(-1);
+    Table t;
+    // abs:    0           1           2 (inactive)              3
+    t.rows = { active(100), active(300), Rec{200,0,0,6,"","",""}, active(150) };
+    Cursor c(1, FilterSpec{}, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());
+    // accepted, time-DESC: 300(abs1), 150(abs3), 100(abs0); abs2 inactive -> out.
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 3u);
+
+    BOOST_CHECK_EQUAL(c.positionOf(1), 0u);   // abs1 -> accepted row 0
+    BOOST_CHECK_EQUAL(c.positionOf(3), 1u);   // abs3 -> accepted row 1
+    BOOST_CHECK_EQUAL(c.positionOf(0), 2u);   // abs0 -> accepted row 2
+    BOOST_CHECK(c.positionOf(2) == NPOS);     // filtered out -> npos
+    BOOST_CHECK(c.positionOf(42) == NPOS);    // absent -> npos
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_windowcache_tests.cpp
+++ b/src/test/qt_windowcache_tests.cpp
@@ -1,0 +1,480 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF unit coverage for the Qt-free consumer-side reconciliation core
+// (src/qt/windowcache.h), the windowed-model PR5 detailed-table window. Exercises
+// the two-channel split that is the class's whole reason for existing:
+//
+//   - STRUCTURAL channel (Reset / Insert / Remove / Change): the sole owner of the
+//     virtual row count and the begin/end{Insert,Remove} brackets. Each delta is
+//     seqno-gated (the PR4-fix B skip) and advances the structural high-water.
+//   - CONTENT channel (scroll fetch): epoch + high-water gated, NEVER advances the
+//     structural seqno and NEVER changes the row count.
+//
+// The cache-base arithmetic on an insert/remove that lands before / inside / after
+// / straddling the cached slice is the corruption hazard (PR5 must-fix #5); the
+// seqno/epoch gates are must-fix #2. WindowCache is a template so it compiles into
+// test_gridcoin with ENABLE_GUI=OFF (TransactionRecord pulls in Qt and cannot) —
+// the same risk-control discipline as the Qt-free Cursor suite.
+
+#include <qt/windowcache.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace GRC;
+
+namespace {
+
+//! A synthetic record carrying just an identity, so a splice/shift bug shows up
+//! as a wrong id at a given row. WindowCache never inspects the contents.
+struct Rec {
+    int id = 0;
+};
+
+//! ids [start, start+n) as records.
+std::vector<Rec> seq(int start, int n)
+{
+    std::vector<Rec> v;
+    v.reserve(n);
+    for (int i = 0; i < n; ++i) v.push_back(Rec{start + i});
+    return v;
+}
+
+//! explicit id list as records.
+std::vector<Rec> recs(std::initializer_list<int> ids)
+{
+    std::vector<Rec> v;
+    v.reserve(ids.size());
+    for (int id : ids) v.push_back(Rec{id});
+    return v;
+}
+
+//! Recording sink: logs every call and, on each begin, probes the cache's row
+//! count so a test can assert the mutation happens INSIDE the begin/end bracket
+//! (the count seen at begin is the pre-mutation value).
+struct RecSink : public WindowCacheSink {
+    const WindowCache<Rec>* cache = nullptr;
+    struct Op {
+        std::string kind;
+        int first = 0;
+        int count = 0;
+        int total_at = -1;   // cache->total() at the moment of the call
+    };
+    std::vector<Op> ops;
+
+    int probe() const { return cache ? cache->total() : -999; }
+    void beginReset() override { ops.push_back({"beginReset", 0, 0, probe()}); }
+    void endReset() override { ops.push_back({"endReset", 0, 0, probe()}); }
+    void beginInsert(int f, int c) override { ops.push_back({"beginInsert", f, c, probe()}); }
+    void endInsert() override { ops.push_back({"endInsert", 0, 0, probe()}); }
+    void beginRemove(int f, int c) override { ops.push_back({"beginRemove", f, c, probe()}); }
+    void endRemove() override { ops.push_back({"endRemove", 0, 0, probe()}); }
+    void dataChanged(int f, int c) override { ops.push_back({"dataChanged", f, c, probe()}); }
+    void clear() { ops.clear(); }
+};
+
+//! Assert the cached slice equals exactly the ids [first_id, first_id+n) at
+//! absolute rows [cache_first, cache_first+n), with nothing cached just outside.
+void check_slice(const WindowCache<Rec>& c, int cache_first, std::initializer_list<int> ids)
+{
+    BOOST_CHECK_EQUAL(c.cacheFirst(), cache_first);
+    BOOST_CHECK_EQUAL(c.cacheSize(), static_cast<int>(ids.size()));
+    int row = cache_first;
+    for (int id : ids) {
+        const Rec* r = c.at(row);
+        BOOST_REQUIRE_MESSAGE(r != nullptr, "expected a cached row at " << row);
+        BOOST_CHECK_EQUAL(r->id, id);
+        ++row;
+    }
+    // Just outside the slice on both sides must be a placeholder.
+    BOOST_CHECK(c.at(cache_first - 1) == nullptr);
+    BOOST_CHECK(c.at(cache_first + static_cast<int>(ids.size())) == nullptr);
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(qt_windowcache_tests)
+
+// ---- seed / query -----------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(seed_sets_state_without_signals)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), /*cache_first*/10, /*total*/30, /*epoch*/4, /*high_water*/7);
+
+    BOOST_CHECK_EQUAL(c.total(), 30);
+    BOOST_CHECK_EQUAL(c.epoch(), 4u);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 7u);
+    BOOST_CHECK(c.has(10));
+    BOOST_CHECK(c.has(19));
+    BOOST_CHECK(!c.has(9));
+    BOOST_CHECK(!c.has(20));
+    check_slice(c, 10, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
+    BOOST_CHECK(s.ops.empty());   // seed issues no sink signals
+}
+
+// ---- structural Insert: the four position regimes ---------------------------
+
+BOOST_AUTO_TEST_CASE(insert_before_window_shifts_base_only)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);
+
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/6, /*pos*/3, recs({100, 101})));
+    BOOST_CHECK_EQUAL(c.total(), 32);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);
+    // slice content unchanged, base shifted +2.
+    check_slice(c, 12, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
+    // bracket: count seen at begin is the pre-mutation total.
+    BOOST_REQUIRE_EQUAL(s.ops.size(), 2u);
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "beginInsert");
+    BOOST_CHECK_EQUAL(s.ops[0].first, 3);
+    BOOST_CHECK_EQUAL(s.ops[0].count, 2);
+    BOOST_CHECK_EQUAL(s.ops[0].total_at, 30);
+    BOOST_CHECK_EQUAL(s.ops[1].kind, "endInsert");
+    BOOST_CHECK_EQUAL(s.ops[1].total_at, 32);
+}
+
+BOOST_AUTO_TEST_CASE(insert_inside_window_splices)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);
+
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/13, recs({100, 101})));
+    BOOST_CHECK_EQUAL(c.total(), 32);
+    check_slice(c, 10, {10, 11, 12, 100, 101, 13, 14, 15, 16, 17, 18, 19});
+}
+
+BOOST_AUTO_TEST_CASE(insert_at_window_top_splices_no_flash)
+{
+    // pos == cacheFirst: the new rows must appear at the top of the window, NOT
+    // push the window down (that would flash placeholders for a fresh tx).
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);
+
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/10, recs({100})));
+    check_slice(c, 10, {100, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
+    BOOST_CHECK_EQUAL(c.total(), 31);
+}
+
+BOOST_AUTO_TEST_CASE(insert_at_window_end_appends)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);   // slice covers abs [10,20)
+
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/20, recs({200})));   // pos == base+len
+    check_slice(c, 10, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 200});
+    BOOST_CHECK_EQUAL(c.total(), 31);
+}
+
+BOOST_AUTO_TEST_CASE(insert_after_window_changes_total_only)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);
+
+    BOOST_CHECK(c.applyInsert(s, 6, /*pos*/25, recs({300})));   // pos > base+len
+    check_slice(c, 10, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
+    BOOST_CHECK_EQUAL(c.total(), 31);
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "beginInsert");
+    BOOST_CHECK_EQUAL(s.ops[0].first, 25);
+}
+
+BOOST_AUTO_TEST_CASE(insert_empty_or_out_of_range_is_noop)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);
+
+    BOOST_CHECK(!c.applyInsert(s, 6, 5, recs({})));     // empty
+    BOOST_CHECK(!c.applyInsert(s, 6, -1, recs({1})));   // pos < 0
+    BOOST_CHECK(!c.applyInsert(s, 6, 31, recs({1})));   // pos > total
+    BOOST_CHECK_EQUAL(c.total(), 30);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 5u);
+    BOOST_CHECK(s.ops.empty());
+}
+
+// ---- structural Remove: every overlap regime (cache-base hazard) ------------
+
+BOOST_AUTO_TEST_CASE(remove_before_window)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(10, 10), 10, 30, 1, 5);
+
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/3, /*count*/2));   // [3,5) entirely before
+    BOOST_CHECK_EQUAL(c.total(), 28);
+    check_slice(c, 8, {10, 11, 12, 13, 14, 15, 16, 17, 18, 19});
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "beginRemove");
+    BOOST_CHECK_EQUAL(s.ops[0].total_at, 30);
+}
+
+BOOST_AUTO_TEST_CASE(remove_front_overlap)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);   // abs [5,15) ids 5..14
+
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/3, /*count*/4));   // [3,7) -> drops ids 5,6
+    BOOST_CHECK_EQUAL(c.total(), 26);
+    check_slice(c, 3, {7, 8, 9, 10, 11, 12, 13, 14});
+}
+
+BOOST_AUTO_TEST_CASE(remove_strictly_inside)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/8, /*count*/3));   // [8,11) -> drops ids 8,9,10
+    BOOST_CHECK_EQUAL(c.total(), 27);
+    check_slice(c, 5, {5, 6, 7, 11, 12, 13, 14});
+}
+
+BOOST_AUTO_TEST_CASE(remove_back_overlap)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/12, /*count*/5));   // [12,17) -> drops ids 12,13,14
+    BOOST_CHECK_EQUAL(c.total(), 25);
+    check_slice(c, 5, {5, 6, 7, 8, 9, 10, 11});
+}
+
+BOOST_AUTO_TEST_CASE(remove_spans_whole_cache)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/2, /*count*/20));   // [2,22) -> drops all cached
+    BOOST_CHECK_EQUAL(c.total(), 10);
+    BOOST_CHECK_EQUAL(c.cacheFirst(), 2);
+    BOOST_CHECK_EQUAL(c.cacheSize(), 0);
+    BOOST_CHECK(c.at(2) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(remove_after_window)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyRemove(s, 6, /*pos*/20, /*count*/3));   // entirely after
+    BOOST_CHECK_EQUAL(c.total(), 27);
+    check_slice(c, 5, {5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
+}
+
+BOOST_AUTO_TEST_CASE(remove_out_of_range_is_noop)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(!c.applyRemove(s, 6, 0, 0));     // count 0
+    BOOST_CHECK(!c.applyRemove(s, 6, -1, 2));    // pos < 0
+    BOOST_CHECK(!c.applyRemove(s, 6, 29, 5));    // pos+count > total
+    BOOST_CHECK_EQUAL(c.total(), 30);
+    BOOST_CHECK(s.ops.empty());
+}
+
+// ---- structural Change ------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(change_refreshes_in_cache_overlap)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/7, /*count*/2, recs({77, 88})));
+    check_slice(c, 5, {5, 6, 77, 88, 9, 10, 11, 12, 13, 14});
+    BOOST_CHECK_EQUAL(c.total(), 30);   // no size change
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);
+    // exactly one dataChanged over the refreshed rows.
+    BOOST_REQUIRE_EQUAL(s.ops.size(), 1u);
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "dataChanged");
+    BOOST_CHECK_EQUAL(s.ops[0].first, 7);
+    BOOST_CHECK_EQUAL(s.ops[0].count, 2);
+}
+
+BOOST_AUTO_TEST_CASE(change_partial_overlap_clips_to_cache)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    // Change abs [3,8): only [5,8) is in cache -> rows 5,6,7 get fresh[2..4].
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/3, /*count*/5, recs({30, 40, 50, 60, 70})));
+    check_slice(c, 5, {50, 60, 70, 8, 9, 10, 11, 12, 13, 14});
+    BOOST_REQUIRE_EQUAL(s.ops.size(), 1u);
+    BOOST_CHECK_EQUAL(s.ops[0].first, 5);
+    BOOST_CHECK_EQUAL(s.ops[0].count, 3);
+}
+
+BOOST_AUTO_TEST_CASE(change_fully_off_window_no_signal)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/20, /*count*/2, recs({1, 2})));
+    check_slice(c, 5, {5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);   // seqno still advances
+    BOOST_CHECK(s.ops.empty());                   // but no dataChanged (nothing visible)
+}
+
+// ---- the seqno gate (PR4-fix B, must-fix #2) --------------------------------
+
+BOOST_AUTO_TEST_CASE(structural_seqno_gate_skips_already_reflected)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, 5, 1, /*high_water*/10);
+
+    BOOST_CHECK(!c.applyInsert(s, /*seqno*/10, 0, recs({99})));   // == high-water: skip
+    BOOST_CHECK(!c.applyInsert(s, /*seqno*/9, 0, recs({99})));    // <  high-water: skip
+    BOOST_CHECK(!c.applyRemove(s, 10, 0, 1));
+    BOOST_CHECK(!c.applyChange(s, 10, 0, 1, recs({1})));
+    BOOST_CHECK_EQUAL(c.total(), 5);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 10u);
+    BOOST_CHECK(s.ops.empty());
+
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/11, 0, recs({99})));    // > high-water: apply
+    BOOST_CHECK_EQUAL(c.total(), 6);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 11u);
+}
+
+BOOST_AUTO_TEST_CASE(reset_skips_stale_and_takes_max_baseline)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, 5, 1, /*high_water*/10);
+
+    // A Reset whose seqno is already reflected is skipped.
+    BOOST_CHECK(!c.applyReset(s, /*seqno*/10, seq(0, 3), 0, 3, /*epoch*/2, /*hw*/10));
+    BOOST_CHECK_EQUAL(c.total(), 5);
+
+    // A live Reset: new geometry; baseline = max(high_water, seqno).
+    BOOST_CHECK(c.applyReset(s, /*seqno*/12, seq(100, 4), 0, 20, /*epoch*/2, /*hw*/15));
+    BOOST_CHECK_EQUAL(c.total(), 20);
+    BOOST_CHECK_EQUAL(c.epoch(), 2u);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 15u);   // hw(15) > seqno(12)
+    check_slice(c, 0, {100, 101, 102, 103});
+    BOOST_CHECK_EQUAL(s.ops.size(), 2u);
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "beginReset");
+    BOOST_CHECK_EQUAL(s.ops[1].kind, "endReset");
+}
+
+// ---- the content channel (must-fix #2: never advances structural state) -----
+
+BOOST_AUTO_TEST_CASE(content_fill_adopts_on_exact_match)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, 100, /*epoch*/3, /*high_water*/10);
+
+    // user scrolled to abs 50: fetch matches epoch AND structural seqno -> adopt.
+    BOOST_CHECK(c.fillContent(s, /*first*/50, seq(50, 5), /*epoch*/3, /*high_water*/10));
+    check_slice(c, 50, {50, 51, 52, 53, 54});
+    BOOST_CHECK_EQUAL(c.total(), 100);             // content NEVER changes the count
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 10u);   // content NEVER advances the seqno
+    BOOST_REQUIRE_EQUAL(s.ops.size(), 1u);
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "dataChanged");
+    BOOST_CHECK_EQUAL(s.ops[0].first, 50);
+    BOOST_CHECK_EQUAL(s.ops[0].count, 5);
+}
+
+BOOST_AUTO_TEST_CASE(content_fill_discards_on_epoch_mismatch)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, 100, /*epoch*/3, /*high_water*/10);
+
+    // a resort happened since the fetch was requested (epoch bumped) -> discard.
+    BOOST_CHECK(!c.fillContent(s, 50, seq(50, 5), /*epoch*/2, /*high_water*/10));
+    check_slice(c, 0, {0, 1, 2, 3, 4});   // unchanged
+    BOOST_CHECK(s.ops.empty());
+}
+
+BOOST_AUTO_TEST_CASE(content_fill_discards_on_seqno_mismatch_either_way)
+{
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, 100, /*epoch*/3, /*high_water*/10);
+
+    BOOST_CHECK(!c.fillContent(s, 50, seq(50, 5), 3, /*high_water*/9));    // fetch staler
+    BOOST_CHECK(!c.fillContent(s, 50, seq(50, 5), 3, /*high_water*/11));   // fetch ahead
+    check_slice(c, 0, {0, 1, 2, 3, 4});
+    BOOST_CHECK(s.ops.empty());
+}
+
+BOOST_AUTO_TEST_CASE(structural_delta_applies_after_a_content_fill)
+{
+    // A content fill must not poison the structural coordinate system: a later
+    // insert still shifts the content-filled slice exactly as the structural
+    // channel dictates.
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, 100, 3, 10);
+
+    BOOST_CHECK(c.fillContent(s, 50, seq(50, 5), 3, 10));   // cache now abs [50,55)
+    s.clear();
+
+    // insert before the window: base shifts, total grows, seqno advances.
+    BOOST_CHECK(c.applyInsert(s, /*seqno*/11, /*pos*/40, recs({900, 901})));
+    BOOST_CHECK_EQUAL(c.total(), 102);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 11u);
+    check_slice(c, 52, {50, 51, 52, 53, 54});
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "beginInsert");
+    BOOST_CHECK_EQUAL(s.ops[0].total_at, 100);   // pre-mutation count inside the bracket
+}
+
+BOOST_AUTO_TEST_CASE(content_fill_rejects_slice_past_table_end)
+{
+    // Even with matching epoch + seqno, a slice that would fall outside [0,total)
+    // is rejected so it cannot corrupt the [cacheFirst, cacheFirst+cacheSize)
+    // invariant (has()/at() reporting rows >= total as present). PR5-A review.
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(0, 5), 0, /*total*/100, /*epoch*/3, /*high_water*/10);
+
+    BOOST_CHECK(!c.fillContent(s, /*first*/96, seq(96, 10), 3, 10));  // [96,106) past 100
+    BOOST_CHECK(!c.fillContent(s, /*first*/100, seq(100, 1), 3, 10)); // first == total
+    check_slice(c, 0, {0, 1, 2, 3, 4});   // unchanged
+    BOOST_CHECK(s.ops.empty());
+
+    // a slice ending exactly at the table end is accepted.
+    BOOST_CHECK(c.fillContent(s, /*first*/95, seq(95, 5), 3, 10));    // [95,100)
+    check_slice(c, 95, {95, 96, 97, 98, 99});
+}
+
+BOOST_AUTO_TEST_CASE(change_short_fresh_refreshes_what_it_has_and_advances_seqno)
+{
+    // Contract violation (fresh shorter than count): the covered rows refresh, the
+    // rest keep their cached values (no out-of-bounds read), and the seqno still
+    // advances so the Change event is consumed exactly once. PR5-A review.
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+    c.seedInitial(seq(5, 10), 5, 30, 1, 5);
+
+    BOOST_CHECK(c.applyChange(s, 6, /*pos*/7, /*count*/3, recs({77})));   // only 1 of 3
+    check_slice(c, 5, {5, 6, 77, 8, 9, 10, 11, 12, 13, 14});             // 8,9 unchanged
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 6u);                          // advanced regardless
+    BOOST_REQUIRE_EQUAL(s.ops.size(), 1u);
+    BOOST_CHECK_EQUAL(s.ops[0].kind, "dataChanged");
+    BOOST_CHECK_EQUAL(s.ops[0].first, 7);
+    BOOST_CHECK_EQUAL(s.ops[0].count, 1);                               // only the refreshed row
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

PR5-A — the gating, **behavior-neutral** first step of the detailed transaction table's viewport windowing (windowed-model **PR5**). It lands the producer read contract and the Qt-free consumer reconciliation core that PR5-B will wire, with **no change to current behavior**.

Stacked on the merged PR4 (#3022). First of a small A→C ladder:
- **PR5-A (this PR):** read APIs + `WindowCache` core + GUI-off tests. No consumer wired.
- **PR5-B:** wire `DetailedTxModel` as a virtual windowed model + viewport-slice fetch + anchor-on-resort (HIGH risk, ASan-GUI soak-gated).
- **PR5-C:** retire the Qt-thread `index()` lock paths; route `describe()` through a producer-side `getRowDetail`.

## Changes

- **`GRC::RowsResult{records, total_accepted, epoch, high_water}`** — `WalletTxStore::getRows(viewId, first, count)` now returns the row slice **and** the view metadata sampled under **one `cs_store` hold** (atomic), generalizing the PR4-fix B race fix to PR5's scroll path. The six existing `OverviewTxModel`/`DetailedTxModel` call sites are adapted and remain behavior-identical (still the full replica).
- **Remove the dead `WalletTxStore::totalAccepted(int)`** (0 callers). PR5-B reads the row count from `RowsResult.total_accepted`, never via a second lock that would reopen that race.
- **`Cursor::positionOf(absidx)`** — public identity-locate backing PR5-B's `rowForKey` (click-through / anchor-on-resort).
- **New header-only Qt-free `GRC::WindowCache<Record>` + `WindowCacheSink`** — the consumer-side **two-channel reconciliation**:
  - **STRUCTURAL** channel (seqno-gated Reset/Insert/Remove/Change deltas) owns the virtual row count and the `begin/end{Insert,Remove,Reset}` brackets.
  - **CONTENT** channel (scroll-driven slice fetch) is epoch + high-water gated and **never** advances structural state.

  Templated on the record type so it compiles into the `ENABLE_GUI=OFF` test binary (`TransactionRecord` pulls in Qt and cannot).

## Testing

- New GUI-off `qt_windowcache_tests` — every insert/remove overlap regime (the cache-base arithmetic), the structural seqno gate, the content/structural channel separation, and the bounds/contract edges. `qt_cursor_tests` gains a `positionOf` case. `test_gridcoin` green (39 cases across the two suites).
- GUI target builds clean with the `getRows`→`RowsResult` signature change. Lint clean (whitespace + include-guards).

## Review

Adversarially reviewed (multi-angle finders + refute-by-default verification). Surviving findings fixed with pinning tests: a `fillContent` upper-bound check, the `applyChange` short-`fresh` contract made explicit, and a stale comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)