### PR TITLE
qt: add Multisign (PSGT) dialog

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(gridcoinqt STATIC
     sendcoinsentry.cpp
     sidestaketablemodel.cpp
     signverifymessagedialog.cpp
+    multisigndialog.cpp
     trafficgraphwidget.cpp
     transactiondesc.cpp
     transactiondescdialog.cpp

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -18,6 +18,7 @@
 #include "sendcoinsdialog.h"
 #include "favoritespage.h"
 #include "signverifymessagedialog.h"
+#include "multisigndialog.h"
 #include "optionsdialog.h"
 #include "aboutdialog.h"
 #include "voting/polltab.h"
@@ -208,6 +209,7 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
     votingPage = new VotingPage(this);
 
     signVerifyMessageDialog = new SignVerifyMessageDialog(this);
+    multisignDialog = new MultisignPSGTDialog(this);
 
     centralWidget = new QStackedWidget(this);
     centralWidget->addWidget(overviewPage);
@@ -453,6 +455,7 @@ void BitcoinGUI::createActions()
     lockWalletAction->setToolTip(tr("Lock wallet"));
     signMessageAction = new QAction(tr("Sign &message..."), this);
     verifyMessageAction = new QAction(tr("&Verify message..."), this);
+    multisignAction = new QAction(tr("&Multisign (PSGT)..."), this);
 
     exportAction = new QAction(tr("&Export..."), this);
     exportAction->setToolTip(tr("Export the data in the current tab to a file"));
@@ -482,6 +485,7 @@ void BitcoinGUI::createActions()
     connect(lockWalletAction, &QAction::triggered, this, &BitcoinGUI::lockWallet);
     connect(signMessageAction, &QAction::triggered, this, [this]{ this->gotoSignMessageTab(QString {}); });
     connect(verifyMessageAction, &QAction::triggered, this, [this]{ this->gotoVerifyMessageTab(QString {}); });
+    connect(multisignAction, &QAction::triggered, this, &BitcoinGUI::gotoMultisignDialog);
     connect(diagnosticsAction, &QAction::triggered, this, &BitcoinGUI::diagnosticsClicked);
     connect(snapshotAction, &QAction::triggered, this, &BitcoinGUI::snapshotClicked);
     connect(resetblockchainAction, &QAction::triggered, this, &BitcoinGUI::resetblockchainClicked);
@@ -557,6 +561,7 @@ void BitcoinGUI::setIcons()
     changePassphraseAction->setIcon(QPixmap(":/icons/key"));
     signMessageAction->setIcon(QPixmap(":/icons/edit"));
     verifyMessageAction->setIcon(QPixmap(":/icons/transaction_0"));
+    multisignAction->setIcon(QPixmap(":/icons/edit"));
     exportAction->setIcon(QPixmap(":/icons/export"));
     openRPCConsoleAction->setIcon(QPixmap(":/icons/debugwindow"));
     snapshotAction->setIcon(QPixmap(":/images/gridcoin"));
@@ -589,8 +594,10 @@ void BitcoinGUI::createMenuBar()
     // Configure the menus
     file->addAction(backupWalletAction);
     file->addAction(exportAction);
-    file->addAction(signMessageAction);
-    file->addAction(verifyMessageAction);
+    QMenu *signMenu = file->addMenu(tr("Sign &message"));
+    signMenu->addAction(signMessageAction);
+    signMenu->addAction(verifyMessageAction);
+    signMenu->addAction(multisignAction);
     file->addSeparator();
 
     // Snapshot GUI menu action disabled due to snapshot CDN abuse in 202308.
@@ -861,6 +868,7 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
         receiveCoinsPage->setAddressTableModel(walletModel->getAddressTableModel());
         sendCoinsPage->setModel(walletModel);
         signVerifyMessageDialog->setModel(walletModel);
+        multisignDialog->setModel(walletModel);
 
         setEncryptionStatus(walletModel->getEncryptionStatus());
         connect(walletModel, &WalletModel::encryptionStatusChanged, this, &BitcoinGUI::setEncryptionStatus);
@@ -1642,6 +1650,13 @@ void BitcoinGUI::gotoVerifyMessageTab(QString addr)
 
     if(!addr.isEmpty())
         signVerifyMessageDialog->setAddress_VM(addr);
+}
+
+void BitcoinGUI::gotoMultisignDialog()
+{
+    multisignDialog->show();
+    multisignDialog->raise();
+    multisignDialog->activateWindow();
 }
 
 void BitcoinGUI::dragEnterEvent(QDragEnterEvent *event)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -28,6 +28,7 @@ class ReceiveCoinsPage;
 class SendCoinsDialog;
 class VotingPage;
 class SignVerifyMessageDialog;
+class MultisignPSGTDialog;
 class Notificator;
 class RPCConsole;
 class DiagnosticsDialog;
@@ -126,6 +127,7 @@ private:
     TransactionView *transactionView;
     VotingPage *votingPage;
     SignVerifyMessageDialog *signVerifyMessageDialog;
+    MultisignPSGTDialog *multisignDialog;
     std::unique_ptr<UpdateDialog> updateMessageDialog;
 
     SyncOverlay *m_sync_overlay;
@@ -160,6 +162,7 @@ private:
     QAction *sendCoinsAction;
     QAction *addressBookAction;
     QAction *signMessageAction;
+    QAction *multisignAction;
     QAction *bxAction;
     QAction *websiteAction;
     QAction *boincAction;
@@ -273,6 +276,8 @@ private slots:
     void gotoSignMessageTab(QString addr = "");
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
+    /** Show the Multisign (PSGT) dialog */
+    void gotoMultisignDialog();
     /** Show configuration dialog */
     void optionsClicked();
     /** Switch the active light/dark theme */

--- a/src/qt/forms/multisigndialog.ui
+++ b/src/qt/forms/multisigndialog.ui
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MultisignPSGTDialog</class>
+ <widget class="QDialog" name="MultisignPSGTDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>720</width>
+    <height>620</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Multisign (PSGT)</string>
+  </property>
+  <property name="modal">
+   <bool>false</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="infoLabel">
+     <property name="text">
+      <string>Load a Partially Signed Gridcoin Transaction (PSGT), inspect it, sign your inputs with this wallet, combine signatures from co-signers, and finalize it to a broadcast-ready raw transaction. Paste the base64 PSGT below.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="psgtInLabel">
+     <property name="text">
+      <string>PSGT (base64):</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="psgtInEdit">
+     <property name="toolTip">
+      <string>Paste the base64-encoded PSGT here. Operations below update this working PSGT in place.</string>
+     </property>
+     <property name="placeholderText">
+      <string>Paste a base64 PSGT (e.g. from createpsgt)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonRow">
+     <item>
+      <widget class="QPushButton" name="inspectButton">
+       <property name="toolTip">
+        <string>Decode the PSGT and show its inputs, outputs and signing status</string>
+       </property>
+       <property name="text">
+        <string>&amp;Inspect</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="signButton">
+       <property name="toolTip">
+        <string>Sign every input this wallet has keys for, then update the working PSGT</string>
+       </property>
+       <property name="text">
+        <string>&amp;Sign with wallet</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="finalizeButton">
+       <property name="toolTip">
+        <string>If fully signed, extract the completed raw transaction (hex) for broadcast</string>
+       </property>
+       <property name="text">
+        <string>&amp;Finalize &#8594; hex</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="toolTip">
+        <string>Clear all fields</string>
+       </property>
+       <property name="text">
+        <string>Clear &amp;All</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="buttonSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="statusLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="decodedLabel">
+     <property name="text">
+      <string>Decoded:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="decodedView">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="placeholderText">
+      <string>Click &quot;Inspect&quot; to decode the PSGT</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="combineLabel">
+     <property name="text">
+      <string>Co-signers' PSGTs to combine (one base64 PSGT per line):</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="combineRow">
+     <item>
+      <widget class="QPlainTextEdit" name="combineInEdit">
+       <property name="toolTip">
+        <string>Paste one or more co-signers' PSGTs (one per line). Combine merges them with the working PSGT above.</string>
+       </property>
+       <property name="placeholderText">
+        <string>One base64 PSGT per line</string>
+       </property>
+       <property name="maximumHeight">
+        <number>80</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="combineButton">
+       <property name="toolTip">
+        <string>Merge the co-signers' PSGTs into the working PSGT</string>
+       </property>
+       <property name="text">
+        <string>&amp;Combine</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="resultLabel">
+     <property name="text">
+      <string>Result (signed PSGT base64, or finalized transaction hex):</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="resultRow">
+     <item>
+      <widget class="QPlainTextEdit" name="resultOutEdit">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+       <property name="maximumHeight">
+        <number>90</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copyResultButton">
+       <property name="toolTip">
+        <string>Copy the result to the clipboard</string>
+       </property>
+       <property name="text">
+        <string>Cop&amp;y</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../bitcoin.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/qt/forms/multisigndialog.ui
+++ b/src/qt/forms/multisigndialog.ui
@@ -146,7 +146,7 @@
    <item>
     <widget class="QLabel" name="combineLabel">
      <property name="text">
