### PR TITLE
refactor: hoist ThreadStakeMiner out of StartNode into AppInit2

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -645,7 +645,7 @@ Gridcoin is a multi-threaded application. Key threads include:
 
 | Thread | Source | Description |
 |--------|--------|-------------|
-| `ThreadStakeMiner` | `src/net.cpp` | Proof-of-stake block creation (calls `StakeMiner()` in `src/miner.cpp`) |
+| `ThreadStakeMiner` | `src/miner.cpp` | Proof-of-stake block creation (calls `StakeMiner()`); launched from `AppInit2`, joined in `Shutdown()` before the block-file flush |
 | `ThreadScraper` | `src/gridcoin/gridcoin.cpp` | Active scraper: downloads BOINC project stats and publishes signed manifests (mutually exclusive with subscriber) |
 | `ThreadScraperSubscriber` | `src/gridcoin/gridcoin.cpp` | Subscriber: receives scraper manifests and runs convergence to build superblocks (mutually exclusive with scraper) |
 | `ThreadSocketHandler` | `src/net.cpp` | Low-level socket I/O for P2P connections |

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,8 +29,17 @@
 
 #include <openssl/crypto.h>
 
+#include <thread>
+
 static boost::thread_group threadGroup;
 static CScheduler scheduler;
+
+//! The proof-of-stake miner thread. Launched from AppInit2 Step 12 and joined
+//! in Shutdown() after StopNode(), before the block-file flush, so a block
+//! staked during shutdown cannot land after the flush (issue #2865). Owned
+//! here rather than by net.cpp's netThreads because it is a staking thread,
+//! not a network thread (issue #2558 PR 0).
+static std::thread g_stake_miner_thread;
 
 extern void ThreadAppInit2(void* parg);
 
@@ -166,6 +175,13 @@ void Shutdown(void* parg)
         LogPrintf("INFO: %s: Stopping net (node) threads.", __func__);
         StopNode();
 
+        // The stake miner exits via fShutdown plus the g_thread_interrupt()
+        // call above, which wakes its MilliSleep.
+        LogPrintf("INFO: %s: Stopping the stake miner thread.", __func__);
+        if (g_stake_miner_thread.joinable()) {
+            g_stake_miner_thread.join();
+        }
+
         // Coordinate block-file and block-index DB state before exit so a
         // clean shutdown never leaves the LevelDB index referencing flat-file
         // data that hasn't been fsynced. The fsync on the active blk*.dat
@@ -174,12 +190,13 @@ void Shutdown(void* parg)
         // the LevelDB WAL to disk so any pending CDiskBlockIndex entries are
         // durable. See issue #2865.
         //
-        // This must run after StopNode() so that every thread that can write
-        // a block (ThreadMessageHandler, ThreadStakeMiner, ThreadScraper, and
-        // the rest of the net/peer thread group) has been joined. Running it
-        // earlier leaves a small race window where a block accepted during
-        // shutdown could land after our flush and bypass the coordination
-        // guarantee Phase 2's startup recovery relies on.
+        // This must run after StopNode() and the stake-miner join so that
+        // every thread that can write a block (ThreadMessageHandler,
+        // ThreadStakeMiner, ThreadScraper, and the rest of the net/peer
+        // thread group) has been joined. Running it earlier leaves a small
+        // race window where a block accepted during shutdown could land
+        // after our flush and bypass the coordination guarantee Phase 2's
+        // startup recovery relies on.
         LogPrintf("INFO: %s: Flushing block files and index DB.", __func__);
         {
             LOCK(cs_main);
@@ -1733,6 +1750,12 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     if (!threads->createThread(StartNode, nullptr, "Start Thread"))
         InitError(_("Error: could not start node"));
+
+    // The stake miner is a staking thread, not a network thread, so it is
+    // launched here rather than from StartNode(). It self-gates each loop
+    // iteration via IsMiningAllowed(), so starting it concurrently with the
+    // net threads is safe.
+    g_stake_miner_thread = std::thread(ThreadStakeMiner, pwalletMain);
 
     if (gArgs.GetBoolArg("-server", false)) StartRPCThreads();
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -27,6 +27,7 @@
 #include "policy/fees.h"
 #include "random.h"
 #include "util.h"
+#include "util/threadnames.h"
 #include "validation.h"
 #include "wallet/wallet.h"
 
@@ -1768,4 +1769,31 @@ bool TryMineRegtestBlock(CWallet* pwallet,
     g_miner_status.UpdateLastStake(StakeBlock.vtx[1].GetHash());
     blocknew_out = StakeBlock;
     return true;
+}
+
+void ThreadStakeMiner(void* parg)
+{
+    RenameThread("grc-stakeminer");
+    util::ThreadSetInternalName("grc-stakeminer");
+
+    LogPrint(BCLog::LogFlags::NET, "ThreadStakeMiner started");
+    CWallet* pwallet = (CWallet*)parg;
+    try
+    {
+        StakeMiner(pwallet);
+    }
+    catch (std::exception& e)
+    {
+        PrintException(&e, "ThreadStakeMiner()");
+    }
+    catch(boost::thread_interrupted&)
+    {
+        LogPrintf("ThreadStakeMiner exited (interrupt)");
+        return;
+    }
+    catch (...)
+    {
+        PrintException(nullptr, "ThreadStakeMiner()");
+    }
+    LogPrintf("ThreadStakeMiner exited");
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -58,4 +58,13 @@ bool TryMineRegtestBlock(CWallet* pwallet,
                          CBlock& blocknew_out,
                          std::string& err);
 
+//! \brief The proof-of-stake miner loop. Runs until \ref fShutdown is set.
+void StakeMiner(CWallet* pwallet);
+
+//! \brief Thread entry point wrapping StakeMiner. \p parg is the CWallet to
+//! stake with. Launched from AppInit2 and joined in Shutdown() before the
+//! block-file flush, so a block staked during shutdown cannot land after the
+//! flush (see issue #2865).
+void ThreadStakeMiner(void* parg);
+
 #endif // BITCOIN_MINER_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -52,7 +52,6 @@ void ThreadMapPort2(void* parg);
 #endif
 void ThreadDNSAddressSeed2(void* parg);
 bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant* grantOutbound = nullptr, const char* strDest = nullptr, bool fOneShot = false);
-void StakeMiner(CWallet *pwallet);
 
 //
 // Global state variables
@@ -1577,33 +1576,6 @@ void static ProcessOneShot()
     }
 }
 
