### PR TITLE
mempool: bound size with -maxmempool and feerate eviction (mempool Phase 4)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1044,7 +1044,15 @@ bool AppInit2(ThreadHandlerPtr threads)
     nMinerSleep = gArgs.GetArg("-minersleep", 8000);
 
     // Cap the transaction memory pool size (#3029 Phase 4). Value is in MB.
-    int64_t nMaxMempoolMB = std::max<int64_t>(0, gArgs.GetArg("-maxmempool", 300));
+    // Enforce a small floor: a tiny (or zero/negative) cap would evict
+    // transactions as fast as they arrive -- including the node's own sends --
+    // effectively disabling tx relay. Reject the misconfiguration rather than
+    // silently clamping it, so the operator sees what happened.
+    static const int64_t nMaxMempoolMinMB = 5;
+    int64_t nMaxMempoolMB = gArgs.GetArg("-maxmempool", 300);
+    if (nMaxMempoolMB < nMaxMempoolMinMB) {
+        return InitError(strprintf(_("-maxmempool must be at least %d MB."), nMaxMempoolMinMB));
+    }
     mempool.SetMaxSize(static_cast<size_t>(nMaxMempoolMB) * 1000 * 1000);
 
     nDerivationMethodIndex = 0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1044,14 +1044,19 @@ bool AppInit2(ThreadHandlerPtr threads)
     nMinerSleep = gArgs.GetArg("-minersleep", 8000);
 
     // Cap the transaction memory pool size (#3029 Phase 4). Value is in MB.
-    // Enforce a small floor: a tiny (or zero/negative) cap would evict
-    // transactions as fast as they arrive -- including the node's own sends --
-    // effectively disabling tx relay. Reject the misconfiguration rather than
-    // silently clamping it, so the operator sees what happened.
+    // Enforce a floor: a tiny (or zero/negative) cap would evict transactions as
+    // fast as they arrive -- including the node's own sends -- effectively
+    // disabling tx relay. Enforce a ceiling too: it keeps the byte value well
+    // within a 32-bit size_t so the conversion below cannot overflow on 32-bit
+    // builds (where a large value would silently wrap to a tiny, relay-breaking
+    // cap). 4000 MB is far above any real need. Reject a misconfiguration rather
+    // than silently clamping, so the operator sees what happened.
     static const int64_t nMaxMempoolMinMB = 5;
+    static const int64_t nMaxMempoolMaxMB = 4000;
     int64_t nMaxMempoolMB = gArgs.GetArg("-maxmempool", 300);
