### PR TITLE
net: use a per-connection nonce for self-connection detection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -433,22 +433,16 @@ void CNode::PushVersion()
     int64_t nTime = GetAdjustedTime();
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(LookupNumeric("0.0.0.0", 0)));
     CAddress addrMe = CAddress(CService(), nLocalServices);
-    // GetRandBytes() writes raw bytes into the provided buffer; that's
-    // incompatible with memcpy'ing into a std::atomic's storage directly,
-    // so go through a local and store atomically.
-    //
-    // The local `nonce` is what we send on the wire below -- the atomic
-    // store is only to publish it to ProcessMessage's self-connection
-    // sentinel check. Reading the atomic back here for the PushMessage
-    // payload would lose the value to a concurrent PushVersion() on
-    // another outbound connection that ran between our store() and
-    // load(). (The single-global-nonce design is still racy across
-    // multiple simultaneous outbound connections versus their respective
-    // self-connection echoes -- a separate per-connection-nonce follow-up
-    // is the proper fix; see PR #2957 commit message for context.)
+    // Generate this connection's VERSION nonce once and remember it on the
+    // CNode (issue #3067). Self-connection detection (CheckIncomingNonce)
+    // compares an incoming VERSION's nonce against every connection's own nonce,
+    // so each connection carries its own rather than sharing one global that a
+    // concurrent PushVersion() on another outbound connection could overwrite.
+    // GetRandBytes() can't write into a std::atomic's storage directly, so go
+    // through a local: it is both what we send on the wire and what we store.
     uint64_t nonce;
     GetRandBytes({(unsigned char*)&nonce, sizeof(nonce)});
-    if (g_connman) g_connman->SetLocalHostNonce(nonce);
+    nLocalHostNonce = nonce;
 
     // Snapshot the chain height under cs_main so this method can be called
     // from CNode construction (socket handler thread, no outer locks held)
@@ -2038,6 +2032,21 @@ void CConnman::ForEachNode(const std::function<void(CNode*)>& func) const
     for (const auto& pnode : m_nodes) {
         func(pnode);
     }
+}
+
+bool CConnman::CheckIncomingNonce(uint64_t nonce)
+{
+    // Self-connection detection (issue #3067). The nonce is one of ours only if
+    // a still-handshaking OUTBOUND connection sent it (an inbound peer echoing
+    // our nonce is the loopback we want to catch; established connections have
+    // moved past the handshake). Restricting to !fInbound && !fSuccessfullyConnected
+    // also makes a 1-in-2^64 collision with a genuine peer's nonce harmless.
+    LOCK(m_nodes_mutex);
+    for (const auto& pnode : m_nodes) {
+        if (!pnode->fSuccessfullyConnected && !pnode->fInbound && pnode->nLocalHostNonce == nonce)
+            return false;
+    }
+    return true;
 }
 
 bool CConnman::DisconnectNode(const std::string& strNode)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -440,8 +440,13 @@ void CNode::PushVersion()
     // concurrent PushVersion() on another outbound connection could overwrite.
     // GetRandBytes() can't write into a std::atomic's storage directly, so go
     // through a local: it is both what we send on the wire and what we store.
+    // ProcessMessage's self-connection sentinel only fires for an incoming nonce > 1
+    // (nNonce defaults to 1 when the field is absent), so re-roll the rare {0,1} draw to
+    // keep the invariant explicit: our own nonce is always detectable as a self-connect.
     uint64_t nonce;
-    GetRandBytes({(unsigned char*)&nonce, sizeof(nonce)});
+    do {
+        GetRandBytes({(unsigned char*)&nonce, sizeof(nonce)});
+    } while (nonce <= 1);
     nLocalHostNonce = nonce;
 
     // Snapshot the chain height under cs_main so this method can be called
@@ -2034,7 +2039,7 @@ void CConnman::ForEachNode(const std::function<void(CNode*)>& func) const
     }
 }
 