-      <string>Co-signers' PSGTs to combine (one base64 PSGT per line):</string>
+      <string>Out-of-band: co-signers' PSGTs to combine (one base64 PSGT per line):</string>
      </property>
     </widget>
    </item>
@@ -155,7 +155,7 @@
      <item>
       <widget class="QPlainTextEdit" name="combineInEdit">
        <property name="toolTip">
-        <string>Paste one or more co-signers' PSGTs (one per line). Combine merges them with the working PSGT above.</string>
+        <string>Out-of-band combine: paste one or more co-signers' PSGTs (one per line). Combine merges them with the working PSGT above. This is the manual path, distinct from the future network PSGT pool.</string>
        </property>
        <property name="placeholderText">
         <string>One base64 PSGT per line</string>
@@ -168,7 +168,7 @@
      <item>
       <widget class="QPushButton" name="combineButton">
        <property name="toolTip">
-        <string>Merge the co-signers' PSGTs into the working PSGT</string>
+        <string>Merge the co-signers' PSGTs into the working PSGT (out-of-band)</string>
        </property>
        <property name="text">
         <string>&amp;Combine</string>

--- a/src/qt/multisigndialog.cpp
+++ b/src/qt/multisigndialog.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "multisigndialog.h"
+#include "ui_multisigndialog.h"
+
+#include "guiutil.h"
+#include "qt/decoration.h"
+#include "walletmodel.h"
+
+#include <psgt.h>
+#include <key_io.h>
+#include <main.h>
+#include <script/standard.h>
+#include <streams.h>
+#include <sync.h>
+#include <util.h>
+#include <util/strencodings.h>
+#include <version.h>
+#include <wallet/wallet.h>
+
+#include <string>
+#include <vector>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QString>
+
+extern CWallet* pwalletMain;
+
+namespace {
+
+//! Strip all whitespace (newlines/spaces from pasted text) so DecodeBase64 sees
+//! a clean base64 string.
+std::string CleanBase64(const QString& in)
+{
+    std::string out;
+    out.reserve(in.size());
+    for (const QChar& c : in)
+    {
+        if (!c.isSpace())
+            out.push_back(c.toLatin1());
+    }
+    return out;
+}
+
+//! Format a satoshi amount as "<value> GRC".
+QString FormatAmount(int64_t nValue)
+{
+    return QString::fromStdString(FormatMoney(nValue)) + " GRC";
+}
+
+//! Build a human-readable description of a decoded PSGT (mirrors the data
+//! surfaced by the decodepsgt RPC, formatted for display).
+QString DescribePSGT(const PartiallySignedTransaction& psgt)
+{
+    QString out;
+    CTransaction ctx(psgt.tx);
+
+    out += QString("Transaction id: %1\n").arg(QString::fromStdString(ctx.GetHash().GetHex()));
+    out += QString("Version: %1   Time: %2   Locktime: %3\n")
+               .arg(psgt.tx.nVersion)
+               .arg((qlonglong)psgt.tx.nTime)
+               .arg((qlonglong)psgt.tx.nLockTime);
+    out += QString("Inputs: %1   Outputs: %2\n\n")
+               .arg(psgt.tx.vin.size())
+               .arg(psgt.tx.vout.size());
+
+    unsigned int signed_inputs = 0;
+
+    out += "Inputs:\n";
+    for (unsigned int i = 0; i < psgt.tx.vin.size(); ++i)
+    {
+        const CTxIn& txin = psgt.tx.vin[i];
+        QString status;
+        QString amount = "(prev tx not loaded)";
+
+        if (i < psgt.inputs.size())
+        {
+            const PSGTInput& input = psgt.inputs[i];
+
+            if (!input.non_witness_utxo.IsNull()
+                && txin.prevout.n < input.non_witness_utxo.vout.size())
+            {
+                amount = FormatAmount(input.non_witness_utxo.vout[txin.prevout.n].nValue);
+            }
+
+            if (PSGTInputSigned(input))
+            {
+                status = "finalized";
+                ++signed_inputs;
+            }
+            else if (!input.partial_sigs.empty())
+            {
+                status = QString("%1 partial sig(s)").arg(input.partial_sigs.size());
+            }
+            else
+            {
+                status = "unsigned";
+            }
+        }
+        else
+        {
+            status = "no metadata";
+        }
+
+        out += QString("  [%1] %2:%3   %4   %5\n")
+                   .arg(i)
+                   .arg(QString::fromStdString(txin.prevout.hash.GetHex()))
+                   .arg(txin.prevout.n)
+                   .arg(amount)
+                   .arg(status);
+    }
+
+    out += "\nOutputs:\n";
+    for (unsigned int i = 0; i < psgt.tx.vout.size(); ++i)
+    {
+        const CTxOut& txout = psgt.tx.vout[i];
+        QString dest = "(non-standard)";
+
+        txnouttype type;
+        std::vector<CTxDestination> addresses;
+        int nRequired;
+        if (ExtractDestinations(txout.scriptPubKey, type, addresses, nRequired))
+        {
+            QStringList addrs;
+            for (const CTxDestination& addr : addresses)
+                addrs << QString::fromStdString(EncodeDestination(addr));
+            dest = addrs.join(", ");
+            if (nRequired > 1)
+                dest = QString("%1-of-%2 [%3]").arg(nRequired).arg(addresses.size()).arg(dest);
+        }
+
+        out += QString("  [%1] %2   %3\n").arg(i).arg(dest).arg(FormatAmount(txout.nValue));
+    }
+
+    // Completeness: attempt finalization on a copy (same approach the RPC uses).
+    PartiallySignedTransaction copy = psgt;
+    bool complete = FinalizePSGT(copy);
+
+    out += QString("\nSigned inputs: %1/%2   Complete: %3\n")
+               .arg(signed_inputs)
+               .arg(psgt.tx.vin.size())
+               .arg(complete ? "yes" : "no");
+
+    return out;
+}
+
+} // namespace
+
+MultisignPSGTDialog::MultisignPSGTDialog(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::MultisignPSGTDialog)
+    , model(nullptr)
+{
+    ui->setupUi(this);
+
+    resize(GRC::ScaleSize(this, width(), height()));
+
+    ui->psgtInEdit->setFont(GUIUtil::bitcoinAddressFont());
+    ui->resultOutEdit->setFont(GUIUtil::bitcoinAddressFont());
+    ui->decodedView->setFont(GUIUtil::bitcoinAddressFont());
+}
+
+MultisignPSGTDialog::~MultisignPSGTDialog()
+{
+    delete ui;
+}
+
+void MultisignPSGTDialog::setModel(WalletModel *model)
+{
+    this->model = model;
+}
+
+void MultisignPSGTDialog::setStatus(const QString& text, bool error)
+{
+    ui->statusLabel->setStyleSheet(error ? "QLabel { color: red; }" : "QLabel { color: green; }");
+    ui->statusLabel->setText(text);
+}
+
+bool MultisignPSGTDialog::loadWorkingPSGT(PartiallySignedTransaction& psgt)
+{
+    std::string b64 = CleanBase64(ui->psgtInEdit->toPlainText());
+    if (b64.empty())
+    {
+        setStatus(tr("Paste a base64 PSGT first."), true);
+        return false;
+    }
+
+    std::string error;
+    if (!DecodeRawPSGT(psgt, b64, error))
+    {
+        setStatus(tr("Could not decode PSGT: %1").arg(QString::fromStdString(error)), true);
+        return false;
+    }
+    return true;
+}
+
+void MultisignPSGTDialog::on_inspectButton_clicked()
+{
+    PartiallySignedTransaction psgt;
+    if (!loadWorkingPSGT(psgt))
+        return;
+
+    ui->decodedView->setPlainText(DescribePSGT(psgt));
+    setStatus(tr("Decoded %1 input(s), %2 output(s).")
+                  .arg(psgt.tx.vin.size())
+                  .arg(psgt.tx.vout.size()),
+              false);
+}
+
+void MultisignPSGTDialog::on_signButton_clicked()
+{
+    if (!model || !pwalletMain)
+    {
+        setStatus(tr("Wallet is not available."), true);
+        return;
+    }
+
+    PartiallySignedTransaction psgt;
+    if (!loadWorkingPSGT(psgt))
+        return;
+
+    WalletModel::UnlockContext ctx(model->requestUnlock());
+    if (!ctx.isValid())
+    {
+        setStatus(tr("Wallet unlock was cancelled."), true);
+        return;
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    // Fill in non_witness_utxo and redeem_script for inputs that need them
+    // (mirrors walletprocesspsgt in src/rpc/psgt.cpp).
+    for (unsigned int i = 0; i < psgt.inputs.size(); ++i)
+    {
+        if (psgt.inputs[i].non_witness_utxo.IsNull())
+        {
+            const uint256& prevHash = psgt.tx.vin[i].prevout.hash;
+            CTransaction prevTx;
+            uint256 hashBlock;
+            if (GetTransaction(prevHash, prevTx, hashBlock))
+                psgt.inputs[i].non_witness_utxo = prevTx;
+        }
+
+        if (psgt.inputs[i].redeem_script.empty() && !psgt.inputs[i].non_witness_utxo.IsNull())
+        {
+            const COutPoint& prevout = psgt.tx.vin[i].prevout;
+            if (prevout.n < psgt.inputs[i].non_witness_utxo.vout.size())
+            {
+                const CScript& scriptPubKey = psgt.inputs[i].non_witness_utxo.vout[prevout.n].scriptPubKey;
+                if (scriptPubKey.IsPayToScriptHash())
+                {
+                    CScriptID scriptID(uint160(std::vector<unsigned char>(
+                        scriptPubKey.begin() + 2, scriptPubKey.begin() + 22)));
+                    CScript redeemScript;
+                    if (pwalletMain->GetCScript(scriptID, redeemScript))
+                        psgt.inputs[i].redeem_script = redeemScript;
+                }
+            }
+        }
+    }
+
+    // Sign each input with wallet keys.
+    for (unsigned int i = 0; i < psgt.inputs.size(); ++i)
+    {
+        SignPSGTInput(*pwalletMain, psgt, i, SIGHASH_ALL);
+    }
+
+    // Determine completeness on a copy, then update output metadata.
+    PartiallySignedTransaction psgt_copy = psgt;
+    bool complete = FinalizePSGT(psgt_copy);
+
+    for (unsigned int i = 0; i < psgt.outputs.size(); ++i)
+    {
+        UpdatePSGTOutput(*pwalletMain, psgt, i);
+    }
+
+    std::vector<unsigned char> data = SerializePSGT(psgt);
+    QString b64 = QString::fromStdString(EncodeBase64(data.data(), data.size()));
+
+    // The signed PSGT becomes the new working PSGT so it can be combined/finalized.
+    ui->psgtInEdit->setPlainText(b64);
+    ui->resultOutEdit->setPlainText(b64);
+    ui->decodedView->setPlainText(DescribePSGT(psgt));
+
+    setStatus(tr("Signed with wallet. Complete: %1").arg(complete ? tr("yes") : tr("no")),
+              complete ? false : true);
+}
+
+void MultisignPSGTDialog::on_combineButton_clicked()
+{
+    PartiallySignedTransaction primary;
+    if (!loadWorkingPSGT(primary))
+        return;
+
+    std::vector<PartiallySignedTransaction> psgts;
+    psgts.push_back(primary);
+
+    const QStringList lines = ui->combineInEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
+    for (const QString& line : lines)
+    {
+        std::string b64 = CleanBase64(line);
+        if (b64.empty())
+            continue;
+
+        PartiallySignedTransaction other;
+        std::string error;
+        if (!DecodeRawPSGT(other, b64, error))
+        {
+            setStatus(tr("Could not decode a co-signer PSGT: %1").arg(QString::fromStdString(error)), true);
+            return;
+        }
+        psgts.push_back(other);
+    }
+
+    if (psgts.size() < 2)
+    {
+        setStatus(tr("Add at least one co-signer PSGT to combine."), true);
+        return;
+    }
+
+    PartiallySignedTransaction merged;
+    if (!CombinePSGTs(merged, psgts))
+    {
+        setStatus(tr("PSGTs do not refer to the same transaction."), true);
+        return;
+    }
+
+    std::vector<unsigned char> data = SerializePSGT(merged);
+    QString b64 = QString::fromStdString(EncodeBase64(data.data(), data.size()));
+
+    ui->psgtInEdit->setPlainText(b64);
+    ui->resultOutEdit->setPlainText(b64);
+    ui->decodedView->setPlainText(DescribePSGT(merged));
+
+    setStatus(tr("Combined %1 PSGT(s).").arg(psgts.size()), false);
+}
+
+void MultisignPSGTDialog::on_finalizeButton_clicked()
+{
+    PartiallySignedTransaction psgt;
+    if (!loadWorkingPSGT(psgt))
+        return;
+
+    CMutableTransaction mtx;
+    if (!FinalizeAndExtractPSGT(psgt, mtx))
+    {
+        ui->decodedView->setPlainText(DescribePSGT(psgt));
+        setStatus(tr("PSGT is not complete yet; cannot finalize."), true);
+        return;
+    }
+
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << mtx;
+    QString hex = QString::fromStdString(HexStr(ssTx));
+
+    ui->resultOutEdit->setPlainText(hex);
+    setStatus(tr("Finalized. Raw transaction hex is ready to broadcast (e.g. via sendrawtransaction)."), false);
+}
+
+void MultisignPSGTDialog::on_copyResultButton_clicked()
+{
+    QApplication::clipboard()->setText(ui->resultOutEdit->toPlainText());
+}
+
+void MultisignPSGTDialog::on_clearButton_clicked()
+{
+    ui->psgtInEdit->clear();
+    ui->combineInEdit->clear();
+    ui->decodedView->clear();
+    ui->resultOutEdit->clear();
+    ui->statusLabel->clear();
+    ui->psgtInEdit->setFocus();
+}

--- a/src/qt/multisigndialog.cpp
+++ b/src/qt/multisigndialog.cpp
@@ -6,6 +6,7 @@
 #include "ui_multisigndialog.h"
 
 #include "guiutil.h"
+#include "bitcoinunits.h"
 #include "qt/decoration.h"
 #include "walletmodel.h"
 

--- a/src/qt/multisigndialog.cpp
+++ b/src/qt/multisigndialog.cpp
@@ -5,8 +5,9 @@
 #include "multisigndialog.h"
 #include "ui_multisigndialog.h"
 
-#include "guiutil.h"
 #include "bitcoinunits.h"
+#include "guiutil.h"
+#include "optionsmodel.h"
 #include "qt/decoration.h"
 #include "walletmodel.h"
 
@@ -46,36 +47,43 @@ std::string CleanBase64(const QString& in)
     return out;
 }
 