-    if (nMaxMempoolMB < nMaxMempoolMinMB) {
-        return InitError(strprintf(_("-maxmempool must be at least %d MB."), nMaxMempoolMinMB));
+    if (nMaxMempoolMB < nMaxMempoolMinMB || nMaxMempoolMB > nMaxMempoolMaxMB) {
+        return InitError(strprintf(_("-maxmempool must be between %d and %d MB."),
+                                   nMaxMempoolMinMB, nMaxMempoolMaxMB));
     }
     mempool.SetMaxSize(static_cast<size_t>(nMaxMempoolMB) * 1000 * 1000);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,6 +25,7 @@
 #include "gridcoin/contract/registry.h"
 #include "miner.h"
 #include "net_processing.h"
+#include "txmempool.h"
 #include "node/blockstorage.h"
 #include "node/coherence.h"
 #include <util/syserror.h>
@@ -650,6 +651,8 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-maxoutboundconnections=<n>", "Maximum number of outbound connections (default: 8)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-maxmempool=<n>", "Keep the transaction memory pool below <n> megabytes (default: 300)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-addnode=<ip>", "Add a node to connect to and attempt to keep the connection open",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-connect=<ip>", "Connect only to the specified node(s)",
@@ -1039,6 +1042,10 @@ bool AppInit2(ThreadHandlerPtr threads)
     fUseFastIndex = gArgs.GetBoolArg("-fastindex", false);
 
     nMinerSleep = gArgs.GetArg("-minersleep", 8000);
+
+    // Cap the transaction memory pool size (#3029 Phase 4). Value is in MB.
+    int64_t nMaxMempoolMB = std::max<int64_t>(0, gArgs.GetArg("-maxmempool", 300));
+    mempool.SetMaxSize(static_cast<size_t>(nMaxMempoolMB) * 1000 * 1000);
 
     nDerivationMethodIndex = 0;
     fTestNet = gArgs.GetBoolArg("-testnet");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,10 +451,15 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         CTxMemPoolEntry entry(tx, nFees, GetAdjustedTime(), nBestHeight, nSize);
         pool.addUnchecked(hash, entry);
 
-        // Enforce the -maxmempool cap. If this transaction is itself the lowest
-        // priority (and not a protected contract tx), it may be evicted again;
-        // treat that as a "mempool full" rejection.
-        pool.TrimToSize(pool.GetMaxSize());
+        // Enforce the -maxmempool cap. Protect the transaction we just accepted so
+        // it is not immediately self-evicted: given Gridcoin's flat feerate and the
+        // newest-first tie-break it would otherwise always be the first victim,
+        // failing the node's own sends. Room is made by evicting other, lower-
+        // priority entries instead. If the pool is still over the cap afterwards,
+        // this transaction alone exceeds it -- only possible with an unreasonably
+        // small -maxmempool, which the init-time floor already rejects; treat that
+        // as a "mempool full" rejection.
+        pool.TrimToSize(pool.GetMaxSize(), /*removed=*/nullptr, /*protect=*/&hash);
         if (!pool.exists(hash)) {
             return error("AcceptToMemoryPool : transaction %s rejected, mempool full",
                          hash.ToString());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -450,6 +450,15 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
         }
         CTxMemPoolEntry entry(tx, nFees, GetAdjustedTime(), nBestHeight, nSize);
         pool.addUnchecked(hash, entry);
+
+        // Enforce the -maxmempool cap. If this transaction is itself the lowest
+        // priority (and not a protected contract tx), it may be evicted again;
+        // treat that as a "mempool full" rejection.
+        pool.TrimToSize(pool.GetMaxSize());
+        if (!pool.exists(hash)) {
+            return error("AcceptToMemoryPool : transaction %s rejected, mempool full",
+                         hash.ToString());
+        }
     }
 
     // Notify the validation-signal layer that the transaction was added to

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -143,6 +143,8 @@ static const RPCHelpMan getmempoolinfo_help{
         {
             {RPCResult::Type::NUM, "size", "Current transaction count."},
             {RPCResult::Type::NUM, "bytes", "Sum of all transaction serialized sizes."},
+            {RPCResult::Type::NUM, "usage", "Total estimated memory usage of the mempool."},
+            {RPCResult::Type::NUM, "maxmempool", "Maximum memory usage for the mempool, in bytes."},
             {RPCResult::Type::NUM, "mrc_count", "Number of MRC contract transactions in the pool."},
             {RPCResult::Type::NUM, "beacon_count", "Number of distinct CPIDs with a pending beacon advertisement in the pool (duplicate same-CPID advertisements collapse to one)."},
             {RPCResult::Type::NUM, "mandatory_sidestake_count", "Number of mandatory sidestake transactions in the pool."},
@@ -160,6 +162,8 @@ UniValue getmempoolinfo(const UniValue& params)
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("size", (int64_t)info.tx_count);
     obj.pushKV("bytes", (int64_t)info.bytes);
+    obj.pushKV("usage", (int64_t)info.usage);
+    obj.pushKV("maxmempool", (int64_t)info.max_size);
     obj.pushKV("mrc_count", (int64_t)info.mrc_count);
     obj.pushKV("beacon_count", (int64_t)info.beacon_count);
     obj.pushKV("mandatory_sidestake_count", (int64_t)info.mandatory_sidestake_count);

--- a/src/test/txmempool_tests.cpp
+++ b/src/test/txmempool_tests.cpp
@@ -370,4 +370,33 @@ BOOST_AUTO_TEST_CASE(trim_protects_contract_when_room_for_one)
     BOOST_CHECK_EQUAL(pool.m_mrc_by_cpid.size(), 1U);
 }
 
+BOOST_AUTO_TEST_CASE(trim_never_evicts_the_protected_transaction)
+{
+    CTxMemPool pool;
+
+    // Two transactions in the same feerate tier.
+    const CTransaction a = MakePlainTx(11);
+    const CTransaction b = MakePlainTx(12);
+    pool.addUnchecked(a.GetHash(), MakeEntryFee(a, 10));
+    pool.addUnchecked(b.GetHash(), MakeEntryFee(b, 10));
+
+    // Whichever sits at the front of the eviction set is the natural first victim.
+    // Protect exactly that one: TrimToSize must evict the OTHER transaction instead
+    // and keep the protected one -- this is the AcceptToMemoryPool self-eviction
+    // guard that stops a just-accepted tx (newest, so first in the tie-break) from
+    // being dropped as its own victim.
+    const uint256 natural_victim = pool.m_eviction_index.begin()->hash;
+
+    // Room for exactly one entry (both txs serialize to the same size).
+    const size_t one_entry = ::GetSerializeSize(a, SER_NETWORK, PROTOCOL_VERSION)
+                             + CTxMemPool::PER_ENTRY_OVERHEAD;
+    pool.TrimToSize(one_entry, /*removed=*/nullptr, /*protect=*/&natural_victim);
+
+    BOOST_CHECK(pool.exists(natural_victim));
+    BOOST_CHECK_EQUAL(pool.size(), 1UL);
+    BOOST_CHECK_EQUAL(pool.m_eviction_index.size(), 1U);
+    BOOST_CHECK_EQUAL(pool.m_total_tx_size,
+                      ::GetSerializeSize(a, SER_NETWORK, PROTOCOL_VERSION));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txmempool_tests.cpp
+++ b/src/test/txmempool_tests.cpp
@@ -295,4 +295,79 @@ BOOST_AUTO_TEST_CASE(rpc_mempool_diagnostics)
     mempool.clear();
 }
 
+// ---------------------------------------------------------------------------
+// Phase 4 (#3029): bounded size + eviction
+// ---------------------------------------------------------------------------
+
+namespace {
+//! Distinct plain (no-contract) transaction, made unique by its output value.
+CTransaction MakePlainTx(CAmount out_value)
+{
+    CTxOut vout;
+    vout.nValue = out_value;
+    return MakeTx({}, {}, {vout});
+}
+
+CTxMemPoolEntry MakeEntryFee(const CTransaction& tx, CAmount fee)
+{
+    return CTxMemPoolEntry(tx, fee, 0, 0, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+}
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(trim_evicts_lowest_feerate_first_then_contracts_last)
+{
+    CTxMemPool pool;
+
+    const CTransaction lo = MakePlainTx(1);
+    const CTransaction mid = MakePlainTx(2);
+    const CTransaction hi = MakePlainTx(3);
+    pool.addUnchecked(lo.GetHash(), MakeEntryFee(lo, 10));
+    pool.addUnchecked(mid.GetHash(), MakeEntryFee(mid, 20));
+    pool.addUnchecked(hi.GetHash(), MakeEntryFee(hi, 30));
+
+    // A contract (MRC) tx with no fee -- lowest feerate of all, but protected.
+    const CTransaction mrc = MakeMrcTx(GRC::Cpid(InsecureRandBytes(16)), 5);
+    pool.addUnchecked(mrc.GetHash(), MakeEntryFee(mrc, 0));
+
+    BOOST_CHECK_EQUAL(pool.size(), 4UL);
+
+    std::vector<CTransaction> removed;
+    pool.TrimToSize(0, &removed);
+
+    // Order: non-contract by feerate ascending (lo, mid, hi), contract evicted last.
+    BOOST_REQUIRE_EQUAL(removed.size(), 4U);
+    BOOST_CHECK(removed[0].GetHash() == lo.GetHash());
+    BOOST_CHECK(removed[1].GetHash() == mid.GetHash());
+    BOOST_CHECK(removed[2].GetHash() == hi.GetHash());
+    BOOST_CHECK(removed[3].GetHash() == mrc.GetHash());
+
+    // Every index drained and consistent.
+    BOOST_CHECK_EQUAL(pool.size(), 0UL);
+    BOOST_CHECK_EQUAL(pool.m_total_tx_size, 0U);
+    BOOST_CHECK(pool.m_eviction_index.empty());
+    BOOST_CHECK(pool.m_mrc_by_cpid.empty());
+    BOOST_CHECK(pool.m_mrc_by_fee.empty());
+}
+
+BOOST_AUTO_TEST_CASE(trim_protects_contract_when_room_for_one)
+{
+    CTxMemPool pool;
+
+    const CTransaction plain = MakePlainTx(7);
+    const CTransaction mrc = MakeMrcTx(GRC::Cpid(InsecureRandBytes(16)), 9);
+    pool.addUnchecked(plain.GetHash(), MakeEntryFee(plain, 50)); // higher fee, but not protected
+    pool.addUnchecked(mrc.GetHash(), MakeEntryFee(mrc, 0));      // no fee, but a contract
+
+    // Leave room for exactly one entry. The non-contract plain tx is evicted even
+    // though it pays more, because contract txns are protected (evicted last).
+    const size_t mrc_size = ::GetSerializeSize(mrc, SER_NETWORK, PROTOCOL_VERSION);
+    pool.TrimToSize(mrc_size + CTxMemPool::PER_ENTRY_OVERHEAD);
+
+    BOOST_CHECK(!pool.exists(plain.GetHash()));
+    BOOST_CHECK(pool.exists(mrc.GetHash()));
+    BOOST_CHECK_EQUAL(pool.size(), 1UL);
+    BOOST_CHECK_EQUAL(pool.m_eviction_index.size(), 1U);
+    BOOST_CHECK_EQUAL(pool.m_mrc_by_cpid.size(), 1U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -112,14 +112,23 @@ void CTxMemPool::eraseIndexes(const CTxMemPoolEntry& entry)
     if (entry.HasMandatorySidestake() && m_mandatory_sidestake_count > 0)
         --m_mandatory_sidestake_count;
 
-    // Size accounting + eviction ordering.
-    if (m_total_tx_size >= entry.GetTxSize()) m_total_tx_size -= entry.GetTxSize();
+    // Size accounting + eviction ordering. add/erase are balanced in practice
+    // (every addUnchecked is matched by exactly one erase), so this cannot
+    // underflow; clamp to 0 anyway -- rather than wrapping size_t or leaving the
+    // counter stuck high -- so it stays self-correcting if it ever desynced.
+    m_total_tx_size = (m_total_tx_size >= entry.GetTxSize())
+                          ? m_total_tx_size - entry.GetTxSize()
+                          : 0;
     m_eviction_index.erase(EvictionKeyFor(entry));
 }
 
 
 bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive, MemPoolRemovalReason reason)
 {
+    // NOTE: `reason` is threaded through (including into the recursive call below)
+    // as groundwork for a future TransactionRemovedFromMempool validation signal.
+    // No subscriber consumes it yet, so it has no observable effect today.
+
     // Remove transaction from memory pool
     {
         LOCK(cs);
@@ -173,17 +182,26 @@ void CTxMemPool::clear()
     m_eviction_index.clear();
 }
 
-void CTxMemPool::TrimToSize(size_t limit, std::vector<CTransaction>* removed)
+void CTxMemPool::TrimToSize(size_t limit, std::vector<CTransaction>* removed,
+                            const uint256* protect)
 {
     LOCK(cs);
 
-    while (DynamicMemoryUsage() > limit && !m_eviction_index.empty()) {
-        const uint256 victim_hash = m_eviction_index.begin()->hash;
+    while (DynamicMemoryUsage() > limit) {
+        // Lowest-priority entry is the next victim, but never evict the protected
+        // transaction (the just-accepted one) -- skip it and take the next.
+        auto key_it = m_eviction_index.begin();
+        if (protect && key_it != m_eviction_index.end() && key_it->hash == *protect)
+            ++key_it;
+        if (key_it == m_eviction_index.end())
+            break; // nothing evictable remains but the protected tx (it alone is over-limit)
+
+        const uint256 victim_hash = key_it->hash;
 
         auto it = mapTx.find(victim_hash);
         if (it == mapTx.end()) {
             // Defensive: drop a stale key that has no backing entry.
-            m_eviction_index.erase(m_eviction_index.begin());
+            m_eviction_index.erase(key_it);
             continue;
         }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -87,6 +87,10 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry)
             m_beacon_by_cpid.insert_or_assign(e.GetBeaconCpid(), hash);
         if (e.HasMandatorySidestake())
             ++m_mandatory_sidestake_count;
+
+        // Size accounting + eviction ordering.
+        m_total_tx_size += e.GetTxSize();
+        m_eviction_index.insert(EvictionKeyFor(e));
     }
     return true;
 }
@@ -107,10 +111,14 @@ void CTxMemPool::eraseIndexes(const CTxMemPoolEntry& entry)
         m_beacon_by_cpid.erase(entry.GetBeaconCpid());
     if (entry.HasMandatorySidestake() && m_mandatory_sidestake_count > 0)
         --m_mandatory_sidestake_count;
+
+    // Size accounting + eviction ordering.
+    if (m_total_tx_size >= entry.GetTxSize()) m_total_tx_size -= entry.GetTxSize();
+    m_eviction_index.erase(EvictionKeyFor(entry));
 }
 
 
-bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
+bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive, MemPoolRemovalReason reason)
 {
     // Remove transaction from memory pool
     {
@@ -123,7 +131,7 @@ bool CTxMemPool::remove(const CTransaction &tx, bool fRecursive)
                 for (unsigned int i = 0; i < tx.vout.size(); i++) {
                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));
                     if (it != mapNextTx.end())
-                        remove(*it->second.ptx, true);
+                        remove(*it->second.ptx, true, reason);
                 }
             }
             // Tear down the secondary indexes before erasing the entry.
@@ -161,6 +169,31 @@ void CTxMemPool::clear()
     m_beacon_by_cpid.clear();
     m_mandatory_sidestake_count = 0;
     m_mrc_by_fee.clear();
+    m_total_tx_size = 0;
+    m_eviction_index.clear();
+}
+
+void CTxMemPool::TrimToSize(size_t limit, std::vector<CTransaction>* removed)
+{
+    LOCK(cs);
+
+    while (DynamicMemoryUsage() > limit && !m_eviction_index.empty()) {
+        const uint256 victim_hash = m_eviction_index.begin()->hash;
+
+        auto it = mapTx.find(victim_hash);
+        if (it == mapTx.end()) {
+            // Defensive: drop a stale key that has no backing entry.
+            m_eviction_index.erase(m_eviction_index.begin());
+            continue;
+        }
+
+        const CTransaction victim = it->second.GetTx();
+        if (removed) removed->push_back(victim);
+
+        // Route through remove() so every index (and the running size total)
+        // stays consistent. Recursive so dependents go too.
+        remove(victim, /*fRecursive=*/true, MemPoolRemovalReason::SIZELIMIT);
+    }
 }
 
 void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -40,6 +40,13 @@ enum class MemPoolRemovalReason {
 //! are evicted last so reward-bearing MRCs survive), then lowest feerate, then
 //! newest-first among ties, then hash for uniqueness.
 //!
+//! Caveat: eviction ranks by INDIVIDUAL transaction, not by ancestor/descendant
+//! package (this tree has no package-feerate accounting). When the chosen victim
+//! is removed recursively, an unconfirmed contract child spending a cheaper
+//! non-contract parent can be dropped as collateral, so the "contracts last"
+//! guarantee is best-effort for such chains. Acceptable given low tx volume and
+//! the non-consensus nature of the pool; revisit if package relay is added.
+//!
 struct CTxMemPoolEvictionKey
 {
     bool is_contract;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -32,6 +32,31 @@ enum class MemPoolRemovalReason {
 };
 
 //!
+//! \brief Ordering key for size-based eviction (#3029 Phase 4).
+//!
+//! The eviction set's first element is always the next victim. Gridcoin's flat,
+//! size-scaled fee makes feerate nearly identical across transactions, so the
+//! order is: non-contract transactions before contract transactions (contracts
+//! are evicted last so reward-bearing MRCs survive), then lowest feerate, then
+//! newest-first among ties, then hash for uniqueness.
+//!
+struct CTxMemPoolEvictionKey
+{
+    bool is_contract;
+    CAmount feerate;
+    int64_t time;
+    uint256 hash;
+
+    bool operator<(const CTxMemPoolEvictionKey& other) const
+    {
+        if (is_contract != other.is_contract) return is_contract < other.is_contract;
+        if (feerate != other.feerate) return feerate < other.feerate;
+        if (time != other.time) return time > other.time;
+        return hash < other.hash;
+    }
+};
+
+//!
 //! \brief A transaction stored in the memory pool together with the metadata
 //! computed once when it was accepted.
 //!
@@ -102,6 +127,8 @@ struct CTxMemPoolInfo
 {
     size_t tx_count{0};
     size_t bytes{0};
+    size_t usage{0};
+    size_t max_size{0};
     size_t mrc_count{0};
     size_t beacon_count{0};
     size_t mandatory_sidestake_count{0};
@@ -136,11 +163,36 @@ public:
     //! MRCs in fee-descending order, for the GUI/RPC queue ranking.
     std::multimap<CAmount, GRC::Cpid, std::greater<CAmount>> m_mrc_by_fee;
 
+    // Size accounting + eviction (#3029 Phase 4).
+    size_t m_total_tx_size{0};                        //!< Running sum of entry serialized sizes.
+    std::set<CTxMemPoolEvictionKey> m_eviction_index; //!< Victim ordering; begin() is evicted first.
+    size_t m_max_size_bytes{300 * 1000 * 1000};       //!< -maxmempool cap in bytes (default 300 MB).
+
+    //! Estimated per-entry bookkeeping overhead (CTxMemPoolEntry + map/index nodes)
+    //! added on top of the serialized size in DynamicMemoryUsage().
+    static constexpr size_t PER_ENTRY_OVERHEAD = 256;
+
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
-    bool remove(const CTransaction &tx, bool fRecursive = false);
+    bool remove(const CTransaction &tx, bool fRecursive = false,
+                MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     bool removeConflicts(const CTransaction &tx);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
+
+    //! \brief Estimated dynamic memory used by the pool and its indexes.
+    size_t DynamicMemoryUsage() const
+    {
+        LOCK(cs);
+        return m_total_tx_size + mapTx.size() * PER_ENTRY_OVERHEAD;
+    }
+
+    //! \brief Evict transactions until DynamicMemoryUsage() is at or below \p limit,
+    //! lowest-priority first (see CTxMemPoolEvictionKey). Routes every eviction
+    //! through remove() so all indexes stay consistent.
+    void TrimToSize(size_t limit, std::vector<CTransaction>* removed = nullptr);
+
+    size_t GetMaxSize() const { LOCK(cs); return m_max_size_bytes; }
+    void SetMaxSize(size_t bytes) { LOCK(cs); m_max_size_bytes = bytes; }
 
     //! \brief Whether the pool already holds an MRC for \p cpid. When it does and
     //! \p existing is non-null, the colliding transaction hash is written there.
@@ -181,7 +233,9 @@ public:
         LOCK(cs);
         CTxMemPoolInfo info;
         info.tx_count = mapTx.size();
-        for (const auto& [_, entry] : mapTx) info.bytes += entry.GetTxSize();
+        info.bytes = m_total_tx_size;
+        info.usage = m_total_tx_size + mapTx.size() * PER_ENTRY_OVERHEAD;
+        info.max_size = m_max_size_bytes;
         info.mrc_count = m_mrc_by_cpid.size();
         info.beacon_count = m_beacon_by_cpid.size();
         info.mandatory_sidestake_count = m_mandatory_sidestake_count;
@@ -223,8 +277,16 @@ public:
     }
 
 private:
-    //! Remove an entry's contributions from the secondary indexes. Caller holds cs.
+    //! Remove an entry's contributions from the secondary indexes, the running
+    //! size total, and the eviction index. Caller holds cs.
     void eraseIndexes(const CTxMemPoolEntry& entry);
+
+    //! Build the eviction-ordering key for an entry.
+    static CTxMemPoolEvictionKey EvictionKeyFor(const CTxMemPoolEntry& entry)
+    {
+        return {!entry.GetContractTypes().empty(), entry.GetFeeRate(),
+                entry.GetTime(), entry.GetTx().GetHash()};
+    }
 };
 
 extern CTxMemPool mempool;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -176,7 +176,11 @@ public:
     size_t m_max_size_bytes{300 * 1000 * 1000};       //!< -maxmempool cap in bytes (default 300 MB).
 
     //! Estimated per-entry bookkeeping overhead (CTxMemPoolEntry + map/index nodes)
-    //! added on top of the serialized size in DynamicMemoryUsage().
+    //! added on top of the serialized size in DynamicMemoryUsage(). This is an
+    //! optimistic floor, not a tight bound: the entry also stores a full in-memory
+    //! CTransaction copy whose heap footprint runs larger than its serialized size,
+    //! so real RSS exceeds the reported usage. Adequate for bounding a low-volume,
+    //! non-consensus pool; revisit if a tighter memory bound is ever needed.
     static constexpr size_t PER_ENTRY_OVERHEAD = 256;
 
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry);
@@ -196,7 +200,17 @@ public:
     //! \brief Evict transactions until DynamicMemoryUsage() is at or below \p limit,
     //! lowest-priority first (see CTxMemPoolEvictionKey). Routes every eviction
     //! through remove() so all indexes stay consistent.
-    void TrimToSize(size_t limit, std::vector<CTransaction>* removed = nullptr);
+    //!
+    //! If \p protect is non-null, the transaction with that hash is never chosen as
+    //! a victim -- room is made by evicting other (lower-priority) entries instead.
+    //! AcceptToMemoryPool passes the just-accepted hash here so it is not immediately
+    //! self-evicted (which, given Gridcoin's flat feerate and the newest-first
+    //! tie-break, it otherwise always would be), while the pool still stays bounded.
+    //!
+    //! \p removed, when non-null, receives the primary victims chosen here; it does
+    //! NOT include transactions dropped as recursive descendants of a victim.
+    void TrimToSize(size_t limit, std::vector<CTransaction>* removed = nullptr,
+                    const uint256* protect = nullptr);
 
     size_t GetMaxSize() const { LOCK(cs); return m_max_size_bytes; }
     void SetMaxSize(size_t bytes) { LOCK(cs); m_max_size_bytes = bytes; }


### PR DESCRIPTION
## What

Phase 4 of the mempool modernization (**part of #3029**), stacked on Phase 3 (#3092). Adds a size cap and eviction to `CTxMemPool`:

- A running `m_total_tx_size` and a composite eviction index (`CTxMemPoolEvictionKey`). Because Gridcoin's flat, size-scaled fee makes feerate nearly identical across transactions, victims are ordered: **non-contract before contract** (contracts evicted last, so reward-bearing MRCs survive), then feerate ascending, then newest-first.
- `DynamicMemoryUsage()` = serialized bytes + a fixed per-entry overhead.
- `TrimToSize(limit)` evicts lowest-priority first, routing every removal through `remove(..., SIZELIMIT)` so all indexes stay consistent. `remove()` gains a `MemPoolRemovalReason`.
- `-maxmempool` (default 300 MB) parsed in `init.cpp` and applied via `SetMaxSize()`; `AcceptToMemoryPool` trims after `addUnchecked` and rejects the incoming tx if it was itself evicted (mempool full).
- `getmempoolinfo` now reports `usage` and `maxmempool`.

## Why

Caps unbounded mempool growth (a DoS vector) while protecting Gridcoin's low-volume, time-sensitive contract transactions. Indexes are still maintained only in the add/remove/clear paths, so reorg resurrection rebuilds them. **No consensus change.**

## Stacked on #3092 → #3091 → #3090 → #3072

The diff narrows to just the Phase 4 change once the predecessors land. Not intended to close the #3029 umbrella.

## Testing

`txmempool_tests.cpp`: eviction order (feerate ascending, contracts last) and contract protection when room remains for one. Full local `ctest` suite green; fork CI matrix green (Quality Gate, Functional Tests, Compatibility, Distribution Native, Production).