### PR TITLE
qt: window the detailed transaction table on WindowCache (windowed-model PR5-B)

### DIFF
--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -9,6 +9,8 @@
 #include "qt/wallettxstore.h"
 #include "util/system.h"
 
+#include <QTimer>
+
 #include <algorithm>
 #include <type_traits>
 #include <variant>
@@ -26,36 +28,50 @@ static_assert(static_cast<int>(GRC::TXCOL_TYPE)    == static_cast<int>(Transacti
 static_assert(static_cast<int>(GRC::TXCOL_ADDRESS) == static_cast<int>(TransactionTableModel::ToAddress), "TXCOL_ADDRESS mirror drift");
 static_assert(static_cast<int>(GRC::TXCOL_AMOUNT)  == static_cast<int>(TransactionTableModel::Amount),    "TXCOL_AMOUNT mirror drift");
 
+namespace {
+//! Bounded seed/Reset window: large enough to cover any plausible pre-layout
+//! viewport; the first real viewport report fetches the visible range. Must NOT be
+//! -1 ("all served"), which under the unlimited VIEW_DETAILED cap would return the
+//! full replica and negate the windowing (windowed-model PR5-B).
+constexpr int kInitialWindow = 200;
+//! Scroll-fetch debounce (ms): coalesce a scroll burst into a single fetch.
+constexpr int kDebounceMs = 100;
+//! Hard backstop on a single fetch span so a mis-reported viewport can never
+//! materialize the whole table (PR5-B review GAP #1).
+constexpr int kMaxFetch = 4096;
+//! Bounded fillContent-rejection retries before deferring to the next report.
+constexpr int kMaxFetchRetries = 4;
+} // namespace
+
 DetailedTxModel::DetailedTxModel(WalletModel* walletModel, QObject* parent)
     : QAbstractTableModel(parent)
     , m_walletModel(walletModel)
     , m_ttm(walletModel->getTransactionTableModel())
+    , m_sink(this)
 {
     // Register the server-side view: the full history sorted by Date DESC, the
     // TransactionView's default ordering. The default FilterSpec is the
-    // "show everything" initial state of the unfiltered detailed view (all dates,
-    // ALL_TYPES, no address filter, min_amount 0, show_inactive true). The one
-    // runtime input is -showorphans, read once here — exactly mirroring the old
-    // TransactionFilterProxy ctor (a launch-time arg with no runtime mutation
-    // path, so reading it once is behavior-identical). limit_rows defaults to
-    // unlimited, so the served window is the full filtered+sorted set (PR4); the
-    // viewport-slice cap is PR5.
+    // "show everything" initial state of the unfiltered detailed view. The one
+    // runtime input is -showorphans, read once here (a launch-time arg with no
+    // runtime mutation path, behavior-identical to reading it repeatedly).
     GRC::FilterSpec spec;
     spec.show_orphans = gArgs.GetBoolArg("-showorphans", false);
     GRC::WalletTxStore& store = m_walletModel->getTxStore();
     store.registerView(GRC::VIEW_DETAILED, spec, GRC::TXCOL_DATE, GRC::TXSORT_DESC);
 
-    // registerView pushed a RowsReset that the next drain will deliver, but also
-    // seed synchronously so the table is populated before the first drain tick.
-    // Capture the high-water (PR4-fix B): the registration Reset that arrives on
-    // the first drain carries this same seqno and is skipped as already reflected.
-    // count = -1 ("all served") reads the rows + the high-water (RowsResult) in
-    // one cs_store hold — atomic, so a concurrent worker insert can't drop a row
-    // that the seqno skip would then suppress. (PR4 holds the full replica; the
-    // viewport slice + RowsResult.total_accepted/epoch are PR5-B.)
-    GRC::RowsResult seed = store.getRows(GRC::VIEW_DETAILED, 0, -1);
-    m_rows = std::move(seed.records);
-    m_applied_seqno = seed.high_water;
+    // Seed a BOUNDED initial window into the cache (NOT count=-1: under the unlimited
+    // VIEW_DETAILED cap that returns the full replica and negates the windowing).
+    // kInitialWindow covers any plausible pre-layout viewport; the first
+    // showEvent/resizeEvent reports the real visible range and fetches it. The
+    // registration Reset that arrives on the first drain carries this same
+    // high-water and is skipped by the cache's structural seqno gate.
+    GRC::RowsResult seed = store.getRows(GRC::VIEW_DETAILED, 0, kInitialWindow);
+    m_cache.seedInitial(std::move(seed.records), 0, seed.total_accepted,
+                        seed.epoch, seed.high_water);
+
+    m_fetchTimer = new QTimer(this);
+    m_fetchTimer->setSingleShot(true);
+    connect(m_fetchTimer, &QTimer::timeout, this, &DetailedTxModel::onFetchTimeout);
 
     connect(m_walletModel, &WalletModel::walletEventsDrained,
             this, &DetailedTxModel::applyEventBatch);
@@ -63,7 +79,7 @@ DetailedTxModel::DetailedTxModel(WalletModel* walletModel, QObject* parent)
 
 int DetailedTxModel::rowCount(const QModelIndex& parent) const
 {
-    return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+    return parent.isValid() ? 0 : m_cache.total();
 }
 
 int DetailedTxModel::columnCount(const QModelIndex& parent) const
@@ -74,15 +90,19 @@ int DetailedTxModel::columnCount(const QModelIndex& parent) const
 
 QVariant DetailedTxModel::data(const QModelIndex& index, int role) const
 {
-    if (!index.isValid() || index.row() < 0
-            || static_cast<std::size_t>(index.row()) >= m_rows.size()) {
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_cache.total()) {
         return QVariant();
     }
-    // Reuse the TransactionTableModel formatters for whichever column the table
-    // asks for. const_cast: formatRole takes a non-const record (legacy
-    // getTxID()/describe() are non-const) but does not mutate it.
-    return m_ttm->formatRole(const_cast<TransactionRecord*>(&m_rows[index.row()]),
-                             index.column(), role);
+    // Pure on the paint path: render the cached record, or a placeholder for an
+    // off-window row. NO fetch here — the viewport report drives content fills.
+    const TransactionRecord* rec = m_cache.at(index.row());
+    if (!rec) {
+        return QVariant();
+    }
+    // Reuse the TransactionTableModel formatters. const_cast: formatRole takes a
+    // non-const record (legacy getTxID()/describe() are non-const) but does not
+    // mutate it; the pointer is valid only within this call (m_cache.at contract).
+    return m_ttm->formatRole(const_cast<TransactionRecord*>(rec), index.column(), role);
 }
 
 QVariant DetailedTxModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -109,84 +129,214 @@ void DetailedTxModel::setFilter(const GRC::FilterSpec& spec)
 
 QModelIndex DetailedTxModel::indexForTxid(const uint256& hash) const
 {
-    for (std::size_t i = 0; i < m_rows.size(); ++i) {
-        if (m_rows[i].hash == hash) {
-            return index(static_cast<int>(i), 0);
+    // Resolve over the producer, not the cached slice: a click-through can target a
+    // row outside the window. rowForKey returns the accepted row in the live
+    // filtered+sorted view, or -1 if absent/filtered.
+    const int row = m_walletModel->getTxStore().rowForKey(GRC::VIEW_DETAILED, hash, -1);
+    return row >= 0 ? index(row, 0) : QModelIndex();
+}
+
+std::vector<TransactionRecord> DetailedTxModel::getAllRows() const
+{
+    // CSV export must cover every matching row, not just the cached window — read
+    // the full filtered+sorted set from the producer (cap-independent).
+    return m_walletModel->getTxStore().getAllRows(GRC::VIEW_DETAILED).records;
+}
+
+int DetailedTxModel::rowForKey(const uint256& hash, int idx) const
+{
+    return m_walletModel->getTxStore().rowForKey(GRC::VIEW_DETAILED, hash, idx);
+}
+
+bool DetailedTxModel::keyAt(int row, uint256& hash, int& idx) const
+{
+    const TransactionRecord* rec = m_cache.at(row);
+    if (!rec) {
+        return false;
+    }
+    hash = rec->hash;
+    idx = rec->idx;
+    return true;
+}
+
+void DetailedTxModel::ensureRowCached(int row)
+{
+    const int total = m_cache.total();
+    if (row < 0 || row >= total || m_cache.has(row)) {
+        return;
+    }
+    // Cover BOTH the current viewport AND `row` when they are within reach, so an
+    // in/near-viewport ensure never evicts the visible slice (fillContent REPLACES
+    // it — PR5-B review GAP #4/cluster C). Only a FAR jump — where the view is
+    // navigating to `row` anyway (focusTransaction / restoreAnchor scrollTo) — falls
+    // back to a bounded window centred on the row. Clamp the (possibly stale) pending
+    // range into the table first so the span can't blow up.
+    const int pf = std::min(std::max(0, m_pending_first), total - 1);
+    const int pl = std::min(std::max(0, m_pending_last), total - 1);
+    const int margin = std::max(kInitialWindow, pl - pf + 1);
+    const int lo = std::min(row, pf);
+    const int hi = std::max(row, pl);
+    int first = std::max(0, lo - margin);
+    int last = std::min(total - 1, hi + margin);
+    if (last - first + 1 > kMaxFetch) {
+        // Row is far from the viewport: centre a bounded window on the row.
+        first = std::max(0, row - kMaxFetch / 2);
+        last = std::min(total - 1, first + kMaxFetch - 1);
+    }
+    fetchWindow(first, last - first + 1);
+}
+
+void DetailedTxModel::onViewportChanged(int firstVisible, int lastVisible)
+{
+    // Bail on a not-yet-laid-out / empty viewport (TransactionView clamps too); a
+    // garbage range here must never reach onFetchTimeout (PR5-B review GAP #1).
+    if (firstVisible < 0 || lastVisible < firstVisible) {
+        return;
+    }
+    const int total = m_cache.total();
+    if (total <= 0) {
+        return;
+    }
+    // Clamp into the current table (rowAt can momentarily report stale indices during
+    // a resize/Reset before relayout) so onFetchTimeout never sees an out-of-bounds
+    // range (PR5-B review).
+    m_pending_first = std::min(firstVisible, total - 1);
+    m_pending_last = std::min(lastVisible, total - 1);
+    if (m_pending_last < m_pending_first) {
+        m_pending_last = m_pending_first;
+    }
+    m_fetch_retries = 0;                        // a fresh report restarts the retry budget
+    if (m_fetchTimer) {
+        m_fetchTimer->start(kDebounceMs);       // restart-to-coalesce a scroll burst
+    }
+}
+
+void DetailedTxModel::onFetchTimeout()
+{
+    const int total = m_cache.total();
+    if (total <= 0) {
+        return;
+    }
+    // Clamp the last-reported range into the CURRENT table before using it: a
+    // sort/filter Reset can shrink total below a pre-Reset m_pending_* (which is only
+    // refreshed by the next viewport report), and an unclamped range yields a negative
+    // count / out-of-bounds window that would evict the freshly-rebuilt slice (PR5-B
+    // review cluster A). After clamping, pf <= pl and count >= 1 are guaranteed.
+    const int pf = std::min(std::max(0, m_pending_first), total - 1);
+    const int pl = std::min(std::max(0, m_pending_last), total - 1);
+    // Margin ~ one viewport on each side, so small scrolls stay inside the cache and
+    // the window is ~3x the visible range.
+    const int span = std::max(1, pl - pf + 1);
+    int first = std::max(0, pf - span);
+    int last = std::min(total - 1, pl + span);
+    int count = last - first + 1;
+    // Hard backstop (GAP #1): never request more than kMaxFetch rows.
+    if (count > kMaxFetch) {
+        count = kMaxFetch;
+    }
+    // Hysteresis (GAP #6): skip when the wanted range is already fully cached.
+    if (count > 0 && m_cache.has(first) && m_cache.has(first + count - 1)) {
+        return;
+    }
+    fetchWindow(first, count);
+}
+
+void DetailedTxModel::fetchWindow(int first, int count)
+{
+    if (count <= 0 || first < 0 || m_fetch_in_progress) {
+        return;
+    }
+    m_fetch_in_progress = true;
+    // RAII reset so a throw from drainEventQueue / getRows / fillContent cannot wedge
+    // the flag and freeze the viewport permanently (PR5-B review: exception safety).
+    struct Guard { bool& f; ~Guard() { f = false; } } guard{m_fetch_in_progress};
+
+    GRC::WalletTxStore& store = m_walletModel->getTxStore();
+    bool adopted = false;
+    // Synchronous bounded retry: drain the queue FIRST so the cache's structural
+    // seqno matches the store's high-water (GAP #2), then read + fill. The only
+    // reason fillContent rejects here is a worker push landing between the drain and
+    // getRows; retrying the drain+read resolves it in a couple of iterations, so the
+    // visible/selected row is cached SYNCHRONOUSLY and a follow-up copy / Show-details
+    // reads real data rather than a placeholder (PR5-B review GAP #3/#8). Each
+    // drainEventQueue is sequential, not nested (the reentrancy guard in WalletModel
+    // no-ops only a re-entry from WITHIN an apply).
+    for (int attempt = 0; attempt < kMaxFetchRetries && !adopted; ++attempt) {
+        m_walletModel->drainEventQueue();
+        GRC::RowsResult r = store.getRows(GRC::VIEW_DETAILED, first, count);
+        adopted = m_cache.fillContent(m_sink, first, std::move(r.records),
+                                      r.epoch, r.high_water);
+    }
+    if (adopted) {
+        m_fetch_retries = 0;
+        return;
+    }
+    // Sustained churn (reorg/IBD storm pushing faster than we drain): defer to a
+    // debounced retry; the next viewport report resets the budget. Bounded so it
+    // cannot spin forever (the guard above resets m_fetch_in_progress on this exit).
+    if (m_fetch_retries < kMaxFetchRetries) {
+        ++m_fetch_retries;
+        if (m_fetchTimer) {
+            m_fetchTimer->start(kDebounceMs);
         }
     }
-    return QModelIndex();
+}
+
+void DetailedTxModel::sinkDataChanged(int first, int count)
+{
+    const int lastCol = columnCount(QModelIndex()) - 1;
+    emit dataChanged(index(first, 0), index(first + count - 1, lastCol));
 }
 
 void DetailedTxModel::applyEventBatch(const std::vector<GRC::WalletEvent>& events)
 {
     GRC::WalletTxStore& store = m_walletModel->getTxStore();
-    const int lastColumn = columnCount(QModelIndex()) - 1;
     for (const GRC::WalletEvent& ev : events) {
         const uint64_t seqno = ev.seqno;
         std::visit([&](auto&& payload) {
             using P = std::decay_t<decltype(payload)>;
             if constexpr (std::is_same_v<P, GRC::RowsResetPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
-                if (seqno <= m_applied_seqno) return;   // already reflected (PR4-fix B)
-                // Refetch the FULL current served set together with the store's
-                // high-water in one cs_store hold (RowsResult): the slice and the
-                // high-water are mutually consistent, so any worker insert/remove
-                // that landed after this Reset was emitted is captured here exactly
-                // once and is skipped when its own event arrives.
-                beginResetModel();
-                // count = -1: rows + high-water in ONE cs_store hold (RowsResult,
-                // atomic — a separately-locked count could under-fetch a row the
-                // high-water already covered, dropping it permanently). (PR4-fix B)
-                GRC::RowsResult r = store.getRows(GRC::VIEW_DETAILED, 0, -1);
-                m_rows = std::move(r.records);
-                endResetModel();
-                m_applied_seqno = std::max(r.high_water, seqno);
+                if (seqno <= m_cache.structuralSeqno()) return;   // already reflected
+                // Bounded refetch (NOT count=-1): the cache rebuilds its window; the
+                // viewport fetch below fills the actual visible range. applyReset
+                // brackets begin/endReset and sets the structural baseline to
+                // max(high_water, seqno) — capturing any off-window insert/remove that
+                // raced this Reset (PR4-fix B, via RowsResult atomicity).
+                GRC::RowsResult r = store.getRows(GRC::VIEW_DETAILED, 0, kInitialWindow);
+                if (m_cache.applyReset(m_sink, seqno, std::move(r.records), 0,
+                                       r.total_accepted, r.epoch, r.high_water)) {
+                    // The pre-Reset viewport range is meaningless against the rebuilt
+                    // (possibly resized) table; reset it to the top — where a model
+                    // reset scrolls the view — so the re-armed fetch targets a valid
+                    // window. restoreAnchor's scrollTo (or the view's own post-reset
+                    // scroll) then reports the real range and refines it (PR5-B review
+                    // cluster A).
+                    m_pending_first = 0;
+                    m_pending_last = std::max(0, std::min(m_cache.total() - 1,
+                                                          kInitialWindow - 1));
+                    emit viewReset();                    // drives anchor-on-resort
+                    if (m_fetchTimer) m_fetchTimer->start(kDebounceMs);   // refetch visible
+                }
             } else if constexpr (std::is_same_v<P, GRC::RowsInsertedPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
-                if (seqno <= m_applied_seqno) return;   // already reflected in a refetch
-                if (payload.records.empty()) return;  // empty insert → invalid beginInsertRows range
-                const int pos = payload.position;
-                if (pos < 0 || static_cast<std::size_t>(pos) > m_rows.size()) return;
-                beginInsertRows(QModelIndex(), pos,
-                                pos + static_cast<int>(payload.records.size()) - 1);
-                m_rows.insert(m_rows.begin() + pos,
-                              payload.records.begin(), payload.records.end());
-                endInsertRows();
-                m_applied_seqno = seqno;
+                // payload carries the inserted records; the cache gates on seqno,
+                // forwards begin/endInsertRows (before/after growing total) and either
+                // splices into the slice or shifts the cache base.
+                m_cache.applyInsert(m_sink, seqno, payload.position, payload.records);
             } else if constexpr (std::is_same_v<P, GRC::RowsRemovedPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
-                if (seqno <= m_applied_seqno) return;
-                const int pos = payload.position;
-                if (pos < 0 || payload.count <= 0
-                        || static_cast<std::size_t>(pos) + static_cast<std::size_t>(payload.count)
-                               > m_rows.size()) return;
-                beginRemoveRows(QModelIndex(), pos, pos + payload.count - 1);
-                m_rows.erase(m_rows.begin() + pos, m_rows.begin() + pos + payload.count);
-                endRemoveRows();
-                m_applied_seqno = seqno;
+                m_cache.applyRemove(m_sink, seqno, payload.position, payload.count);
             } else if constexpr (std::is_same_v<P, GRC::RowsChangedPayload>) {
                 if (payload.viewId != GRC::VIEW_DETAILED) return;
-                if (seqno <= m_applied_seqno) return;
-                // The payload carries no records (a Change does not move the row),
-                // so re-fetch the changed slice from the cursor and refresh. A
-                // row spans every column, so the dataChanged span is full-width.
+                if (seqno <= m_cache.structuralSeqno()) return;   // skip the wasted getRows
+                // A Change carries no records (no reorder); refetch the changed slice.
                 const std::vector<TransactionRecord> fresh =
                     store.getRows(GRC::VIEW_DETAILED, payload.first, payload.count).records;
-                for (std::size_t i = 0; i < fresh.size()
-                        && static_cast<std::size_t>(payload.first) + i < m_rows.size(); ++i) {
-                    m_rows[static_cast<std::size_t>(payload.first) + i] = fresh[i];
-                }
-                if (!fresh.empty()) {
-                    emit dataChanged(index(payload.first, 0),
-                                     index(payload.first + static_cast<int>(fresh.size()) - 1,
-                                           lastColumn));
-                }
-                m_applied_seqno = seqno;
+                m_cache.applyChange(m_sink, seqno, payload.first, payload.count, fresh);
             }
-            // VIEW_FULL/VIEW_OVERVIEW Rows* events and RowCountChanged are not
-            // consumed here. RowCountChanged signals a served-count change under a
-            // finite cap; PR4 holds the full set (unlimited cap) so it never fires.
-            // PR5's windowed cap will consume it to drive the scrollbar extent.
+            // RowCountChanged / ChainTipChanged / VIEW_FULL / VIEW_OVERVIEW are not
+            // consumed here (the detailed view's cap stays unlimited).
         }, ev.payload);
     }
 }

--- a/src/qt/detailedtxmodel.h
+++ b/src/qt/detailedtxmodel.h
@@ -8,6 +8,7 @@
 #include "qt/transactionrecord.h"
 #include "qt/txfilter.h"
 #include "qt/wallet_event_queue.h"
+#include "qt/windowcache.h"
 #include "uint256.h"
 
 #include <QAbstractTableModel>
@@ -17,21 +18,36 @@
 class WalletModel;
 class TransactionTableModel;
 
+QT_BEGIN_NAMESPACE
+class QTimer;
+QT_END_NAMESPACE
+
 //!
-//! \brief Windowed-model consumer for the detailed transaction-history view (PR4).
+//! \brief Windowed-model consumer for the detailed transaction-history view.
 //!
 //! Replaces the client-side TransactionFilterProxy: it registers a VIEW_DETAILED
 //! cursor in the producer GRC::WalletTxStore (server-side filter + sort, maintained
-//! off cs_main/cs_wallet on the store-worker), holds the cursor's served rows, and
-//! renders through TransactionTableModel::formatRole — so the detailed table reads
-//! identical role values with no formatter duplication. It is the TransactionView's
-//! direct model (no proxy layer): a header click drives sort() → the producer's
-//! setViewSort; the filter UI drives setFilter() → setViewFilter.
+//! off cs_main/cs_wallet on the store-worker) and renders through
+//! TransactionTableModel::formatRole — so the detailed table reads identical role
+//! values with no formatter duplication. It is the TransactionView's direct model
+//! (no proxy): a header click drives sort() → setViewSort; the filter UI drives
+//! setFilter() → setViewFilter.
 //!
-//! PR4 uses an UNLIMITED cursor cap, so this holds the full filtered+sorted replica
-//! (servedCount == totalAccepted). The viewport-slice windowing — where it would
-//! hold only the visible rows — is deferred to PR5; this model's count/limit
-//! mechanics are the same ones OverviewPage proved in PR3.
+//! As of PR5-B this is a VIRTUAL windowed model. The producer cursor cap stays
+//! UNLIMITED (so getRows(first) is an absolute accepted index), but only a
+//! contiguous viewport slice of records is cached here, in a Qt-free
+//! GRC::WindowCache<TransactionRecord>:
+//!   - rowCount() == m_cache.total() — the full accepted count, so the scrollbar
+//!     spans the whole history;
+//!   - data(row) renders m_cache.at(row) via formatRole, or returns a placeholder
+//!     QVariant() for an off-window row (data() is pure — no fetch on the paint path);
+//!   - the STRUCTURAL channel (drained WalletEvents) routes through the cache + a
+//!     nested CacheSink that forwards begin/end{Insert,Remove,Reset}Rows;
+//!   - the CONTENT channel (viewport-driven getRows slice) fills the cache via
+//!     fillContent (epoch + high-water gated; never advances the structural seqno).
+//! TransactionView drives the viewport reporting, selection-ensure and
+//! anchor-on-resort; CSV export and click-through use the producer's getAllRows /
+//! rowForKey (the cache holds only a slice).
 //!
 class DetailedTxModel : public QAbstractTableModel
 {
@@ -52,24 +68,97 @@ public:
     //! Push a new filter spec to the producer cursor (the filter UI calls this).
     void setFilter(const GRC::FilterSpec& spec);
 
-    //! Model index of the first served row whose tx hash is \p hash, or an invalid
-    //! index — maps a click-through (e.g. from OverviewPage) to a row here.
+    //! Model index of the (first part of the) row whose tx hash is \p hash in the
+    //! current filtered+sorted view, or an invalid index if absent/filtered — maps
+    //! a click-through (e.g. from OverviewPage) to a row here. Resolved over the
+    //! producer (store.rowForKey), so it works for ANY accepted row, in or out of
+    //! the cached slice.
     QModelIndex indexForTxid(const uint256& hash) const;
+
+    //! The whole filtered+sorted set in view order (producer getAllRows) — for CSV
+    //! export, which must cover every matching row, not just the cached window.
+    std::vector<TransactionRecord> getAllRows() const;
+
+    //! Accepted-view row of (\p hash, \p idx) or -1 (producer rowForKey). idx < 0 ==
+    //! first part. Backs anchor-on-resort and click-through.
+    int rowForKey(const uint256& hash, int idx = -1) const;
+
+    //! The exact (hash, idx) identity of the cached record at \p row, or false if
+    //! \p row is outside the cached slice. Used to capture a SPECIFIC decomposed
+    //! part for anchor-on-resort: a transaction's parts share one hash but have
+    //! distinct idx/amount/address, so they scatter under an Amount/Address sort —
+    //! anchoring by hash alone (rowForKey idx=-1 → the min-position part) lands on
+    //! the wrong row. Capturing idx lets restoreAnchor return to the EXACT part.
+    bool keyAt(int row, uint256& hash, int& idx) const;
+
+    //! Bring \p row into the cached slice if it is not already (a viewport-sized,
+    //! row-centred fetch) so the selected/operated row is never a placeholder for
+    //! copy / Show details. No-op if already cached. Called by TransactionView at
+    //! selection time and before a context action.
+    void ensureRowCached(int row);
+
+public slots:
+    //! TransactionView reports the visible row range [firstVisible, lastVisible]
+    //! (scroll / resize / show). Coalesced via a single-shot timer; the timeout
+    //! fetches the range + a margin into the cache.
+    void onViewportChanged(int firstVisible, int lastVisible);
+
+signals:
+    //! Emitted after a structural Reset has been applied to the cache (sort/filter/
+    //! reload) — TransactionView restores the resort anchor on it.
+    void viewReset();
 
 private slots:
     //! Apply a drained wallet-event batch; ignores everything not VIEW_DETAILED.
     void applyEventBatch(const std::vector<GRC::WalletEvent>& events);
+    //! Debounced content fetch for the last-reported viewport range.
+    void onFetchTimeout();
 
 private:
+    //! Drain the event queue (so structuralSeqno is current), then fetch
+    //! [first, first+count) into the cache via fillContent. On a (rare) gate
+    //! rejection — a worker push raced the read — re-arm a bounded retry.
+    void fetchWindow(int first, int count);
+
+    //! Forwarders so the nested CacheSink drives our QAbstractItemModel row signals
+    //! from within a DetailedTxModel member (avoids any protected-base access
+    //! subtlety, and keeps the begin/end bracket ownership in the cache).
+    void sinkBeginReset() { beginResetModel(); }
+    void sinkEndReset() { endResetModel(); }
+    void sinkBeginInsert(int first, int count) { beginInsertRows(QModelIndex(), first, first + count - 1); }
+    void sinkEndInsert() { endInsertRows(); }
+    void sinkBeginRemove(int first, int count) { beginRemoveRows(QModelIndex(), first, first + count - 1); }
+    void sinkEndRemove() { endRemoveRows(); }
+    void sinkDataChanged(int first, int count);
+
+    //! Adapter handed to WindowCache: turns its structural callbacks into this
+    //! model's row signals. A member (not a base) because WindowCacheSink's
+    //! dataChanged(int,int) would otherwise overload QAbstractItemModel's
+    //! dataChanged signal — a moc hazard.
+    struct CacheSink : public GRC::WindowCacheSink {
+        explicit CacheSink(DetailedTxModel* model) : m(model) {}
+        DetailedTxModel* m;
+        void beginReset() override { m->sinkBeginReset(); }
+        void endReset() override { m->sinkEndReset(); }
+        void beginInsert(int first, int count) override { m->sinkBeginInsert(first, count); }
+        void endInsert() override { m->sinkEndInsert(); }
+        void beginRemove(int first, int count) override { m->sinkBeginRemove(first, count); }
+        void endRemove() override { m->sinkEndRemove(); }
+        void dataChanged(int first, int count) override { m->sinkDataChanged(first, count); }
+    };
+
     WalletModel* m_walletModel;
-    TransactionTableModel* m_ttm;            //!< formatter source (formatRole/headerData)
-    std::vector<TransactionRecord> m_rows;   //!< served-window replica (full set in PR4)
-    //! Highest store seqno already reflected in m_rows (PR4-fix B). A getRows
-    //! refetch (initial seed or a Reset) reads the store's high-water; any later
-    //! event whose seqno is <= this is already in m_rows and must be skipped, so a
-    //! worker insert/remove that landed between a Reset emission and the refetch is
-    //! never double-applied.
-    uint64_t m_applied_seqno = 0;
+    TransactionTableModel* m_ttm;                 //!< formatter source (formatRole/headerData)
+    GRC::WindowCache<TransactionRecord> m_cache;  //!< viewport slice + virtual rowCount
+    CacheSink m_sink;                             //!< structural-callback adapter
+
+    QTimer* m_fetchTimer = nullptr;               //!< single-shot scroll-fetch debounce
+    int m_pending_first = 0;                      //!< last-reported visible range
+    int m_pending_last = 0;
+    int m_fetch_retries = 0;                      //!< bounded retry on fillContent rejection
+    bool m_fetch_in_progress = false;             //!< reentrancy guard: fetchWindow drains
+                                                  //!< the queue synchronously, so a nested
+                                                  //!< fetch (via an applied event) is skipped
 };
 
 #endif // BITCOIN_QT_DETAILEDTXMODEL_H

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -14,7 +14,10 @@
 #include "qt/decoration.h"
 #include "util/system.h"
 
+#include <QAbstractTableModel>
+#include <QItemSelectionModel>
 #include <QScrollBar>
+#include <QShowEvent>
 #include <QComboBox>
 #include <QDoubleValidator>
 #include <QHBoxLayout>
@@ -192,6 +195,21 @@ void TransactionView::setModel(WalletModel *model)
 
         connect(transactionView->horizontalHeader(), &QHeaderView::sectionResized,
                 this, &TransactionView::txnViewSectionResized);
+
+        // Windowed model (PR5-B): drive the viewport-slice content fetch from scroll
+        // and resize, and capture/restore the resort anchor around a sort/filter
+        // Reset. The selected row is kept cached by the synchronous ensure in the
+        // context actions (copy/Show details) and by the scroll-driven fetch that
+        // follows focusTransaction/restoreAnchor's scrollTo — so there is deliberately
+        // NO currentChanged hook (it would call drainEventQueue from inside a
+        // selection-changed handler, resetting the model mid-notification; PR5-B
+        // review #12).
+        connect(transactionView->verticalScrollBar(), &QScrollBar::valueChanged,
+                this, &TransactionView::reportViewport);
+        connect(transactionView->horizontalHeader(), &QHeaderView::sectionClicked,
+                this, &TransactionView::captureAnchor);
+        connect(m_detailedModel, &DetailedTxModel::viewReset,
+                this, &TransactionView::restoreAnchor);
     }
 
     if (model && model->getOptionsModel()) {
@@ -210,6 +228,40 @@ namespace {
 constexpr int64_t MIN_DATE_SECS = 0;
 constexpr int64_t MAX_DATE_SECS = 0xFFFFFFFF;
 int64_t StartOfDaySecs(const QDate& date) { return GUIUtil::StartOfDay(date).toSecsSinceEpoch(); }
+
+//! Transient read-only model over a full snapshot of the detailed view's rows, used
+//! ONLY for CSV export (PR5-B). The live windowed DetailedTxModel caches just the
+//! viewport, so exporting through it would blank every off-window row; this wraps
+//! the producer's full filtered+sorted set (getAllRows) and reuses
+//! TransactionTableModel::formatRole so the exported values are identical. The
+//! snapshot vector lives only for the export and is freed at scope exit. No Q_OBJECT
+//! needed — CSVModelWriter drives it polymorphically through QAbstractItemModel.
+class ExportRowsModel : public QAbstractTableModel
+{
+public:
+    ExportRowsModel(std::vector<TransactionRecord> rows, TransactionTableModel* ttm)
+        : m_rows(std::move(rows)), m_ttm(ttm) {}
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override
+    {
+        return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+    }
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override
+    {
+        return parent.isValid() ? 0 : m_ttm->columnCount(QModelIndex());
+    }
+    QVariant data(const QModelIndex& index, int role) const override
+    {
+        if (!index.isValid() || index.row() < 0
+                || static_cast<std::size_t>(index.row()) >= m_rows.size()) {
+            return QVariant();
+        }
+        return m_ttm->formatRole(const_cast<TransactionRecord*>(&m_rows[index.row()]),
+                                 index.column(), role);
+    }
+private:
+    std::vector<TransactionRecord> m_rows;
+    TransactionTableModel* m_ttm;
+};
 } // namespace
 
 void TransactionView::chooseDate(int idx)
@@ -290,6 +342,7 @@ void TransactionView::applyFilter()
 {
     if(!m_detailedModel)
         return;
+    captureAnchor();   // preserve the user's row across the filter Reset (PR5-B)
     m_detailedModel->setFilter(m_filterSpec);
 }
 
@@ -305,9 +358,12 @@ void TransactionView::exportClicked()
 
     CSVModelWriter writer(filename);
 
-    // name, column, role. The cursor model exposes the full filtered+sorted set
-    // (unlimited cap in PR4), so export still covers every matching row.
-    writer.setModel(m_detailedModel);
+    // Export the FULL filtered+sorted set, not the live windowed model (which caches
+    // only the viewport slice — exporting through it would blank every off-window
+    // row). The snapshot vector is freed at scope exit (windowed-model PR5-B).
+    ExportRowsModel exportModel(m_detailedModel->getAllRows(),
+                                model->getTransactionTableModel());
+    writer.setModel(&exportModel);
     writer.addColumn(tr("Confirmed"), 0, TransactionTableModel::ConfirmedRole);
     writer.addColumn(tr("Date"), 0, TransactionTableModel::DateRole);
     writer.addColumn(tr("Type"), TransactionTableModel::Type, Qt::EditRole);
@@ -334,21 +390,25 @@ void TransactionView::contextualMenu(const QPoint &point)
 
 void TransactionView::copyAddress()
 {
+    ensureSelectedRowCached();   // the copied row must not be a placeholder (PR5-B)
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::AddressRole);
 }
 
 void TransactionView::copyLabel()
 {
+    ensureSelectedRowCached();
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::LabelRole);
 }
 
 void TransactionView::copyAmount()
 {
+    ensureSelectedRowCached();
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::FormattedAmountRole);
 }
 
 void TransactionView::copyTxID()
 {
+    ensureSelectedRowCached();
     GUIUtil::copyEntryData(transactionView, 0, TransactionTableModel::TxIDRole);
 }
 
@@ -359,6 +419,8 @@ void TransactionView::editLabel()
     QModelIndexList selection = transactionView->selectionModel()->selectedRows();
     if(!selection.isEmpty())
     {
+        // Ensure the row is cached so AddressRole is not an off-window placeholder (PR5-B).
+        if (m_detailedModel) m_detailedModel->ensureRowCached(selection.at(0).row());
         AddressTableModel *addressBook = model->getAddressTableModel();
         if(!addressBook)
             return;
@@ -405,6 +467,9 @@ void TransactionView::showDetails()
     QModelIndexList selection = transactionView->selectionModel()->selectedRows();
     if(!selection.isEmpty())
     {
+        // Ensure the row is cached so its LongDescriptionRole is the real HTML, not
+        // an off-window placeholder's empty dialog (PR5-B).
+        if (m_detailedModel) m_detailedModel->ensureRowCached(selection.at(0).row());
         TransactionDescDialog dlg(selection.at(0));
         dlg.exec();
     }
@@ -470,6 +535,96 @@ void TransactionView::focusTransaction(const QModelIndex &idx)
     transactionView->scrollTo(targetIdx);
     transactionView->setCurrentIndex(targetIdx);
     transactionView->setFocus();
+}
+
+void TransactionView::reportViewport()
+{
+    if (!m_detailedModel || !transactionView->model()) return;
+    // rowAt() returns -1 before first layout and for the empty strip below the last
+    // row. Bail when the top is not laid out yet — the bounded ctor seed covers the
+    // pre-layout window, and a later scroll/resize reports once geometry exists.
+    // NEVER derive `last` from rowCount() unless the top is valid, or a pre-layout
+    // report would request the whole table (PR5-B review GAP #1).
+    const int first = transactionView->rowAt(0);
+    if (first < 0) return;
+    int last = transactionView->rowAt(transactionView->viewport()->height() - 1);
+    if (last < 0) {
+        // Content shorter than the viewport: safe to clamp to the last row.
+        last = m_detailedModel->rowCount() - 1;
+    }
+    if (last < first) last = first;
+    m_detailedModel->onViewportChanged(first, last);
+}
+
+void TransactionView::captureAnchor()
+{
+    m_have_anchor = false;
+    if (!m_detailedModel || !transactionView->selectionModel()) return;
+    // Prefer the current index; fall back to the topmost visible row.
+    QModelIndex idx = transactionView->selectionModel()->currentIndex();
+    if (!idx.isValid()) {
+        const int top = transactionView->rowAt(0);
+        if (top < 0) return;
+        idx = m_detailedModel->index(top, 0);
+    }
+    // The anchor row may be a placeholder (just scrolled/clicked, not yet fetched);
+    // ensure it synchronously so its record is readable — otherwise a resort right
+    // after a click-through / scroll would capture nothing and fail to restore the
+    // selection (PR5-B review). captureAnchor runs in a non-drain user-action context
+    // (header click / filter widget), so the synchronous ensure is safe.
+    m_detailedModel->ensureRowCached(idx.row());
+    // Capture the EXACT (hash, idx) of the selected part, not just the hash: a tx's
+    // decomposed parts share the hash but scatter under an Amount/Address sort, so a
+    // hash-only anchor (rowForKey idx=-1 -> the min-position part) would restore to
+    // the wrong row (PR5-B soak finding).
+    uint256 anchor_hash;
+    int anchor_idx = -1;
+    if (!m_detailedModel->keyAt(idx.row(), anchor_hash, anchor_idx)) {
+        return;   // still a placeholder (filtered/empty) — no anchor
+    }
+    m_anchor_hash = anchor_hash;
+    m_anchor_idx = anchor_idx;
+    m_have_anchor = true;
+}
+
+void TransactionView::restoreAnchor()
+{
+    if (!m_have_anchor || !m_detailedModel) return;
+    m_have_anchor = false;
+    const int row = m_detailedModel->rowForKey(m_anchor_hash, m_anchor_idx);
+    if (row < 0) {
+        // Anchor filtered out / gone after the resort: keep the current scroll, but
+        // refresh the model's pending viewport from the post-Reset geometry so its
+        // re-armed fetch targets the right window instead of a stale pre-Reset range
+        // (PR5-B review cluster A).
+        reportViewport();
+        return;
+    }
+    const QModelIndex idx = m_detailedModel->index(row, 0);
+    // scrollTo moves the viewport to the anchor; setCurrentIndex re-selects it.
+    transactionView->scrollTo(idx, QAbstractItemView::PositionAtCenter);
+    transactionView->setCurrentIndex(idx);
+    // Explicitly refresh the pending viewport from the post-scroll geometry: scrollTo
+    // usually fires valueChanged -> reportViewport, but NOT if the scroll position is
+    // unchanged (anchor already centred) — so call it directly to guarantee the
+    // re-armed fetch targets the anchor region, not the post-Reset top (PR5-B review).
+    // (A copy / Show details on the anchor re-ensures synchronously.)
+    reportViewport();
+}
+
+void TransactionView::ensureSelectedRowCached()
+{
+    if (!m_detailedModel || !transactionView->selectionModel()) return;
+    const QModelIndexList sel = transactionView->selectionModel()->selectedRows();
+    if (!sel.isEmpty()) m_detailedModel->ensureRowCached(sel.at(0).row());
+}
+
+void TransactionView::showEvent(QShowEvent *event)
+{
+    QFrame::showEvent(event);
+    // First real geometry after layout: fetch the actually-visible window (the
+    // bounded ctor seed only covers a pre-layout guess).
+    reportViewport();
 }
 
 void TransactionView::updateIcons(const QString& theme)
@@ -555,6 +710,8 @@ void TransactionView::resizeEvent(QResizeEvent *event)
     resizeTableColumns();
 
     QWidget::resizeEvent(event);
+
+    reportViewport();   // the visible row count changed; refetch the window (PR5-B)
 }
 
 void TransactionView::txnViewSectionResized(int index, int old_size, int new_size)

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -14,6 +14,9 @@
 #include "qt/decoration.h"
 #include "util/system.h"
 
+#include <algorithm>
+#include <limits>
+
 #include <QAbstractTableModel>
 #include <QItemSelectionModel>
 #include <QScrollBar>
@@ -243,7 +246,12 @@ public:
         : m_rows(std::move(rows)), m_ttm(ttm) {}
     int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
-        return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+        if (parent.isValid()) return 0;
+        // Saturate the size_t->int cast (consistent with getRows/getAllRows): a CSV
+        // export can never exceed 2^31 rows, but a saturating cast keeps the count
+        // well-defined for CSVModelWriter rather than wrapping negative (Copilot PR5-B).
+        return static_cast<int>(std::min<std::size_t>(
+            m_rows.size(), static_cast<std::size_t>(std::numeric_limits<int>::max())));
     }
     int columnCount(const QModelIndex& parent = QModelIndex()) const override
     {

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -2,6 +2,7 @@
 #define BITCOIN_QT_TRANSACTIONVIEW_H
 
 #include "qt/txfilter.h"
+#include "uint256.h"
 
 #include <QFrame>
 
@@ -16,6 +17,7 @@ class QModelIndex;
 class QMenu;
 class QFrame;
 class QDateTimeEdit;
+class QShowEvent;
 
 QT_END_NAMESPACE
 
@@ -44,6 +46,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 private:
     WalletModel *model;
@@ -55,8 +58,25 @@ private:
     GRC::FilterSpec m_filterSpec;
 
     //! Push m_filterSpec to the cursor (the date/type/address/amount handlers
-    //! mutate the relevant field, then call this).
+    //! mutate the relevant field, then call this). Captures the resort anchor first.
     void applyFilter();
+
+    //! Ensure the currently selected row is cached before a copy / Show details so
+    //! it is never a placeholder under the windowed model (PR5-B GAP #3).
+    void ensureSelectedRowCached();
+
+    //! The resort anchor: the EXACT (hash, idx) of the (current, else
+    //! topmost-visible) row captured before a sort/filter Reset, re-found +
+    //! re-selected by restoreAnchor() after the model's viewReset, so the list
+    //! reorders around the user's row instead of jumping to the top (PR5-B). idx
+    //! (the decomposed-part index) is essential: a tx's parts share the hash but
+    //! scatter under an Amount/Address sort, so a hash-only anchor would restore to
+    //! the wrong part. Multi-row selection is not preserved across a resort (the
+    //! Reset invalidates persistent indexes) — a minor regression vs the old proxy,
+    //! but strictly better than PR4 which lost all selection + scrolled to the top.
+    uint256 m_anchor_hash;
+    int m_anchor_idx = -1;
+    bool m_have_anchor = false;
 
     QComboBox *dateWidget;
     QComboBox *typeWidget;
@@ -86,6 +106,14 @@ private slots:
     void copyTxID();
     void updateIcons(const QString& theme);
     void txnViewSectionResized(int index, int old_size, int new_size);
+
+    //! Report the visible row range [rowAt(0), rowAt(bottom)] to the windowed model
+    //! so it fetches that slice (PR5-B). Bails if the table is not yet laid out
+    //! (rowAt returns -1), so a pre-layout report can never request the whole table.
+    void reportViewport();
+    //! Capture / restore the resort anchor around a sort/filter Reset.
+    void captureAnchor();
+    void restoreAnchor();
 
 signals:
     void doubleClicked(const QModelIndex&);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -166,6 +166,17 @@ void WalletModel::checkBalanceChanged()
 
 void WalletModel::drainEventQueue()
 {
+    // Reentrancy guard (PR5-B): a windowed consumer's fetch path calls this
+    // synchronously, and applying a Reset can re-enter via viewReset ->
+    // restoreAnchor -> setCurrentIndex. A nested call no-ops — the outer drain owns
+    // the queue, so events are applied exactly once and in order. The RAII reset
+    // also keeps an exception in any apply* from wedging the flag.
+    if (m_draining) {
+        return;
+    }
+    m_draining = true;
+    struct DrainGuard { bool& f; ~DrainGuard() { f = false; } } drain_guard{m_draining};
+
     // Any drain (periodic, backlog re-arm, or a requestEventDrainSoon kick) satisfies
     // a pending user-requested drain, so clear the coalescing flag up front: a fresh
     // request that arrives after this point schedules a new kick (PR4-fix D).

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -183,6 +183,14 @@ private:
     //! (e.g. per-keystroke filter changes) collapses to one drain. Qt-thread only.
     bool m_event_drain_requested = false;
 
+    //! Reentrancy guard for drainEventQueue() (windowed-model PR5-B): true while a
+    //! drain is applying events. A windowed consumer's synchronous fetch path
+    //! (DetailedTxModel::fetchWindow) calls drainEventQueue(), and applying a Reset
+    //! can synchronously re-enter (viewReset -> restoreAnchor -> setCurrentIndex ->
+    //! ...). A nested call no-ops so the outer drain owns the queue and events are
+    //! never double-processed. Qt-thread only.
+    bool m_draining = false;
+
     //!
     //! \brief MPSC queue carrying producer-side wallet events to the GUI.
     //! Producers push under the locks they already hold; the consumer is

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -789,7 +789,10 @@ RowsResult WalletTxStore::getAllRows(int viewId)
     res.high_water = (sit == m_view_seqno.end()) ? 0 : sit->second;
     // CAP-INDEPENDENT: iterate the full accepted set, not the served window, so a
     // CSV export is never silently truncated by a finite cap (windowed-model PR5-B).
-    const std::size_t n = cur.totalAccepted();
+    // Bound the row count to the same INT_MAX clamp as total_accepted: a wallet can
+    // never hold 2^31 rows, but keeping records.size() == total_accepted avoids a huge
+    // over-allocation and an int-unrepresentable count if it ever did (Copilot PR5-B).
+    const std::size_t n = static_cast<std::size_t>(res.total_accepted);
     res.records.reserve(n);
     for (std::size_t i = 0; i < n; ++i) {
         res.records.push_back(m_records[cur.rowAt(i)]);
@@ -821,7 +824,12 @@ int WalletTxStore::rowForKey(int viewId, const uint256& hash, int idx)
         const std::size_t pos = cur.positionOf(absidx);
         if (pos != NPOS && pos < best) best = pos;
     }
-    return (best == NPOS) ? -1 : static_cast<int>(best);
+    // Guard the size_t->int cast: a position beyond INT_MAX is not representable as a
+    // Qt row, so treat it as not-found (Copilot PR5-B). Unreachable at real wallet sizes.
+    if (best == NPOS || best > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        return -1;
+    }
+    return static_cast<int>(best);
 }
 
 void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -771,6 +771,59 @@ RowsResult WalletTxStore::getRows(int viewId, int first, int count)
     return res;
 }
 