-//! Format a satoshi amount as "<value> GRC".
-QString FormatAmount(int64_t nValue)
+} // namespace
+
+QString MultisignPSGTDialog::FormatAmount(int64_t nValue) const
 {
-    return QString::fromStdString(FormatMoney(nValue)) + " GRC";
+    // Match the rest of the GUI: format in the wallet's selected display unit
+    // (GRC/mGRC/uBTC) with thin-space grouping, rather than core FormatMoney().
+    int unit = BitcoinUnits::BTC; // BTC == GRC display
+    if (model && model->getOptionsModel())
+        unit = model->getOptionsModel()->getDisplayUnit();
+
+    return BitcoinUnits::formatWithUnit(unit, nValue);
 }
 
 //! Build a human-readable description of a decoded PSGT (mirrors the data
 //! surfaced by the decodepsgt RPC, formatted for display).
-QString DescribePSGT(const PartiallySignedTransaction& psgt)
+QString MultisignPSGTDialog::DescribePSGT(const PartiallySignedTransaction& psgt) const
 {
     QString out;
     CTransaction ctx(psgt.tx);
 
-    out += QString("Transaction id: %1\n").arg(QString::fromStdString(ctx.GetHash().GetHex()));
-    out += QString("Version: %1   Time: %2   Locktime: %3\n")
+    out += tr("Transaction id: %1\n").arg(QString::fromStdString(ctx.GetHash().GetHex()));
+    out += tr("Version: %1   Time: %2   Locktime: %3\n")
                .arg(psgt.tx.nVersion)
                .arg((qlonglong)psgt.tx.nTime)
                .arg((qlonglong)psgt.tx.nLockTime);
-    out += QString("Inputs: %1   Outputs: %2\n\n")
+    out += tr("Inputs: %1   Outputs: %2\n\n")
                .arg(psgt.tx.vin.size())
                .arg(psgt.tx.vout.size());
 
     unsigned int signed_inputs = 0;
 
-    out += "Inputs:\n";
+    out += tr("Inputs:\n");
     for (unsigned int i = 0; i < psgt.tx.vin.size(); ++i)
     {
         const CTxIn& txin = psgt.tx.vin[i];
         QString status;
-        QString amount = "(prev tx not loaded)";
+        QString amount = tr("(prev tx not loaded)");
 
         if (i < psgt.inputs.size())
         {
@@ -89,21 +97,21 @@ QString DescribePSGT(const PartiallySignedTransaction& psgt)
 
             if (PSGTInputSigned(input))
             {
-                status = "finalized";
+                status = tr("finalized");
                 ++signed_inputs;
             }
             else if (!input.partial_sigs.empty())
             {
-                status = QString("%1 partial sig(s)").arg(input.partial_sigs.size());
+                status = tr("%n partial sig(s)", nullptr, (int)input.partial_sigs.size());
             }
             else
             {
-                status = "unsigned";
+                status = tr("unsigned");
             }
         }
         else
         {
-            status = "no metadata";
+            status = tr("no metadata");
         }
 
         out += QString("  [%1] %2:%3   %4   %5\n")
@@ -125,23 +133,23 @@ QString DescribePSGT(const PartiallySignedTransaction& psgt)
             std::vector<std::vector<unsigned char>> rsols;
             if (Solver(redeem, rtype, rsols) && rtype == TX_MULTISIG && rsols.size() >= 3)
             {
-                out += QString("        multisig %1-of-%2   image P2SH:%3\n")
+                out += tr("        multisig %1-of-%2   image P2SH:%3\n")
                            .arg((int)rsols.front()[0])
                            .arg((int)rsols.size() - 2)
                            .arg(image);
             }
             else
             {
-                out += QString("        image P2SH:%1\n").arg(image);
+                out += tr("        image P2SH:%1\n").arg(image);
             }
         }
     }
 
