### PR TITLE
rpc: fix getaddednodeinfo dns=true to return an array

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -171,12 +171,10 @@ static const RPCHelpMan getaddednodeinfo_help{
         {"node", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
             "If provided, return information about this specific added node, otherwise all are returned."},
     },
-    RPCResult{RPCResult::Type::OBJ, "", "",
-        {
-            {RPCResult::Type::ELISION, "",
-                "Shape depends on the 'dns' argument: a map of \"addednode\" -> node string when dns=false, "
-                "or nested per-node connection detail when dns=true."},
-        }},
+    RPCResult{RPCResult::Type::ANY, "",
+        "Shape depends on the 'dns' argument: an object mapping \"addednode\" -> "
+        "node string when dns=false, or an ARRAY of per-added-node objects "
+        "(addednode / connected / addresses) when dns=true."},
     RPCExamples{
         HelpExampleCli("getaddednodeinfo", "true") +
         HelpExampleCli("getaddednodeinfo", "true \"192.168.0.6:32749\"") +
@@ -218,7 +216,11 @@ UniValue getaddednodeinfo(const UniValue& params)
         return ret;
     }
 
-    UniValue ret(UniValue::VOBJ);
+    // dns=true returns an ARRAY of per-added-node objects. (Fix: this was a
+    // VOBJ, but UniValue::push_back is a no-op on objects, so the handler always
+    // returned {}; and the Lookup-failure branch built an object it never
+    // pushed, dropping unresolvable nodes. Both are corrected here.)
+    UniValue ret(UniValue::VARR);
 
     list<pair<string, vector<CService> > > laddedAddresses(0);
     for (auto const& strAddNode : laddedNodes)
@@ -233,6 +235,7 @@ UniValue getaddednodeinfo(const UniValue& params)
             obj.pushKV("connected", false);
             UniValue addresses(UniValue::VARR);
             obj.pushKV("addresses", addresses);
+            ret.push_back(obj);
         }
     }
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -7,6 +7,7 @@
 #include <rpc/client.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
+#include <net.h>
 
 #include <univalue.h>
 
@@ -116,6 +117,28 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1.00000000")), 100000000LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.9999999")), 2099999999999990LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.99999999")), 2099999999999999LL);
+}
+
+// Regression guard: getaddednodeinfo dns=true must return an ARRAY of per-node
+// objects. It previously built a UniValue object and populated it with
+// push_back (a no-op on objects), so it always returned {}. g_connman is
+// provided by the global TestingSetup fixture.
+BOOST_AUTO_TEST_CASE(getaddednodeinfo_dns_true_returns_array)
+{
+    BOOST_REQUIRE(g_connman);
+    const std::string node = "192.0.2.10:32749"; // TEST-NET-1, never a live peer
+    BOOST_REQUIRE(g_connman->AddNode(node));
+
+    UniValue params(UniValue::VARR);
+    params.push_back(true); // dns=true
+    UniValue r = tableRPC["getaddednodeinfo"]->actor(params);
+
+    BOOST_CHECK(r.isArray());
+    BOOST_CHECK_EQUAL(r.size(), 1u);
+    BOOST_CHECK_EQUAL(r[0]["addednode"].get_str(), node);
+    BOOST_CHECK_EQUAL(r[0]["connected"].get_bool(), false);
+
+    g_connman->RemoveAddedNode(node); // vAddedNodes is process-global; clean up
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/rpc_getaddednodeinfo.py
+++ b/test/functional/rpc_getaddednodeinfo.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""Functional coverage for the getaddednodeinfo dns=true array fix.
+
+dns=true previously returned {} because the handler built a UniValue object and
+populated it with push_back (a no-op on objects). This guards the fix: dns=true
+now returns an ARRAY of per-added-node objects, while dns=false still returns the
+object mapping "addednode" -> node string. Single investor-mode regtest node; no
+connection is needed since the added node is never reachable.
+"""
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class RpcGetAddedNodeInfoTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.extra_args = [["-staking=0"]]
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def run_test(self):
+        node = self.nodes[0]
+        dummy = "192.0.2.10:32749"  # TEST-NET-1, never reachable
+
+        # No added nodes yet: dns=false is an empty object, dns=true an empty array.
+        assert_equal(node.getaddednodeinfo(False), {})
+        assert_equal(node.getaddednodeinfo(True), [])
+
+        node.addnode(dummy, "add")
+
+        # dns=false: object mapping "addednode" -> the node string.
+        info = node.getaddednodeinfo(False)
+        assert_equal(info["addednode"], dummy)
+
+        # dns=true: ARRAY of per-added-node objects (the fix; previously {}).
+        detail = node.getaddednodeinfo(True)
+        assert_equal(isinstance(detail, list), True)
+        assert_equal(len(detail), 1)
+        assert_equal(detail[0]["addednode"], dummy)
+        assert_equal(detail[0]["connected"], False)
+        self.log.info("getaddednodeinfo dns=true returns an array of per-node objects")
+
+        # Removing empties both shapes again.
+        node.addnode(dummy, "remove")
+        assert_equal(node.getaddednodeinfo(False), {})
+        assert_equal(node.getaddednodeinfo(True), [])
+
+
+if __name__ == "__main__":
+    RpcGetAddedNodeInfoTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -142,6 +142,7 @@ BASE_SCRIPTS = [
     'rpc_htlc.py',
     'rpc_blockchain.py',
     'rpc_netinfo.py',
+    'rpc_getaddednodeinfo.py',
     'rpc_multisig.py',
     'wallet_basic.py',
     'wallet_backup.py',


### PR DESCRIPTION
## Problem

`getaddednodeinfo` with `dns=true` always returns `{}`. The handler builds a
`UniValue` `VOBJ` but populates it with `push_back`, which is a no-op on objects
(only arrays accept `push_back`). It also builds an object for each added node
whose `Lookup` fails but never pushes it, silently dropping unresolvable nodes.

## Fix

- Make the `dns=true` result a `VARR`, matching the documented "per-node
  connection detail" shape and Bitcoin Core's `getaddednodeinfo`.
- Push the `Lookup`-failure objects so unresolvable nodes are no longer dropped.
- Correct the `RPCResult` type to `ANY` with an accurate description of the dual
  shape (object when `dns=false`, array of per-node objects when `dns=true`).
- `dns=false` is unchanged.

## Test

Adds an `rpc_tests` unit test asserting `dns=true` returns an array of per-node
objects (`g_connman` is provided by the global `TestingSetup` fixture).

## Notes

Found while working on #2558 (now merged). The bug is independent of that work and
still reproduces on current `development`. This branch is the 2-file fix
cherry-picked cleanly onto `development` after the #2558 stack landed.
