### PR TITLE
gui: windowed transaction-table bug fixes

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -325,8 +325,29 @@ QString TransactionTableModel::formatTxStatus(const TransactionRecord *wtx) cons
         status = tr("Confirming (%1 of %2 recommended confirmations)<br>").arg(wtx->status.depth).arg(TransactionRecord::RecommendedNumConfirmations);
         break;
     case TransactionStatus::Confirmed:
-        status = tr("Confirmed (%1 confirmations)").arg(wtx->status.depth);
+    {
+        // Derive the displayed count from the current chain height rather than the
+        // cached snapshot. status.depth was captured when the tip was
+        // status.cur_num_blocks, but a Confirmed tx is no longer in the per-tip
+        // refresh set (PR4-fix A only re-snapshots volatile rows), so the raw
+        // snapshot would freeze at the recommended-confirmations threshold. Adding
+        // how far the tip has advanced since the snapshot keeps the tooltip live with
+        // no per-row refresh — O(1) on read, the windowed model's whole point
+        // preserved. The tip height comes from WalletModel::getChainHeight(), the
+        // height PUSHED to the GUI via the wallet event stream (ChainTipChangedPayload)
+        // and cached on the GUI thread — NOT a read of the cs_main-guarded core
+        // nBestHeight: the render path must never take a core lock (process-separation
+        // invariant). Guards: the cached height is 0 until the first chain-tip event
+        // drains, and cur_num_blocks is -1 when unset — in both the delta is skipped
+        // and the snapshot stands. confirmations is int64_t to match status.depth.
+        int64_t confirmations = wtx->status.depth;
+        const int chain_height = walletModel->getChainHeight();
+        if (wtx->status.cur_num_blocks >= 0 && chain_height >= wtx->status.cur_num_blocks) {
+            confirmations += chain_height - wtx->status.cur_num_blocks;
+        }
+        status = tr("Confirmed (%1 confirmations)").arg(confirmations);
         break;
+    }
     case TransactionStatus::Conflicted:
         status = tr("Conflicted");
         break;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -203,9 +203,13 @@ void WalletModel::drainEventQueue()
     // a single block.
     bool chain_tip_advanced = false;
     for (const auto& ev : events) {
-        if (std::holds_alternative<GRC::ChainTipChangedPayload>(ev.payload)) {
+        if (const auto* tip = std::get_if<GRC::ChainTipChangedPayload>(&ev.payload)) {
             chain_tip_advanced = true;
-            break;
+            // Cache the pushed tip height (GUI-thread-owned) so the transaction
+            // table can derive live confirmation counts on read — no cs_main, no
+            // reach-through to core state, wallet model self-contained for the
+            // eventual process split. Last tip event in the batch wins.
+            cachedNumBlocks = tip->height;
         }
     }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -69,6 +69,14 @@ public:
     AddressTableModel *getAddressTableModel();
     TransactionTableModel *getTransactionTableModel();
 
+    //! Last chain-tip height pushed to the GUI via the wallet event stream
+    //! (ChainTipChangedPayload), cached on the GUI thread. Lets the transaction
+    //! table derive live confirmation counts on read without reaching into core
+    //! state or taking cs_main — GUI-thread-owned, no lock, process-separation safe.
+    //! 0 until the first chain-tip event drains (callers must guard, as the count
+    //! derivation does); never blocks.
+    int getChainHeight() const { return cachedNumBlocks; }
+
     qint64 getBalance() const;
     qint64 getStake() const;
     qint64 getUnconfirmedBalance() const;

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -552,16 +552,27 @@ void WalletTxStore::updateTransaction(std::vector<TransactionRecord> records)
     // incomingTransaction (fresh inserts), focusTransaction (TxIDRole), indexForTxid
     // (hash) — do not depend on post-insert status freshness. Re-evaluate each cursor
     // per affected row: under a status sort a first confirmation repositions the row.
+    //
+    // Overwrite + re-drive ONE part at a time. applyStatusUpdate repositions a row
+    // via lower_bound, which needs the rest of view_index sorted; for a multi-part
+    // tx, recomputing ALL parts' keys first (then driving) would leave the
+    // not-yet-repositioned siblings mis-keyed in their old slots and break that
+    // precondition under a Status sort — producing a mis-sorted view_index and
+    // inconsistent deltas that duplicate a row in the consumer caches. Interleave to
+    // keep every untouched part at its consistent prior key/slot, exactly as
+    // applyChainTipRefresh (PR4-fix A) and applyAddressBookChange (PR4-fix C) do, and
+    // as the interleaved_reposition_to_equal_keys cursor test pins. Positions in
+    // m_records are stable across the loop (status is not part of RecordOrder).
+    // (Single-part txs are unaffected: the loop body runs once either way.)
+    //
     for (std::size_t k = 0; k < records.size(); ++k) {
         m_records[minPos + k] = records[k];
         recomputeCacheAt(minPos + k);   // refresh F-cache before the cursor drive reads it
-    }
-    updateVolatileForHash(hash);        // status may have crossed a maturity threshold (PR4-fix A)
-    for (auto& [viewId, cursor] : m_cursors) {
-        for (std::size_t p = minPos; p <= maxPos; ++p) {
-            emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStatusUpdate(p));
+        for (auto& [viewId, cursor] : m_cursors) {
+            emitCursorDeltas(viewId, cursor.epoch(), cursor.applyStatusUpdate(minPos + k));
         }
     }
+    updateVolatileForHash(hash);        // status may have crossed a maturity threshold (PR4-fix A)
 }
 
 void WalletTxStore::applyAddressBookChange(const std::string& address, const std::string& label)