-    out += "\nOutputs:\n";
+    out += tr("\nOutputs:\n");
     for (unsigned int i = 0; i < psgt.tx.vout.size(); ++i)
     {
         const CTxOut& txout = psgt.tx.vout[i];
-        QString dest = "(non-standard)";
+        QString dest = tr("(non-standard)");
 
         txnouttype type;
         std::vector<CTxDestination> addresses;
@@ -163,15 +171,13 @@ QString DescribePSGT(const PartiallySignedTransaction& psgt)
     PartiallySignedTransaction copy = psgt;
     bool complete = FinalizePSGT(copy);
 
-    out += QString("\nSigned inputs: %1/%2   Complete: %3\n")
+    out += tr("\nSigned inputs: %1/%2   Complete: %3\n")
                .arg(signed_inputs)
                .arg(psgt.tx.vin.size())
-               .arg(complete ? "yes" : "no");
+               .arg(complete ? tr("yes") : tr("no"));
 
     return out;
 }
-
-} // namespace
 
 MultisignPSGTDialog::MultisignPSGTDialog(QWidget* parent)
     : QDialog(parent)
@@ -263,7 +269,7 @@ void MultisignPSGTDialog::showDecoded(const PartiallySignedTransaction& psgt)
     // contributed at least one signature; surface the precondition now.
     if (pwalletMain)
     {
-        text += QString("This wallet's signature present: %1\n")
+        text += tr("This wallet's signature present: %1\n")
                     .arg(walletHasSignature(psgt) ? tr("yes") : tr("no"));
     }
 

--- a/src/qt/multisigndialog.cpp
+++ b/src/qt/multisigndialog.cpp
@@ -14,6 +14,7 @@
 #include <psgt.h>
 #include <key_io.h>
 #include <main.h>
+#include <script/interpreter.h>
 #include <script/standard.h>
 #include <streams.h>
 #include <sync.h>
