### PR TITLE
qt: retire the lazy render-thread lock path; producer-side tx detail (windowed-model PR5-C)

### DIFF
--- a/src/qt/test/wallettxstore_tests.cpp
+++ b/src/qt/test/wallettxstore_tests.cpp
@@ -150,3 +150,36 @@ void WalletTxStoreTests::dtorWithPendingIntakeIsClean()
     } // store dtor here: stop + join. If it hung, this test would never return.
     QVERIFY(true);
 }
+
+void WalletTxStoreTests::getRowDetailUnknownHashReturnsEmpty()
+{
+    WalletEventQueue q;
+    // Null wallet is safe: an unknown hash finds no m_by_hash entry, so
+    // getRowDetail returns under cs_store before reaching the LOCK2(cs_main,
+    // cs_wallet) / mapWallet path that would dereference the wallet (PR5-C).
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    // Empty store, query a hash that was never inserted.
+    QVERIFY(store.getRowDetail(hashOf(99), 0).isEmpty());
+    // idx < 0 (first-part fallback) on an absent hash is equally a miss.
+    QVERIFY(store.getRowDetail(hashOf(99), -1).isEmpty());
+}
+
+void WalletTxStoreTests::getRowDetailWrongIdxReturnsEmpty()
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    // Insert a single-part record (idx 0). After the worker applies it, m_by_hash
+    // holds h, but a query for a DIFFERENT part index matches no record, so
+    // getRowDetail returns empty WITHOUT taking the wallet locks — null-wallet
+    // safe. (A query for the real idx 0 would proceed to toHTML and need a live
+    // wallet, so that path is GUI-soak-only.)
+    const uint256 h = hashOf(7);
+    store.enqueueInsert(std::vector<TransactionRecord>{makeRec(h, 1000, 0)});
+    waitForQueue(q, 1);
+
+    QVERIFY(store.getRowDetail(h, 5).isEmpty());
+}

--- a/src/qt/test/wallettxstore_tests.cpp
+++ b/src/qt/test/wallettxstore_tests.cpp
@@ -180,6 +180,12 @@ void WalletTxStoreTests::getRowDetailWrongIdxReturnsEmpty()
     const uint256 h = hashOf(7);
     store.enqueueInsert(std::vector<TransactionRecord>{makeRec(h, 1000, 0)});
     waitForQueue(q, 1);
+    // The RowsInserted event is pushed AFTER the store mutation, so a queued event
+    // proves h is in m_by_hash. Assert it explicitly: otherwise, if the insert were
+    // never applied, getRowDetail would return empty for the WRONG reason (unknown
+    // hash) and this test would still pass without exercising the wrong-idx path
+    // (Copilot review, PR5-C).
+    QVERIFY(q.size() >= 1);
 
     QVERIFY(store.getRowDetail(h, 5).isEmpty());
 }

--- a/src/qt/test/wallettxstore_tests.h
+++ b/src/qt/test/wallettxstore_tests.h
@@ -24,6 +24,13 @@ private slots:
     void workerHandlesInterleavedInsertRemove();
     void workerPreservesAllUnderConcurrentProducers();
     void dtorWithPendingIntakeIsClean();
+    //! getRowDetail (windowed-model PR5-C): the null-wallet-safe early-return
+    //! paths — an unknown hash and a known hash with a non-matching idx both
+    //! return an empty QString under cs_store BEFORE any wallet dereference. The
+    //! matching-key -> toHTML path needs a live CWallet/cs_main and is covered by
+    //! the GUI mesh soak.
+    void getRowDetailUnknownHashReturnsEmpty();
+    void getRowDetailWrongIdxReturnsEmpty();
 };
 
 #endif // BITCOIN_QT_TEST_WALLETTXSTORE_TESTS_H

--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -1,23 +1,23 @@
 #include "qt/decoration.h"
 #include "transactiondescdialog.h"
-#include "transactiontablemodel.h"
 #include "ui_transactiondescdialog.h"
 #include "main.h"
 #include "util.h"
 #include <QMessageBox>
-#include <QModelIndex>
 
 QString ToQString(std::string s);
 