+RowsResult WalletTxStore::getAllRows(int viewId)
+{
+    LOCK(cs_store);
+    RowsResult res;
+    auto it = m_cursors.find(viewId);
+    if (it == m_cursors.end()) {
+        return res;   // unknown view: empty, zero metadata (matches getRows)
+    }
+    const Cursor& cur = it->second;
+    // Same atomic metadata sampling as getRows (one cs_store hold).
+    res.total_accepted = static_cast<int>(
+        std::min<std::size_t>(cur.totalAccepted(),
+                              static_cast<std::size_t>(std::numeric_limits<int>::max())));
+    res.epoch = cur.epoch();
+    auto sit = m_view_seqno.find(viewId);
+    res.high_water = (sit == m_view_seqno.end()) ? 0 : sit->second;
+    // CAP-INDEPENDENT: iterate the full accepted set, not the served window, so a
+    // CSV export is never silently truncated by a finite cap (windowed-model PR5-B).
+    const std::size_t n = cur.totalAccepted();
+    res.records.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        res.records.push_back(m_records[cur.rowAt(i)]);
+    }
+    return res;
+}
+
+int WalletTxStore::rowForKey(int viewId, const uint256& hash, int idx)
+{
+    LOCK(cs_store);
+    auto cit = m_cursors.find(viewId);
+    if (cit == m_cursors.end()) {
+        return -1;
+    }
+    const Cursor& cur = cit->second;
+    constexpr std::size_t NPOS = static_cast<std::size_t>(-1);
+    // Resolve hash -> absolute record index(es) via m_by_hash, then the accepted
+    // row via Cursor::positionOf. idx < 0 -> first part: the MIN accepted row across
+    // all parts of the tx (old indexForTxid hash-only semantics). positionOf is a
+    // value scan over view_index, so this tolerates a (defensive) de-clustered index
+    // and triggers no projector evaluation.
+    std::size_t best = NPOS;
+    auto range = m_by_hash.equal_range(hash);
+    for (auto it = range.first; it != range.second; ++it) {
+        const std::size_t absidx = it->second;
+        if (idx >= 0) {
+            if (absidx >= m_records.size() || m_records[absidx].idx != idx) continue;
+        }
+        const std::size_t pos = cur.positionOf(absidx);
+        if (pos != NPOS && pos < best) best = pos;
+    }
+    return (best == NPOS) ? -1 : static_cast<int>(best);
+}
+
 void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,
                                      const std::vector<CursorDelta>& deltas)
 {

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -189,6 +189,23 @@ public:
     //! Reset refetch and the PR5 scroll fetch — see \ref RowsResult.
     RowsResult getRows(int viewId, int first, int count);
 
+    //! Qt thread: ALL accepted rows of \p viewId in view order, plus the same
+    //! metadata as getRows, under ONE cs_store hold. CAP-INDEPENDENT — iterates the
+    //! full accepted set (totalAccepted), not the served window — so a CSV export
+    //! covers every matching row even if a finite served cap is ever introduced
+    //! (windowed-model PR5-B; the detailed view's cap stays unlimited today, so this
+    //! equals getRows(viewId,0,-1), but the contract is the distinction).
+    RowsResult getAllRows(int viewId);
+
+    //! Qt thread: the accepted-view row of the record identified by (\p hash,
+    //! \p idx), or -1 if the key is absent, filtered out, or the view is unknown.
+    //! \p idx < 0 matches the FIRST part of the transaction — the lowest accepted
+    //! row across all parts sharing \p hash — reproducing the old indexForTxid
+    //! hash-only semantics. Resolves \p hash via m_by_hash to absolute record
+    //! indices, then Cursor::positionOf to the accepted row. Backs click-through and
+    //! anchor-on-resort (windowed-model PR5-B). Pure read; no projector calls.
+    int rowForKey(int viewId, const uint256& hash, int idx = -1);
+
     //!
     //! \brief Qt thread: rebuild the store from the wallet and return a full
     //! decomposed snapshot for the consumer's replica.

--- a/src/test/qt_cursor_tests.cpp
+++ b/src/test/qt_cursor_tests.cpp
@@ -438,4 +438,27 @@ BOOST_AUTO_TEST_CASE(position_of_maps_absidx_to_accepted_row_or_npos)
     BOOST_CHECK(c.positionOf(42) == NPOS);    // absent -> npos
 }
 
