### PR TITLE
net: adopt a shared_ptr<CNode> connection-lifetime model

### DIFF
--- a/build_targets.sh
+++ b/build_targets.sh
@@ -346,7 +346,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "native" ]] && [[ "$(uname -s)" == "Lin
         cmake --build build -j $CORES
 
         # Test
-        ctest --test-dir build -j $CORES
+        ctest --test-dir build -j $CORES --output-on-failure
 
         # Write state file (Only if build and test succeeded)
         write_build_state "build"
@@ -433,7 +433,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "depends" ]] && [[ "$(uname -s)" == "Li
         cmake --build build_linux_depends -j $CORES
 
         # Test
-        ctest --test-dir build_linux_depends -j $CORES
+        ctest --test-dir build_linux_depends -j $CORES --output-on-failure
 
         # Write state file
         write_build_state "build_linux_depends"
@@ -523,7 +523,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "win64" ]] && [[ "$(uname -s)" == "Linu
         cmake --build build_win64 -j $CORES
 
         # Test
-        ctest --test-dir build_win64 -j $CORES
+        ctest --test-dir build_win64 -j $CORES --output-on-failure
 
         # Write state file
         write_build_state "build_win64"
@@ -618,7 +618,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "macos" ]] && [[ "$(uname -s)" == "Darw
         cmake --build build_macos -j $CORES
 
         # Test
-        ctest --test-dir build_macos -j $CORES
+        ctest --test-dir build_macos -j $CORES --output-on-failure
 
         # Write state file
         write_build_state "build_macos"

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2153,8 +2153,11 @@ void CConnman::RelayAddress(const CAddress& addr, bool fReachable)
     for (auto const& pnode : m_nodes)
     {
         CNode* pnodeRaw = pnode.get();
-        unsigned int nPointer;
-        memcpy(&nPointer, &pnodeRaw, sizeof(nPointer));
+        // Mix node identity into the relay selection. Cast the pointer value to an
+        // integer rather than memcpy'ing its object representation: well-defined, and
+        // (intentionally) the same low-order value as the old memcpy on this platform,
+        // so relay-node selection is unchanged.
+        unsigned int nPointer = static_cast<unsigned int>(reinterpret_cast<uintptr_t>(pnodeRaw));
         uint256 hashKey = ArithToUint256(UintToArith256(hashRand) ^ nPointer);
         hashKey = Hash(hashKey);
         mapMix.insert(make_pair(hashKey, pnodeRaw));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -302,7 +302,7 @@ CNode* CConnman::FindNode(const CNetAddr& ip)
     LOCK(m_nodes_mutex);
     for (auto const& pnode : m_nodes) {
         if (static_cast<CNetAddr>(pnode->addr) == ip) {
-            return pnode;
+            return pnode.get();
         }
     }
     return nullptr;
@@ -313,7 +313,7 @@ CNode* CConnman::FindNode(const std::string& addrName)
     LOCK(m_nodes_mutex);
     for (auto const& pnode : m_nodes) {
         if (pnode->addrName == addrName) {
-            return pnode;
+            return pnode.get();
         }
     }
     return nullptr;
@@ -324,7 +324,7 @@ CNode* CConnman::FindNode(const CService& addr)
     LOCK(m_nodes_mutex);
     for (auto const& pnode : m_nodes) {
         if (static_cast<CService>(pnode->addr) == addr) {
-            return pnode;
+            return pnode.get();
         }
     }
     return nullptr;
@@ -340,7 +340,7 @@ void AddressCurrentlyConnected(const CService& addr)
 }
 
 
-CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest)
+std::shared_ptr<CNode> CConnman::ConnectNode(CAddress addrConnect, const char *pszDest)
 {
     if (pszDest == nullptr) {
         if (IsLocal(addrConnect))
@@ -373,9 +373,9 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest)
             LogPrintf("ConnectSocket() : fcntl non-blocking setting error %d", errno);
 #endif
 
-        // Add node
-        CNode* pnode = new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false);
-        pnode->AddRef();
+        // Add node. m_nodes owns the connection via shared_ptr (issue #3066);
+        // returning a copy keeps it alive for the caller while it finishes setup.
+        auto pnode = std::make_shared<CNode>(hSocket, addrConnect, pszDest ? pszDest : "", false);
 
         {
             LOCK(m_nodes_mutex);
@@ -721,7 +721,7 @@ void CConnman::ThreadSocketHandler()
 void CConnman::ThreadSocketHandler2()
 {
     LogPrint(BCLog::LogFlags::NET, "ThreadSocketHandler started");
-    list<CNode*> vNodesDisconnected;
+    std::list<std::shared_ptr<CNode>> vNodesDisconnected;
     unsigned int nPrevNodeCount = 0;
 
     while (true)
@@ -731,45 +731,40 @@ void CConnman::ThreadSocketHandler2()
         //
         {
             LOCK(m_nodes_mutex);
-            // Disconnect unused nodes
-            vector<CNode*> vNodesCopy = m_nodes;
-            for (auto const& pnode : vNodesCopy)
+            // Disconnect flagged nodes. (The former empty-buffer auto-disconnect
+            // path was dead code: every connected node held a permanent creation
+            // reference, so its GetRefCount() never reached 0 -- the gate that
+            // path required. Disconnection has therefore always been driven by
+            // fDisconnect alone, which is preserved here. issue #3066.)
             {
-                // vRecvMsg / nSendSize / ssSend are guarded by per-node locks.
-                // Take them in canonical order (cs_vRecvMsg first, then cs_vSend)
-                // for the disconnect-eligibility check. Lazy: only if refcount
-                // has dropped to zero, since the test short-circuits otherwise.
-                bool empty_buffers = false;
-                if (pnode->GetRefCount() <= 0) {
-                    LOCK2(pnode->cs_vRecvMsg, pnode->cs_vSend);
-                    empty_buffers = pnode->vRecvMsg.empty()
-                                    && pnode->nSendSize == 0
-                                    && pnode->ssSend.empty();
-                }
-                if (pnode->fDisconnect || empty_buffers)
+                std::vector<std::shared_ptr<CNode>> vNodesCopy = m_nodes;
+                for (const auto& pnode : vNodesCopy)
                 {
-                    // remove from m_nodes
-                    m_nodes.erase(remove(m_nodes.begin(), m_nodes.end(), pnode), m_nodes.end());
+                    if (pnode->fDisconnect)
+                    {
+                        // remove from m_nodes (drops its owning reference)
+                        m_nodes.erase(remove(m_nodes.begin(), m_nodes.end(), pnode), m_nodes.end());
 
-                    // release outbound grant (if any)
-                    pnode->grantOutbound.Release();
+                        // release outbound grant (if any)
+                        pnode->grantOutbound.Release();
 
-                    // close socket and cleanup
-                    pnode->CloseSocketDisconnect();
+                        // close socket and cleanup
+                        pnode->CloseSocketDisconnect();
 
-                    // hold in disconnected pool until all refs are released
-                    if (pnode->fNetworkNode || pnode->fInbound)
-                        pnode->Release();
-                    vNodesDisconnected.push_back(pnode);
+                        // hold in the disconnected pool until no other reference remains
+                        vNodesDisconnected.push_back(pnode);
+                    }
                 }
-            }
+            } // vNodesCopy released here so it does not inflate use_count() below
 
-            // Delete disconnected nodes
-            list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
-            for (auto const& pnode : vNodesDisconnectedCopy)
+            // Delete disconnected nodes. use_count() == 1 means only
+            // vNodesDisconnected still references the node -- no snapshot on
+            // another thread is using it -- so once the per-node locks are free
+            // the node can be dropped from the list, which deletes it (issue #3066).
+            for (auto it = vNodesDisconnected.begin(); it != vNodesDisconnected.end(); )
             {
-                // wait until threads are done using it
-                if (pnode->GetRefCount() <= 0)
+                const std::shared_ptr<CNode>& pnode = *it;
+                if (pnode.use_count() == 1)
                 {
                     bool fDelete = false;
                     {
@@ -787,10 +782,11 @@ void CConnman::ThreadSocketHandler2()
                     }
                     if (fDelete)
                     {
-                        vNodesDisconnected.remove(pnode);
-                        delete pnode;
+                        it = vNodesDisconnected.erase(it);
+                        continue;
                     }
                 }
+                ++it;
             }
         }
 
@@ -939,8 +935,7 @@ void CConnman::ThreadSocketHandler2()
                 }
 
                 LogPrint(BCLog::LogFlags::NET, "accepted connection %s", addr.ToString());
-                CNode* pnode = new CNode(hSocket, addr, "", true);
-                pnode->AddRef();
+                auto pnode = std::make_shared<CNode>(hSocket, addr, "", true);
                 {
                     LOCK(m_nodes_mutex);
                     m_nodes.push_back(pnode);
@@ -955,12 +950,12 @@ void CConnman::ThreadSocketHandler2()
         //
         // Service each socket
         //
-        vector<CNode*> vNodesCopy;
+        // Snapshot the node list; the shared_ptr copies keep each node alive for
+        // the duration of this service pass without a manual AddRef (issue #3066).
+        std::vector<std::shared_ptr<CNode>> vNodesCopy;
         {
             LOCK(m_nodes_mutex);
             vNodesCopy = m_nodes;
-            for (auto const& pnode : vNodesCopy)
-                pnode->AddRef();
         }
         for (auto const& pnode : vNodesCopy)
         {
@@ -1045,7 +1040,7 @@ void CConnman::ThreadSocketHandler2()
             {
                 TRY_LOCK(pnode->cs_vSend, lockSend);
                 if (lockSend)
-                    SocketSendData(pnode);
+                    SocketSendData(pnode.get());
             }
 
             //
@@ -1108,11 +1103,8 @@ void CConnman::ThreadSocketHandler2()
                 }
             }
         }