-TransactionDescDialog::TransactionDescDialog(const QModelIndex &idx, QWidget *parent) :
+TransactionDescDialog::TransactionDescDialog(const QString& html, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::TransactionDescDialog)
 {
     ui->setupUi(this);
     resize(GRC::ScaleSize(this, width(), height()));
 
-    QString desc = idx.data(TransactionTableModel::LongDescriptionRole).toString();
-    ui->detailText->setHtml(desc);
+    // Detail HTML is rendered producer-side by WalletTxStore::getRowDetail
+    // (windowed-model PR5-C); an empty result means the tx is no longer in the
+    // wallet (or the key was stale), so show a plain fallback rather than a blank.
+    ui->detailText->setHtml(html.isEmpty() ? tr("Transaction details unavailable.") : html);
 }
 
 TransactionDescDialog::~TransactionDescDialog()

--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -1,11 +1,6 @@
 #include "qt/decoration.h"
 #include "transactiondescdialog.h"
 #include "ui_transactiondescdialog.h"
-#include "main.h"
-#include "util.h"
-#include <QMessageBox>
-
-QString ToQString(std::string s);
 
 TransactionDescDialog::TransactionDescDialog(const QString& html, QWidget *parent) :
     QDialog(parent),

--- a/src/qt/transactiondescdialog.h
+++ b/src/qt/transactiondescdialog.h
@@ -2,13 +2,11 @@
 #define BITCOIN_QT_TRANSACTIONDESCDIALOG_H
 
 #include <QDialog>
+#include <QString>
 
 namespace Ui {
     class TransactionDescDialog;
 }
-QT_BEGIN_NAMESPACE
-class QModelIndex;
-QT_END_NAMESPACE
 
 /** Dialog showing transaction details. */
 class TransactionDescDialog : public QDialog
@@ -16,7 +14,11 @@ class TransactionDescDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TransactionDescDialog(const QModelIndex& idx, QWidget* parent = nullptr);
+    //! \p html is the pre-rendered transaction-detail HTML produced
+    //! producer-side by WalletTxStore::getRowDetail (windowed-model PR5-C). The
+    //! dialog no longer reaches back through a model role to format detail, so it
+    //! has no dependency on TransactionTableModel.
+    explicit TransactionDescDialog(const QString& html, QWidget* parent = nullptr);
     ~TransactionDescDialog();
 
 private:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -2,7 +2,6 @@
 #include "guiutil.h"
 #include "transactionrecord.h"
 #include "guiconstants.h"
-#include "transactiondesc.h"
 #include "walletmodel.h"
 #include "optionsmodel.h"
 #include "addresstablemodel.h"
@@ -200,52 +199,23 @@ public:
         return static_cast<int>(cachedWallet.size());
     }
 
+    // Returns the cached record for replica row \p idx (backs indexForTxid ->
+    // OverviewPage click-through). NO lazy status refresh: status is computed
+    // producer-side — on insert under cs_main (walletmodel.cpp, before enqueue)
+    // and per-block via WalletTxStore::applyChainTipRefresh — so the Qt render
+    // and click-through threads never touch cs_main / cs_wallet here
+    // (windowed-model PR5-C; the detail dialog now formats via
+    // WalletTxStore::getRowDetail on the producer).
     TransactionRecord *index(int idx)
     {
         if(idx >= 0 && static_cast<std::size_t>(idx) < cachedWallet.size())
         {
-            TransactionRecord *rec = &cachedWallet[idx];
-
-            // Get required locks upfront. This avoids the GUI from getting
-            // stuck if the core is holding the locks for a longer time - for
-            // example, during a wallet rescan.
-            //
-            // If a status update is needed (blocks came in since last check),
-            //  update the status of this transaction from the wallet. Otherwise,
-            // simply reuse the cached status.
-            TRY_LOCK(cs_main, lockMain);
-            if(lockMain)
-            {
-                TRY_LOCK(wallet->cs_wallet, lockWallet);
-                if(lockWallet && rec->statusUpdateNeeded())
-                {
-                    std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
-
-                    if(mi != wallet->mapWallet.end())
-                    {
-                        rec->updateStatus(mi->second);
-                    }
-                }
-            }
-            return rec;
+            return &cachedWallet[idx];
         }
         else
         {
             return nullptr;
         }
-    }
-
-    QString describe(TransactionRecord *rec)
-    {
-        {
-            LOCK2(cs_main, wallet->cs_wallet);
-            std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
-            if(mi != wallet->mapWallet.end())
-            {
-                return TransactionDesc::toHTML(wallet, mi->second, rec->vout);
-            }
-        }
-        return QString("");
     }
 
 };