+BOOST_AUTO_TEST_CASE(position_of_multipart_same_key_distinct_rows)
+{
+    // The store's rowForKey resolves a tx's multiple decomposed parts (same hash,
+    // contiguous absidx) to accepted rows via positionOf, taking the MIN for idx<0.
+    // The GUI-OFF-provable engine behind it: distinct absidx -> distinct accepted
+    // rows, and parts sharing a sort key fall in native-index order (the tie-break).
+    constexpr std::size_t NPOS = static_cast<std::size_t>(-1);
+    Table t;
+    // abs 0,1,2 share time=500 (one tx's three parts); abs 3 is a later-time tx.
+    t.rows = { active(500), active(500), active(500), active(900) };
+    Cursor c(1, FilterSpec{}, TXCOL_DATE, TXSORT_DESC, t.fields(), t.keys());
+    c.rebuild(t.rows.size());
+    // DESC by time: 900(abs3) first, then the three 500-parts in native order 0,1,2.
+    BOOST_REQUIRE_EQUAL(c.viewIndex().size(), 4u);
+    BOOST_CHECK_EQUAL(c.positionOf(3), 0u);
+    BOOST_CHECK_EQUAL(c.positionOf(0), 1u);
+    BOOST_CHECK_EQUAL(c.positionOf(1), 2u);
+    BOOST_CHECK_EQUAL(c.positionOf(2), 3u);
+    // rowForKey(idx<0) takes the MIN accepted position across the parts -> abs0, row 1.
+    BOOST_CHECK_EQUAL(std::min({c.positionOf(0), c.positionOf(1), c.positionOf(2)}), 1u);
+    BOOST_CHECK(c.positionOf(7) == NPOS);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_windowcache_tests.cpp
+++ b/src/test/qt_windowcache_tests.cpp
@@ -477,4 +477,62 @@ BOOST_AUTO_TEST_CASE(change_short_fresh_refreshes_what_it_has_and_advances_seqno
     BOOST_CHECK_EQUAL(s.ops[0].count, 1);                               // only the refreshed row
 }
 
+BOOST_AUTO_TEST_CASE(consumer_routing_scenario)
+{
+    // Mirror DetailedTxModel::applyEventBatch's exact call sequence against the cache
+    // + sink, pinning the windowed consumer's structural/content routing end to end
+    // (the model shell itself is not GUI-OFF-testable; this is its reconcilable core).
+    WindowCache<Rec> c;
+    RecSink s; s.cache = &c;
+
+    // ctor seed: bounded window [0,5) of a 50-row table, epoch 1, high-water 10.
+    c.seedInitial(seq(0, 5), 0, 50, /*epoch*/1, /*high_water*/10);
+    BOOST_CHECK_EQUAL(c.total(), 50);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 10u);
+
+    // RowsInserted at the top (a fresh tx): payload carries the record.
+    BOOST_CHECK(c.applyInsert(s, 11, /*pos*/0, recs({100})));
+    BOOST_CHECK_EQUAL(c.total(), 51);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 11u);
+    check_slice(c, 0, {100, 0, 1, 2, 3, 4});
+
+    // RowsRemoved off-window (below the cache): total shrinks, window unchanged.
+    BOOST_CHECK(c.applyRemove(s, 12, /*pos*/40, /*count*/2));
+    BOOST_CHECK_EQUAL(c.total(), 49);
+    check_slice(c, 0, {100, 0, 1, 2, 3, 4});
+
+    // RowsChanged in-window: the consumer fetched `fresh`; refresh row 2.
+    BOOST_CHECK(c.applyChange(s, 13, /*pos*/2, /*count*/1, recs({222})));
+    check_slice(c, 0, {100, 0, 222, 2, 3, 4});
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 13u);
+
+    // Stale / duplicate deltas (seqno <= structural): skipped, no signals.
+    s.clear();
+    BOOST_CHECK(!c.applyInsert(s, 13, 0, recs({999})));
+    BOOST_CHECK(!c.applyRemove(s, 5, 0, 1));
+    BOOST_CHECK_EQUAL(c.total(), 49);
+    BOOST_CHECK(s.ops.empty());
+
+    // CONTENT fetch that raced an insert/remove (high-water 12 != structural 13): drop.
+    BOOST_CHECK(!c.fillContent(s, /*first*/20, seq(20, 6), /*epoch*/1, /*high_water*/12));
+    // CONTENT fetch that raced a resort (epoch 0 != 1): drop.
+    BOOST_CHECK(!c.fillContent(s, 20, seq(20, 6), /*epoch*/0, 13));
+    BOOST_CHECK_EQUAL(c.cacheFirst(), 0);   // still the original window
+    BOOST_CHECK(s.ops.empty());
+
+    // CONTENT fetch that matches (epoch 1, high-water 13): adopted; structural untouched.
+    BOOST_CHECK(c.fillContent(s, /*first*/20, seq(20, 6), /*epoch*/1, /*high_water*/13));
+    check_slice(c, 20, {20, 21, 22, 23, 24, 25});
+    BOOST_CHECK_EQUAL(c.total(), 49);            // content never changes the count
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 13u); // content never advances the seqno
+
+    // A structural Reset (sort/filter) with a fresh epoch: rebuild + new baseline.
+    BOOST_CHECK(c.applyReset(s, /*seqno*/14, seq(0, 5), 0, /*total*/49, /*epoch*/2, /*hw*/14));
+    BOOST_CHECK_EQUAL(c.epoch(), 2u);
+    BOOST_CHECK_EQUAL(c.structuralSeqno(), 14u);
+    check_slice(c, 0, {0, 1, 2, 3, 4});
+    // A content fetch from the OLD epoch is now rejected.
+    BOOST_CHECK(!c.fillContent(s, 20, seq(20, 6), /*epoch*/1, 14));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