@@ -89,10 +90,19 @@ QString MultisignPSGTDialog::DescribePSGT(const PartiallySignedTransaction& psgt
         {
             const PSGTInput& input = psgt.inputs[i];
 
+            // Only trust the amount if the provided previous transaction actually
+            // matches this input's prevout (the same guard AnalyzePSGT uses); a
+            // mismatched non_witness_utxo would otherwise show a bogus value at
+            // the exact moment the user is deciding what to sign.
             if (!input.non_witness_utxo.IsNull()
-                && txin.prevout.n < input.non_witness_utxo.vout.size())
+                && txin.prevout.n < input.non_witness_utxo.vout.size()
+                && input.non_witness_utxo.GetHash() == txin.prevout.hash)
             {
                 amount = FormatAmount(input.non_witness_utxo.vout[txin.prevout.n].nValue);
+            }
+            else if (!input.non_witness_utxo.IsNull())
+            {
+                amount = tr("(prev tx mismatch)");
             }
 
             if (PSGTInputSigned(input))
@@ -127,20 +137,25 @@ QString MultisignPSGTDialog::DescribePSGT(const PartiallySignedTransaction& psgt
         if (i < psgt.inputs.size() && !psgt.inputs[i].redeem_script.empty())
         {
             const CScript& redeem = psgt.inputs[i].redeem_script;
-            const QString image = QString::fromStdString(EncodeDestination(CScriptID(redeem)));
+            const CScriptID scriptID(redeem);
+            const QString image = QString::fromStdString(EncodeDestination(scriptID));
+            // Raw Hash160 is what a Phase II pool keys on; show it next to the
+            // friendlier P2SH address so the two are directly comparable.
+            const QString imageHash = QString::fromStdString(scriptID.ToString());
 
             txnouttype rtype;
             std::vector<std::vector<unsigned char>> rsols;
             if (Solver(redeem, rtype, rsols) && rtype == TX_MULTISIG && rsols.size() >= 3)
             {
-                out += tr("        multisig %1-of-%2   image P2SH:%3\n")
+                out += tr("        multisig %1-of-%2   image P2SH:%3 (hash %4)\n")
                            .arg((int)rsols.front()[0])
                            .arg((int)rsols.size() - 2)
-                           .arg(image);
+                           .arg(image)
+                           .arg(imageHash);
             }
             else
             {
-                out += tr("        image P2SH:%1\n").arg(image);
+                out += tr("        image P2SH:%1 (hash %2)\n").arg(image).arg(imageHash);
             }
         }
     }
@@ -250,11 +265,50 @@ bool MultisignPSGTDialog::walletHasSignature(const PartiallySignedTransaction& p
     if (!pwalletMain)
         return false;
 
-    for (const PSGTInput& input : psgt.inputs)
+    for (unsigned int i = 0; i < psgt.inputs.size() && i < psgt.tx.vin.size(); ++i)
     {
-        for (const auto& sig : input.partial_sigs)
+        const PSGTInput& input = psgt.inputs[i];
+        if (input.partial_sigs.empty())
+            continue;
+
+        // We must know what was signed, so require the provided previous
+        // transaction to actually match the prevout (the AnalyzePSGT guard) and
+        // verify against the real scriptPubKey.
+        const COutPoint& prevout = psgt.tx.vin[i].prevout;
+        if (input.non_witness_utxo.IsNull()
+            || prevout.n >= input.non_witness_utxo.vout.size()
+            || input.non_witness_utxo.GetHash() != prevout.hash)
+            continue;
+
+        // P2SH multisig signatures are made over the redeem script.
+        CScript signScript = input.non_witness_utxo.vout[prevout.n].scriptPubKey;
+        if (signScript.IsPayToScriptHash())
         {
-            if (pwalletMain->HaveKey(sig.first))
+            if (input.redeem_script.empty())
+                continue;
+            signScript = input.redeem_script;
+        }
+
+        // Map each partial signature back to its multisig pubkey and verify the
+        // bytes cryptographically. Presence under an owned CKeyID is not enough:
+        // a crafted or combined PSGT could carry arbitrary bytes under our key id,
+        // and Phase II's pool-acceptance precondition (#2910) is >=1 *valid* sig.
+        txnouttype scriptType;
+        std::vector<std::vector<unsigned char>> vSolutions;
+        if (!Solver(signScript, scriptType, vSolutions) || scriptType != TX_MULTISIG)
+            continue;
+
+        for (unsigned int j = 1; j + 1 < vSolutions.size(); ++j)
+        {
+            const CPubKey pubkey(vSolutions[j]);
+            if (!pubkey.IsValid() || !pwalletMain->HaveKey(pubkey.GetID()))
+                continue;
+
+            auto it = input.partial_sigs.find(pubkey.GetID());
+            if (it == input.partial_sigs.end())
+                continue;
+
+            if (CheckSig(it->second, vSolutions[j], signScript, CTransaction(psgt.tx), i))
                 return true;
         }
     }
@@ -401,6 +455,16 @@ void MultisignPSGTDialog::on_signButton_clicked()
         }
     }
 
+    // Inputs that cannot be signed yet because they still lack updater data
+    // (the previous transaction or a P2SH redeem script). Distinct from both
+    // "no key" and a genuine signing failure, so call them out separately.
+    unsigned int needs_data = 0;
+    for (const PSGTInputAnalysis& ia : analysis.inputs)
+    {
+        if (!ia.is_final && (!ia.has_utxo || ia.missing_redeem_script))
+            ++needs_data;
+    }
+
     // The signed PSGT becomes the new working PSGT so it can be combined/finalized.
     setWorking(psgt);
     showDecoded(psgt);
@@ -408,16 +472,17 @@ void MultisignPSGTDialog::on_signButton_clicked()
     QString msg = tr("Signed %1 input(s) with this wallet. Complete: %2.")
                       .arg(signed_now)
                       .arg(complete ? tr("yes") : tr("no"));
+    if (needs_data > 0)
+    {
+        msg += " " + tr("%n input(s) still need a previous transaction or redeem "
+                        "script before they can be signed.", nullptr, needs_data);
+    }
     if (could_not_sign > 0)
     {
         msg += " " + tr("%n input(s) the wallet holds keys for could not be signed.",
                         nullptr, could_not_sign);
-        setStatus(msg, true);
     }
-    else
-    {
-        setStatus(msg, !complete);
-    }
+    setStatus(msg, could_not_sign > 0 || !complete);
 }
 
 void MultisignPSGTDialog::on_combineButton_clicked()

--- a/src/qt/multisigndialog.cpp
+++ b/src/qt/multisigndialog.cpp
@@ -111,6 +111,29 @@ QString DescribePSGT(const PartiallySignedTransaction& psgt)
                    .arg(txin.prevout.n)
                    .arg(amount)
                    .arg(status);
+
+        // Multisig "image": the P2SH redeem-script hash (as an address) and the
+        // m-of-n threshold. This is the key a Phase II PSGT pool (#2910) indexes
+        // on; surfacing it here builds on the per-input signing-status display.
+        if (i < psgt.inputs.size() && !psgt.inputs[i].redeem_script.empty())
+        {
+            const CScript& redeem = psgt.inputs[i].redeem_script;
+            const QString image = QString::fromStdString(EncodeDestination(CScriptID(redeem)));
+
+            txnouttype rtype;
+            std::vector<std::vector<unsigned char>> rsols;
+            if (Solver(redeem, rtype, rsols) && rtype == TX_MULTISIG && rsols.size() >= 3)
+            {
+                out += QString("        multisig %1-of-%2   image P2SH:%3\n")
+                           .arg((int)rsols.front()[0])
+                           .arg((int)rsols.size() - 2)
+                           .arg(image);
+            }
+            else
+            {
+                out += QString("        image P2SH:%1\n").arg(image);
+            }
+        }
     }
 
     out += "\nOutputs:\n";
@@ -179,7 +202,7 @@ void MultisignPSGTDialog::setStatus(const QString& text, bool error)
     ui->statusLabel->setText(text);
 }
 
-bool MultisignPSGTDialog::loadWorkingPSGT(PartiallySignedTransaction& psgt)
+bool MultisignPSGTDialog::syncWorkingFromInput()
 {
     std::string b64 = CleanBase64(ui->psgtInEdit->toPlainText());
     if (b64.empty())
@@ -188,25 +211,75 @@ bool MultisignPSGTDialog::loadWorkingPSGT(PartiallySignedTransaction& psgt)
         return false;
     }
 
+    // Decode into a temporary so a failure never leaves m_working half-updated.
+    PartiallySignedTransaction decoded;
     std::string error;
-    if (!DecodeRawPSGT(psgt, b64, error))
+    if (!DecodeRawPSGT(decoded, b64, error))
     {
         setStatus(tr("Could not decode PSGT: %1").arg(QString::fromStdString(error)), true);
         return false;
     }
+
+    m_working = decoded;
     return true;