@@ -286,10 +256,18 @@ void TransactionTableModel::updateConfirmations()
 {
     LogPrint(BCLog::MISC, "TransactionTableModel::updateConfirmations()");
 
-    // Blocks came in since last poll.
-    // Invalidate status (number of confirmations) and (possibly) description
-    //  for all rows. Qt is smart enough to only actually request the data for the
-    //  visible rows.
+    // Blocks came in since last poll: invalidate the Status (confirmation count)
+    // and ToAddress columns for all rows.
+    //
+    // NOTE (windowed-model PR5-C): this dataChanged is currently OBSERVERLESS — no
+    // view binds TransactionTableModel as its model (the views are DetailedTxModel /
+    // OverviewTxModel, refreshed by their own producer event stream; only
+    // BitcoinGUI consumes TTM's rowsInserted, not dataChanged). It is kept as the
+    // model-correct signal should TTM ever be re-attached as a view model. If it is,
+    // note that index() no longer self-refreshes status from the wallet (the lazy
+    // TRY_LOCK was removed in PR5-C); status is computed producer-side on insert and
+    // refreshed per-block via WalletTxStore::applyChainTipRefresh, so a re-wire must
+    // rely on that producer path, not on a paint-thread refresh.
     emit dataChanged(index(0, Status), index(priv->size()-1, Status));
     emit dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
 }
@@ -787,8 +765,6 @@ QVariant TransactionTableModel::formatRole(TransactionRecord *rec, int columnInt
         return rec->type;
     case DateRole:
         return QDateTime::fromSecsSinceEpoch(rec->time);
-    case LongDescriptionRole:
-        return priv->describe(rec);
     case AddressRole:
         return QString::fromStdString(rec->address);
     case LabelRole:

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -40,8 +40,6 @@ public:
         TypeRole = Qt::UserRole,
         /** Date and time this transaction was created */
         DateRole,
-        /** Long description (HTML format) */
-        LongDescriptionRole,
         /** Address of transaction */
         AddressRole,
         /** Label of address related to transaction */

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -3,6 +3,7 @@
 #include "detailedtxmodel.h"
 #include "transactionrecord.h"
 #include "walletmodel.h"
+#include "qt/wallettxstore.h"
 #include "addresstablemodel.h"
 #include "transactiontablemodel.h"
 #include "bitcoinunits.h"
@@ -473,13 +474,24 @@ void TransactionView::showDetails()
     if(!transactionView->selectionModel())
         return;
     QModelIndexList selection = transactionView->selectionModel()->selectedRows();
-    if(!selection.isEmpty())
+    if(!selection.isEmpty() && model && m_detailedModel)
     {
-        // Ensure the row is cached so its LongDescriptionRole is the real HTML, not
-        // an off-window placeholder's empty dialog (PR5-B).
-        if (m_detailedModel) m_detailedModel->ensureRowCached(selection.at(0).row());
-        TransactionDescDialog dlg(selection.at(0));
-        dlg.exec();
+        const int row = selection.at(0).row();
+        // Sync the consumer cache to the producer cursor, then read the clicked
+        // row's identity (hash, idx) from our OWN cache — the user-visible truth.
+        // Resolving detail by identity (not by view-relative row) keeps it
+        // drift-free: a row coordinate handed to the producer could map to a
+        // neighbouring tx if our drain queue lagged the cursor, and same-hash
+        // parts scatter under the Amount/Address sorts (windowed-model PR5-C).
+        m_detailedModel->ensureRowCached(row);
+        uint256 hash;
+        int idx = -1;
+        if (m_detailedModel->keyAt(row, hash, idx))
+        {
+            const QString html = model->getTxStore().getRowDetail(hash, idx);
+            TransactionDescDialog dlg(html, this);
+            dlg.exec();
+        }
     }
 }
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -486,12 +486,16 @@ void TransactionView::showDetails()
         m_detailedModel->ensureRowCached(row);
         uint256 hash;
         int idx = -1;