-        {
-            LOCK(m_nodes_mutex);
-            for (auto const& pnode : vNodesCopy)
-                pnode->Release();
-        }
+        // vNodesCopy's shared_ptr copies are released as it goes out of scope
+        // at the next loop iteration (issue #3066); no manual Release needed.
 
         UninterruptibleSleep(std::chrono::milliseconds{10});
     }
@@ -1697,7 +1689,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGran
     if (strDest && FindNode(strDest))
         return false;
 
-    CNode* pnode = ConnectNode(addrConnect, strDest);
+    std::shared_ptr<CNode> pnode = ConnectNode(addrConnect, strDest);
     if (fShutdown)
         return false;
     if (!pnode)
@@ -1747,18 +1739,19 @@ void CConnman::ThreadMessageHandler2()
         // here. Null if none is configured (no pumping then).
         NetEventsInterface* msgproc = g_connman ? g_connman->GetMessageProcessor() : nullptr;
 
-        vector<CNode*> vNodesCopy;
+        // Snapshot via shared_ptr copies (issue #3066): each node stays alive for
+        // this processing pass without a manual AddRef, and is released when
+        // vNodesCopy goes out of scope at the next loop iteration.
+        std::vector<std::shared_ptr<CNode>> vNodesCopy;
         {
             LOCK(m_nodes_mutex);
             vNodesCopy = m_nodes;
-            for (auto const& pnode : vNodesCopy)
-                pnode->AddRef();
         }
 
         // Poll the connected nodes for messages
         CNode* pnodeTrickle = nullptr;
         if (!vNodesCopy.empty())
