### PR TITLE
test: add interface_cli.py CLI client-path functional test (refs #2932, closes #3018)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,9 @@ if(ENABLE_TESTS AND ENABLE_DAEMON)
         set(PACKAGE_NAME "${PROJECT_NAME}")
         set(PACKAGE_BUGREPORT "https://github.com/gridcoin-community/Gridcoin-Research/issues")
         set(ENABLE_GRIDCOIND_CONF "true")
-        set(ENABLE_CLI_CONF "false")     # no separate gridcoin-cli; daemon answers RPC
+        set(ENABLE_CLI_CONF "true")      # no separate gridcoin-cli, but the daemon
+                                         # doubles as the RPC client (GRIDCOINCLI below
+                                         # points at it), so CLI tests can run.
         set(ENABLE_WALLET_CONF "true")   # Gridcoin always builds the BDB wallet
         set(ENABLE_ZMQ_CONF "false")     # Gridcoin has no ZMQ support
 

--- a/test/functional/interface_cli.py
+++ b/test/functional/interface_cli.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""End-to-end test of the CLI client argument path on regtest.
+
+The functional framework normally drives the node through authproxy.py (typed
+JSON-RPC over HTTP), so it never exercises the CLI client's string->JSON
+parameter conversion (RPCConvertValues / vRPCConvertParams in
+src/rpc/client.cpp). A missing conversion-table entry breaks a command from the
+shell while every other functional test still passes.
+
+Gridcoin has no separate gridcoin-cli binary: gridcoinresearchd, given a
+non-switch argv, acts as the RPC client (CommandLineRPC). This test spawns that
+client mode (via the framework's node.cli wrapper) for a representative sample
+of commands whose arguments are NOT plain strings -- int, bool, JSON array,
+JSON object -- plus the deliberately dual-mode `logging <category>` plain-string
+form, and asserts each call round-trips to the same value the typed RPC path
+returns. It is the end-to-end complement to the static check-rpc-mappings unit
+test, which cross-checks the conversion table against the RPCHelpMan arg types.
+"""
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class InterfaceCLITest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.extra_args = [["-staking=0", "-connect=0", "-listen=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_cli()
+        self.skip_if_no_wallet()
+
+    def setup_network(self):
+        # Single isolated node; nothing to connect or sync.
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def run_test(self):
+        node = self.nodes[0]
+        cli = node.cli
+
+        # Establish a short chain so the lookups below have real data.
+        node.generatetoaddress(3, node.getnewaddress())
+        height = node.getblockcount()
+
+        self.log.info("no-argument command agrees over CLI and RPC")
+        assert_equal(cli.getblockcount(), height)
+
+        # int argument: getblockhash <height>. The client converts "3" -> 3
+        # (vRPCConvertParams { "getblockhash", 0 }); without the entry the server
+        # would receive a string and reject it.
+        self.log.info("int argument round-trips: getblockhash")
+        assert_equal(cli.getblockhash(height), node.getblockhash(height))
+
+        # bool argument: getblock <hash> <txinfo>. Param 1 is converted string->bool
+        # ({ "getblock", 1 } in the table); a missing entry would send "True" and
+        # the server's get_bool() would reject it.
+        self.log.info("bool argument round-trips: getblock txinfo")
+        best = node.getbestblockhash()
+        assert_equal(cli.getblock(best, True), node.getblock(best, True))
+
+        # array + object arguments: createrawtransaction <inputs> <outputs>.
+        # Param 0 (JSON array) and param 1 (JSON object) are both string->JSON
+        # converted by the client. No funded utxo is needed -- the command only
+        # serializes the values it is handed -- so a dummy input keeps the test
+        # deterministic.
+        self.log.info("array + object arguments round-trip: createrawtransaction")
+        inputs = [{"txid": "00" * 32, "vout": 0}]
+        outputs = {node.getnewaddress(): 1.0}
+        assert_equal(cli.createrawtransaction(inputs, outputs),
+                     node.createrawtransaction(inputs, outputs))
+
+        # int + bool arguments: getbalance "*" <minconf> <include_watchonly>.
+        # Param 1 string->int, param 2 string->bool.
+        self.log.info("int + bool arguments round-trip: getbalance")
+        assert_equal(cli.getbalance("*", 0, True), node.getbalance("*", 0, True))
+
+        # logging dual-mode: `logging` is deliberately absent from the conversion
+        # table, so the client passes a bare category name through as a string.
+        # EnableOrDisableLogCategories accepts that non-array form (see the
+        # comment in src/rpc/misc.cpp); the JSON-array form only works over CURL.
+        self.log.info("logging <category> round-trips as a plain string")
+        baseline = cli.logging()
+        assert isinstance(baseline, dict) and "net" in baseline, baseline
+        enabled = cli.logging("net")
+        assert_equal(enabled["net"], True)
+        disabled = cli.logging("", "net")
+        assert_equal(disabled["net"], False)
+
+
+if __name__ == "__main__":
+    InterfaceCLITest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -216,10 +216,14 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
             "bin",
             "gridcoinresearchd" + config["environment"]["EXEEXT"],
         )
+        # Gridcoin has no separate gridcoin-cli binary; gridcoinresearchd doubles
+        # as the RPC client (it runs CommandLineRPC when given a non-switch argv).
+        # Default the "cli" binary to the daemon so direct invocations work; the
+        # CMake suite also exports GRIDCOINCLI pointing at the same binary.
         fname_gridcoincli = os.path.join(
             config["environment"]["BUILDDIR"],
             "bin",
-            "gridcoin-cli" + config["environment"]["EXEEXT"],
+            "gridcoinresearchd" + config["environment"]["EXEEXT"],
         )
         self.options.gridcoind = os.getenv("GRIDCOIND", default=fname_gridcoind)
         self.options.gridcoincli = os.getenv("GRIDCOINCLI", default=fname_gridcoincli)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -130,6 +130,10 @@ BASE_SCRIPTS = [
     #   - rpc_netinfo.py: getnetworkinfo/getnettotals/getconnectioncount/getpeerinfo
     #   - rpc_multisig.py: addmultisigaddress -> validateaddress
     #   - wallet_listtransactions.py: listtransactions/gettransaction/listsinceblock
+    # Phase 4A.3 adds the CLI client-path test (#3018):
+    #   - interface_cli.py: drives gridcoinresearchd in client mode and asserts
+    #     string->JSON arg conversion (RPCConvertValues) round-trips for int/
+    #     bool/array/object args plus the dual-mode `logging <category>` form
     'feature_hello.py',
     'feature_regtest_staking.py',
     'p2p_version_handshake.py',
@@ -147,6 +151,7 @@ BASE_SCRIPTS = [
     'wallet_backup.py',
     'wallet_keypool.py',
     'wallet_listtransactions.py',
+    'interface_cli.py',
     'mempool_accept.py',
     'rpc_net.py',
     'feature_sidestake.py',


### PR DESCRIPTION
Closes #3018. Part of the #2932 functional-test port. The blockers (#2991 regtest chain mode, #2993 CI wiring) are merged, so the CLI test is now a small addition.

## Why

The functional framework drives nodes through `authproxy.py` (typed JSON-RPC over HTTP), so it never exercises the CLI client's string→JSON parameter conversion (`RPCConvertValues` / `vRPCConvertParams` in `src/rpc/client.cpp`). A missing conversion-table entry breaks a command from the shell while every other functional test still passes. The `check-rpc-mappings` unit test covers the table statically; this adds the missing end-to-end path: shell argv → `CommandLineRPC` → conversion → HTTP → server.

## What

`test/functional/interface_cli.py` spawns the client mode for a representative sample of commands whose arguments are **not** plain strings and asserts each round-trips to the same value the typed RPC path returns:

- **int** — `getblockhash <height>`
- **bool** — `getblock <hash> <txinfo>`
- **int + bool** — `getbalance "*" <minconf> <include_watchonly>`
- **array + object** — `createrawtransaction <inputs> <outputs>`
- **dual-mode plain-string** — `logging <category>` (the deliberately non-array form Gridcoin's `EnableOrDisableLogCategories` accepts; the JSON-array form only works over CURL)

## Plumbing

Gridcoin has no separate `gridcoin-cli` binary — `gridcoinresearchd`, given a non-switch argv, acts as the RPC client. To let the framework use it as the CLI binary:

- `CMakeLists.txt` — `ENABLE_CLI_CONF "true"` so `config.ini` reports `ENABLE_CLI=true` and `skip_if_no_cli()` no longer skips (the suite already exports `GRIDCOINCLI` pointing at `gridcoinresearchd`).
- `test/functional/test_framework/test_framework.py` — default the "cli" binary to `gridcoinresearchd` so direct invocations resolve without the env override.
- `test/functional/test_runner.py` — register `interface_cli.py` in `BASE_SCRIPTS`.

No C++ changes.

## Test

Validated against a regtest `gridcoinresearchd`: the test passes, correctly **skips** when `ENABLE_CLI=false`, and is discovered/run by `test_runner.py`. Fork CI (incl. the functional suite) is green.