### PR TITLE
refactor: hoist CScheduler into a g_scheduler unique_ptr

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -645,7 +645,7 @@ Gridcoin is a multi-threaded application. Key threads include:
 
 | Thread | Source | Description |
 |--------|--------|-------------|
-| `ThreadStakeMiner` | `src/net.cpp` | Proof-of-stake block creation (calls `StakeMiner()` in `src/miner.cpp`) |
+| `ThreadStakeMiner` | `src/miner.cpp` | Proof-of-stake block creation (calls `StakeMiner()`); launched from `AppInit2`, joined in `Shutdown()` before the block-file flush |
 | `ThreadScraper` | `src/gridcoin/gridcoin.cpp` | Active scraper: downloads BOINC project stats and publishes signed manifests (mutually exclusive with subscriber) |
 | `ThreadScraperSubscriber` | `src/gridcoin/gridcoin.cpp` | Subscriber: receives scraper manifests and runs convergence to build superblocks (mutually exclusive with scraper) |
 | `ThreadSocketHandler` | `src/net.cpp` | Low-level socket I/O for P2P connections |

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,8 +29,17 @@
 
 #include <openssl/crypto.h>
 
+#include <thread>
+
 static boost::thread_group threadGroup;
 static CScheduler scheduler;
+
+//! The proof-of-stake miner thread. Launched from AppInit2 Step 12 and joined
+//! in Shutdown() after StopNode(), before the block-file flush, so a block
+//! staked during shutdown cannot land after the flush (issue #2865). Owned
+//! here rather than by net.cpp's netThreads because it is a staking thread,
+//! not a network thread (issue #2558 PR 0).
+static std::thread g_stake_miner_thread;
 
 extern void ThreadAppInit2(void* parg);
 
@@ -166,6 +175,13 @@ void Shutdown(void* parg)
         LogPrintf("INFO: %s: Stopping net (node) threads.", __func__);
         StopNode();
 
+        // The stake miner exits via fShutdown plus the g_thread_interrupt()
+        // call above, which wakes its MilliSleep.
+        LogPrintf("INFO: %s: Stopping the stake miner thread.", __func__);
+        if (g_stake_miner_thread.joinable()) {
+            g_stake_miner_thread.join();
+        }
+
         // Coordinate block-file and block-index DB state before exit so a
         // clean shutdown never leaves the LevelDB index referencing flat-file
         // data that hasn't been fsynced. The fsync on the active blk*.dat
@@ -174,12 +190,13 @@ void Shutdown(void* parg)
         // the LevelDB WAL to disk so any pending CDiskBlockIndex entries are
         // durable. See issue #2865.
         //