+        QString html;
         if (m_detailedModel->keyAt(row, hash, idx))
         {
-            const QString html = model->getTxStore().getRowDetail(hash, idx);
-            TransactionDescDialog dlg(html, this);
-            dlg.exec();
+            html = model->getTxStore().getRowDetail(hash, idx);
         }
+        // Always open the dialog: an empty html renders the "details unavailable"
+        // fallback, so a double-click on an off-window/placeholder row (keyAt false)
+        // still responds rather than silently doing nothing (Copilot review, PR5-C).
+        TransactionDescDialog dlg(html, this);
+        dlg.exec();
     }
 }
 

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -4,6 +4,7 @@
 
 #include "qt/wallettxstore.h"
 
+#include "qt/transactiondesc.h"
 #include "main.h"
 #include "wallet/wallet.h"
 
@@ -411,8 +412,11 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
                 continue;
             }
             // Compute status producer-side (cs_main held here) so the cursors
-            // rebuilt over m_records can filter/sort by it. The VIEW_FULL consumer
-            // still refreshes status lazily on read; this is a harmless head-start.
+            // rebuilt over m_records can filter/sort by it and the served records
+            // carry current status. Consumers no longer refresh status lazily on
+            // read — the TransactionTablePriv::index() lazy path was removed in
+            // windowed-model PR5-C — so this producer-side computation is the
+            // authoritative refresh, not a head-start.
             TransactionRecord r = rec;
             r.updateStatus(it->second);
             r.populateDisplayLabel(*m_wallet);  // address-book label snapshot (PR4)
@@ -539,10 +543,15 @@ void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)
     }
 
     // In-place overwrite: the status changed but the ordering key (time,hash,idx)
-    // did not, so positions are unchanged. No VIEW_FULL event is emitted — the
-    // detailed table refreshes confirmation status lazily on read (unchanged
-    // behaviour). Re-evaluate each cursor per affected row: under a status sort a
-    // first confirmation repositions the row.
+    // did not, so positions are unchanged. The change is propagated to each
+    // registered cursor below via RowsChanged (the detailed/overview views refetch
+    // the affected rows). No VIEW_FULL event is emitted, so the TransactionTableModel
+    // replica is NOT refreshed for in-place status changes; post-PR5-C there is also
+    // no lazy on-read refresh (TransactionTablePriv::index() no longer touches the
+    // wallet). Acceptable because no view renders TTM and its only readers —
+    // incomingTransaction (fresh inserts), focusTransaction (TxIDRole), indexForTxid
+    // (hash) — do not depend on post-insert status freshness. Re-evaluate each cursor
+    // per affected row: under a status sort a first confirmation repositions the row.
     for (std::size_t k = 0; k < records.size(); ++k) {
         m_records[minPos + k] = records[k];
         recomputeCacheAt(minPos + k);   // refresh F-cache before the cursor drive reads it
@@ -830,6 +839,44 @@ int WalletTxStore::rowForKey(int viewId, const uint256& hash, int idx)
         return -1;
     }
     return static_cast<int>(best);