PR5-B (the high-risk, user-visible rung of the windowed transaction-table stack) migrates the detailed `TransactionView` from a full filtered+sorted replica to a **virtual windowed model** backed by the Qt-free `GRC::WindowCache<TransactionRecord>` landed in PR5-A (#3023).

The producer cursor cap stays **unlimited**, so `getRows(first)` is an absolute accepted index and the store read path is unchanged; only a contiguous viewport slice is held GUI-side. `rowCount() == cache.total()` (full-height scrollbar); `data(row)` renders the cached slice or a placeholder; off-window rows are fetched on demand. The in-process win is **latency + getting the Qt thread off the wallet locks** (the 80MB→50KB memory win lands at the #2937 multiprocess split, when the store is node-side).

## Changes

- **Store:** `getAllRows(viewId)` (cap-independent full set, for CSV) and `rowForKey(viewId, hash, idx=-1)` (accepted row of a key, via `m_by_hash` → `Cursor::positionOf`).
- **`DetailedTxModel`:** `WindowCache` replaces the replica; a nested `CacheSink` forwards structural callbacks to `begin/end{Insert,Remove,Reset}Rows`; `applyEventBatch` routes deltas through the cache (which owns the seqno gate); a debounced viewport-driven content channel fetches slices via `fillContent` (epoch + high-water gated).
- **`TransactionView`:** viewport reporting via `rowAt()` (bails pre-layout so it can never request the whole table); CSV export through a transient snapshot model over `getAllRows`; click-through via `rowForKey`; **anchor-on-resort** that captures + restores the exact `(hash, idx)` of the selected row (a tx's decomposed parts share one hash but scatter under an Amount/Address sort, so a hash-only anchor would land on the wrong part).

## Testing

- **GUI-off** (`test_gridcoin`, runs in CI's ENABLE_GUI=OFF config): new `qt_windowcache_tests` (the two-channel structural/content reconciliation + cache-base arithmetic) and a multi-part `positionOf` case in `qt_cursor_tests`.
- Two adversarial-review rounds; surviving findings fixed (exception-safe fetch/drain guards, reentrancy guard on `drainEventQueue`, synchronous bounded fetch so a copied row isn't a placeholder, stale-pending-after-Reset clamp, `ensureRowCached` cover-both).
- **ASan/UBSan-GUI mesh soak** on an isolated heavy-stake testnet wallet: windowing correct, **Address sort now fast** (was very slow pre-windowing), clean resize/scroll, and anchor-on-resort holding on every column in both directions. (CI's sanitizer job is GUI-off, so the model/view shell is covered by this manual soak.)

Stacked on #3023 (PR5-A). The small lock-path retirement (route `describe()` through a producer `getRowDetail`, delete the lazy `index()` `TRY_LOCK`) follows as PR5-C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)