### PR TITLE
refactor: add CTxMemPoolEntry metadata wrapper (mempool Phase 1)

### DIFF
--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -155,7 +155,7 @@ std::string SendContractTx(CWalletTx& wtx_new) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     }
 
     for (const auto& pool_tx : mempool.mapTx) {
-        for (const auto& pool_tx_contract : pool_tx.second.GetContracts()) {
+        for (const auto& pool_tx_contract : pool_tx.second.GetTx().GetContracts()) {
             if (pool_tx_contract.m_type == GRC::ContractType::SIDESTAKE) {
                 std::string strError = _(
                     "Error: The mandatory sidestake transaction was rejected. "

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -696,7 +696,8 @@ BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid) EXCL
         return BeaconError::INSUFFICIENT_FUNDS;
     }
 
-    for (const auto& [_, pool_tx] : mempool.mapTx) {
+    for (const auto& [_, pool_entry] : mempool.mapTx) {
+        const CTransaction& pool_tx = pool_entry.GetTx();
         for (const auto& pool_tx_contract : pool_tx.GetContracts()) {
             if (pool_tx_contract.m_type == GRC::ContractType::BEACON) {
                 GRC::BeaconPayload pool_tx_beacon = pool_tx_contract.CopyPayloadAs<GRC::BeaconPayload>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -345,7 +345,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
             }
 
             bool found{false};
-            for (const auto& [_, pool_tx] : mempool.mapTx) {
+            for (const auto& [_, pool_entry] : mempool.mapTx) {
+                const CTransaction& pool_tx = pool_entry.GetTx();
                 for (const auto& pool_tx_contract : pool_tx.GetContracts()) {
                     if (pool_tx_contract.m_type == GRC::ContractType::MRC) {
                         GRC::MRC pool_tx_mrc = pool_tx_contract.CopyPayloadAs<GRC::MRC>();
@@ -408,6 +409,11 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         }
     }
 
+    // Computed inside the CTxDB scope below and reused when building the
+    // mempool entry after acceptance.
+    CAmount nFees = 0;
+    unsigned int nSize = 0;
+
     {
         CTxDB txdb("r");
 
@@ -435,8 +441,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         // you should add code here to check that the transaction does a
         // reasonable number of ECDSA signature verifications.
 
-        CAmount nFees = GetValueIn(tx, mapInputs) - tx.GetValueOut();
-        unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+        nFees = GetValueIn(tx, mapInputs) - tx.GetValueOut();
+        nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 
         // Don't accept it if it can't get into a block
         CAmount txMinFee = GetMinFee(tx, 1000, GMF_RELAY, nSize);
@@ -483,7 +489,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
             LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : replacing tx %s with new version", ptxOld->GetHash().ToString());
             pool.remove(*ptxOld);
         }
-        pool.addUnchecked(hash, tx);
+        CTxMemPoolEntry entry(tx, nFees, GetAdjustedTime(), nBestHeight, nSize);
+        pool.addUnchecked(hash, entry);
     }
 
     // Notify the validation-signal layer that the transaction was added to

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -374,8 +374,9 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
 
         Fraction foundation_fee_fraction = FoundationSideStakeAllocation();
 
-        for (auto& [_, tx] : mempool.mapTx)
+        for (auto& [_, entry] : mempool.mapTx)
         {
+            CTransaction& tx = entry.GetTxMutable();
             if (tx.IsCoinBase() || tx.IsCoinStake() || !IsFinalTx(tx, nHeight))
                 continue;
 
@@ -434,7 +435,7 @@ bool CreateRestOfTheBlock(CBlock &block, CMutableTransaction& mtxCoinbase,
                     }
                     mapDependers[txin.prevout.hash].push_back(porphan);
                     porphan->setDependsOn.insert(txin.prevout.hash);
-                    nTotalIn += mempool.mapTx[txin.prevout.hash].vout[txin.prevout.n].nValue;
+                    nTotalIn += mempool.mapTx.at(txin.prevout.hash).GetTx().vout[txin.prevout.n].nValue;
 
                     continue;
                 }

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -401,7 +401,8 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
             // AcceptToMemoryPool. Here we just need to do a staleness check.
             std::vector<CTransaction> to_be_erased;
 
-            for (const auto& [_, pool_tx] : mempool.mapTx) {
+            for (const auto& [_, pool_entry] : mempool.mapTx) {
+                const CTransaction& pool_tx = pool_entry.GetTx();
                 for (const auto& pool_tx_contract : pool_tx.GetContracts()) {
                     if (pool_tx_contract.m_type == GRC::ContractType::MRC) {
                         GRC::MRC pool_tx_mrc = pool_tx_contract.CopyPayloadAs<GRC::MRC>();

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -344,7 +344,8 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     // ---------- mrc fee --- mrc ------ descending order
     std::multimap<CAmount, GRC::MRC, std::greater<CAmount>> mrc_multimap;
 
-    for (const auto& [_, tx] : mempool.mapTx) {
+    for (const auto& [_, entry] : mempool.mapTx) {
+        const CTransaction& tx = entry.GetTx();
         if (!tx.GetContracts().empty()) {
             // By protocol the MRC contract MUST be the only one in the transaction.
             const GRC::Contract& contract = tx.GetContracts()[0];

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -4549,7 +4549,8 @@ UniValue createmrcrequest(const UniValue& params) {
     // ---------- mrc fee --- mrc ------ descending order
     std::multimap<CAmount, GRC::MRC, std::greater<CAmount>> mrc_multimap;
 
-    for (const auto& [_, tx] : mempool.mapTx) {
+    for (const auto& [_, entry] : mempool.mapTx) {
+        const CTransaction& tx = entry.GetTx();
         if (!tx.GetContracts().empty()) {
             // By protocol the MRC contract MUST be the only one in the transaction.
             const GRC::Contract& contract = tx.GetContracts()[0];

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(test_gridcoin
     test_gridcoin.cpp
     transaction_identity_tests.cpp
     transaction_tests.cpp
+    txmempool_tests.cpp
     uint256_tests.cpp
     util_tests.cpp
     wallet_tests.cpp

--- a/src/test/txmempool_tests.cpp
+++ b/src/test/txmempool_tests.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// Phase 1 tests for the modernized mempool (#3029): verify that
+// CTxMemPoolEntry caches the right metadata, that the Gridcoin contract
+// tags are extracted from a transaction's contracts, and that adding an
+// entry keeps mapNextTx / lookup consistent.
+
+#include <boost/test/unit_test.hpp>
+
+#include <key.h>
+#include <primitives/transaction.h>
+#include <txmempool.h>
+#include <uint256.h>
+#include <gridcoin/beacon.h>
+#include <gridcoin/cpid.h>
+#include <gridcoin/mrc.h>
+#include <gridcoin/sidestake.h>
+#include <gridcoin/contract/contract.h>
+#include <test/test_gridcoin.h>
+
+namespace {
+//! Build a v2 transaction carrying the supplied contracts (if any).
+CTransaction MakeTx(const std::vector<GRC::Contract>& contracts = {},
+                    const std::vector<CTxIn>& vin = {},
+                    const std::vector<CTxOut>& vout = {})
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.vin = vin;
+    mtx.vout = vout;
+    mtx.vContracts = contracts;
+    return CTransaction(mtx);
+}
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(txmempool_tests)
+
+BOOST_AUTO_TEST_CASE(entry_caches_fee_size_time_height)
+{
+    const CTransaction tx = MakeTx();
+    const size_t size = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+
+    CTxMemPoolEntry entry(tx, /*fee=*/5000, /*time=*/111, /*height=*/222, size);
+
+    BOOST_CHECK_EQUAL(entry.GetFee(), 5000);
+    BOOST_CHECK_EQUAL(entry.GetTxSize(), size);
+    BOOST_CHECK_EQUAL(entry.GetTime(), 111);
+    BOOST_CHECK_EQUAL(entry.GetHeight(), 222);
+    BOOST_CHECK_EQUAL(entry.GetFeeRate(), size ? 5000 * 1000 / (CAmount)size : 0);
+
+    // A plain transaction has no contract tags.
+    BOOST_CHECK(entry.GetContractTypes().empty());
+    BOOST_CHECK(!entry.HasMRC());
+    BOOST_CHECK(!entry.HasBeacon());
+    BOOST_CHECK(!entry.HasMandatorySidestake());
+}
+
+BOOST_AUTO_TEST_CASE(entry_tags_mrc_contract)
+{
+    const GRC::Cpid cpid(InsecureRandBytes(16));
+
+    GRC::MRC mrc;
+    mrc.m_mining_id = cpid;
+    mrc.m_fee = 1234;
+    mrc.m_last_block_hash = uint256S("0x01");
+
+    const GRC::Contract contract = GRC::MakeContract<GRC::MRC>(GRC::ContractAction::ADD, mrc);
+    const CTransaction tx = MakeTx({contract});
+
+    CTxMemPoolEntry entry(tx, 0, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+
+    BOOST_CHECK(entry.HasMRC());
+    BOOST_CHECK(entry.GetMRCCpid() == cpid);
+    BOOST_CHECK_EQUAL(entry.GetMRCFee(), 1234);
+    BOOST_CHECK(entry.GetMRCLastBlockHash() == uint256S("0x01"));
+    BOOST_CHECK(entry.GetContractTypes().count(GRC::ContractType::MRC) == 1);
+    BOOST_CHECK(!entry.HasBeacon());
+    BOOST_CHECK(!entry.HasMandatorySidestake());
+}
+
+BOOST_AUTO_TEST_CASE(entry_tags_beacon_contract)
+{
+    const GRC::Cpid cpid(InsecureRandBytes(16));
+
+    CKey key;
+    key.MakeNewKey(false);
+
+    const GRC::Contract contract = GRC::MakeContract<GRC::BeaconPayload>(
+        GRC::ContractAction::ADD, cpid, key.GetPubKey());
+    const CTransaction tx = MakeTx({contract});
+
+    CTxMemPoolEntry entry(tx, 0, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+
+    BOOST_CHECK(entry.HasBeacon());
+    BOOST_CHECK(entry.GetBeaconCpid() == cpid);
+    BOOST_CHECK(entry.GetContractTypes().count(GRC::ContractType::BEACON) == 1);
+    BOOST_CHECK(!entry.HasMRC());
+    BOOST_CHECK(!entry.HasMandatorySidestake());
+}
+
+BOOST_AUTO_TEST_CASE(entry_tags_mandatory_sidestake_contract)
+{
+    GRC::SideStakePayload payload;
+    const GRC::Contract contract = GRC::MakeContract<GRC::SideStakePayload>(
+        GRC::ContractAction::ADD, payload);
+    const CTransaction tx = MakeTx({contract});
+
+    CTxMemPoolEntry entry(tx, 0, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+
+    BOOST_CHECK(entry.HasMandatorySidestake());
+    BOOST_CHECK(entry.GetContractTypes().count(GRC::ContractType::SIDESTAKE) == 1);
+    BOOST_CHECK(!entry.HasMRC());
+    BOOST_CHECK(!entry.HasBeacon());
+}
+
+BOOST_AUTO_TEST_CASE(addunchecked_preserves_mapnexttx_and_lookup)
+{
+    CTxIn vin;
+    vin.prevout = COutPoint(uint256S("0xbeef"), 0);
+    CTxOut vout;
+    vout.nValue = 100;
+
+    const CTransaction tx = MakeTx({}, {vin}, {vout});
+    const uint256 hash = tx.GetHash();
+
+    CTxMemPool pool;
+    CTxMemPoolEntry entry(tx, 0, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+    BOOST_CHECK(pool.addUnchecked(hash, entry));
+
+    // mapNextTx points back at the stored transaction.
+    auto it = pool.mapNextTx.find(vin.prevout);
+    BOOST_REQUIRE(it != pool.mapNextTx.end());
+    BOOST_REQUIRE(it->second.ptx != nullptr);
+    BOOST_CHECK(it->second.ptx->GetHash() == hash);
+
+    // lookup returns the original transaction byte-for-byte.
+    CTransaction result;
+    BOOST_CHECK(pool.lookup(hash, result));
+    BOOST_CHECK(result == tx);
+    BOOST_CHECK(pool.exists(hash));
+    BOOST_CHECK_EQUAL(pool.size(), 1UL);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -5,18 +5,67 @@
 
 #include "txmempool.h"
 
+#include "consensus/tx_verify.h"
+#include "gridcoin/beacon.h"
+#include "gridcoin/mrc.h"
 #include "sync.h"
 
 CTxMemPool mempool;
 
-bool CTxMemPool::addUnchecked(const uint256& hash, CTransaction &tx)
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& tx_in, CAmount fee, int64_t time,
+                                 int height, size_t tx_size)
+    : tx(tx_in)
+    , nFee(fee)
+    , nTxSize(tx_size)
+    , nTime(time)
+    , entryHeight(height)
+    , nSigOps(GetLegacySigOpCount(tx_in))
+{
+    // Single pass over the transaction's contracts to populate the metadata tags
+    // that Phase 2 will index on. By protocol a transaction carries at most one
+    // contract, but we tolerate more without assuming an order.
+    for (const auto& contract : tx.GetContracts()) {
+        m_contract_types.insert(contract.m_type.Value());
+
+        switch (contract.m_type.Value()) {
+        case GRC::ContractType::MRC: {
+            GRC::MRC mrc = contract.CopyPayloadAs<GRC::MRC>();
+            m_has_mrc = true;
+            if (auto cpid = mrc.m_mining_id.TryCpid()) {
+                m_mrc_cpid = *cpid;
+            }
+            m_mrc_fee = mrc.m_fee;
+            m_mrc_last_block_hash = mrc.m_last_block_hash;
+            break;
+        }
+        case GRC::ContractType::BEACON: {
+            GRC::BeaconPayload beacon = contract.CopyPayloadAs<GRC::BeaconPayload>();
+            m_has_beacon = true;
+            m_beacon_cpid = beacon.m_cpid;
+            break;
+        }
+        case GRC::ContractType::SIDESTAKE: {
+            m_has_mandatory_sidestake = true;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+}
+
+bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
 {
     // Add to memory pool without checking anything.  Don't call this directly,
     // call AcceptToMemoryPool to properly check the transaction first.
     {
-        mapTx[hash] = tx;
-        for (unsigned int i = 0; i < tx.vin.size(); i++)
-            mapNextTx[tx.vin[i].prevout] = CInPoint(&mapTx[hash], i);
+        auto [it, inserted] = mapTx.insert_or_assign(hash, entry);
+        // Point mapNextTx at the transaction stored inside the pool's own map
+        // node (std::map never relocates nodes, so the pointer stays valid until
+        // the entry is removed).
+        CTransaction& stored_tx = it->second.GetTxMutable();
+        for (unsigned int i = 0; i < stored_tx.vin.size(); i++)
+            mapNextTx[stored_tx.vin[i].prevout] = CInPoint(&stored_tx, i);
     }
     return true;
 }
@@ -76,6 +125,6 @@ void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
 
     LOCK(cs);
     vtxid.reserve(mapTx.size());
-    for (std::map<uint256, CTransaction>::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi)
+    for (auto mi = mapTx.begin(); mi != mapTx.end(); ++mi)
         vtxid.push_back(mi->first);
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -59,7 +59,13 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
     // Add to memory pool without checking anything.  Don't call this directly,
     // call AcceptToMemoryPool to properly check the transaction first.
     {
-        auto [it, inserted] = mapTx.insert_or_assign(hash, entry);
+        // Caller contract: AcceptToMemoryPool holds cs and has already rejected a
+        // tx that exists() in the pool, so this is a fresh txid. insert_or_assign
+        // would only "overwrite" on a duplicate txid -- and an identical txid
+        // implies identical vins, so re-pointing mapNextTx below to the new node
+        // is still correct. (Other mutators lock internally; this one relies on
+        // the caller holding cs, matching the "unchecked = caller-locked" idiom.)
+        auto it = mapTx.insert_or_assign(hash, entry).first;
         // Point mapNextTx at the transaction stored inside the pool's own map
         // node (std::map never relocates nodes, so the pointer stays valid until
         // the entry is removed).

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -6,12 +6,16 @@
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
+#include "amount.h"
+#include "gridcoin/contract/payload.h"
+#include "gridcoin/cpid.h"
 #include "primitives/transaction.h"
 #include "sync.h"
 #include "uint256.h"
 
 #include <cstdint>
 #include <map>
+#include <set>
 #include <vector>
 
 /** Reason why transaction was removed from mempool */
@@ -25,16 +29,76 @@ enum class MemPoolRemovalReason {
     REPLACED = 6      //!< Removed due to replacement (RBF)
 };
 
+//!
+//! \brief A transaction stored in the memory pool together with the metadata
+//! computed once when it was accepted.
+//!
+//! Phase 1 of the mempool modernization (#3029). The entry caches the fee, size,
+//! time, and entry height that callers previously recomputed, plus lightweight
+//! Gridcoin contract tags (contract type(s); CPID and fee for MRC/BEACON; the
+//! mandatory-sidestake flag) derived from a single pass over the transaction's
+//! contracts. The tags are populated here but not yet consumed -- the O(n)
+//! contract scans they will replace remain in place until Phase 2 swaps them for
+//! index lookups.
+//!
+class CTxMemPoolEntry
+{
+private:
+    CTransaction tx;
+    CAmount nFee;            //!< GetValueIn() - GetValueOut(), at accept time.
+    size_t nTxSize;          //!< Serialized size (SER_NETWORK, PROTOCOL_VERSION).
+    int64_t nTime;           //!< Adjusted time when accepted.
+    int entryHeight;         //!< Chain height when accepted.
+    unsigned int nSigOps;    //!< Legacy sig-op count.
+
+    // Gridcoin contract tags -- computed in the constructor (txmempool.cpp).
+    std::set<GRC::ContractType> m_contract_types;
+    bool m_has_mrc{false};
+    GRC::Cpid m_mrc_cpid;
+    CAmount m_mrc_fee{0};
+    uint256 m_mrc_last_block_hash;
+    bool m_has_beacon{false};
+    GRC::Cpid m_beacon_cpid;
+    bool m_has_mandatory_sidestake{false};
+
+public:
+    CTxMemPoolEntry(const CTransaction& tx, CAmount fee, int64_t time,
+                    int height, size_t tx_size);
+
+    const CTransaction& GetTx() const { return tx; }
+    //! Non-const access for addUnchecked() to wire mapNextTx pointers into the
+    //! pool's stable map node. Not for general use.
+    CTransaction& GetTxMutable() { return tx; }
+
+    CAmount GetFee() const { return nFee; }
+    size_t GetTxSize() const { return nTxSize; }
+    int64_t GetTime() const { return nTime; }
+    int GetHeight() const { return entryHeight; }
+    unsigned int GetSigOps() const { return nSigOps; }
+    //! Fee per 1000 bytes. No CFeeRate type exists in this tree; returns a plain
+    //! CAmount derived from the cached fee and size.
+    CAmount GetFeeRate() const { return nTxSize ? nFee * 1000 / (CAmount)nTxSize : 0; }
+
+    const std::set<GRC::ContractType>& GetContractTypes() const { return m_contract_types; }
+    bool HasMRC() const { return m_has_mrc; }
+    const GRC::Cpid& GetMRCCpid() const { return m_mrc_cpid; }
+    CAmount GetMRCFee() const { return m_mrc_fee; }
+    const uint256& GetMRCLastBlockHash() const { return m_mrc_last_block_hash; }
+    bool HasBeacon() const { return m_has_beacon; }
+    const GRC::Cpid& GetBeaconCpid() const { return m_beacon_cpid; }
+    bool HasMandatorySidestake() const { return m_has_mandatory_sidestake; }
+};
+
 class CTxMemPool
 {
 public:
     mutable CCriticalSection cs;
-    std::map<uint256, CTransaction> mapTx;
+    std::map<uint256, CTxMemPoolEntry> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
     uint64_t m_mrc_bloom{0};
     bool m_mrc_bloom_dirty{false};
 
-    bool addUnchecked(const uint256& hash, CTransaction &tx);
+    bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
     bool remove(const CTransaction &tx, bool fRecursive = false);
     bool removeConflicts(const CTransaction &tx);
     void clear();
@@ -55,9 +119,9 @@ public:
     bool lookup(uint256 hash, CTransaction& result) const
     {
         LOCK(cs);
-        std::map<uint256, CTransaction>::const_iterator i = mapTx.find(hash);
+        auto i = mapTx.find(hash);
         if (i == mapTx.end()) return false;
-        result = i->second;
+        result = i->second.GetTx();
         return true;
     }
 };

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -35,8 +35,9 @@ enum class MemPoolRemovalReason {
 //!
 //! Phase 1 of the mempool modernization (#3029). The entry caches the fee, size,
 //! time, and entry height that callers previously recomputed, plus lightweight
-//! Gridcoin contract tags (contract type(s); CPID and fee for MRC/BEACON; the
-//! mandatory-sidestake flag) derived from a single pass over the transaction's
+//! Gridcoin contract tags (contract type(s); the BEACON CPID; the MRC CPID, fee,
+//! and last-block-hash; the mandatory-sidestake flag) derived from a single pass
+//! over the transaction's
 //! contracts. The tags are populated here but not yet consumed -- the O(n)
 //! contract scans they will replace remain in place until Phase 2 swaps them for
 //! index lookups.
@@ -66,8 +67,13 @@ public:
                     int height, size_t tx_size);
 
     const CTransaction& GetTx() const { return tx; }
-    //! Non-const access for addUnchecked() to wire mapNextTx pointers into the
-    //! pool's stable map node. Not for general use.
+    //! Non-const access to the stored transaction, used ONLY to obtain a stable
+    //! CTransaction* for legacy non-const APIs: addUnchecked()'s mapNextTx wiring
+    //! and the miner's COrphan / vecPriority structures (which hold CTransaction*).
+    //! Callers MUST NOT mutate the transaction -- doing so would silently
+    //! invalidate this entry's cached fee/size/sigops/contract-tag metadata.
+    //! (Making those legacy consumers const-correct so this can be removed is a
+    //! tracked follow-up.)
     CTransaction& GetTxMutable() { return tx; }
 
     CAmount GetFee() const { return nFee; }


### PR DESCRIPTION
## What

Phase 1 of the mempool modernization (**part of #3029**). Wrap every pooled transaction in a new `CTxMemPoolEntry` that caches the fee, size, time, and entry height computed at accept time, plus lightweight Gridcoin contract tags (contract type(s); MRC/beacon CPID; MRC fee and last-block-hash; mandatory-sidestake flag) derived from a single pass over the transaction's contracts.

`mapTx` becomes `std::map<uint256, CTxMemPoolEntry>`; `AcceptToMemoryPool` threads its already-computed fee/size into a new `addUnchecked(entry)`; every value-reader of `mapTx` switches to `.GetTx()`.

**No functional change.** The tags are populated but not yet consumed, and the five O(n) contract scans are left intact — they become index lookups in Phase 2. This PR adds only the metadata substrate.

## Why

`CTxMemPool` stores bare `CTransaction`s with no per-entry metadata, forcing fee/size recomputation everywhere and blocking both the diagnostic RPCs (#1142) and the index-based dedup that removes the O(n) scans (#3029). Phase 1 is the foundation for Phases 2–6.

## Stacked on #3072

Builds on Phase 0 (#3072, itself on #3060). The diff narrows to just the Phase 1 change once those land. This PR is **not** intended to close the #3029 umbrella.

## Testing

New `src/test/txmempool_tests.cpp`: entry-metadata tagging for MRC/beacon/sidestake; `addUnchecked` preserves `mapNextTx`/`lookup` byte-for-byte; size/feerate consistency. Full local `ctest` suite green (behavior-neutral); `getrawmempool`/`getmrcrequestdata` output unchanged.