-            pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())];
+            pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())].get();
         for (auto const& pnode : vNodesCopy)
         {
             if (pnode->fDisconnect)
@@ -1769,7 +1762,7 @@ void CConnman::ThreadMessageHandler2()
             {
                 TRY_LOCK(pnode->cs_vRecvMsg, lockRecv);
                 if (lockRecv)
-                    if (msgproc && !msgproc->ProcessMessages(pnode))
+                    if (msgproc && !msgproc->ProcessMessages(pnode.get()))
                         pnode->CloseSocketDisconnect();
             }
 
@@ -1792,7 +1785,7 @@ void CConnman::ThreadMessageHandler2()
                     TRY_LOCK(pnode->cs_vSend, lockSend);
                     if (lockSend)
                     {
-                        if (msgproc) msgproc->SendMessages(pnode, pnode == pnodeTrickle);
+                        if (msgproc) msgproc->SendMessages(pnode.get(), pnode.get() == pnodeTrickle);
                     }
                 }
             }
@@ -1800,12 +1793,7 @@ void CConnman::ThreadMessageHandler2()
             if (fShutdown)
                 return;
         }
-
-        {
-            LOCK(m_nodes_mutex);
-            for (auto const& pnode : vNodesCopy)
-                pnode->Release();
-        }
+        // vNodesCopy released as it leaves scope at the next iteration (issue #3066).
 
         // Wait and allow messages to bunch up.
         // we're sleeping, but we must always check fShutdown after doing this.