-        // This must run after StopNode() so that every thread that can write
-        // a block (ThreadMessageHandler, ThreadStakeMiner, ThreadScraper, and
-        // the rest of the net/peer thread group) has been joined. Running it
-        // earlier leaves a small race window where a block accepted during
-        // shutdown could land after our flush and bypass the coordination
-        // guarantee Phase 2's startup recovery relies on.
+        // This must run after StopNode() and the stake-miner join so that
+        // every thread that can write a block (ThreadMessageHandler,
+        // ThreadStakeMiner, ThreadScraper, and the rest of the net/peer
+        // thread group) has been joined. Running it earlier leaves a small
+        // race window where a block accepted during shutdown could land
+        // after our flush and bypass the coordination guarantee Phase 2's
+        // startup recovery relies on.
         LogPrintf("INFO: %s: Flushing block files and index DB.", __func__);
         {
             LOCK(cs_main);
@@ -1733,6 +1750,12 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     if (!threads->createThread(StartNode, nullptr, "Start Thread"))
         InitError(_("Error: could not start node"));
+
+    // The stake miner is a staking thread, not a network thread, so it is
+    // launched here rather than from StartNode(). It self-gates each loop
+    // iteration via IsMiningAllowed(), so starting it concurrently with the
+    // net threads is safe.
+    g_stake_miner_thread = std::thread(ThreadStakeMiner, pwalletMain);
 
     if (gArgs.GetBoolArg("-server", false)) StartRPCThreads();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -32,7 +32,6 @@
 #include <thread>
 
 static boost::thread_group threadGroup;
-static CScheduler scheduler;
 
 //! The proof-of-stake miner thread. Launched from AppInit2 Step 12 and joined
 //! in Shutdown() after StopNode(), before the block-file flush, so a block
@@ -66,6 +65,7 @@ extern constexpr int DEFAULT_WAIT_CLIENT_TIMEOUT = 0;
 
 
 std::unique_ptr<BanMan> g_banman;
+std::unique_ptr<CScheduler> g_scheduler;
 
 /**
  * The PID file facilities.
@@ -156,9 +156,10 @@ void Shutdown(void* parg)
 
         fShutdown = true;
 
-        // Signal to the scheduler to stop.
+        // Signal to the scheduler to stop. Guarded because Shutdown() can run
+        // after an early AppInit2 failure, before the scheduler is constructed.
         LogPrintf("INFO: %s: Stopping the scheduler.", __func__);
-        scheduler.stop();
+        if (g_scheduler) g_scheduler->stop();
 
         // clean up any remaining threads running serviceQueue:
         LogPrintf("INFO: %s: Cleaning up any remaining threads in scheduler.", __func__);
@@ -1772,22 +1773,24 @@ bool AppInit2(ThreadHandlerPtr threads)
     pwalletMain->FixSpentCoins(nMismatchSpent, nBalanceInQuestion);
 
     // Start the lightweight task scheduler thread
-    CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
+    assert(!g_scheduler);
+    g_scheduler = std::make_unique<CScheduler>();
+    CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, g_scheduler.get());
     threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
     // Gather some entropy once per minute.
-    scheduler.scheduleEvery([]{
+    g_scheduler->scheduleEvery([]{
         RandAddPeriodic();
     }, std::chrono::minutes{1});
 
     // TODO: Do we need this? It would require porting the Bitcoin signal handler.
-    // GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+    // GetMainSignals().RegisterBackgroundSignalScheduler(*g_scheduler);
 
-    scheduler.scheduleEvery([]{
+    g_scheduler->scheduleEvery([]{
         g_banman->DumpBanlist();
     }, std::chrono::seconds{DUMP_BANS_INTERVAL});
 
-    GRC::ScheduleBackgroundJobs(scheduler);
+    GRC::ScheduleBackgroundJobs(*g_scheduler);
 
     #if HAVE_SYSTEM
         StartupNotify(gArgs);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -27,6 +27,7 @@
 #include "policy/fees.h"
 #include "random.h"
 #include "util.h"
+#include "util/threadnames.h"
 #include "validation.h"
 #include "wallet/wallet.h"
 
@@ -1768,4 +1769,31 @@ bool TryMineRegtestBlock(CWallet* pwallet,
     g_miner_status.UpdateLastStake(StakeBlock.vtx[1].GetHash());
     blocknew_out = StakeBlock;
     return true;
+}
+
+void ThreadStakeMiner(void* parg)
+{
+    RenameThread("grc-stakeminer");
+    util::ThreadSetInternalName("grc-stakeminer");
+
+    LogPrint(BCLog::LogFlags::NET, "ThreadStakeMiner started");
+    CWallet* pwallet = (CWallet*)parg;
+    try
+    {
+        StakeMiner(pwallet);
+    }
+    catch (std::exception& e)
+    {
+        PrintException(&e, "ThreadStakeMiner()");
+    }
+    catch(boost::thread_interrupted&)
+    {
+        LogPrintf("ThreadStakeMiner exited (interrupt)");
+        return;
+    }
+    catch (...)
+    {
+        PrintException(nullptr, "ThreadStakeMiner()");
+    }
+    LogPrintf("ThreadStakeMiner exited");
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -58,4 +58,13 @@ bool TryMineRegtestBlock(CWallet* pwallet,
                          CBlock& blocknew_out,
                          std::string& err);
 
+//! \brief The proof-of-stake miner loop. Runs until \ref fShutdown is set.
+void StakeMiner(CWallet* pwallet);
+
+//! \brief Thread entry point wrapping StakeMiner. \p parg is the CWallet to
+//! stake with. Launched from AppInit2 and joined in Shutdown() before the
+//! block-file flush, so a block staked during shutdown cannot land after the
+//! flush (see issue #2865).
+void ThreadStakeMiner(void* parg);
+
 #endif // BITCOIN_MINER_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -52,7 +52,6 @@ void ThreadMapPort2(void* parg);
 #endif
 void ThreadDNSAddressSeed2(void* parg);
 bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant* grantOutbound = nullptr, const char* strDest = nullptr, bool fOneShot = false);
-void StakeMiner(CWallet *pwallet);
 
 //
 // Global state variables
@@ -1577,33 +1576,6 @@ void static ProcessOneShot()
     }
 }
 
-void static ThreadStakeMiner(void* parg)
-{
-    RenameThread("grc-stakeminer");
-    util::ThreadSetInternalName("grc-stakeminer");
-
-    LogPrint(BCLog::LogFlags::NET, "ThreadStakeMiner started");
-    CWallet* pwallet = (CWallet*)parg;
-    try
-    {
-        StakeMiner(pwallet);
-    }
-    catch (std::exception& e)
-    {
-        PrintException(&e, "ThreadStakeMiner()");
-    }
-    catch(boost::thread_interrupted&)
-    {
-        LogPrintf("ThreadStakeMiner exited (interrupt)");
-        return;
-    }
-    catch (...)
-    {
-        PrintException(nullptr, "ThreadStakeMiner()");
-    }
-    LogPrintf("ThreadStakeMiner exited");
-}
-
 void CNode::RecordBytesRecv(uint64_t bytes)
 {
     nTotalBytesRecv += bytes;
@@ -2189,11 +2161,6 @@ void StartNode(void* parg)
     if (!netThreads->createThread(ThreadDumpAddress, nullptr, "ThreadDumpAddress")) {
         LogPrintf("Error: createThread(ThreadDumpAddress) failed");
     }
-
-    if (!netThreads->createThread(ThreadStakeMiner, pwalletMain, "ThreadStakeMiner")) {
-        LogPrintf("Error: createThread(ThreadStakeMiner) failed");
-    }
-
 }
 
 bool StopNode()

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <thread>
 
 #include <sync.h>
@@ -103,6 +104,12 @@ private:
     bool stopWhenEmpty GUARDED_BY(newTaskMutex){false};
     bool shouldStop() const EXCLUSIVE_LOCKS_REQUIRED(newTaskMutex) { return stopRequested || (stopWhenEmpty && taskQueue.empty()); }
 };
+
+//! The process-wide background task scheduler. Constructed in AppInit2 before
+//! its serviceQueue thread is launched and destroyed at shutdown after that
+//! thread is joined. Owned via unique_ptr (mirroring g_banman) so it can be
+//! injected into PeerManager::StartScheduledTasks() once that lands.
+extern std::unique_ptr<CScheduler> g_scheduler;
 
 /**
  * Class used by CScheduler clients which may schedule multiple jobs


### PR DESCRIPTION
_Stacked on #3024 (PR 0). Until that merges, the diff also shows the ThreadStakeMiner hoist commit; review the top commit._

Second step of the CConnman backport series (issue #2558). PR 8 injects the
scheduler into PeerManager::StartScheduledTasks(CScheduler&) via dependency
injection. The scheduler was a file-static in init.cpp, unreachable from other
translation units, so hoist it to a global std::unique_ptr<CScheduler>
g_scheduler -- the same ownership pattern already used for g_banman.

- Declare extern g_scheduler in scheduler.h; define it next to g_banman in
  init.cpp; drop the file-static CScheduler.
- Construct g_scheduler in AppInit2 immediately before its serviceQueue thread
  is launched (assert(!g_scheduler) first, mirroring g_banman), and rewrite the
  scheduleEvery / ScheduleBackgroundJobs call sites against it.
- Guard the Shutdown() stop() with if (g_scheduler), because Shutdown() can run
  after an early AppInit2 failure that aborts before construction. The static
  could never be null; this is strictly safer and the only behavioral delta.

No translation unit outside init.cpp referenced the static, so there is no
call-site churn elsewhere. The single instance is still constructed before its
service thread and destroyed (at static teardown) after threadGroup.join_all()
joins that thread -- ordering identical to the file-static.

NetEventsInterface, originally bundled into this step, is deferred to PR 8 where
PeerManagerImpl first implements it and CConnman::m_msgproc first uses it.

