### PR TITLE
qt: fix sticky/inconsistent transaction Type filter (anchor misapplied to filter changes)

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -350,7 +350,14 @@ void TransactionView::applyFilter()
 {
     if(!m_detailedModel)
         return;
-    captureAnchor();   // preserve the user's row across the filter Reset (PR5-B)
+    // A filter change alters the row SET, not just its order, so re-anchoring to the
+    // prior filter's selected/top row is meaningless — it parks the viewport at a
+    // switch-history-dependent position (e.g. toggling All Types <-> Mined landing on
+    // a different scroll each time: the "sticky filter" bug). Drop any anchor so the
+    // new filtered list shows from the top; the model reset resets the scroll and
+    // applyReset seeds the top window synchronously. Anchor-on-RESORT is unaffected —
+    // it is captured on the header click (QHeaderView::sectionClicked -> captureAnchor).
+    m_have_anchor = false;
     m_detailedModel->setFilter(m_filterSpec);
 }
 


### PR DESCRIPTION
## Summary

Switching the **Type** filter in the transaction view (e.g. *All Types* ↔ *Mined*) gave **inconsistent results**: the list landed at a scroll position that depended on the switch history rather than showing the new filtered set from the top. Reported during the PR5-C GUI mesh soak.

## Root cause

`TransactionView::applyFilter()` reused the **anchor-on-resort** machinery (`captureAnchor`, introduced in PR5-B #3041) for **filter** changes. It captured the `(hash, idx)` of the *old* filter's selected/top row; after the cursor rebuilt and the model reset, `restoreAnchor()` re-centred the viewport on that prior-filter row in the *new* filtered view (`scrollTo(…, PositionAtCenter)`), or — when the row was filtered out — left the scroll wherever it was. A filter changes the row **set**, not just its order, so re-anchoring to a prior row is meaningless and the landing position depended on what was selected before the switch — the "sticky" symptom.

Everything downstream was already correct (confirmed by an adversarial trace of the whole path):
- the type predicate is a stateless bitmask (`txfilter.cpp` `Accepts`);
- the cursor fully rebuilds + bumps epoch + emits a `Reset` on every `setFilter` (no dedup, no `FilterSpec operator==`);
- event delivery and the `WindowCache` content channel **provably converge to the latest filter on every drain** (monotonic seqno, atomic `getRows`, coalesced-Reset self-heal).

The defect was purely in viewport/anchor restoration.

## Fix

`applyFilter()` now **drops any anchor** (`m_have_anchor = false`) instead of capturing one. A filter change therefore shows the new filtered list **from the top**: the model reset resets the view scroll, and `applyReset` seeds the top window synchronously (so no blank rows for the first screen). **Anchor-on-resort is unaffected** — it is captured independently on the header click (`QHeaderView::sectionClicked → captureAnchor`), which is the conceptually correct split: a *sort* keeps the same rows reordered (preserve the row), a *filter* changes the set (reset to top).

One-line change in `applyFilter()`; `captureAnchor`/`restoreAnchor` are otherwise untouched.

## Behaviour change

All filter widgets (type / date / amount / search) now consistently reset to the top and clear the selection on change — the conventional behaviour for a filter (and an improvement over the prior per-change re-centre jump). Header-click **sort** still preserves and re-centres the clicked row.

## Testing

- GUI-off regression: `qt_cursor_tests` / `qt_windowcache_tests` / `qt_txfilter_tests` / `qt_txorder_tests` green; Qt suites green; clean clang + thread-safety build.
- No GUI-off test exists for the anchor/viewport UI behaviour (it lives in the GUI shell); this is best confirmed by a quick GUI check (toggle All Types ↔ Mined → list shows from the top each time; header-click sort still keeps the clicked row centred).

Pre-existing since PR5-B (#3041); independent of PR5-C (#3049).