-bool CConnman::CheckIncomingNonce(uint64_t nonce)
+bool CConnman::CheckIncomingNonce(uint64_t nonce) const
 {
     // Self-connection detection (issue #3067). The nonce is one of ours only if
     // a still-handshaking OUTBOUND connection sent it (an inbound peer echoing

--- a/src/net.h
+++ b/src/net.h
@@ -308,6 +308,14 @@ public:
     // Best measured round-trip time.
     std::atomic<int64_t> nMinPingUsecTime{std::numeric_limits<int64_t>::max()};
 
+    // The random nonce this connection puts in its outgoing VERSION message
+    // (issue #3067). Carried per-CNode so self-connection detection compares an
+    // incoming VERSION's nonce against the nonce WE sent on each connection
+    // (CConnman::CheckIncomingNonce), rather than a single process-global nonce
+    // that concurrent outbound handshakes could overwrite. Set in PushVersion;
+    // read on the message-handler thread under m_nodes_mutex, hence atomic.
+    std::atomic<uint64_t> nLocalHostNonce{0};
+
     // Whether a ping is requested.
     bool fPingQueued;
 
@@ -347,6 +355,7 @@ public:
         setInventoryKnown.max_size(SendBufferSize() / 1000);
         nPingNonceSent = 0;
         nPingUsecStart = 0;
+        nLocalHostNonce = 0; // overwritten by PushVersion (issue #3067)
         fPingQueued = false;
 
         // Be shy and don't send version until we hear
@@ -733,11 +742,12 @@ public:
     //! PR 9c; moved from net_processing's ADDR handler).
     void RelayAddress(const CAddress& addr, bool fReachable);
 
-    //! Local-host version nonce for self-connection detection (issue #2558
-    //! PR 9d; moved off the net global). Set on each outgoing VERSION push,
-    //! compared against incoming VERSIONs.
-    uint64_t GetLocalHostNonce() const { return m_local_host_nonce; }
-    void SetLocalHostNonce(uint64_t nonce) { m_local_host_nonce = nonce; }
+    //! Self-connection check (issue #3067; replaces the single process-global
+    //! nonce that was racy across simultaneous outbound handshakes). Returns
+    //! false if `nonce` matches the nonce one of our own still-handshaking
+    //! outbound connections sent -- i.e. the peer echoing it is ourselves --
+    //! and true otherwise. Takes m_nodes_mutex internally.
+    bool CheckIncomingNonce(uint64_t nonce);
 
     //! The address a peer last reported seeing us at (issue #2558 PR 9d; moved
     //! off the net global). Surfaced by the getinfo RPCs.
@@ -783,10 +793,6 @@ private:
     mutable RecursiveMutex m_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
 
-    //! Local-host version nonce (issue #2558 PR 9d). Atomic: written on the
-    //! socket-handler thread (PushVersion), read on the message-handler thread
-    //! (self-connection check).
-    std::atomic<uint64_t> m_local_host_nonce{0};
     //! The address a peer reports seeing us at (issue #2558 PR 9d). CAddress
     //! copy is not atomic, hence the mutex.
     mutable CCriticalSection m_addr_seen_by_peer_cs;

--- a/src/net.h
+++ b/src/net.h
@@ -747,7 +747,7 @@ public:
     //! false if `nonce` matches the nonce one of our own still-handshaking
     //! outbound connections sent -- i.e. the peer echoing it is ourselves --
     //! and true otherwise. Takes m_nodes_mutex internally.
-    bool CheckIncomingNonce(uint64_t nonce);
+    bool CheckIncomingNonce(uint64_t nonce) const;
 
     //! The address a peer last reported seeing us at (issue #2558 PR 9d; moved
     //! off the net global). Surfaced by the getinfo RPCs.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -334,9 +334,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             SeenLocal(addrMe);
         }
 
-        // Disconnect if we connected to ourself (issue #2558 PR 9d: the nonce
-        // now lives on CConnman).
-        if (g_connman && nNonce == g_connman->GetLocalHostNonce() && nNonce > 1)
+        // Disconnect if we connected to ourself (issue #3067: the nonce is now
+        // per-connection; CheckIncomingNonce scans our outgoing handshakes).
+        if (g_connman && nNonce > 1 && !g_connman->CheckIncomingNonce(nNonce))
         {
             LogPrint(BCLog::LogFlags::NET, "connected to self at %s, disconnecting", pfrom->addr.ToString());
             pfrom->fDisconnect = true;


### PR DESCRIPTION
Closes #3067.

## Problem

Self-connection detection compared an incoming VERSION's nonce against a **single
process-global** local-host nonce (`CConnman::m_local_host_nonce`). In the outbound
version handshake, a concurrent `PushVersion()` on another outbound connection could
overwrite that nonce between our `store()` and the peer's echo, so a genuine
self-connection could go undetected in the multiple-simultaneous-outbound window.
The race was documented in an in-code comment (PR #2957 context).

## Fix

Carry the nonce **per `CNode`** instead of sharing one global:

- Each connection generates and remembers its own nonce (`CNode::nLocalHostNonce`)
  in `PushVersion`, and sends that on the wire.
- A new `CConnman::CheckIncomingNonce(nonce)` scans the node list for a
  still-handshaking outbound connection whose nonce matches the received one — a
  faithful port of Bitcoin Core's `CheckIncomingNonce`. Restricting the match to
  `!fInbound && !fSuccessfullyConnected` also makes a 1-in-2^64 collision with a
  genuine peer's nonce harmless.
- The detection site in `net_processing.cpp` now calls `CheckIncomingNonce`; the
  global nonce and its getter/setter are removed.

## Test

Build + the existing functional/unit suites (all green on the fork's cmake_* checks).
Manual smoke: a self-`addnode` still disconnects on the self-connection path.
