### PR TITLE
refactor: move CTxMemPool into txmempool.{h,cpp}

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(gridcoin_util STATIC
     support/cleanse.cpp
     support/lockedpool.cpp
     sync.cpp
+    txmempool.cpp
     uint256.cpp
     util.cpp
     util/bip32.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,8 +68,6 @@ set<CWallet*> setpwalletRegistered;
 CCriticalSection cs_main;
 CCriticalSection cs_tx_val_commit_to_disk;
 
-CTxMemPool mempool;
-
 ///////////////////////MINOR VERSION////////////////////////////////
 
 extern int64_t GetCoinYearReward(int64_t nTime);
@@ -507,77 +505,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());
 
     return true;
-}
-
-bool CTxMemPool::addUnchecked(const uint256& hash, CTransaction &tx)
-{
-    // Add to memory pool without checking anything.  Don't call this directly,
-    // call AcceptToMemoryPool to properly check the transaction first.
-    {
-        mapTx[hash] = tx;
-        for (unsigned int i = 0; i < tx.vin.size(); i++)
-            mapNextTx[tx.vin[i].prevout] = CInPoint(&mapTx[hash], i);
-    }
-    return true;
-}
-
-
-bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
-{
-    m_mrc_bloom_dirty = true;
-    // Remove transaction from memory pool
-    {
-        LOCK(cs);
-        uint256 hash = tx.GetHash();
-        if (mapTx.count(hash))
-        {
-            if (fRecursive) {
-                for (unsigned int i = 0; i < tx.vout.size(); i++) {
-                    std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
-                    if (it != mapNextTx.end())
-                        remove(*it->second.ptx, true);
-                }
-            }
-            for (auto const& txin : tx.vin)
-                mapNextTx.erase(txin.prevout);
-            mapTx.erase(hash);
-        }
-    }
-    return true;
-}
-
-bool CTxMemPool::removeConflicts(const CTransaction &tx)
-{
-    m_mrc_bloom_dirty = true;
-    // Remove transactions which depend on inputs of tx, recursively
-    LOCK(cs);
-    for (auto const &txin : tx.vin)
-    {
-        std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(txin.prevout);
-        if (it != mapNextTx.end()) {
-            const CTransaction &txConflict = *it->second.ptx;
-            if (txConflict != tx)
-                remove(txConflict, true);
-        }
-    }
-    return true;
-}
-
-void CTxMemPool::clear()
-{
-    LOCK(cs);
-    mapTx.clear();
-    mapNextTx.clear();
-}
-
-void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
-{
-    vtxid.clear();
-
-    LOCK(cs);
-    vtxid.reserve(mapTx.size());
-    for (map<uint256, CTransaction>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
-        vtxid.push_back(mi->first);
 }
 
 int CMerkleTx::GetDepthInMainChainINTERNAL(CBlockIndex* &pindexRet) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/main.h
+++ b/src/main.h
@@ -21,6 +21,7 @@
 #include "sync.h"
 #include "script.h"
 #include "scrypt.h"
+#include "txmempool.h"
 #include "validation.h"
 
 #include <map>
@@ -36,7 +37,6 @@ class COutPoint;
 class CAddress;
 class CInv;
 class CNode;
-class CTxMemPool;
 
 namespace GRC {
 class Claim;
@@ -112,19 +112,6 @@ extern int nGrandfather;
 class CReserveKey;
 class CTxDB;
 class CTxIndex;
-
-/** Reason why transaction was removed from mempool */
-// TODO: Consider moving MemPoolRemovalReason to a shared header (e.g. txmempool.h)
-// so that both main.cpp and wallet code can reference it without pulling in all of main.h.
-enum class MemPoolRemovalReason {
-    UNKNOWN = 0,      //!< Manually removed or unknown reason
-    EXPIRY = 1,       //!< Expired from mempool
-    SIZELIMIT = 2,    //!< Removed due to size limit
-    REORG = 3,        //!< Removed for reorganization
-    BLOCK = 4,        //!< Removed because included in block
-    CONFLICT = 5,     //!< Removed due to conflict
-    REPLACED = 6      //!< Removed due to replacement (RBF)
-};
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
@@ -255,50 +242,4 @@ public:
     bool AcceptToMemoryPool();
 };
 
-
-
-
-
-
-
-
-
-class CTxMemPool
-{
-public:
-    mutable CCriticalSection cs;
-    std::map<uint256, CTransaction> mapTx;
-    std::map<COutPoint, CInPoint> mapNextTx;
-    uint64_t m_mrc_bloom{0};
-    bool m_mrc_bloom_dirty{false};
-
-    bool addUnchecked(const uint256& hash, CTransaction &tx);
-    bool remove(const CTransaction &tx, bool fRecursive = false);
-    bool removeConflicts(const CTransaction &tx);
-    void clear();
-    void queryHashes(std::vector<uint256>& vtxid);
-
-    unsigned long size() const
-    {
-        LOCK(cs);
-        return mapTx.size();
-    }
-
-    bool exists(uint256 hash) const
-    {
-        LOCK(cs);
-        return (mapTx.count(hash) != 0);
-    }
-
-    bool lookup(uint256 hash, CTransaction& result) const
-    {
-        LOCK(cs);
-        std::map<uint256, CTransaction>::const_iterator i = mapTx.find(hash);
-        if (i == mapTx.end()) return false;
-        result = i->second;
-        return true;
-    }
-};
-
-extern CTxMemPool mempool;
 #endif

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "txmempool.h"
+
+#include "sync.h"
+
+CTxMemPool mempool;
+
+bool CTxMemPool::addUnchecked(const uint256& hash, CTransaction &tx)
+{
+    // Add to memory pool without checking anything.  Don't call this directly,
+    // call AcceptToMemoryPool to properly check the transaction first.
+    {
+        mapTx[hash] = tx;
+        for (unsigned int i = 0; i < tx.vin.size(); i++)
+            mapNextTx[tx.vin[i].prevout] = CInPoint(&mapTx[hash], i);
+    }
+    return true;
+}
+
+
+bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
+{
+    m_mrc_bloom_dirty = true;
+    // Remove transaction from memory pool
+    {
+        LOCK(cs);
+        uint256 hash = tx.GetHash();
+        if (mapTx.count(hash))
+        {
+            if (fRecursive) {
+                for (unsigned int i = 0; i < tx.vout.size(); i++) {
+                    std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
+                    if (it != mapNextTx.end())
+                        remove(*it->second.ptx, true);
+                }
+            }
+            for (auto const& txin : tx.vin)
+                mapNextTx.erase(txin.prevout);
+            mapTx.erase(hash);
+        }
+    }
+    return true;
+}
+
+bool CTxMemPool::removeConflicts(const CTransaction &tx)
+{
+    m_mrc_bloom_dirty = true;
+    // Remove transactions which depend on inputs of tx, recursively
+    LOCK(cs);
+    for (auto const &txin : tx.vin)
+    {
+        std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(txin.prevout);
+        if (it != mapNextTx.end()) {
+            const CTransaction &txConflict = *it->second.ptx;
+            if (txConflict != tx)
+                remove(txConflict, true);
+        }
+    }
+    return true;
+}
+
+void CTxMemPool::clear()
+{
+    LOCK(cs);
+    mapTx.clear();
+    mapNextTx.clear();
+}
+
+void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
+{
+    vtxid.clear();
+
+    LOCK(cs);
+    vtxid.reserve(mapTx.size());
+    for (std::map<uint256, CTransaction>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
+        vtxid.push_back(mi->first);
+}

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TXMEMPOOL_H
+#define BITCOIN_TXMEMPOOL_H
+
+#include "primitives/transaction.h"
+#include "sync.h"
+#include "uint256.h"
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+/** Reason why transaction was removed from mempool */
+enum class MemPoolRemovalReason {
+    UNKNOWN = 0,      //!< Manually removed or unknown reason
+    EXPIRY = 1,       //!< Expired from mempool
+    SIZELIMIT = 2,    //!< Removed due to size limit
+    REORG = 3,        //!< Removed for reorganization
+    BLOCK = 4,        //!< Removed because included in block
+    CONFLICT = 5,     //!< Removed due to conflict
+    REPLACED = 6      //!< Removed due to replacement (RBF)
+};
+
+class CTxMemPool
+{
+public:
+    mutable CCriticalSection cs;
+    std::map<uint256, CTransaction> mapTx;
+    std::map<COutPoint, CInPoint> mapNextTx;
+    uint64_t m_mrc_bloom{0};
+    bool m_mrc_bloom_dirty{false};
+
+    bool addUnchecked(const uint256& hash, CTransaction &tx);
+    bool remove(const CTransaction &tx, bool fRecursive = false);
+    bool removeConflicts(const CTransaction &tx);
+    void clear();
+    void queryHashes(std::vector<uint256>& vtxid);
+
+    unsigned long size() const
+    {
+        LOCK(cs);
+        return mapTx.size();
+    }
+
+    bool exists(uint256 hash) const
+    {
+        LOCK(cs);
+        return (mapTx.count(hash) != 0);
+    }
+
+    bool lookup(uint256 hash, CTransaction& result) const
+    {
+        LOCK(cs);
+        std::map<uint256, CTransaction>::const_iterator i = mapTx.find(hash);
+        if (i == mapTx.end()) return false;
+        result = i->second;
+        return true;
+    }
+};
+
+extern CTxMemPool mempool;
+
+#endif // BITCOIN_TXMEMPOOL_H


### PR DESCRIPTION
## What

Moves `CTxMemPool`, `enum class MemPoolRemovalReason`, and the `extern CTxMemPool mempool;` declaration out of the ~1200-line `src/main.h` god-header into a new, `main.h`-free `src/txmempool.{h,cpp}` (guard `BITCOIN_TXMEMPOOL_H`), mirroring Bitcoin Core's `txmempool.h`.

The global `mempool` definition and the five out-of-line methods — `addUnchecked`, `remove`, `removeConflicts`, `clear`, `queryHashes` — move into `txmempool.cpp` (one unqualified `map<>` qualified to `std::map<>` in the process).

`main.h` keeps `#include "txmempool.h"`, so every existing consumer — including `wallet/wallet.{h,cpp}`, which uses `MemPoolRemovalReason` — resolves transitively with no edits. **No functional change** — pure code move.

## Why

Continues the incremental `main.h` / `main.cpp` decomposition tracked in #3030, following A1 (block primitives, #3060). Pulling `CTxMemPool` into its own translation unit shrinks the god-header further and doubles as **Phase 0 of the mempool modernization in #3029**.

> **Stacked on #3060.** Until that merges, the diff here also includes the A1 block-primitives commits; it narrows to just the txmempool move once #3060 lands.

## Diffstat

`main.h` −60, `main.cpp` −73; new `src/txmempool.{h,cpp}`; `txmempool.cpp` registered in `src/CMakeLists.txt` (`gridcoin_util`, after `sync.cpp`).

## Testing

Full CI matrix green on the source branch — **Quality Gate** (compile + Clang thread-safety / lock-order analysis), **Distribution Native**, **Compatibility**, **Production** builds, and **Functional Tests**. Move-only diff (`git diff -M`), no logic change.
