### PR TITLE
refactor: extract chain-state globals into src/chain.h

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CHAIN_H
+#define BITCOIN_CHAIN_H
+
+#include "arith_uint256.h"
+#include "primitives/block.h"
+#include "sync.h"
+#include "uint256.h"
+
+#include <atomic>
+#include <unordered_map>
+
+class CBlockIndex;
+
+// BlockHasher lives in primitives/block.h (extracted in #3060); use it here for
+// the block-hash-keyed mapBlockIndex rather than redefining it.
+typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+
+//! The chain-state lock. Guards the active-chain globals below.
+extern CCriticalSection cs_main;
+
+//! Active chain state, extracted from main.h (issue #3030, workstream A6).
+//! These remain defined in main.cpp; only the declarations live here so
+//! consumers can depend on chain state without pulling in all of main.h.
+extern BlockMap mapBlockIndex GUARDED_BY(cs_main);
+extern CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main);
+extern int nBestHeight GUARDED_BY(cs_main);
+extern arith_uint256 nBestChainTrust GUARDED_BY(cs_main);
+extern uint256 hashBestChain GUARDED_BY(cs_main);
+extern CBlockIndex* pindexBest GUARDED_BY(cs_main);
+extern std::atomic<bool> g_reorg_in_progress;
+// Sync clocks updated by UpdateSyncTime() (node/chainman.cpp) and read by
+// OutOfSyncByAge() (main.cpp).
+extern std::atomic<int64_t> g_previous_block_time;
+extern std::atomic<int64_t> g_nTimeBestReceived;
+
+#endif // BITCOIN_CHAIN_H

--- a/src/main.h
+++ b/src/main.h
@@ -7,6 +7,7 @@
 
 #include "amount.h"
 #include "arith_uint256.h"
+#include "chain.h"
 #include "chainparams.h"
 #include "consensus/consensus.h"
 #include "index/disktxpos.h"
@@ -64,27 +65,17 @@ static const uint256 hashGenesisBlockRegTest = uint256S("0x4692b9564c585f76f41e0
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-
-typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+// BlockHasher, BlockMap, cs_main and the active-chain-state globals
+// (mapBlockIndex, pindexBest, hashBestChain, nBestHeight, ...) now live in
+// chain.h, included above (issue #3030, workstream A6). FutureDrift and
+// GetTargetSpacing live in primitives/block.h (extracted in #3060).
 
 extern CScript COINBASE_FLAGS;
-extern CCriticalSection cs_main;
 extern CCriticalSection cs_tx_val_commit_to_disk;
-extern BlockMap mapBlockIndex GUARDED_BY(cs_main);
-extern CBlockIndex* pindexGenesisBlock GUARDED_BY(cs_main);
 extern unsigned int nStakeMinAge;
 extern unsigned int nStakeMaxAge;
 extern unsigned int nNodeLifespan;
 extern int nCoinbaseMaturity;
-extern int nBestHeight GUARDED_BY(cs_main);
-extern arith_uint256 nBestChainTrust GUARDED_BY(cs_main);
-extern uint256 hashBestChain GUARDED_BY(cs_main);
-extern CBlockIndex* pindexBest GUARDED_BY(cs_main);
-extern std::atomic<bool> g_reorg_in_progress;
-// Sync clocks updated by UpdateSyncTime() (node/chainman.cpp) and read by
-// OutOfSyncByAge() (main.cpp).
-extern std::atomic<int64_t> g_previous_block_time;
-extern std::atomic<int64_t> g_nTimeBestReceived;
 extern const std::string strMessageMagic;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered GUARDED_BY(cs_setpwalletRegistered);


### PR DESCRIPTION
## What

Moves the active-chain-state declarations out of the `main.h` god-header into a new,
narrow `src/chain.h`:

  `BlockHasher`, `BlockMap`, `cs_main`, `mapBlockIndex`, `pindexGenesisBlock`,
  `nBestHeight`, `nBestChainTrust`, `hashBestChain`, `pindexBest`, `g_reorg_in_progress`,
  `g_previous_block_time`, `g_nTimeBestReceived`

These remain **defined** in main.cpp; only the declarations and the `BlockMap` /
`BlockHasher` types move. `main.h` keeps everything compiling by re-`#include`'ing
`chain.h`, so the ~79 main.h includers are unaffected (repointing individual consumers at
the narrower header is left as optional later cleanup). Non-chain-state globals stay in
main.h.

## Why

Issue #3030 workstream A6 (the last in-scope decomposition target). **Stacked on #3081.**
`chain.h` is self-sufficient (arith_uint256 / uint256 / sync.h / `<atomic>` /
`<unordered_map>`, forward-declared `CBlockIndex`). Header-only change, no CMake edit, no
behavior change.

## Testing

Full CI matrix green on the source branch.
