### PR TITLE
test: de-flake rpc_multisig.py — scale CI timeouts and add SIGTERM teardown fallback

### DIFF
--- a/build_targets.sh
+++ b/build_targets.sh
@@ -346,7 +346,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "native" ]] && [[ "$(uname -s)" == "Lin
         cmake --build build -j $CORES
 
         # Test
-        ctest --test-dir build -j $CORES
+        ctest --test-dir build -j $CORES --output-on-failure
 
         # Write state file (Only if build and test succeeded)
         write_build_state "build"
@@ -433,7 +433,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "depends" ]] && [[ "$(uname -s)" == "Li
         cmake --build build_linux_depends -j $CORES
 
         # Test
-        ctest --test-dir build_linux_depends -j $CORES
+        ctest --test-dir build_linux_depends -j $CORES --output-on-failure
 
         # Write state file
         write_build_state "build_linux_depends"
@@ -523,7 +523,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "win64" ]] && [[ "$(uname -s)" == "Linu
         cmake --build build_win64 -j $CORES
 
         # Test
-        ctest --test-dir build_win64 -j $CORES
+        ctest --test-dir build_win64 -j $CORES --output-on-failure
 
         # Write state file
         write_build_state "build_win64"
@@ -618,7 +618,7 @@ if [[ "$TARGET" == "all" || "$TARGET" == "macos" ]] && [[ "$(uname -s)" == "Darw
         cmake --build build_macos -j $CORES
 
         # Test
-        ctest --test-dir build_macos -j $CORES
+        ctest --test-dir build_macos -j $CORES --output-on-failure
 
         # Write state file
         write_build_state "build_macos"

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -344,6 +344,17 @@ class TestNode():
                 except Exception:
                     pass
 
+            # If the stop RPC never landed (e.g. the node never finished
+            # starting, so we never had an RPC connection), the daemon is still
+            # running and nothing has told it to exit. Send SIGTERM so
+            # wait_until_stopped() doesn't burn the full timeout and we don't
+            # leak a daemon that would starve the next parallel test. SIGTERM is
+            # graceful (the daemon's signal handler exits 0, keeping
+            # is_node_stopped()'s return-code assertion valid); we never kill -9.
+            # stop_exc is still re-raised below, so the failure stays visible.
+            if stop_exc is not None and self.process is not None and self.process.poll() is None:
+                self.process.terminate()
+
             # If there are any running perf processes, stop them. Per-process
             # try/except so one perf failure doesn't strand the rest.
             for profile_name in tuple(self.perf_subprocesses.keys()):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -67,6 +67,14 @@ if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):  # type: ignore
 TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77
 
+# Under --ci the suite runs several daemons in parallel on machines that are
+# often slow and heavily loaded (e.g. a full distro build job), so the default
+# 60 s rpc_timeout / wait_until_* budgets are too tight and produce spurious
+# "Unable to connect to gridcoinresearchd after 60s" flakes. Scale them up by
+# this factor for CI runs (Bitcoin Core's --ci does the same). Callers can still
+# override by passing an explicit --timeout-factor.
+CI_TIMEOUT_FACTOR = 4
+
 TEST_FRAMEWORK_MODULES = [
     # Phase 1 only has util.py. Phase 3 will add address / blocktools / key /
     # script / messages once messages.py and p2p.py land.
@@ -205,6 +213,13 @@ def main():
     config.read_file(open(configfile, encoding="utf8"))
 
     passon_args.append("--configfile=%s" % configfile)
+
+    # On CI, scale per-test timeouts (rpc_timeout, wait_until_*) so slow daemon
+    # startup under heavy parallel load doesn't fail spuriously. --timeout-factor
+    # is consumed by the test framework (test_framework.py) and reaches each
+    # script via passon_args. Skip if a caller already set one explicitly.
+    if args.ci and not any(a.startswith("--timeout-factor") for a in passon_args):
+        passon_args.append("--timeout-factor=%s" % CI_TIMEOUT_FACTOR)
 
     # Set up logging
     logging_level = logging.INFO if args.quiet else logging.DEBUG


### PR DESCRIPTION
## Summary

Fixes the intermittent `rpc_multisig.py` failure that #3088 surfaced once it added `--output-on-failure`. On the **Debian Unstable (Sid)** runner the captured output was:

```
[node 0] Unable to connect to gridcoinresearchd after 60s   (rpc_multisig.py setup_network)
...
1/3 Test #1: functional_tests .................***Failed  213.22 sec
```

`rpc_multisig.py` is minimal (1 node, `-staking=0 -connect=0 -listen=0`, no blocks), so this isn't a logic bug — node 0's RPC just didn't come up within the fixed **60 s** `rpc_timeout` on a runner saturated by a full distro build. It then **cascaded**: `stop_node()` never signaled the unreachable daemon, so `wait_until_stopped()` hung the full timeout and leaked the process (~180 s total, which also starves the next parallel test).

Two amplifying gaps, both fixed here (and both align with Bitcoin Core upstream):

## Changes

- **`test/functional/test_runner.py`** — under `--ci`, inject `--timeout-factor=4` (`CI_TIMEOUT_FACTOR`) into `passon_args` unless a caller passed one explicitly. This scales `rpc_timeout` and every `wait_until_*` budget (60 s → 240 s) for the parallel-daemon CI environment. Local dev runs (no `--ci`) are unchanged at 60 s. Previously `--ci` only enabled `fail_on_warn`; it never scaled timeouts the way upstream's `--ci` does.
- **`test/functional/test_framework/test_node.py`** — in `stop_node()`, if the stop RPC failed and the daemon is still alive, send **SIGTERM** so teardown doesn't burn the timeout or leak a daemon. It's graceful (exit 0) and the original error is **still re-raised**, so a genuine failure stays visible — and a node that ignores SIGTERM too still surfaces as a teardown timeout.

## Does this mask real bugs?

No. Deterministic failures (bad assert, wrong RPC result, crash) fail immediately regardless of `timeout_factor`. A genuine hang still fails — just up to 4× slower to report, still well under the `functional_tests` ctest `TIMEOUT 1800`. The SIGTERM fallback only fires after the stop RPC already failed and always re-raises, so it cleans up the process without hiding the failure.

## What this intentionally does NOT do

- Does **not** quarantine `rpc_multisig.py` to `EXTENDED_SCRIPTS` — it's deterministic; the slow-startup cause is generic to every test (unlike `feature_reorg.py`'s intrinsic shared-premine nondeterminism).
- Does **not** add retry/rerun — masks rather than fixes.
- Does **not** change `--jobs`.

## Testing

Validated live in WSL (Ubuntu, real `gridcoinresearchd`):

- `--ci` → `timeout_factor=4.0, rpc_timeout=240`; no `--ci` → `1.0 / 60`; `--ci --timeout-factor=2` → `2.0 / 120` (explicit override respected).
- Teardown fallback: simulated an undeliverable stop RPC on a live daemon → SIGTERM exited it in ~1.1 s (vs a ~60 s hang) and the original error was re-raised.
- Full default suite **20/20 passed** under `--ci`.

The identical 2-file change rides on **#3088**, whose full CI matrix (including the Debian Sid job that exposed the flake) is now green.

Follow-up to #3088 / #3083.