+}
+
+QString WalletTxStore::getRowDetail(const uint256& hash, int idx)
+{
+    // Resolve (hash, idx) -> the clicked part's vout under cs_store ONLY, then
+    // RELEASE cs_store before taking the wallet locks: the class invariant
+    // (header threading note) is that cs_store is NEVER held while acquiring
+    // cs_main / cs_wallet. mapWallet is authoritative for the formatted detail,
+    // so a worker reordering m_records after we release cs_store is irrelevant —
+    // we already captured the part's identity (hash, vout).
+    unsigned int vout = 0;
+    bool found = false;
+    {
+        LOCK(cs_store);
+        auto range = m_by_hash.equal_range(hash);
+        for (auto it = range.first; it != range.second; ++it) {
+            const std::size_t absidx = it->second;
+            if (absidx >= m_records.size()) continue;   // defensive
+            const TransactionRecord& rec = m_records[absidx];
+            if (idx < 0 || rec.idx == idx) {
+                vout = rec.vout;
+                found = true;
+                if (idx >= 0) break;   // exact part match
+            }
+        }
+    }
+    if (!found) {
+        return QString();
+    }
+    // Heavy detail formatting under the canonical wallet locks, OFF the store
+    // leaf. A future edit MUST NOT hoist this under the cs_store scope above —
+    // that would invert cs_store -> cs_main/cs_wallet and violate the lock order.
+    LOCK2(cs_main, m_wallet->cs_wallet);
+    auto mi = m_wallet->mapWallet.find(hash);
+    if (mi == m_wallet->mapWallet.end()) {
+        return QString();
+    }
+    return TransactionDesc::toHTML(m_wallet, mi->second, vout);
 }
 
 void WalletTxStore::emitCursorDeltas(int viewId, uint64_t epoch,

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -865,7 +865,10 @@ QString WalletTxStore::getRowDetail(const uint256& hash, int idx)
             }
         }
     }