@@ -2036,7 +2024,7 @@ void CConnman::ForEachNode(const std::function<void(CNode*)>& func) const
 {
     LOCK(m_nodes_mutex);
     for (const auto& pnode : m_nodes) {
-        func(pnode);
+        func(pnode.get());
     }
 }
 
@@ -2054,7 +2042,7 @@ bool CConnman::DisconnectNode(const CSubNet& subnet)
 {
     bool disconnected = false;
     LOCK(m_nodes_mutex);
-    for (CNode* pnode : m_nodes) {
+    for (const auto& pnode : m_nodes) {
         if (subnet.Match(pnode->addr)) {
             pnode->fDisconnect = true;
             disconnected = true;
@@ -2071,7 +2059,7 @@ bool CConnman::DisconnectNode(const CNetAddr& addr)
 bool CConnman::DisconnectNode(NodeId id)
 {
     LOCK(m_nodes_mutex);
-    for (CNode* pnode : m_nodes) {
+    for (const auto& pnode : m_nodes) {
         if (id == pnode->GetId()) {
             pnode->fDisconnect = true;
             return true;
@@ -2139,7 +2127,7 @@ void CConnman::ForEachNodeUnderLock(const std::function<void(CNode*)>& func) con
     AssertLockHeld(cs_main);
     LOCK(m_nodes_mutex);
     for (const auto& pnode : m_nodes) {
-        func(pnode);
+        func(pnode.get());
     }
 }
 
@@ -2164,11 +2152,12 @@ void CConnman::RelayAddress(const CAddress& addr, bool fReachable)
     multimap<uint256, CNode*> mapMix;
     for (auto const& pnode : m_nodes)
     {
+        CNode* pnodeRaw = pnode.get();
         unsigned int nPointer;
-        memcpy(&nPointer, &pnode, sizeof(nPointer));
+        memcpy(&nPointer, &pnodeRaw, sizeof(nPointer));
         uint256 hashKey = ArithToUint256(UintToArith256(hashRand) ^ nPointer);
         hashKey = Hash(hashKey);
-        mapMix.insert(make_pair(hashKey, pnode));
+        mapMix.insert(make_pair(hashKey, pnodeRaw));
     }
     int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
     for (multimap<uint256, CNode*>::iterator mi = mapMix.begin(); mi != mapMix.end() && nRelayNodes-- > 0; ++mi)

--- a/src/net.h
+++ b/src/net.h
@@ -260,14 +260,6 @@ public:
     bool fSuccessfullyConnected;
     std::atomic_bool fDisconnect;
     CSemaphoreGrant grantOutbound;
-    // Reference count gating the reaper's delete in ThreadSocketHandler2. Atomic
-    // because it is correct only by the convention that every mutation runs under
-    // the node mutex EXCEPT the two pre-publish AddRef()s (ConnectNode / inbound
-    // accept) on a not-yet-listed node. A plain int could not be GUARDED_BY the
-    // node mutex anyway once that mutex becomes a CConnman private member (a CNode
-    // field cannot name CConnman's private lock), so atomic is the analyzer-clean
-    // expression of the existing all-but-two-under-lock discipline (issue #2558).
-    std::atomic<int> nRefCount{0};
 protected:
 
     // Denial-of-service detection/prevention. The misbehavior score map and its
@@ -330,7 +322,6 @@ public:
         fNetworkNode = false;
         fSuccessfullyConnected = false;
         fDisconnect = false;
-        nRefCount = 0;
         nSendSize = 0;
         nSendOffset = 0;
         hashContinue.SetNull();
@@ -382,12 +373,6 @@ public:
         return id;
     }
 
-    int GetRefCount()
-    {
-        assert(nRefCount >= 0);
-        return nRefCount;
-    }
-
     unsigned int GetTotalRecvSize() EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)
     {
         unsigned int total = 0;
@@ -404,19 +389,6 @@ public:
         for (auto &msg : vRecvMsg)
             msg.SetVersion(nVersionIn);
     }
-
-    CNode* AddRef()
-    {
-        nRefCount++;
-        return this;
-    }
-
-    void Release()
-    {
-        nRefCount--;
-    }
-
-
 
     void AddAddressKnown(const CAddress& addr)
     {
@@ -710,8 +682,10 @@ public:
     //! Open an outbound connection (reusing an existing one if already connected)
     //! and register the new CNode in m_nodes (issue #2558; was a net.cpp free
     //! function). Public because the addnode "onetry" RPC dials directly; the
-    //! internal outbound machinery goes through OpenNetworkConnection.
-    CNode* ConnectNode(CAddress addrConnect, const char* strDest = nullptr);
+    //! internal outbound machinery goes through OpenNetworkConnection. Returns a
+    //! shared_ptr so the caller keeps the node alive while it finishes wiring it
+    //! up, even if the reaper races to disconnect it (issue #3066).
+    std::shared_ptr<CNode> ConnectNode(CAddress addrConnect, const char* strDest = nullptr);
 
     //! Persistent added-node ("addnode add/remove/getaddednodeinfo") list
     //! (issue #2558 PR 9b2). Backed by the still-global vAddedNodes. AddNode
@@ -781,7 +755,12 @@ private:
     //! graph slot the old cs_vNodes held: a leaf among the net locks (after cs_main,
     //! before the per-CNode cs_vSend/cs_vRecvMsg/cs_inventory leaves).
     mutable RecursiveMutex m_nodes_mutex;
-    std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
+    //! Connections are owned via shared_ptr (issue #3066): m_nodes holds the sole
+    //! persistent owning reference, transient snapshots and the ConnectNode return
+    //! value are shared_ptr copies, and the reaper deletes a node once it has been
+    //! moved out of m_nodes and no other reference remains (use_count() == 1). This
+    //! retires the manual AddRef/Release refcount and the explicit `delete pnode`.
+    std::vector<std::shared_ptr<CNode>> m_nodes GUARDED_BY(m_nodes_mutex);
 
     //! Local-host version nonce (issue #2558 PR 9d). Atomic: written on the
     //! socket-handler thread (PushVersion), read on the message-handler thread

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -76,7 +76,7 @@ UniValue addnode(const UniValue& params)
             throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
         }
         CAddress addr;
-        CNode* pnode = g_connman->ConnectNode(addr, strNode.c_str());
+        std::shared_ptr<CNode> pnode = g_connman->ConnectNode(addr, strNode.c_str());
         if(!pnode)
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: Node connection failed");
         UniValue result(UniValue::VOBJ);


### PR DESCRIPTION
Closes #3066.

## Background

The #2558 stack moved the connection list into `CConnman` but deliberately kept the
inherited manual lifetime model: `CNode` lifetime was managed by `AddRef()`/`Release()`
on an atomic `nRefCount`, and the `ThreadSocketHandler2` reaper moved disconnected
nodes into a local `std::list<CNode*>` and `delete pnode` once the refcount and the
per-node locks cleared. Now that `CConnman` owns the storage, this adopts ownership via
`std::shared_ptr<CNode>` and retires the by-convention refcount foot-gun.

## Change

- `m_nodes` becomes `std::vector<std::shared_ptr<CNode>>` — it holds the sole persistent
  owning reference.
- `ConnectNode` returns `std::shared_ptr<CNode>` so `OpenNetworkConnection` and the addnode
  "onetry" RPC keep the node alive while they finish wiring it up, preserving the
  protection the old pre-publish `AddRef()` provided.
- The socket-handler and message-handler service passes snapshot `m_nodes` by copying the
  shared_ptr vector; the copies keep nodes alive for the pass and are released when the
  snapshot leaves scope, replacing the `AddRef`/`Release` loops.
- The reaper moves a disconnected node's shared_ptr into the disconnected pool and deletes
  it once `use_count() == 1` (only the pool references it) and the per-node locks are free,
  replacing the explicit `delete pnode`.

## Behavior-preserving note

The former empty-buffer auto-disconnect path is dropped: every connected node held a
permanent creation reference, so the `GetRefCount() <= 0` gate that path required never
held, making it dead code. Disconnection has always been driven by `fDisconnect` alone,
which is preserved.

## Risk / testing

MEDIUM — touches the hot connect/accept/reap path. Validated by a clean full local build
and all four fork cmake_* checks + Functional Tests green. The borrowing API
(`FindNode`/`ForEachNode`/etc.) keeps raw `CNode*` parameters; no caller stores a `CNode*`
past lock release and there are no `CNode*`-keyed maps, so the change stays contained to
`src/net.h` + `src/net.cpp` (and one `ConnectNode` caller in `rpc/net.cpp`).