-void static ThreadStakeMiner(void* parg)
-{
-    RenameThread("grc-stakeminer");
-    util::ThreadSetInternalName("grc-stakeminer");
-
-    LogPrint(BCLog::LogFlags::NET, "ThreadStakeMiner started");
-    CWallet* pwallet = (CWallet*)parg;
-    try
-    {
-        StakeMiner(pwallet);
-    }
-    catch (std::exception& e)
-    {
-        PrintException(&e, "ThreadStakeMiner()");
-    }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadStakeMiner exited (interrupt)");
-        return;
-    }
-    catch (...)
-    {
-        PrintException(nullptr, "ThreadStakeMiner()");
-    }
-    LogPrintf("ThreadStakeMiner exited");
-}
-
 void CNode::RecordBytesRecv(uint64_t bytes)
 {
     nTotalBytesRecv += bytes;
@@ -2189,11 +2161,6 @@ void StartNode(void* parg)
     if (!netThreads->createThread(ThreadDumpAddress, nullptr, "ThreadDumpAddress")) {
         LogPrintf("Error: createThread(ThreadDumpAddress) failed");
     }
-
-    if (!netThreads->createThread(ThreadStakeMiner, pwalletMain, "ThreadStakeMiner")) {
-        LogPrintf("Error: createThread(ThreadStakeMiner) failed");
-    }
-
 }
 
 bool StopNode()


### PR DESCRIPTION
First step of the CConnman backport series planned in #2558 (PR 0 in the plan comment).

## What

`ThreadStakeMiner` is the proof-of-stake staking thread, but it was launched as the last of the eight `netThreads` inside `StartNode()` and torn down via `StopNode()`. When `CConnman` is introduced it must own only network threads, so the miner moves out first:

- The `ThreadStakeMiner` wrapper moves verbatim from `net.cpp` to `miner.cpp` (next to `StakeMiner()`, which it wraps); both are now declared in `miner.h`. `net.cpp` no longer references `StakeMiner` or `pwalletMain`.
- `AppInit2` Step 12 launches the miner on an `init.cpp`-owned `std::thread`, immediately after the `StartNode` thread is created.
- `Shutdown()` joins it right after `StopNode()` and **before** the block-file/index flush, preserving the #2865 guarantee that every thread which can write a block is joined before the flush. The comment block there is updated accordingly.
- `doc/developer-notes.md` thread table updated.

## Why behavior is preserved

- **Termination path unchanged.** The miner exits via `fShutdown` plus `g_thread_interrupt()` waking its `MilliSleep` (`CThreadInterrupt`-based). Boost interruption was already vestigial for this thread — its loop contains no boost interruption points — so leaving the boost-based `ThreadHandler` does not change shutdown behavior. (The `catch (boost::thread_interrupted&)` clause is kept verbatim with the move; happy to drop it as dead code if preferred.)
- **Startup ordering.** The miner now starts concurrently with the `StartNode` thread instead of strictly after the seven net threads. Benign: its first action is `MilliSleep(nMinerSleep)` and every iteration self-gates via `IsMiningAllowed()`.
- **`fShutdown` re-arm.** The `fShutdown = false` at the top of `StartNode()` no longer precedes the miner launch; `fShutdown` initializes to `false` and is only set `true` on shutdown or fatal-error paths that abort init before Step 12.
- **Qt and daemon both covered** — the join lives in the shared `Shutdown()`.
- Thread names (`grc-stakeminer` / `grc-stake-miner`) and log lines are unchanged.

After the hoist, `netThreads` holds only network threads, so its name is accurate and the rename floated in the plan is unnecessary.

## Testing

- Clean incremental build (`-DENABLE_GUI=ON -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo`), full `ctest` suite.
- Manual: daemon start/stop — `ThreadStakeMiner started` appears at startup; on shutdown the miner join logs after "Stopping net (node) threads" and before "Flushing block files and index DB"; `getstakinginfo` unchanged.
