### PR TITLE
greylist: fix cs_lock/autogreylist_lock lock-order inversion in AutoGreylist::RefreshWithSuperblock

### DIFF
--- a/src/gridcoin/project.cpp
+++ b/src/gridcoin/project.cpp
@@ -441,6 +441,20 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
     // now impossible -- Refresh fires explicitly at the chain handler points, not from inside Snapshot).
     const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED, false);
 
+    // Capture the Whitelist first-actives by value BEFORE taking autogreylist_lock. GetProjectsFirstActive()
+    // self-acquires cs_lock; calling it while holding autogreylist_lock (as the post-PR2997 code did) formed the
+    // reverse lock edge autogreylist_lock -> cs_lock -- an ABBA deadlock against the canonical cs_lock ->
+    // autogreylist_lock taken by Whitelist::Snapshot -> IsDeepCopyActive/Contains (Snapshot is not cs_main-gated,
+    // so the two run concurrently). Taking the by-value copy here, with no autogreylist_lock held, removes that
+    // edge. It is safe without autogreylist_lock: the copy bumps the entries' shared_ptr refcounts (so they
+    // outlive any concurrent slot replace/erase under cs_lock), and the only field the loop reads, m_timestamp,
+    // is write-once (set on the local payload before insertion). Guarded by the lock-free Populated() to preserve
+    // the original short-circuit (the getter ran only on the populated path).
+    Whitelist::ProjectEntryMap project_first_actives;
+    if (whitelist.Populated()) {
+        project_first_actives = GetWhitelist().GetProjectsFirstActive();
+    }
+
     LOCK(autogreylist_lock);
 
     // Gate: is the non-mutating deep-copy overlay active at this superblock's height? Stored under
@@ -454,8 +468,6 @@ void AutoGreylist::RefreshWithSuperblock(SuperblockPtr superblock_ptr_in,
     if (!whitelist.Populated()) {
         return;
     }
-
-    const Whitelist::ProjectEntryMap& project_first_actives = GetWhitelist().GetProjectsFirstActive();
 
     // If this superblock version is less than 3, then all prior ones must also be less than 3, so bail.
     if (superblock_ptr_in->m_version < 3) {


### PR DESCRIPTION
## Summary

`AutoGreylist::RefreshWithSuperblock` takes `autogreylist_lock` and then, still holding it, calls `GetWhitelist().GetProjectsFirstActive()` (project.cpp:458), which self-acquires the Whitelist `cs_lock`. That forms the reverse lock edge **`autogreylist_lock → cs_lock`** — an ABBA deadlock against the canonical **`cs_lock → autogreylist_lock`** taken by `Whitelist::Snapshot → IsDeepCopyActive/Contains`. `Snapshot` is `const` and **not** `cs_main`-gated, so the two legs run on different threads concurrently (scraper convergence/refresh vs. manifest-receive). A `-DENABLE_DEBUG_LOCKORDER=ON` build flagged it on an isolated testnet:

```
potential deadlock detected: cs_lock -> autogreylist_lock -> cs_lock
  Historical: cs_lock(project.cpp:668, Snapshot) -> autogreylist_lock(:363, IsDeepCopyActive)   [grc-msghand]
  Current:    autogreylist_lock(:444, RefreshWithSuperblock) -> cs_lock(:1138, GetProjectsFirstActive) [grc-scraper]
```

## Root cause

Introduced by the refresh-redesign (PR #2997): pre-redesign `AutoGreylist::Refresh` ran *inside* `Whitelist::Snapshot` with `cs_lock` already held, so the order was uniformly `cs_lock → autogreylist_lock`. The redesign (a) moved `Refresh` out to the chain handlers (no outer `cs_lock`) **and** (b) made `GetProjectsFirstActive` self-acquire `cs_lock` — so the refresh now grabs `cs_lock` *fresh* while holding `autogreylist_lock`. The existing comment on the self-locking getter reasoned only about harmless *forward* recursive re-entry and missed this reverse edge.

## Fix

Capture the first-actives by value **before** taking `autogreylist_lock` (the getter's internal `cs_lock` then fully acquires + releases with no `autogreylist_lock` held, eliminating the reverse edge). The canonical `cs_main → cs_lock → autogreylist_lock` order is restored and the lock graph is acyclic.

This is **safe without `autogreylist_lock`** and **consensus-neutral**:
- The by-value `std::map<std::string, ProjectEntry_ptr>` copy bumps the entries' `shared_ptr` refcounts, so they outlive any concurrent slot replace/erase under `cs_lock` — no use-after-free.
- The only field the loop reads, `m_timestamp`, is write-once (set on the local payload before insertion; no in-place write through any registry-held pointer). It is a distinct member from the one field ever mutated in place (`m_status`, in `Snapshot`'s overlay), so there is no data race on the bytes read.
- Only lock-acquisition order and the variable's storage class change; the greylist computation/output is byte-identical. The lock-free `Populated()` guard preserves the getter's original populated-path-only short-circuit, and the post-lock `Populated()` early-return is kept (it must still set `m_deep_copy_active` and clear `m_greylist_ptr` on the empty path).

Considered and rejected: marking `GetProjectsFirstActive` `EXCLUSIVE_LOCKS_REQUIRED(cs_lock)` and holding `cs_lock` across the refresh — it buys no correctness (the read is already race-free), breaks Whitelist encapsulation (`cs_lock` is private; `AutoGreylist` is a separate class), and would balloon `cs_lock` hold time across the up-to-40-superblock `ReadBlockFromDisk` walk, stalling non-`cs_main` Snapshot readers (`listprojects`/`getrawprojectstatus`/GUI).

## Validation

- Clean Clang **`-Werror=thread-safety`** build (GUI + tests); full unit suite + the `Project`/`Whitelist` suites (which drive `RefreshWithSuperblock`) green.
- **Live-validated** on an isolated-testnet scraper node built with `-DENABLE_DEBUG_LOCKORDER=ON` + ASan/UBSan: before the fix the `cs_lock ↔ autogreylist_lock` warning fired during a convergence cycle; after the fix, two convergence cycles ran with **zero** warnings and no sanitizer reports.
- Multi-agent root-cause + fix-design analysis with adversarial verification, plus an independent review of the committed diff.

`project.cpp` is unchanged by the #2558 net work; this is an independent fix to the post-#2997 AutoGreylist lock structure.