### PR TITLE
refactor: route GUI block-tip notifications through UpdatedBlockTip

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -78,7 +78,7 @@ namespace {
 class UINotificationBridge : public CValidationInterface
 {
 protected:
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* /*pindexFork*/, bool fInitialDownload) override
     {
         if (pindexNew == nullptr) return;
         uiInterface.NotifyBlocksChanged(fInitialDownload, pindexNew->nHeight,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -69,6 +69,25 @@ extern constexpr int DEFAULT_WAIT_CLIENT_TIMEOUT = 0;
 std::unique_ptr<BanMan> g_banman;
 std::unique_ptr<CScheduler> g_scheduler;
 
+namespace {
+//! Bridges the validation-signal layer to the legacy ui_interface block
+//! notification. Routing GUI tip updates through CValidationInterface (issue
+//! #3030, workstream B3) keeps the Qt models subscribing to
+//! uiInterface.NotifyBlocksChanged unchanged while letting any future
+//! subscriber (e.g. a PeerManager) hook UpdatedBlockTip as well.
+class UINotificationBridge : public CValidationInterface
+{
+protected:
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
+    {
+        if (pindexNew == nullptr) return;
+        uiInterface.NotifyBlocksChanged(fInitialDownload, pindexNew->nHeight,
+                                        pindexNew->GetBlockTime(), pindexNew->nBits);
+    }
+};
+UINotificationBridge g_ui_notification_bridge;
+} // namespace
+
 /**
  * The PID file facilities.
  */
@@ -259,10 +278,11 @@ void Shutdown(void* parg)
 
         fs::remove(GetPidFile(gArgs));
         // Defensive/idiomatic: a subscriber unregisters itself before deletion. In the
-        // current teardown order this is a no-op -- GetMainSignals().UnregisterBackground-
+        // current teardown order these are no-ops -- GetMainSignals().UnregisterBackground-
         // SignalScheduler() earlier in Shutdown() already reset CMainSignals' internals and
-        // disconnected every subscriber -- but keeping it makes the wallet's lifetime
+        // disconnected every subscriber -- but keeping them makes the subscribers' lifetimes
         // self-contained and load-bearing again if that ordering is ever changed.
+        UnregisterValidationInterface(&g_ui_notification_bridge);
         UnregisterValidationInterface(pwalletMain);
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
@@ -1868,6 +1888,10 @@ bool AppInit2(ThreadHandlerPtr threads)
     // layer is wired (issue #3030, workstream B). The wallet also stays in
     // setpwalletRegistered for the legacy notifications not yet migrated.
     RegisterValidationInterface(pwalletMain);
+
+    // Bridge chain-tip updates to the legacy ui_interface block notification so
+    // the Qt models keep receiving them (issue #3030, workstream B3).
+    RegisterValidationInterface(&g_ui_notification_bridge);
 
     g_scheduler->scheduleEvery([]{
         g_banman->DumpBanlist();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1249,11 +1249,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     }
     #endif
 
-    uiInterface.NotifyBlocksChanged(
-        fIsInitialDownload,
-        pindexNew->nHeight,
-        pindexNew->GetBlockTime(),
-        blockNew.nBits);
+    // Notify the validation-signal layer that the chain tip advanced. The UI
+    // bridge registered in init.cpp re-emits uiInterface.NotifyBlocksChanged()
+    // for the Qt models, so GUI block notifications now flow through the
+    // validation interface (issue #3030, workstream B3). origBestIndex is the
+    // previous tip / fork point.
+    GetMainSignals().UpdatedBlockTip(pindexNew, origBestIndex, fIsInitialDownload);
 
     return GridcoinServices();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1252,9 +1252,17 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
     // Notify the validation-signal layer that the chain tip advanced. The UI
     // bridge registered in init.cpp re-emits uiInterface.NotifyBlocksChanged()
     // for the Qt models, so GUI block notifications now flow through the
-    // validation interface (issue #3030, workstream B3). origBestIndex is the
-    // previous tip / fork point.
-    GetMainSignals().UpdatedBlockTip(pindexNew, origBestIndex, fIsInitialDownload);
+    // validation interface (issue #3030, workstream B3).
+    //
+    // pindexFork is passed as nullptr: the true reorg fork point is the common
+    // ancestor (pcommon, computed in ReorganizeChain) and is not plumbed up to
+    // this layer, so origBestIndex (the previous tip) would be wrong for any
+    // non-trivial reorg. No current subscriber reads pindexFork (the UI bridge
+    // ignores it), so nullptr is an honest "not supplied" rather than a
+    // misleading value; a future fork-point-dependent subscriber (e.g. the
+    // deferred PeerManager) should thread pcommon through instead. Tracked in
+    // issue #3104.
+    GetMainSignals().UpdatedBlockTip(pindexNew, nullptr, fIsInitialDownload);
 
     return GridcoinServices();
 }


### PR DESCRIPTION
## What

Routes the chain-tip notification that drives the Qt models through the validation-signal
layer instead of calling `ui_interface` directly from consensus code.

- `SetBestChain` now emits `GetMainSignals().UpdatedBlockTip(pindexNew, origBestIndex,
  fIsInitialDownload)` where it previously called `uiInterface.NotifyBlocksChanged()`.
- A small node-side subscriber (`UINotificationBridge`, file-local in init.cpp) translates
  `UpdatedBlockTip` back into `uiInterface.NotifyBlocksChanged()`, so the three Qt
  subscribers (ClientModel, WalletModel, ResearcherModel) are unchanged. Registered with
  the wallet, unregistered at shutdown.

## Why

Optional third step of issue #3030 workstream B. **Stacked on #3079.** The
`PeerManager`-subscriber half of B3 is deferred — `PeerManagerImpl::StartScheduledTasks`
is still an empty shell (#2558) — but it can now hook `UpdatedBlockTip` the same way.

No behavior change: `NotifyBlocksChanged` fires with the same arguments at the same point
under `cs_main`; only the path (now via `CMainSignals`) differs.

## Testing

Full CI matrix green on the source branch (a one-off OpenSUSE/Fedora functional_tests
flake cleared on re-run).