+}
+
+void MultisignPSGTDialog::setWorking(const PartiallySignedTransaction& psgt)
+{
+    m_working = psgt;
+
+    std::vector<unsigned char> data = SerializePSGT(m_working);
+    QString b64 = QString::fromStdString(EncodeBase64(data.data(), data.size()));
+
+    // The input box stays the working PSGT so it can be re-signed/combined/finalized;
+    // the result box mirrors it for copy-out. The decoded view is refreshed
+    // explicitly by the caller (no hidden re-decode here).
+    ui->psgtInEdit->setPlainText(b64);
+    ui->resultOutEdit->setPlainText(b64);
+}
+
+bool MultisignPSGTDialog::walletHasSignature(const PartiallySignedTransaction& psgt) const
+{
+    if (!pwalletMain)
+        return false;
+
+    for (const PSGTInput& input : psgt.inputs)
+    {
+        for (const auto& sig : input.partial_sigs)
+        {
+            if (pwalletMain->HaveKey(sig.first))
+                return true;
+        }
+    }
+    return false;
+}
+
+void MultisignPSGTDialog::showDecoded(const PartiallySignedTransaction& psgt)
+{
+    QString text = DescribePSGT(psgt);
+
+    // "Submit to pool" (Phase II, #2910) will gate on this wallet having
+    // contributed at least one signature; surface the precondition now.
+    if (pwalletMain)
+    {
+        text += QString("This wallet's signature present: %1\n")
+                    .arg(walletHasSignature(psgt) ? tr("yes") : tr("no"));
+    }
+
+    ui->decodedView->setPlainText(text);
 }
 
 void MultisignPSGTDialog::on_inspectButton_clicked()
 {
-    PartiallySignedTransaction psgt;
-    if (!loadWorkingPSGT(psgt))
+    if (!syncWorkingFromInput())
         return;
 
-    ui->decodedView->setPlainText(DescribePSGT(psgt));
+    // Inspect is read-only: it refreshes the decoded view but never rewrites the
+    // input box.
+    showDecoded(m_working);
     setStatus(tr("Decoded %1 input(s), %2 output(s).")
-                  .arg(psgt.tx.vin.size())
-                  .arg(psgt.tx.vout.size()),
+                  .arg(m_working.tx.vin.size())
+                  .arg(m_working.tx.vout.size()),
               false);
 }
 
@@ -218,8 +291,7 @@ void MultisignPSGTDialog::on_signButton_clicked()
         return;
     }
 
-    PartiallySignedTransaction psgt;
-    if (!loadWorkingPSGT(psgt))
+    if (!syncWorkingFromInput())
         return;
 
     WalletModel::UnlockContext ctx(model->requestUnlock());
@@ -230,6 +302,8 @@ void MultisignPSGTDialog::on_signButton_clicked()
     }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    PartiallySignedTransaction psgt = m_working;
 
     // Fill in non_witness_utxo and redeem_script for inputs that need them
     // (mirrors walletprocesspsgt in src/rpc/psgt.cpp).
@@ -262,10 +336,35 @@ void MultisignPSGTDialog::on_signButton_clicked()
         }
     }
 
+    // Snapshot per-input signing state so we can report how many inputs this
+    // wallet actually signed. We cannot use SignPSGTInput's bool return: for a
+    // multisig input it is true whenever *any* co-signer signature is present
+    // (psgt.cpp), so it does not mean "this wallet signed this input".
+    std::vector<size_t> sigs_before(psgt.inputs.size());
+    std::vector<bool> final_before(psgt.inputs.size());
+    for (unsigned int i = 0; i < psgt.inputs.size(); ++i)
+    {
+        sigs_before[i] = psgt.inputs[i].partial_sigs.size();
+        final_before[i] = !psgt.inputs[i].final_script_sig.empty();
+    }
+
     // Sign each input with wallet keys.
     for (unsigned int i = 0; i < psgt.inputs.size(); ++i)
     {
         SignPSGTInput(*pwalletMain, psgt, i, SIGHASH_ALL);
+    }
+
+    // Count inputs this wallet contributed to this round: a new partial sig, or
+    // a newly assembled final scriptSig (single-sig path).
+    unsigned int signed_now = 0;
+    for (unsigned int i = 0; i < psgt.inputs.size(); ++i)
+    {
+        const bool final_now = !psgt.inputs[i].final_script_sig.empty();
+        if (psgt.inputs[i].partial_sigs.size() > sigs_before[i]
+            || (final_now && !final_before[i]))
+        {
+            ++signed_now;
+        }
     }
 
     // Determine completeness on a copy, then update output metadata.
@@ -277,28 +376,54 @@ void MultisignPSGTDialog::on_signButton_clicked()
         UpdatePSGTOutput(*pwalletMain, psgt, i);
     }
 
-    std::vector<unsigned char> data = SerializePSGT(psgt);
-    QString b64 = QString::fromStdString(EncodeBase64(data.data(), data.size()));
+    // Distinguish a genuine signing failure from "no key for this input": any
+    // key still required (AnalyzePSGT::missing_sigs, which already accounts for
+    // the multisig threshold and clears once enough sigs exist) that this wallet
+    // actually holds is an input we should have signed but didn't.
+    PSGTAnalysis analysis = AnalyzePSGT(psgt);
+    unsigned int could_not_sign = 0;
+    for (const PSGTInputAnalysis& ia : analysis.inputs)
+    {
+        for (const CKeyID& keyid : ia.missing_sigs)
+        {
+            if (pwalletMain->HaveKey(keyid))
+            {
+                ++could_not_sign;
+                break; // count each input at most once
+            }
+        }
+    }
 
     // The signed PSGT becomes the new working PSGT so it can be combined/finalized.
-    ui->psgtInEdit->setPlainText(b64);
-    ui->resultOutEdit->setPlainText(b64);
-    ui->decodedView->setPlainText(DescribePSGT(psgt));
+    setWorking(psgt);
+    showDecoded(psgt);
 
-    setStatus(tr("Signed with wallet. Complete: %1").arg(complete ? tr("yes") : tr("no")),
-              complete ? false : true);
+    QString msg = tr("Signed %1 input(s) with this wallet. Complete: %2.")
+                      .arg(signed_now)
+                      .arg(complete ? tr("yes") : tr("no"));
+    if (could_not_sign > 0)
+    {
+        msg += " " + tr("%n input(s) the wallet holds keys for could not be signed.",
+                        nullptr, could_not_sign);
+        setStatus(msg, true);
+    }
+    else
+    {
+        setStatus(msg, !complete);
+    }
 }
 
 void MultisignPSGTDialog::on_combineButton_clicked()
 {
-    PartiallySignedTransaction primary;
-    if (!loadWorkingPSGT(primary))
+    if (!syncWorkingFromInput())
         return;
 
     std::vector<PartiallySignedTransaction> psgts;
-    psgts.push_back(primary);
+    psgts.push_back(m_working);
 
-    const QStringList lines = ui->combineInEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
+    // Plain split (no Qt::SkipEmptyParts, which is Qt >= 5.14 only): the loop
+    // below skips empty/whitespace-only lines after CleanBase64.
+    const QStringList lines = ui->combineInEdit->toPlainText().split('\n');
     for (const QString& line : lines)
     {
         std::string b64 = CleanBase64(line);
@@ -328,26 +453,25 @@ void MultisignPSGTDialog::on_combineButton_clicked()
         return;
     }
 
-    std::vector<unsigned char> data = SerializePSGT(merged);
-    QString b64 = QString::fromStdString(EncodeBase64(data.data(), data.size()));
-
-    ui->psgtInEdit->setPlainText(b64);
-    ui->resultOutEdit->setPlainText(b64);
-    ui->decodedView->setPlainText(DescribePSGT(merged));
+    setWorking(merged);
+    showDecoded(merged);
 
     setStatus(tr("Combined %1 PSGT(s).").arg(psgts.size()), false);
 }
 
 void MultisignPSGTDialog::on_finalizeButton_clicked()
 {
-    PartiallySignedTransaction psgt;
-    if (!loadWorkingPSGT(psgt))
+    if (!syncWorkingFromInput())
         return;
+
+    // Finalize on a copy so the working PSGT (and the input box) keep the partial
+    // form if extraction succeeds; finalize never rewrites the input box.
+    PartiallySignedTransaction psgt = m_working;
 
     CMutableTransaction mtx;
     if (!FinalizeAndExtractPSGT(psgt, mtx))
     {
-        ui->decodedView->setPlainText(DescribePSGT(psgt));
+        showDecoded(m_working);
         setStatus(tr("PSGT is not complete yet; cannot finalize."), true);
         return;
     }
@@ -367,6 +491,7 @@ void MultisignPSGTDialog::on_copyResultButton_clicked()
 
 void MultisignPSGTDialog::on_clearButton_clicked()
 {
+    m_working = PartiallySignedTransaction();
     ui->psgtInEdit->clear();
     ui->combineInEdit->clear();
     ui->decodedView->clear();

--- a/src/qt/multisigndialog.h
+++ b/src/qt/multisigndialog.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MULTISIGNDIALOG_H
+#define BITCOIN_QT_MULTISIGNDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+    class MultisignPSGTDialog;
+}
+class WalletModel;
+
+/**
+ * Dialog for working with Partially Signed Gridcoin Transactions (PSGT):
+ * load a base64 PSGT, inspect its inputs/outputs and signing status, sign the
+ * inputs this wallet holds keys for, combine co-signers' PSGTs, and finalize a
+ * fully-signed PSGT into a broadcast-ready raw transaction.
+ *
+ * Reuses the PSGT C++ API in src/psgt.h directly (the same functions the
+ * psgt RPCs use); does not go through RPC.
+ */
+class MultisignPSGTDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit MultisignPSGTDialog(QWidget* parent = nullptr);
+    ~MultisignPSGTDialog();
+
+    void setModel(WalletModel *model);
+
+private:
+    Ui::MultisignPSGTDialog *ui;
+    WalletModel *model;
+
+    //! Decode the working PSGT from the input box. Reports errors to the
+    //! status label and returns false on failure.
+    bool loadWorkingPSGT(struct PartiallySignedTransaction& psgt);
+
+    void setStatus(const QString& text, bool error);
+
+private slots:
+    void on_inspectButton_clicked();
+    void on_signButton_clicked();
+    void on_combineButton_clicked();
+    void on_finalizeButton_clicked();
+    void on_copyResultButton_clicked();
+    void on_clearButton_clicked();
+};
+
+#endif // BITCOIN_QT_MULTISIGNDIALOG_H