--- a/src/test/qt_cursor_tests.cpp
+++ b/src/test/qt_cursor_tests.cpp
@@ -414,6 +414,61 @@ BOOST_AUTO_TEST_CASE(interleaved_reposition_to_equal_keys)
     BOOST_CHECK_EQUAL(c.viewIndex()[3], 2u);
 }
 
+// ---- ⚠ multi-part status reposition: store MUST drive one part at a time -----
+
+BOOST_AUTO_TEST_CASE(multipart_status_reposition_requires_interleaved_drive)
+{
+    // Regression for the windowed-model duplicate (mainnet, 2026-06-21): a multi-part
+    // tx whose Status sort key changes on confirmation. WalletTxStore::updateTransaction
+    // overwrites the parts in m_records and re-drives the cursors; it MUST overwrite +
+    // drive ONE part at a time. Recompute-all-keys-then-drive-all transiently de-sorts
+    // view_index (siblings sit at old slots while reading new keys), so applyStatusUpdate's
+    // lower_bound misplaces — yielding a view_index that diverges from ground truth (a
+    // fresh rebuild) and inconsistent Insert/Change deltas that DUPLICATE a row in the
+    // consumer caches. Same contract as interleaved_reposition_to_equal_keys, here for a
+    // multi-part Status-sort confirmation. Single-part txs are immune (the loop runs once).
+    auto make = [] {
+        Table t;
+        // 3-part tx (abs 0,1,2) status_sort "5"; neighbours abs3 "3", abs4 "7".
+        t.rows = { active(500, "5"), active(500, "5"), active(500, "5"),
+                   active(400, "3"), active(600, "7") };
+        return t;
+    };
+
+    // Ground truth after the tx confirms ("5" -> "9", crossing past "7"): rebuild.
+    Table gt = make();
+    for (int i = 0; i < 3; ++i) gt.rows[i].status_sort = "9";
+    Cursor truth(1, FilterSpec{}, TXCOL_STATUS, TXSORT_ASC, gt.fields(), gt.keys());
+    truth.rebuild(gt.rows.size());                       // [3,4,0,1,2]
+
+    // (a) THE BUG: recompute ALL parts' keys, THEN drive all (the old updateTransaction).
+    {
+        Table t = make();
+        Cursor c(1, FilterSpec{}, TXCOL_STATUS, TXSORT_ASC, t.fields(), t.keys());
+        c.rebuild(t.rows.size());                        // [3,0,1,2,4]
+        for (int i = 0; i < 3; ++i) t.rows[i].status_sort = "9";    // all keys up front
+        for (std::size_t p = 0; p < 3; ++p) c.applyStatusUpdate(p); // then drive all
+        BOOST_CHECK(c.viewIndex() != truth.viewIndex());            // de-sorted -> WRONG
+    }
+
+    // (b) THE FIX: change one part's key, drive it, repeat (interleaved).
+    {
+        Table t = make();
+        Cursor c(1, FilterSpec{}, TXCOL_STATUS, TXSORT_ASC, t.fields(), t.keys());
+        c.rebuild(t.rows.size());
+        for (std::size_t p = 0; p < 3; ++p) {
+            t.rows[p].status_sort = "9";
+            c.applyStatusUpdate(p);
+        }
+        BOOST_CHECK(c.viewIndex() == truth.viewIndex());            // matches ground truth
+        // And every accepted row appears exactly once (no duplicate absidx).
+        std::vector<std::size_t> vi(c.viewIndex().begin(), c.viewIndex().end());
+        std::sort(vi.begin(), vi.end());
+        BOOST_CHECK(std::unique(vi.begin(), vi.end()) == vi.end());
+        BOOST_CHECK_EQUAL(vi.size(), 5u);
+    }
+}
+
 // ---- positionOf: public identity-locate (PR5 rowForKey backing) -------------
 
 BOOST_AUTO_TEST_CASE(position_of_maps_absidx_to_accepted_row_or_npos)


