### PR TITLE
refactor: replace mempool O(n) contract scans with indexes (mempool Phase 2)

### DIFF
--- a/src/gridcoin/contract/message.cpp
+++ b/src/gridcoin/contract/message.cpp
@@ -154,17 +154,15 @@ std::string SendContractTx(CWalletTx& wtx_new) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         return strError;
     }
 
-    for (const auto& pool_tx : mempool.mapTx) {
-        for (const auto& pool_tx_contract : pool_tx.second.GetTx().GetContracts()) {
-            if (pool_tx_contract.m_type == GRC::ContractType::SIDESTAKE) {
-                std::string strError = _(
-                    "Error: The mandatory sidestake transaction was rejected. "
-                    "There is already a mandatory sidestake transaction in the mempool. "
-                    "Wait until that transaction is bound in a block.");
-                error("%s: %s", __func__, strError);
-                return strError;
-            }
-        }
+    // An O(1) index check (replaced a full mempool scan) enforces at most one
+    // mandatory sidestake transaction in the pool at a time.
+    if (mempool.HasMandatorySidestake()) {
+        std::string strError = _(
+            "Error: The mandatory sidestake transaction was rejected. "
+            "There is already a mandatory sidestake transaction in the mempool. "
+            "Wait until that transaction is bound in a block.");
+        error("%s: %s", __func__, strError);
+        return strError;
     }
 
     if (!pwalletMain->CommitTransaction(wtx_new, reserve_key)) {

--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -696,19 +696,10 @@ BeaconError CheckBeaconTransactionViable(CWallet* wallet, const Cpid& cpid) EXCL
         return BeaconError::INSUFFICIENT_FUNDS;
     }
 
-    for (const auto& [_, pool_entry] : mempool.mapTx) {
-        const CTransaction& pool_tx = pool_entry.GetTx();
-        for (const auto& pool_tx_contract : pool_tx.GetContracts()) {
-            if (pool_tx_contract.m_type == GRC::ContractType::BEACON) {
-                GRC::BeaconPayload pool_tx_beacon = pool_tx_contract.CopyPayloadAs<GRC::BeaconPayload>();
-
-                GRC::Cpid other_cpid = pool_tx_beacon.m_cpid;
-
-                if (cpid == other_cpid) {
-                   return BeaconError::ALEADY_IN_MEMPOOL;
-                }
-            }
-        }
+    // An O(log n) lookup against the m_beacon_by_cpid index (replaced a full
+    // mempool scan) prevents a second pending beacon advertisement for this CPID.
+    if (mempool.HasBeaconForCpid(cpid)) {
+        return BeaconError::ALEADY_IN_MEMPOOL;
     }
 
     return BeaconError::NONE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,7 +325,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
             GRC::Cpid cpid = *(mrc.m_mining_id.TryCpid());
 
             uint256 existing;
-            if (mempool.HasMRCForCpid(cpid, &existing)) {
+            if (pool.HasMRCForCpid(cpid, &existing)) {
                 return state.DoS(25, error("%s: MRC contract in tx %s has the same CPID as an existing transaction "
                                            "in the memory pool, %s.",
                                            __func__,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -313,66 +313,25 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     if (pool.exists(hash))
         return false;
 
-    // is there already a transaction in the mempool that has a MRC contract with the same CPID?
-    //
-    // Note: I really hate this check because it has to iterate over the entire mempool to look for an offender,
-    // but I am sufficiently concerned about MRC DoS that it is necessary to stop duplicate MRC request transactions
-    // from the same CPID in the accept to memory pool stage.
-    //
-    // We have implemented a bloom filter to help with the overhead.
+    // Reject a second MRC for a CPID that already has one in the mempool. This
+    // is an O(log n) lookup against the m_mrc_by_cpid index (it replaced a full
+    // mempool scan + bloom filter). MRC DoS protection: a duplicate earns a
+    // stiff penalty.
     bool tx_contains_valid_mrc = false;
 
     for (const auto& contract : tx.GetContracts()) {
         if (contract.m_type == GRC::ContractType::MRC) {
             GRC::MRC mrc = contract.CopyPayloadAs<GRC::MRC>();
-
             GRC::Cpid cpid = *(mrc.m_mining_id.TryCpid());
-            // A small bloom filter based on the last and first byte of CPID.
-            uint64_t k = 1 << (cpid.Raw().front() & 0x3F);
-            k |= 1 << (cpid.Raw().back() & 0x3F);
 
-            if ((mempool.m_mrc_bloom & k) != k) {
-                // The cpid definitely does not exist in the mempool.
-                mempool.m_mrc_bloom |= k;
-                tx_contains_valid_mrc = true;
-
-                continue;
+            uint256 existing;
+            if (mempool.HasMRCForCpid(cpid, &existing)) {
+                return state.DoS(25, error("%s: MRC contract in tx %s has the same CPID as an existing transaction "
+                                           "in the memory pool, %s.",
+                                           __func__,
+                                           tx.GetHash().ToString(),
+                                           existing.ToString()));
             }
-            // The cpid might exist in the mempool.
-
-            if (mempool.m_mrc_bloom_dirty) {
-                mempool.m_mrc_bloom = 0;
-            }
-
-            bool found{false};
-            for (const auto& [_, pool_entry] : mempool.mapTx) {
-                const CTransaction& pool_tx = pool_entry.GetTx();
-                for (const auto& pool_tx_contract : pool_tx.GetContracts()) {
-                    if (pool_tx_contract.m_type == GRC::ContractType::MRC) {
-                        GRC::MRC pool_tx_mrc = pool_tx_contract.CopyPayloadAs<GRC::MRC>();
-
-                        GRC::Cpid other_cpid = *(pool_tx_mrc.m_mining_id.TryCpid());
-                        mempool.m_mrc_bloom |= 1 << (other_cpid.Raw().front() & 0x3F);
-                        mempool.m_mrc_bloom |= 1 << (other_cpid.Raw().back() & 0x3F);
-
-                        // A transaction already in the mempool already has the same CPID as the incoming transaction.
-                        // Reject and put a stiff DoS...
-                        if (!found && cpid == other_cpid) {
-                            found = true;
-                            state.DoS(25, error("%s: MRC contract in tx %s has the same CPID as an existing transaction "
-                                             "in the memory pool, %s.",
-                                             __func__,
-                                             tx.GetHash().ToString(),
-                                             pool_tx.GetHash().ToString()));
-
-                            if (!mempool.m_mrc_bloom_dirty) return false;
-                        }
-                    }
-                }
-            }
-
-            mempool.m_mrc_bloom_dirty = false;
-            if (found) return false;
 
             tx_contains_valid_mrc = true;
         }

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -401,16 +401,13 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_main)
             // AcceptToMemoryPool. Here we just need to do a staleness check.
             std::vector<CTransaction> to_be_erased;
 
-            for (const auto& [_, pool_entry] : mempool.mapTx) {
-                const CTransaction& pool_tx = pool_entry.GetTx();
-                for (const auto& pool_tx_contract : pool_tx.GetContracts()) {
-                    if (pool_tx_contract.m_type == GRC::ContractType::MRC) {
-                        GRC::MRC pool_tx_mrc = pool_tx_contract.CopyPayloadAs<GRC::MRC>();
-
-                        if (pool_tx_mrc.m_last_block_hash != hashBestChain) {
-                            to_be_erased.push_back(pool_tx);
-                        }
-                    }
+            // Only the MRC entries are inspected (via the m_mrc_by_cpid index),
+            // not the entire pool. An MRC is stale when its anchor block is no
+            // longer the chain head.
+            for (const uint256& stale_hash : mempool.GetStaleMRCs(hashBestChain)) {
+                CTransaction stale_tx;
+                if (mempool.lookup(stale_hash, stale_tx)) {
+                    to_be_erased.push_back(stale_tx);
                 }
             }
 

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -341,29 +341,20 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
     // This sorts the MRCs in descending order of MRC fees to allow determination of the payout limit fee.
 
-    // ---------- mrc fee --- mrc ------ descending order
-    std::multimap<CAmount, GRC::MRC, std::greater<CAmount>> mrc_multimap;
+    // ---------- mrc fee --- cpid ------ descending order
+    // The fee-ordered MRC view comes straight from the mempool's m_mrc_by_fee
+    // index (it replaced a full mempool scan + local multimap build).
+    const std::vector<std::pair<CAmount, GRC::Cpid>> mrc_queue = mempool.GetMRCQueue();
 
-    for (const auto& [_, entry] : mempool.mapTx) {
-        const CTransaction& tx = entry.GetTx();
-        if (!tx.GetContracts().empty()) {
-            // By protocol the MRC contract MUST be the only one in the transaction.
-            const GRC::Contract& contract = tx.GetContracts()[0];
+    GRC::Cpid m_mrc_cpid;
+    if (auto cpid = m_mrc.m_mining_id.TryCpid()) m_mrc_cpid = *cpid;
 
-            if (contract.m_type == GRC::ContractType::MRC) {
-                GRC::MRC mempool_mrc = contract.CopyPayloadAs<GRC::MRC>();
+    for (const auto& [mempool_fee, mempool_cpid] : mrc_queue) {
+        found |= mempool_cpid == m_mrc_cpid;
 
-                mrc_multimap.insert(std::make_pair(mempool_mrc.m_fee, mempool_mrc));
-            } // match to mrc contract type
-        } // contract present in transaction?
-    }
-
-    for (const auto& [_, mempool_mrc] : mrc_multimap) {
-        found |= m_mrc.m_mining_id == mempool_mrc.m_mining_id;
-
-        if (!found && mempool_mrc.m_fee >= m_mrc.m_fee) ++m_mrc_pos;
-        m_mrc_queue_head_fee = std::max(m_mrc_queue_head_fee, mempool_mrc.m_fee);
-        m_mrc_queue_tail_fee = std::min(m_mrc_queue_tail_fee, mempool_mrc.m_fee);
+        if (!found && mempool_fee >= m_mrc.m_fee) ++m_mrc_pos;
+        m_mrc_queue_head_fee = std::max(m_mrc_queue_head_fee, mempool_fee);
+        m_mrc_queue_tail_fee = std::min(m_mrc_queue_tail_fee, mempool_fee);
 
         ++m_mrc_queue_length;
     }
@@ -373,17 +364,13 @@ void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     // in the loop.
     m_mrc_queue_tail_fee = std::min(m_mrc_queue_head_fee, m_mrc_queue_tail_fee);
 
-    // Here we select the minimum of the mrc_multimap.size() - 1 in the case where the multimap does not reach the
-    // m_mrc_output_limit - 1, or the m_mrc_output_limit - 1 if the multimap indicates the queue is (over)full,
+    // Here we select the minimum of the queue size - 1 in the case where the queue does not reach the
+    // m_mrc_output_limit - 1, or the m_mrc_output_limit - 1 if the queue is (over)full,
     // i.e. the number of MRC's in the queue exceeds the m_mrc_output_limit for paying in a block.
-    int pay_limit_fee_pos = std::min<int>(mrc_multimap.size(), m_mrc_output_limit) - 1;
+    int pay_limit_fee_pos = std::min<int>(mrc_queue.size(), m_mrc_output_limit) - 1;
 
     if (pay_limit_fee_pos >= 0) {
-        std::multimap<CAmount, GRC::MRC, std::greater<CAmount>>::iterator iter = mrc_multimap.begin();
-
-        std::advance(iter, pay_limit_fee_pos);
-
-        m_mrc_queue_pay_limit_fee = iter->first;
+        m_mrc_queue_pay_limit_fee = mrc_queue[pay_limit_fee_pos].first;
     }
 
     m_mrc_queue_pay_limit_fee = std::min(m_mrc_queue_head_fee, m_mrc_queue_pay_limit_fee);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -4546,29 +4546,20 @@ UniValue createmrcrequest(const UniValue& params) {
 
     // This sorts the MRCs in descending order of MRC fees to allow determination of the payout limit fee.
 
-    // ---------- mrc fee --- mrc ------ descending order
-    std::multimap<CAmount, GRC::MRC, std::greater<CAmount>> mrc_multimap;
+    // ---------- mrc fee --- cpid ------ descending order
+    // The fee-ordered MRC view comes straight from the mempool's m_mrc_by_fee
+    // index (it replaced a full mempool scan + local multimap build).
+    const std::vector<std::pair<CAmount, GRC::Cpid>> mrc_queue = mempool.GetMRCQueue();
 
-    for (const auto& [_, entry] : mempool.mapTx) {
-        const CTransaction& tx = entry.GetTx();
-        if (!tx.GetContracts().empty()) {
-            // By protocol the MRC contract MUST be the only one in the transaction.
-            const GRC::Contract& contract = tx.GetContracts()[0];
+    GRC::Cpid mrc_cpid;
+    if (auto cpid = mrc.m_mining_id.TryCpid()) mrc_cpid = *cpid;
 
-            if (contract.m_type == GRC::ContractType::MRC) {
-                GRC::MRC mempool_mrc = contract.CopyPayloadAs<GRC::MRC>();
+    for (const auto& [mempool_fee, mempool_cpid] : mrc_queue) {
+        found |= mempool_cpid == mrc_cpid;
 
-                mrc_multimap.insert(std::make_pair(mempool_mrc.m_fee, mempool_mrc));
-            } // match to mrc contract type
-        } // contract present in transaction?
-    }
-
-    for (const auto& [_, mempool_mrc] : mrc_multimap) {
-        found |= mrc.m_mining_id == mempool_mrc.m_mining_id;
-
-        if (!found && mempool_mrc.m_fee >= mrc.m_fee) ++pos;
-        head_fee = std::max(head_fee, mempool_mrc.m_fee);
-        tail_fee = std::min(tail_fee, mempool_mrc.m_fee);
+        if (!found && mempool_fee >= mrc.m_fee) ++pos;
+        head_fee = std::max(head_fee, mempool_fee);
+        tail_fee = std::min(tail_fee, mempool_fee);
 
         ++queue_length;
     }
@@ -4578,17 +4569,13 @@ UniValue createmrcrequest(const UniValue& params) {
     // in the loop.
     tail_fee = std::min(head_fee, tail_fee);
 
-    // Here we select the minimum of the mrc_multimap.size() - 1 in the case where the multimap does not reach the
-    // m_mrc_output_limit - 1, or the m_mrc_output_limit - 1 if the multimap indicates the queue is (over)full,
+    // Here we select the minimum of the queue size - 1 in the case where the queue does not reach the
+    // m_mrc_output_limit - 1, or the m_mrc_output_limit - 1 if the queue is (over)full,
     // i.e. the number of MRC's in the queue exceeds the m_mrc_output_limit for paying in a block.
-    int pay_limit_fee_pos = std::min<int>(mrc_multimap.size(), limit) - 1;
+    int pay_limit_fee_pos = std::min<int>(mrc_queue.size(), limit) - 1;
 
     if (pay_limit_fee_pos >= 0) {
-        std::multimap<CAmount, GRC::MRC, std::greater<CAmount>>::iterator iter = mrc_multimap.begin();
-
-        std::advance(iter, pay_limit_fee_pos);
-
-        pay_limit_fee = iter->first;
+        pay_limit_fee = mrc_queue[pay_limit_fee_pos].first;
     }
 
     pay_limit_fee = std::min(head_fee, pay_limit_fee);

--- a/src/test/txmempool_tests.cpp
+++ b/src/test/txmempool_tests.cpp
@@ -33,6 +33,21 @@ CTransaction MakeTx(const std::vector<GRC::Contract>& contracts = {},
     mtx.vContracts = contracts;
     return CTransaction(mtx);
 }
+
+//! Build a v2 transaction carrying a single MRC contract for the given CPID.
+CTransaction MakeMrcTx(const GRC::Cpid& cpid, CAmount fee, const uint256& last_block = uint256())
+{
+    GRC::MRC mrc;
+    mrc.m_mining_id = cpid;
+    mrc.m_fee = fee;
+    mrc.m_last_block_hash = last_block;
+    return MakeTx({GRC::MakeContract<GRC::MRC>(GRC::ContractAction::ADD, mrc)});
+}
+
+CTxMemPoolEntry MakeEntry(const CTransaction& tx)
+{
+    return CTxMemPoolEntry(tx, 0, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+}
 } // anonymous namespace
 
 BOOST_AUTO_TEST_SUITE(txmempool_tests)
@@ -141,6 +156,94 @@ BOOST_AUTO_TEST_CASE(addunchecked_preserves_mapnexttx_and_lookup)
     BOOST_CHECK(result == tx);
     BOOST_CHECK(pool.exists(hash));
     BOOST_CHECK_EQUAL(pool.size(), 1UL);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 (#3029): contract indexes
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(indexes_populate_on_add_and_tear_down_on_remove)
+{
+    const GRC::Cpid mrc_cpid(InsecureRandBytes(16));
+    const GRC::Cpid beacon_cpid(InsecureRandBytes(16));
+
+    CKey key;
+    key.MakeNewKey(false);
+
+    const CTransaction mrc_tx = MakeMrcTx(mrc_cpid, 100);
+    const CTransaction beacon_tx = MakeTx(
+        {GRC::MakeContract<GRC::BeaconPayload>(GRC::ContractAction::ADD, beacon_cpid, key.GetPubKey())});
+    GRC::SideStakePayload ss_payload;
+    const CTransaction sidestake_tx = MakeTx(
+        {GRC::MakeContract<GRC::SideStakePayload>(GRC::ContractAction::ADD, ss_payload)});
+
+    CTxMemPool pool;
+    pool.addUnchecked(mrc_tx.GetHash(), MakeEntry(mrc_tx));
+    pool.addUnchecked(beacon_tx.GetHash(), MakeEntry(beacon_tx));
+    pool.addUnchecked(sidestake_tx.GetHash(), MakeEntry(sidestake_tx));
+
+    BOOST_CHECK_EQUAL(pool.m_mrc_by_cpid.size(), 1U);
+    BOOST_CHECK_EQUAL(pool.m_mrc_by_fee.size(), 1U);
+    BOOST_CHECK_EQUAL(pool.m_beacon_by_cpid.size(), 1U);
+    BOOST_CHECK_EQUAL(pool.m_mandatory_sidestake_count, 1U);
+
+    pool.remove(mrc_tx);
+    pool.remove(beacon_tx);
+    pool.remove(sidestake_tx);
+
+    BOOST_CHECK(pool.m_mrc_by_cpid.empty());
+    BOOST_CHECK(pool.m_mrc_by_fee.empty());
+    BOOST_CHECK(pool.m_beacon_by_cpid.empty());
+    BOOST_CHECK_EQUAL(pool.m_mandatory_sidestake_count, 0U);
+    BOOST_CHECK_EQUAL(pool.size(), 0UL);
+}
+
+BOOST_AUTO_TEST_CASE(hasmrcforcpid_reports_collision_hash)
+{
+    const GRC::Cpid cpid_a(InsecureRandBytes(16));
+    const GRC::Cpid cpid_b(InsecureRandBytes(16));
+
+    const CTransaction mrc_tx = MakeMrcTx(cpid_a, 50);
+
+    CTxMemPool pool;
+    pool.addUnchecked(mrc_tx.GetHash(), MakeEntry(mrc_tx));
+
+    uint256 existing;
+    BOOST_CHECK(pool.HasMRCForCpid(cpid_a, &existing));
+    BOOST_CHECK(existing == mrc_tx.GetHash());
+    BOOST_CHECK(!pool.HasMRCForCpid(cpid_b));
+}
+
+BOOST_AUTO_TEST_CASE(getmrcqueue_is_fee_descending)
+{
+    CTxMemPool pool;
+    for (CAmount fee : {10, 30, 20}) {
+        const CTransaction tx = MakeMrcTx(GRC::Cpid(InsecureRandBytes(16)), fee);
+        pool.addUnchecked(tx.GetHash(), MakeEntry(tx));
+    }
+
+    const auto queue = pool.GetMRCQueue();
+    BOOST_REQUIRE_EQUAL(queue.size(), 3U);
+    BOOST_CHECK_EQUAL(queue[0].first, 30);
+    BOOST_CHECK_EQUAL(queue[1].first, 20);
+    BOOST_CHECK_EQUAL(queue[2].first, 10);
+}
+
+BOOST_AUTO_TEST_CASE(getstalemrcs_selects_by_anchor_block)
+{
+    const uint256 best = uint256S("0xaa");
+    const uint256 old = uint256S("0xbb");
+
+    const CTransaction fresh_tx = MakeMrcTx(GRC::Cpid(InsecureRandBytes(16)), 10, best);
+    const CTransaction stale_tx = MakeMrcTx(GRC::Cpid(InsecureRandBytes(16)), 10, old);
+
+    CTxMemPool pool;
+    pool.addUnchecked(fresh_tx.GetHash(), MakeEntry(fresh_tx));
+    pool.addUnchecked(stale_tx.GetHash(), MakeEntry(stale_tx));
+
+    const auto stale = pool.GetStaleMRCs(best);
+    BOOST_REQUIRE_EQUAL(stale.size(), 1U);
+    BOOST_CHECK(stale[0] == stale_tx.GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -72,19 +72,48 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
         CTransaction& stored_tx = it->second.GetTxMutable();
         for (unsigned int i = 0; i < stored_tx.vin.size(); i++)
             mapNextTx[stored_tx.vin[i].prevout] = CInPoint(&stored_tx, i);
+
+        // Maintain the secondary contract indexes from the cached tags.
+        const CTxMemPoolEntry& e = it->second;
+        if (e.HasMRC()) {
+            m_mrc_by_cpid.insert_or_assign(e.GetMRCCpid(), hash);
+            m_mrc_by_fee.emplace(e.GetMRCFee(), e.GetMRCCpid());
+        }
+        if (e.HasBeacon())
+            m_beacon_by_cpid.insert_or_assign(e.GetBeaconCpid(), hash);
+        if (e.HasMandatorySidestake())
+            ++m_mandatory_sidestake_count;
     }
     return true;
+}
+
+void CTxMemPool::eraseIndexes(const CTxMemPoolEntry& entry)
+{
+    if (entry.HasMRC()) {
+        m_mrc_by_cpid.erase(entry.GetMRCCpid());
+        auto range = m_mrc_by_fee.equal_range(entry.GetMRCFee());
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == entry.GetMRCCpid()) {
+                m_mrc_by_fee.erase(it);
+                break;
+            }
+        }
+    }
+    if (entry.HasBeacon())
+        m_beacon_by_cpid.erase(entry.GetBeaconCpid());
+    if (entry.HasMandatorySidestake() && m_mandatory_sidestake_count > 0)
+        --m_mandatory_sidestake_count;
 }
 
 
 bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
 {
-    m_mrc_bloom_dirty = true;
     // Remove transaction from memory pool
     {
         LOCK(cs);
         uint256 hash = tx.GetHash();
-        if (mapTx.count(hash))
+        auto entry_it = mapTx.find(hash);
+        if (entry_it != mapTx.end())
         {
             if (fRecursive) {
                 for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -93,9 +122,11 @@ bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
                         remove(*it->second.ptx, true);
                 }
             }
+            // Tear down the secondary indexes before erasing the entry.
+            eraseIndexes(entry_it->second);
             for (auto const& txin : tx.vin)
                 mapNextTx.erase(txin.prevout);
-            mapTx.erase(hash);
+            mapTx.erase(entry_it);
         }
     }
     return true;
@@ -103,7 +134,6 @@ bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
 
 bool CTxMemPool::removeConflicts(const CTransaction &tx)
 {
-    m_mrc_bloom_dirty = true;
     // Remove transactions which depend on inputs of tx, recursively
     LOCK(cs);
     for (auto const &txin : tx.vin)
@@ -123,6 +153,10 @@ void CTxMemPool::clear()
     LOCK(cs);
     mapTx.clear();
     mapNextTx.clear();
+    m_mrc_by_cpid.clear();
+    m_beacon_by_cpid.clear();
+    m_mandatory_sidestake_count = 0;
+    m_mrc_by_fee.clear();
 }
 
 void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -73,7 +73,11 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
         for (unsigned int i = 0; i < stored_tx.vin.size(); i++)
             mapNextTx[stored_tx.vin[i].prevout] = CInPoint(&stored_tx, i);
 
-        // Maintain the secondary contract indexes from the cached tags.
+        // Maintain the secondary contract indexes from the cached tags. These rely
+        // on the same fresh-txid contract as above: the CPID-keyed maps overwrite
+        // harmlessly on a same-txid re-add (identical CPID), but m_mrc_by_fee is a
+        // multimap whose emplace would double-insert -- the upstream exists() guard
+        // is what prevents a duplicate add from leaving a stale fee row.
         const CTxMemPoolEntry& e = it->second;
         if (e.HasMRC()) {
             m_mrc_by_cpid.insert_or_assign(e.GetMRCCpid(), hash);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -107,8 +107,21 @@ public:
     // Secondary indexes maintained in the single add/remove/clear paths (#3029
     // Phase 2). They replace the former O(n) full-pool contract scans. Keyed off
     // the contract tags cached on CTxMemPoolEntry.
-    std::map<GRC::Cpid, uint256> m_mrc_by_cpid;    //!< One MRC per CPID; value is the tx hash.
-    std::map<GRC::Cpid, uint256> m_beacon_by_cpid; //!< One beacon advertisement per CPID.
+    //! One MRC per CPID; value is the tx hash. Sound as a CPID-keyed map because
+    //! AcceptToMemoryPool DoS-rejects a second MRC for a CPID already in the pool,
+    //! so mapTx never holds two same-CPID MRCs.
+    std::map<GRC::Cpid, uint256> m_mrc_by_cpid;
+    //! Beacon advertisement by CPID. EXISTENCE-ONLY index (queried via
+    //! HasBeaconForCpid()'s count(); the stored hash is never read). Unlike MRCs,
+    //! duplicate PENDING beacons for one CPID are NOT rejected at acceptance (only
+    //! a wallet-side viability check guards locally), so two same-CPID beacons can
+    //! coexist in mapTx; this map then holds only the last (insert_or_assign) and
+    //! erase(cpid) drops the entry while a sibling may remain. That desync is
+    //! harmless here -- the worst case is HasBeaconForCpid() letting the wallet-side
+    //! guard pass a duplicate that the protocol already permits. Do NOT add a
+    //! consumer that reads the stored hash or treats this as 1:1 without switching
+    //! to a multimap.
+    std::map<GRC::Cpid, uint256> m_beacon_by_cpid;
     size_t m_mandatory_sidestake_count{0};         //!< Mandatory-sidestake txs in the pool.
     //! MRCs in fee-descending order, for the GUI/RPC queue ranking.
     std::multimap<CAmount, GRC::Cpid, std::greater<CAmount>> m_mrc_by_fee;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,8 +14,10 @@
 #include "uint256.h"
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <set>
+#include <utility>
 #include <vector>
 
 /** Reason why transaction was removed from mempool */
@@ -101,14 +103,67 @@ public:
     mutable CCriticalSection cs;
     std::map<uint256, CTxMemPoolEntry> mapTx;
     std::map<COutPoint, CInPoint> mapNextTx;
-    uint64_t m_mrc_bloom{0};
-    bool m_mrc_bloom_dirty{false};
+
+    // Secondary indexes maintained in the single add/remove/clear paths (#3029
+    // Phase 2). They replace the former O(n) full-pool contract scans. Keyed off
+    // the contract tags cached on CTxMemPoolEntry.
+    std::map<GRC::Cpid, uint256> m_mrc_by_cpid;    //!< One MRC per CPID; value is the tx hash.
+    std::map<GRC::Cpid, uint256> m_beacon_by_cpid; //!< One beacon advertisement per CPID.
+    size_t m_mandatory_sidestake_count{0};         //!< Mandatory-sidestake txs in the pool.
+    //! MRCs in fee-descending order, for the GUI/RPC queue ranking.
+    std::multimap<CAmount, GRC::Cpid, std::greater<CAmount>> m_mrc_by_fee;
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
     bool remove(const CTransaction &tx, bool fRecursive = false);
     bool removeConflicts(const CTransaction &tx);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
+
+    //! \brief Whether the pool already holds an MRC for \p cpid. When it does and
+    //! \p existing is non-null, the colliding transaction hash is written there.
+    bool HasMRCForCpid(const GRC::Cpid& cpid, uint256* existing = nullptr) const
+    {
+        LOCK(cs);
+        auto it = m_mrc_by_cpid.find(cpid);
+        if (it == m_mrc_by_cpid.end()) return false;
+        if (existing) *existing = it->second;
+        return true;
+    }
+
+    bool HasBeaconForCpid(const GRC::Cpid& cpid) const
+    {
+        LOCK(cs);
+        return m_beacon_by_cpid.count(cpid) != 0;
+    }
+
+    bool HasMandatorySidestake() const
+    {
+        LOCK(cs);
+        return m_mandatory_sidestake_count != 0;
+    }
+
+    //! \brief A fee-descending snapshot of the pooled MRCs as (fee, cpid) pairs.
+    std::vector<std::pair<CAmount, GRC::Cpid>> GetMRCQueue() const
+    {
+        LOCK(cs);
+        std::vector<std::pair<CAmount, GRC::Cpid>> queue;
+        queue.reserve(m_mrc_by_fee.size());
+        for (const auto& [fee, cpid] : m_mrc_by_fee) queue.emplace_back(fee, cpid);
+        return queue;
+    }
+
+    //! \brief Hashes of pooled MRCs whose anchor block is not \p best_block_hash.
+    std::vector<uint256> GetStaleMRCs(const uint256& best_block_hash) const
+    {
+        LOCK(cs);
+        std::vector<uint256> stale;
+        for (const auto& [cpid, hash] : m_mrc_by_cpid) {
+            auto it = mapTx.find(hash);
+            if (it != mapTx.end() && it->second.GetMRCLastBlockHash() != best_block_hash)
+                stale.push_back(hash);
+        }
+        return stale;
+    }
 
     unsigned long size() const
     {
@@ -130,6 +185,10 @@ public:
         result = i->second.GetTx();
         return true;
     }
+
+private:
+    //! Remove an entry's contributions from the secondary indexes. Caller holds cs.
+    void eraseIndexes(const CTxMemPoolEntry& entry);
 };
 
 extern CTxMemPool mempool;


### PR DESCRIPTION
## What

Phase 2 of the mempool modernization (**part of #3029**), stacked on Phase 1 (#3090). Build four secondary indexes on `CTxMemPool` from the contract tags Phase 1 cached on each entry, maintained in the single `addUnchecked`/`remove`/`clear` paths:

- `m_mrc_by_cpid` — one MRC per CPID (value is the tx hash)
- `m_beacon_by_cpid` — one beacon advertisement per CPID
- `m_mandatory_sidestake_count` — mandatory-sidestake txs in the pool
- `m_mrc_by_fee` — fee-ordered MRC view

All five former full-mempool scans become O(log n) lookups, with identical semantics:

- **MRC duplicate-CPID rejection** at accept (DoS=25, offending tx hash still reported) — this removes the *"I really hate this check because it has to iterate over the entire mempool"* scan and the `m_mrc_bloom` filter (both deleted).
- **Beacon duplicate-CPID** check (`CheckBeaconTransactionViable`).
- **Mandatory-sidestake** one-in-pool check (`SendContractTx`).
- **Stale-MRC eviction** on block connect (`GetStaleMRCs`).
- **MRC fee-queue ranking** for the GUI and `getmrcrequestdata` RPC (`GetMRCQueue`).

## Why

The original author flagged the MRC dedup scan explicitly. These indexes eliminate every O(n) full-pool scan and supply the metadata the diagnostic RPCs (#1142) will use. Because indexes are maintained only in the add/remove/clear paths, reorg resurrection (`AcceptToMemoryPool` replay) rebuilds them automatically. The miner's per-block MRC selection is unchanged. **No consensus change.**

## Stacked on #3090 → #3072

Builds on Phase 1 (#3090), itself on Phase 0 (#3072). The diff narrows to just the Phase 2 change once those land. Not intended to close the #3029 umbrella.

## Testing

`txmempool_tests.cpp` gains: index population/teardown across add+remove, `HasMRCForCpid` collision-hash reporting, fee-descending `GetMRCQueue`, and `GetStaleMRCs` anchor-block selection. Full local `ctest` suite green (behavior-neutral); `getmrcrequestdata` output unchanged.