--- a/src/qt/multisigndialog.h
+++ b/src/qt/multisigndialog.h
@@ -55,9 +55,10 @@ private:
     //! entry point a future pool source would call.
     void setWorking(const PartiallySignedTransaction& psgt);
 
-    //! True iff some input carries a partial signature from a key this wallet
-    //! owns -- the ">=1 of my signatures present" precondition a future Phase II
-    //! "submit to pool" action (#2910) will gate on.
+    //! True iff some input carries a cryptographically valid partial signature
+    //! from a key this wallet owns -- verified against the input's sighash, not
+    //! merely present under an owned key id. This is the ">=1 valid signature"
+    //! precondition a future Phase II "submit to pool" action (#2910) will gate on.
     bool walletHasSignature(const PartiallySignedTransaction& psgt) const;
 
     //! Render psgt into the read-only decoded view (decode plus, when the wallet

--- a/src/qt/multisigndialog.h
+++ b/src/qt/multisigndialog.h
@@ -64,6 +64,13 @@ private:
     //! is available, the "wallet's signature present" line).
     void showDecoded(const PartiallySignedTransaction& psgt);
 
+    //! Format a satoshi amount with BitcoinUnits in the wallet's selected display
+    //! unit (consistent with the rest of the GUI), falling back to GRC.
+    QString FormatAmount(int64_t nValue) const;
+
+    //! Build the human-readable decoded-PSGT description shown in the decoded view.
+    QString DescribePSGT(const PartiallySignedTransaction& psgt) const;
+
     void setStatus(const QString& text, bool error);
 
 private slots:

--- a/src/qt/multisigndialog.h
+++ b/src/qt/multisigndialog.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_QT_MULTISIGNDIALOG_H
 #define BITCOIN_QT_MULTISIGNDIALOG_H
 
+#include <psgt.h>
+
 #include <QDialog>
 
 namespace Ui {
@@ -35,9 +37,32 @@ private:
     Ui::MultisignPSGTDialog *ui;
     WalletModel *model;
 
-    //! Decode the working PSGT from the input box. Reports errors to the
-    //! status label and returns false on failure.
-    bool loadWorkingPSGT(struct PartiallySignedTransaction& psgt);
+    //! The PSGT the dialog currently operates on. The base64 text box stays the
+    //! user-editable source of truth: every handler refreshes this from the box
+    //! via syncWorkingFromInput() before acting, and the operations that produce
+    //! a new PSGT (sign/combine) push the result back via setWorking(). Holding
+    //! it as a member is also the seam a future Phase II PSGT-pool source (#2910)
+    //! can populate without a base64 text round-trip.
+    PartiallySignedTransaction m_working;
+
+    //! Decode the input box into m_working. On failure, reports the error to the
+    //! status label and leaves m_working untouched (decodes into a temporary and
+    //! only assigns on success). Returns false on failure.
+    bool syncWorkingFromInput();
+
+    //! Adopt psgt as the working PSGT and write its base64 back to the input and
+    //! result boxes. Used by the operations that produce a new PSGT, and the
+    //! entry point a future pool source would call.
+    void setWorking(const PartiallySignedTransaction& psgt);
+
+    //! True iff some input carries a partial signature from a key this wallet
+    //! owns -- the ">=1 of my signatures present" precondition a future Phase II
+    //! "submit to pool" action (#2910) will gate on.
+    bool walletHasSignature(const PartiallySignedTransaction& psgt) const;
+
+    //! Render psgt into the read-only decoded view (decode plus, when the wallet
+    //! is available, the "wallet's signature present" line).
+    void showDecoded(const PartiallySignedTransaction& psgt);
 
     void setStatus(const QString& text, bool error);
 

--- a/src/test/psgt_tests.cpp
+++ b/src/test/psgt_tests.cpp
@@ -477,6 +477,85 @@ BOOST_AUTO_TEST_CASE(multisig_combine_partial)
 }
 
 // ---------------------------------------------------------------------------
