### PR TITLE
ci: fix unwritable MYPY_CACHE_DIR that crashes mypy in lint-python.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ flatpak-build/
 flatpak-repo/
 .flatpak-builder/
 *.flatpak
+
+# mypy cache (lint-python.sh writes here)
+test/.mypy_cache/

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -7,7 +7,12 @@
 # Check for specified flake8 warnings in python files.
 
 export LC_ALL=C
-export MYPY_CACHE_DIR="${BASE_ROOT_DIR}/test/.mypy_cache"
+# MYPY_CACHE_DIR must resolve to a writable path, or the mypyc-compiled mypy SIGSEGVs
+# instead of reporting a usable error. BASE_ROOT_DIR is an optional override (a Bitcoin Core
+# lint convention) that a CI job or caller may export -- it is not set anywhere in this tree,
+# so when unset the path previously resolved to the unwritable "/test/.mypy_cache". Fall back
+# to the repo root so the cache path is always writable, whether run via a harness or standalone.
+export MYPY_CACHE_DIR="${BASE_ROOT_DIR:-$(git rev-parse --show-toplevel)}/test/.mypy_cache"
 
 enabled=(
     E101 # indentation contains mixed spaces and tabs


### PR DESCRIPTION
## Problem
`test/lint/lint-python.sh` sets `MYPY_CACHE_DIR="${BASE_ROOT_DIR}/test/.mypy_cache"`, but `BASE_ROOT_DIR` is never defined anywhere in `test/lint/`, so it expands to the unwritable absolute path `/test/.mypy_cache`. The mypyc-compiled `mypy` then **SIGSEGVs (core dumps)** on that unwritable cache dir instead of reporting a usable error — so `lint-all.sh` fails with a crash rather than a real lint result. This affects both standalone runs and `lint-all.sh` (nothing in the lint tree exports `BASE_ROOT_DIR`).

## Diagnosis
It is **not** a stack overflow (an easy misread of the SIGSEGV). A clean 2x2 isolates the real cause:

| `MYPY_CACHE_DIR` | stack limit | result |
|---|---|---|
| writable | default | pass |
| writable | unlimited | pass |
| unwritable (`/test/.mypy_cache`) | unlimited | **SIGSEGV** |

A writable cache passes at the default stack; an unwritable cache crashes even with an unlimited stack.

## Fix
Fall back to the git repo root when `BASE_ROOT_DIR` is unset, so the cache dir is always writable (no effect when the runner already exports `BASE_ROOT_DIR`), plus a `.gitignore` entry since the cache now lands inside the repo. After this, `test/lint/lint-all.sh` exits 0 (no segfault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