### PR DESCRIPTION
Two bug fixes in the windowed transaction-table model (the cursor/`WalletTxStore` machinery from the PR3–PR5 series), found from a duplicate-row report on a live wallet.

## 1. Duplicate row on a multi-part tx status change

`WalletTxStore::updateTransaction`'s in-place path overwrote **all** parts of a multi-part transaction in `m_records` (and recomputed their cached sort keys) and **then** looped `Cursor::applyStatusUpdate` over each part. `applyStatusUpdate` repositions a row via `lowerBoundSlot` (a `std::lower_bound`), which requires the rest of `view_index` to be sorted by the *current* keys. For a multi-part tx whose sort key moves on a status change (e.g. a confirmation under a **Status** sort), recomputing all parts first leaves the not-yet-repositioned siblings mis-keyed at their old slots — transiently de-sorting `view_index`, so `lower_bound` misplaces a row. The result is a `view_index` that diverges from a fresh rebuild and an inconsistent `Insert`/`Change` delta stream that **duplicates a row** in the consumer caches (overview + detailed views). Single-part txs are immune (the loop body runs once).

This is exactly the contract the two sibling paths already follow and document — `applyChainTipRefresh` (PR4-fix A) and `applyAddressBookChange` (PR4-fix C): recompute + drive **one part at a time**, never recompute-all-then-drive-all. `updateTransaction` simply wasn't written to it.

**Fix:** interleave `updateTransaction`'s overwrite + recompute + cursor drive per part. Adds a GUI-OFF regression test (`qt_cursor_tests/multipart_status_reposition_requires_interleaved_drive`) reproducing the divergence and pinning the interleaved result against a fresh rebuild with no duplicate.

## 2. Confirmation count frozen at 10 in the tx tooltip

The per-tip status refresh (PR4-fix A) only re-snapshots *volatile* rows (status below `Confirmed`). Once a tx reaches the recommended-confirmations depth it becomes `Confirmed` and drops out of that set, so its cached `status.depth` — and the "Confirmed (N confirmations)" tooltip — froze at the threshold (10). Re-snapshotting every row each block to keep it live would reintroduce the O(N)/block work the windowed model exists to avoid.

**Fix:** derive the count at render time — `status.depth + (chain_height - status.cur_num_blocks)`, O(1) on read, no per-row refresh. The chain height comes from `WalletModel::getChainHeight()`, the tip height **already pushed** to the GUI via the wallet event stream (`ChainTipChangedPayload`) and cached on the GUI thread; the render path never reaches into core state or takes `cs_main` (process-separation invariant). The drain previously discarded that pushed height — it now caches it. `Confirming`/`Immature` rows stay volatile and keep the snapshot. The double-click Details dialog already computed confirmations live; this brings the table tooltip in line.

## Validation

- GUI-OFF unit suite green (`qt_cursor_tests` incl. the new regression; `qt_windowcache_tests`, `txfilter_tests`). GUI + daemon build clean.
- Adversarial review of both commits; the conf-derive was reworked from a `cs_main`-guarded core read to the pushed-height source as a result (keeps the Clang thread-safety CI job green and honors the process-separation invariant).
- Isolated-testnet mesh soak: a real 3-output receive confirmed cleanly (no error/assert/corruption through insert→confirm), a confirmed tx's count ticked past 10, and the GUI was visually verified — multi-part receive and a single-part send both render correct, single rows, stable across sorting on every column (including the Status sort that triggered the bug).

### Known benign edge cases (cosmetic, no action)
- Before the first chain-tip event after a fresh open, `getChainHeight()` is 0 and the count falls back to the load-time snapshot — which is accurate while no block has advanced; it goes live on the first new block.
- A shallow reorg can leave a `Confirmed` row's count transiently high until the tip re-advances — the same self-correcting degradation class as the prior frozen behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)