+// Test 12b: P2SH-wrapped 2-of-3 multisig — two signers, each holding only one
+// key, sign independently; combine, finalize, extract, and verify the script.
+// This is the end-to-end path the Multisign (PSGT) GUI dialog drives: a P2SH
+// multisig address (as addmultisigaddress produces) where no single wallet can
+// complete the spend, so the combine step is genuinely exercised.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(multisig_p2sh_combine_roundtrip)
+{
+    CKey key1 = MakeKey();
+    CKey key2 = MakeKey();
+    CKey key3 = MakeKey();
+
+    // 2-of-3 redeem script wrapped in P2SH.
+    CScript redeem;
+    redeem << OP_2
+           << key1.GetPubKey() << key2.GetPubKey() << key3.GetPubKey()
+           << OP_3 << OP_CHECKMULTISIG;
+    CScript scriptPubKey;
+    scriptPubKey << OP_HASH160 << CScriptID(redeem) << OP_EQUAL;
+
+    // Previous tx pays to the P2SH address.
+    CMutableTransaction prevMtx;
+    prevMtx.nVersion = 2;
+    prevMtx.nTime = 1700001600;
+    prevMtx.vin.resize(1);
+    prevMtx.vin[0].prevout.SetNull();
+    prevMtx.vin[0].scriptSig = CScript() << 0;
+    prevMtx.vout.push_back(CTxOut(10 * COIN, scriptPubKey));
+    CTransaction prevTx(prevMtx);
+
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.nTime = 1700001700;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(prevTx.GetHash(), 0);
+    mtx.vout.push_back(CTxOut(9 * COIN, P2PKH(MakeKey().GetPubKey().GetID())));
+
+    // Signer 1 holds only key1.
+    PartiallySignedTransaction psgt1(mtx);
+    psgt1.inputs[0].non_witness_utxo = prevTx;
+    psgt1.inputs[0].redeem_script = redeem;
+    CBasicKeyStore ks1;
+    ks1.AddKey(key1);
+    BOOST_CHECK(SignPSGTInput(ks1, psgt1, 0));
+    BOOST_CHECK_EQUAL(psgt1.inputs[0].partial_sigs.size(), 1u);
+
+    // Signer 2 holds only key3 (any 2 of the 3 keys suffice).
+    PartiallySignedTransaction psgt2(mtx);
+    psgt2.inputs[0].non_witness_utxo = prevTx;
+    psgt2.inputs[0].redeem_script = redeem;
+    CBasicKeyStore ks2;
+    ks2.AddKey(key3);
+    BOOST_CHECK(SignPSGTInput(ks2, psgt2, 0));
+    BOOST_CHECK_EQUAL(psgt2.inputs[0].partial_sigs.size(), 1u);
+
+    // Neither single signer's PSGT can finalize on its own (1 of 2 required).
+    {
+        PartiallySignedTransaction lone = psgt1;
+        CMutableTransaction tmp;
+        BOOST_CHECK(!FinalizeAndExtractPSGT(lone, tmp));
+    }
+
+    // Combine the two independently-signed PSGTs, then finalize and extract.
+    PartiallySignedTransaction merged;
+    BOOST_CHECK(CombinePSGTs(merged, {psgt1, psgt2}));
+    BOOST_CHECK_EQUAL(merged.inputs[0].partial_sigs.size(), 2u);
+
+    CMutableTransaction result;
+    BOOST_CHECK(FinalizeAndExtractPSGT(merged, result));
+
+    // The extracted scriptSig (OP_0 <sig> <sig> <redeemScript>) must satisfy the
+    // P2SH output under standard flags (which include SCRIPT_VERIFY_P2SH).
+    CTransaction signedTx(result);
+    BOOST_CHECK(VerifyScript(
+        signedTx.vin[0].scriptSig, scriptPubKey,
+        STANDARD_SCRIPT_VERIFY_FLAGS, signedTx, 0));
+}
+
+// ---------------------------------------------------------------------------
 // Test 13: Incomplete multisig — only 1 of 2 required sigs, finalize fails.
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(multisig_incomplete_fails)

--- a/src/test/psgt_tests.cpp
+++ b/src/test/psgt_tests.cpp
@@ -532,6 +532,21 @@ BOOST_AUTO_TEST_CASE(multisig_p2sh_combine_roundtrip)
     BOOST_CHECK(SignPSGTInput(ks2, psgt2, 0));
     BOOST_CHECK_EQUAL(psgt2.inputs[0].partial_sigs.size(), 1u);
 
+    // The real GUI flow exchanges PSGTs as base64 between co-signers, so a
+    // co-signer's redeem_script (auto-filled from their wallet) must survive
+    // serialization for the combining party to finalize. Round-trip signer 2's
+    // PSGT through base64 before combining and confirm the field is preserved.
+    {
+        std::vector<unsigned char> ser = SerializePSGT(psgt2);
+        std::string b64 = EncodeBase64(ser.data(), ser.size());
+        PartiallySignedTransaction psgt2_decoded;
+        std::string error;
+        BOOST_REQUIRE(DecodeRawPSGT(psgt2_decoded, b64, error));
+        BOOST_CHECK(psgt2_decoded.inputs[0].redeem_script == redeem);
+        BOOST_CHECK_EQUAL(psgt2_decoded.inputs[0].partial_sigs.size(), 1u);
+        psgt2 = psgt2_decoded;
+    }
+
     // Neither single signer's PSGT can finalize on its own (1 of 2 required).
     {
         PartiallySignedTransaction lone = psgt1;
@@ -541,11 +556,11 @@ BOOST_AUTO_TEST_CASE(multisig_p2sh_combine_roundtrip)
 
     // Combine the two independently-signed PSGTs, then finalize and extract.
     PartiallySignedTransaction merged;
-    BOOST_CHECK(CombinePSGTs(merged, {psgt1, psgt2}));
-    BOOST_CHECK_EQUAL(merged.inputs[0].partial_sigs.size(), 2u);
+    BOOST_REQUIRE(CombinePSGTs(merged, {psgt1, psgt2}));
+    BOOST_REQUIRE_EQUAL(merged.inputs[0].partial_sigs.size(), 2u);
 
     CMutableTransaction result;
-    BOOST_CHECK(FinalizeAndExtractPSGT(merged, result));
+    BOOST_REQUIRE(FinalizeAndExtractPSGT(merged, result));
 
     // The extracted scriptSig (OP_0 <sig> <sig> <redeemScript>) must satisfy the
     // P2SH output under standard flags (which include SCRIPT_VERIFY_P2SH).


### PR DESCRIPTION
Implements the **Qt signing surface (item 10b)** of #3006 — a dialog for working with Partially Signed Gridcoin Transactions (PSGT).

Surfaced via a new **"Sign message" submenu** (Sign message / Verify message / Multisign (PSGT)). The dialog lets a user:
- **Load** a base64 PSGT
- **Inspect** the decoded inputs/outputs with per-input signing status
- **Sign** the inputs the wallet holds keys for
- **Combine** co-signers' PSGTs
- **Finalize** a fully-signed PSGT into a broadcast-ready raw transaction hex (copy out; no in-dialog broadcast)

It reuses the existing PSGT C++ API in `src/psgt.h` directly (`DecodeRawPSGT`, `SignPSGTInput`, `FinalizePSGT`, `CombinePSGTs`, `FinalizeAndExtractPSGT`, `SerializePSGT`), mirroring the `walletprocesspsgt`/`finalizepsgt` RPCs, and follows the `SignVerifyMessageDialog` pattern (`pwalletMain` + `WalletModel::UnlockContext`). **No backend changes.**

**Files**
- New: `src/qt/multisigndialog.{h,cpp}`, `src/qt/forms/multisigndialog.ui`
- Wiring: `src/qt/bitcoingui.{cpp,h}`, `src/qt/CMakeLists.txt`

**Testing**
- Builds cleanly (native Qt6) against current `development`; all fork CI green (Quality Gate, Production, Distribution Native, Compatibility).
- Manually verified the menu/submenu, dialog render (WSLg), and the decode-error/inspect paths on regtest. A full create → sign → finalize multisig round-trip has not yet been exercised end-to-end — flagging that explicitly.
- Screenshots below made with https://github.com/gridcoin-community/Gridcoin-Research/pull/3048

<img width="1918" height="1032" alt="image" src="https://github.com/user-attachments/assets/83489976-8a15-4cf2-8151-1ec70c224db4" />

<img width="1917" height="1029" alt="image" src="https://github.com/user-attachments/assets/f0859465-d870-45c9-bdb0-e4d2296ebb4a" />

<img width="1918" height="1030" alt="image" src="https://github.com/user-attachments/assets/4bd08409-dcef-447b-875e-5442c0e8e9ec" />

<img width="1918" height="1029" alt="image" src="https://github.com/user-attachments/assets/a7d5993b-d396-490a-bab0-f22017681129" />



**Notes**
- Opening as **draft**: #3006 noted 10b was parked pending the Qt transaction-model rework (#2944). The dialog is self-contained and doesn't depend on it, but happy to sequence behind #2944 if preferred.
- HD-keypath metadata population (the file-static `FillHDKeypaths` in `rpc/psgt.cpp`) is intentionally omitted from the GUI signing path — it's optional BIP32 metadata, not required for signing/finalizing.
- UX (single-page load/inspect/sign/combine/finalize) is my proposal since the issue left it unspecified — feedback welcome.

Closes https://github.com/gridcoin-community/Gridcoin-Research/issues/3006