-    if (!found) {
+    if (!found || !m_wallet) {
+        // !found: no such (hash, idx). !m_wallet: defensive — the live GUI always
+        // constructs the store with a wallet, but the nullptr-wallet unit harness
+        // must not dereference it once a match is found (Copilot review, PR5-C).
         return QString();
     }
     // Heavy detail formatting under the canonical wallet locks, OFF the store

--- a/src/qt/wallettxstore.h
+++ b/src/qt/wallettxstore.h
@@ -12,6 +12,8 @@
 #include "sync.h"
 #include "uint256.h"
 
+#include <QString>
+
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -205,6 +207,26 @@ public:
     //! indices, then Cursor::positionOf to the accepted row. Backs click-through and
     //! anchor-on-resort (windowed-model PR5-B). Pure read; no projector calls.
     int rowForKey(int viewId, const uint256& hash, int idx = -1);
+
+    //! Qt thread: full HTML transaction-detail for the record identified by
+    //! (\p hash, \p idx) — the double-click detail dialog. The consumer passes a
+    //! self-describing identity (read from its OWN cached record via
+    //! DetailedTxModel::keyAt), NOT a view-relative row, so the result is
+    //! drift-free even if the consumer's drain queue lags the producer cursor
+    //! (the absolute row a stale cursor maps could be a neighbouring tx). \p idx
+    //! < 0 matches SOME part sharing \p hash — the m_by_hash iteration order is
+    //! unspecified — which is fine for this defensive fallback only because the
+    //! real path (keyAt) always supplies a concrete idx. Resolves the part's vout
+    //! under cs_store (the leaf), RELEASES cs_store, then formats under
+    //! LOCK2(cs_main, cs_wallet) — the same lock pair the deleted
+    //! TransactionTablePriv::describe() took on the Qt thread, relocated to the
+    //! authoritative producer so it is the node-side call at the multiprocess
+    //! split (#2937). IMPORTANT: in-process this still takes the wallet locks on
+    //! the Qt thread, so it RELOCATES (does not remove) the detail-path stall;
+    //! only deleting the lazy index() refresh takes the render thread fully off
+    //! cs_main/cs_wallet. Returns an empty QString for an unknown key or a tx no
+    //! longer in the wallet (the dialog then shows a fallback string).
+    QString getRowDetail(const uint256& hash, int idx);
 
     //!
     //! \brief Qt thread: rebuild the store from the wallet and return a full


### PR DESCRIPTION
## Summary

PR5-C of the windowed transaction-table stack (follows #3023 / #3041). Two moves, distinct in what each buys:

1. **Delete the lazy `TRY_LOCK(cs_main)+TRY_LOCK(cs_wallet)+updateStatus()` block in `TransactionTablePriv::index()`.** This is the change that takes the Qt render and click-through threads **fully off the wallet locks**. `index()` collapses to a bounds-check + cached-record return.

2. **Relocate the transaction-detail HTML into the producer** as `WalletTxStore::getRowDetail(hash, idx)` — the node-side detail call for the multiprocess split (#2937).

### Why deleting the lazy refresh is safe

No view binds `TransactionTableModel` as its model — the views are `DetailedTxModel` / `OverviewTxModel`, which call `formatRole` directly and are refreshed by their own producer event stream. Status is computed **producer-side**: on insert under `cs_main` (before enqueue) and per-block via `WalletTxStore::applyChainTipRefresh`. The surviving `index()`/`data()` readers do not depend on a paint-thread refresh:

- `indexForTxid` → reads only `rec->hash`;
- `BitcoinGUI::incomingTransaction` (wired to TTM `rowsInserted`) → reads freshly-inserted records, whose status is already current at insert;
- `TransactionView::focusTransaction` → reads only `TxIDRole`.

`data()` and `updateConfirmations()` are therefore **kept** (with comments recording that status is producer-refreshed, not lazily on read).

### getRowDetail — identity, not a view row

`showDetails` does `ensureRowCached(row)` → `keyAt(row, hash, idx)` (the user-visible record from the consumer's own cache) → `getRowDetail(hash, idx)`. Passing a **self-describing identity** rather than a view-relative row makes the detail dialog drift-free: a row coordinate resolved against the producer's live cursor could map to a neighbouring tx if the drain queue lagged, and same-hash parts scatter under the Amount/Address sorts.

Lock order is hazard-free: `getRowDetail` resolves the clicked part's `vout` under `cs_store` (the leaf), **releases `cs_store`**, then formats under `LOCK2(cs_main, cs_wallet)` — the identical pair the deleted `describe()` took, relocated to the authoritative producer.

> **Note for reviewers:** in-process, `getRowDetail` still takes `LOCK2(cs_main, cs_wallet)` on the Qt thread when you open a detail dialog — it **relocates**, it does not remove, that in-process interaction. Only the `index()` deletion removes a render-thread lock interaction. The producer-side `getRowDetail` is the #2937 IPC win.

`TransactionDescDialog` now takes a pre-rendered `QString`; `LongDescriptionRole`, `describe()`, and the now-unused `transactiondesc.h` include are removed.

## Testing

- **GUI-off (this PR):** new `wallettxstore_tests` cases for `getRowDetail`'s null-wallet-safe early returns (unknown hash; known hash + non-matching idx — both return under `cs_store` before any wallet deref).
- **GUI-off (regression):** `qt_cursor_tests` / `qt_windowcache_tests` / `qt_txfilter_tests` / `qt_txorder_tests` green (59 cases); Qt suites green.
- **Build:** clang with `HAVE_CLANG_THREAD_SAFETY=1` — clean, no annotation warning on the new `LOCK2`.
- **GUI mesh soak (isolated 4-node testnet, inst 8 Rel + inst 9 ASan/UBSan):** clean restart onto this build, both nodes in consensus; visible-row + off-window double-click → correct HTML; OverviewPage click-through resolves; ASan/UBSan quiet.

### Real-world stress — 122k-tx wallet on a 32-bit ARM SBC

The whole windowed-model stack (PR1→PR5) exists so the detailed transaction table no longer keeps a full GUI-side `QList<TransactionRecord>` replica of the entire history; PR5-C is the capstone that additionally takes the render/click-through threads off `cs_main`/`cs_wallet`. Validated at the extreme on an **ODROID (`armv7l`, 32-bit ARMhf, 8 cores, 1.9 GiB RAM)** running this exact PR branch (`5.5.1.2-qt_tx-detail-windowing-c-6b957b430`):

- **`mapWallet.size() = 121,979`** — a ~122k-transaction, frequently-staking wallet.
- Date filter set to **2025-01-01**; scrolling and column sorting stay **responsive even on the slow CPU** — previously, showing more than ~a month of history would grind the GUI to a halt.
- GUI process RSS ≈ **1021 MiB**, dominated by the unavoidable node-side `mapWallet` (122k `CWalletTx`) + chainstate. The GUI transaction model now adds only a viewport-sized window (~tens of KB) instead of a second full replica of all 122k decomposed parts — so total memory is "barely more than before," the difference between fitting comfortably (≈491 MiB free) and swapping to a halt on a 1.9 GiB box.

The render-thread responsiveness *while the node is syncing* is exactly PR5-C's contribution (no paint-thread `TRY_LOCK(cs_main)`), and it holds up on the most resource-constrained target the wallet ships to.
