### PR TITLE
wallet: disentangle address-book labels from accounts (storage)

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -64,7 +64,7 @@ public:
             for (auto const &item : wallet->mapAddressBook)
             {
                 const CTxDestination& address = item.first;
-                const std::string& strName = item.second;
+                const std::string& strName = item.second.name;
                 isminetype fMine = IsMine(*wallet, address);
                 cachedAddressTable.append(AddressTableEntry((fMine != ISMINE_NO) ? AddressTableEntry::Receiving : AddressTableEntry::Sending,
                                   QString::fromStdString(strName),
@@ -454,10 +454,10 @@ QString AddressTableModel::labelForAddress(const QString &address) const
     {
         LOCK(wallet->cs_wallet);
         CTxDestination address_parsed = DecodeDestination(address.toStdString());
-        std::map<CTxDestination, std::string>::iterator mi = wallet->mapAddressBook.find(address_parsed);
+        auto mi = wallet->mapAddressBook.find(address_parsed);
         if (mi != wallet->mapAddressBook.end())
         {
-            return QString::fromStdString(mi->second);
+            return QString::fromStdString(mi->second.name);
         }
     }
     return QString();

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -182,8 +182,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
                             strHTML += "<b>" + tr("To") + ":</b> ";
                             strHTML += GUIUtil::HtmlEscape(EncodeDestination(address));
 
-                            if (!wallet->mapAddressBook[address].empty())
-                                strHTML += " (" + tr("own address") + ", " + tr("label") + ": " + GUIUtil::HtmlEscape(wallet->mapAddressBook[address]) + ")";
+                            if (!wallet->mapAddressBook[address].name.empty())
+                                strHTML += " (" + tr("own address") + ", " + tr("label") + ": " + GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + ")";
 
                             else
                                 strHTML += " (" + tr("own address") + ")";
@@ -208,8 +208,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
 
         CTxDestination dest = DecodeDestination(strAddress);
 
-        if (wallet->mapAddressBook.count(dest) && !wallet->mapAddressBook[dest].empty())
-            strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[dest]) + " ";
+        if (wallet->mapAddressBook.count(dest) && !wallet->mapAddressBook[dest].name.empty())
+            strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[dest].name) + " ";
 
         strHTML += GUIUtil::HtmlEscape(strAddress) + "<br>";
     }
@@ -269,8 +269,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, unsigned int vo
                     {
                         strHTML += "<b>" + tr("To") + ":</b> ";
 
-                        if (wallet->mapAddressBook.count(address) && !wallet->mapAddressBook[address].empty())
-                            strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address]) + " ";
+                        if (wallet->mapAddressBook.count(address) && !wallet->mapAddressBook[address].name.empty())
+                            strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
 
                         strHTML += GUIUtil::HtmlEscape(EncodeDestination(address));
                         strHTML += "<br>";

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -508,7 +508,7 @@ void TransactionRecord::populateDisplayLabel(const CWallet& wallet) EXCLUSIVE_LO
     label.clear();
     const auto mi = wallet.mapAddressBook.find(DecodeDestination(address));
     if (mi != wallet.mapAddressBook.end()) {
-        label = mi->second;
+        label = mi->second.name;
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -623,10 +623,10 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         {
             LOCK(wallet->cs_wallet);
 
-            std::map<CTxDestination, std::string>::iterator mi = wallet->mapAddressBook.find(dest);
+            auto mi = wallet->mapAddressBook.find(dest);
 
             // Check if we have a new address or an updated label
-            if (mi == wallet->mapAddressBook.end() || mi->second != strLabel)
+            if (mi == wallet->mapAddressBook.end() || mi->second.name != strLabel)
             {
                 wallet->SetAddressBookName(dest, strLabel);
             }
@@ -704,9 +704,11 @@ static void NotifyKeyStoreStatusChanged(WalletModel *walletmodel, CCryptoKeyStor
     QMetaObject::invokeMethod(walletmodel, "updateStatus", Qt::QueuedConnection);
 }
 
-static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, ChangeType status)
+static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, const std::string &purpose, ChangeType status)
 {
-    LogPrintf("NotifyAddressBookChanged %s %s isMine=%i status=%i", EncodeDestination(address), label, isMine, status);
+    // `purpose` is accepted to match the 6-arg core signal but is not yet surfaced to the GUI;
+    // the updateAddressBook slot remains a 4-arg interface (address, label, isMine, status).
+    LogPrintf("NotifyAddressBookChanged %s %s isMine=%i purpose=%s status=%i", EncodeDestination(address), label, isMine, purpose, status);
     QMetaObject::invokeMethod(walletmodel, "updateAddressBook", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(EncodeDestination(address))),
                               Q_ARG(QString, QString::fromStdString(label)),
@@ -898,7 +900,7 @@ void WalletModel::subscribeToCoreSignals()
     wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this,
                                                          boost::placeholders::_1, boost::placeholders::_2,
                                                          boost::placeholders::_3, boost::placeholders::_4,
-                                                         boost::placeholders::_5));
+                                                         boost::placeholders::_5, boost::placeholders::_6));
     wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this,
                                                          boost::placeholders::_1, boost::placeholders::_2,
                                                          boost::placeholders::_3));
@@ -915,7 +917,7 @@ void WalletModel::unsubscribeFromCoreSignals()
     wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this,
                                                             boost::placeholders::_1, boost::placeholders::_2,
                                                             boost::placeholders::_3, boost::placeholders::_4,
-                                                            boost::placeholders::_5));
+                                                            boost::placeholders::_5, boost::placeholders::_6));
     wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this,
                                                             boost::placeholders::_1, boost::placeholders::_2,
                                                             boost::placeholders::_3));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -597,10 +597,10 @@ UniValue listunspent(const UniValue& params)
 
             if (item != pwalletMain->mapAddressBook.end())
             {
-                entry.pushKV("label", item->second);
+                entry.pushKV("label", item->second.name);
 
                 if (gArgs.GetBoolArg("-enableaccounts", false))
-                    entry.pushKV("account", item->second);
+                    entry.pushKV("account", item->second.name);
             }
         }
         entry.pushKV("scriptPubKey", HexStr(pk));

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(test_gridcoin
     csv_tests.cpp
     dos_tests.cpp
     accounting_tests.cpp
+    addressbook_tests.cpp
     addrman_tests.cpp
     allocator_tests.cpp
     base32_tests.cpp

--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -136,13 +136,16 @@ BOOST_AUTO_TEST_CASE(notify_carries_purpose)
             ++calls;
         });
 
+    // dest has no prior entry, so setting its purpose creates the mapAddressBook entry: the
+    // signal must report CT_NEW (not CT_UPDATED), matching SetAddressBookName, so a GUI
+    // subscriber inserts the row rather than updating one it never saw.
     pwalletMain->SetAddressBookPurpose(dest, "receive");
 
     conn.disconnect();
 
     BOOST_CHECK_EQUAL(calls, 1);
     BOOST_CHECK_EQUAL(captured_purpose, "receive");
-    BOOST_CHECK(captured_status == CT_UPDATED);
+    BOOST_CHECK(captured_status == CT_NEW);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/addressbook_tests.cpp
+++ b/src/test/addressbook_tests.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2024 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "key.h"
+#include "key_io.h"
+#include "wallet/wallet.h"
+#include "wallet/walletdb.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+extern CWallet* pwalletMain;
+
+namespace {
+//! Make a fresh, deterministic-enough destination for a test by minting a new key.
+CTxDestination NewDestination()
+{
+    CKey key;
+    key.MakeNewKey(false);
+    return CTxDestination(key.GetPubKey().GetID());
+}
+
+//! Reload the persisted address book from the (mock) wallet DB into a throwaway
+//! CWallet and return the entry for `dest`. Exercises the real load path
+//! (CWalletDB::ReadKeyValue), so it verifies what actually round-trips to disk.
+bool ReloadEntry(const CTxDestination& dest, CAddressBookData& out)
+{
+    CWallet w("wallet.dat");
+    bool fFirstRun;
+    w.LoadWallet(fFirstRun);
+
+    LOCK(w.cs_wallet);
+    auto mi = w.mapAddressBook.find(dest);
+    if (mi == w.mapAddressBook.end()) {
+        return false;
+    }
+    out = mi->second;
+    return true;
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(addressbook_tests)
+
+// A default-constructed entry has an empty label and the "unknown" purpose. This is the
+// default that old wallets (which carry only "name" records) inherit on load.
+BOOST_AUTO_TEST_CASE(addressbookdata_defaults)
+{
+    CAddressBookData data;
+    BOOST_CHECK(data.name.empty());
+    BOOST_CHECK_EQUAL(data.purpose, "unknown");
+}
+
+// Setting a label and a purpose persists both, and they survive a reload independently.
+BOOST_AUTO_TEST_CASE(name_and_purpose_roundtrip)
+{
+    const CTxDestination dest = NewDestination();
+
+    BOOST_CHECK(pwalletMain->SetAddressBookName(dest, "alice"));
+    BOOST_CHECK(pwalletMain->SetAddressBookPurpose(dest, "receive"));
+
+    // In-memory state.
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_CHECK_EQUAL(pwalletMain->mapAddressBook[dest].name, "alice");
+        BOOST_CHECK_EQUAL(pwalletMain->mapAddressBook[dest].purpose, "receive");
+    }
+
+    // Persisted state.
+    CAddressBookData reloaded;
+    BOOST_REQUIRE(ReloadEntry(dest, reloaded));
+    BOOST_CHECK_EQUAL(reloaded.name, "alice");
+    BOOST_CHECK_EQUAL(reloaded.purpose, "receive");
+}
+
+// Backward compat: a wallet that has only a legacy "name" record (no "purpose") loads with
+// the label intact and the purpose defaulting to "unknown" -- no migration write required.
+BOOST_AUTO_TEST_CASE(legacy_name_only_defaults_purpose_unknown)
+{
+    const CTxDestination dest = NewDestination();
+    const std::string strAddress = EncodeDestination(dest);
+
+    // Write only the legacy "name" record, exactly as a pre-disentanglement wallet would.
+    BOOST_CHECK(CWalletDB(pwalletMain->strWalletFile).WriteName(strAddress, "legacy-label"));
+
+    CAddressBookData reloaded;
+    BOOST_REQUIRE(ReloadEntry(dest, reloaded));
+    BOOST_CHECK_EQUAL(reloaded.name, "legacy-label");
+    BOOST_CHECK_EQUAL(reloaded.purpose, "unknown");
+}
+
+// DelAddressBookName must erase BOTH the name and purpose records, so neither survives a
+// reload (a ghost label would otherwise reappear from disk).
+BOOST_AUTO_TEST_CASE(del_erases_name_and_purpose)
+{
+    const CTxDestination dest = NewDestination();
+
+    BOOST_CHECK(pwalletMain->SetAddressBookName(dest, "bob"));
+    BOOST_CHECK(pwalletMain->SetAddressBookPurpose(dest, "send"));
+
+    CAddressBookData before;
+    BOOST_REQUIRE(ReloadEntry(dest, before));
+
+    BOOST_CHECK(pwalletMain->DelAddressBookName(dest));
+
+    // Gone from memory...
+    {
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_CHECK(pwalletMain->mapAddressBook.find(dest) == pwalletMain->mapAddressBook.end());
+    }
+
+    // ...and gone from disk (both records).
+    CAddressBookData after;
+    BOOST_CHECK(!ReloadEntry(dest, after));
+}
+
+// The NotifyAddressBookChanged signal carries the purpose to subscribers. This pins the new
+// 6-arg arity (the highest build-risk item of the disentanglement) at the wallet layer,
+// without involving the Qt event loop.
+BOOST_AUTO_TEST_CASE(notify_carries_purpose)
+{
+    const CTxDestination dest = NewDestination();
+
+    std::string captured_label;
+    std::string captured_purpose;
+    ChangeType captured_status = CT_NEW;
+    int calls = 0;
+
+    auto conn = pwalletMain->NotifyAddressBookChanged.connect(
+        [&](CWallet*, const CTxDestination&, const std::string& label, bool,
+            const std::string& purpose, ChangeType status) {
+            captured_label = label;
+            captured_purpose = purpose;
+            captured_status = status;
+            ++calls;
+        });
+
+    pwalletMain->SetAddressBookPurpose(dest, "receive");
+
+    conn.disconnect();
+
+    BOOST_CHECK_EQUAL(calls, 1);
+    BOOST_CHECK_EQUAL(captured_purpose, "receive");
+    BOOST_CHECK(captured_status == CT_UPDATED);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -416,7 +416,7 @@ UniValue dumpwallet(const UniValue& params)
         if (pwalletMain->GetKey(keyid, key)) {
             file << strprintf("%s %s ", EncodeSecret(key), strTime);
             if (pwalletMain->mapAddressBook.count(keyid)) {
-                file << strprintf("label=%s", EncodeDumpString(pwalletMain->mapAddressBook[keyid]));
+                file << strprintf("label=%s", EncodeDumpString(pwalletMain->mapAddressBook[keyid].name));
             } else if (keyid == masterKeyID) {
                 file << "hdmaster=1";
             } else if (setKeyPool.count(keyid)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -407,7 +407,7 @@ UniValue setaccount(const UniValue& params)
     // Detect when changing the account of an address that is the 'unused current key' of another account:
     if (pwalletMain->mapAddressBook.count(address))
     {
-        string strOldAccount = pwalletMain->mapAddressBook[address];
+        string strOldAccount = pwalletMain->mapAddressBook[address].name;
         if (address == GetAccountAddress(strOldAccount))
             GetAccountAddress(strOldAccount, true);
     }
@@ -442,9 +442,9 @@ UniValue getaccount(const UniValue& params)
 
     string strAccount;
 
-    map<CTxDestination, string>::iterator mi = pwalletMain->mapAddressBook.find(address);
-    if (mi != pwalletMain->mapAddressBook.end() && !mi->second.empty()) {
-        strAccount = mi->second;
+    auto mi = pwalletMain->mapAddressBook.find(address);
+    if (mi != pwalletMain->mapAddressBook.end() && !mi->second.name.empty()) {
+        strAccount = mi->second.name;
     }
     return strAccount;
 }
@@ -477,7 +477,7 @@ UniValue getaddressesbyaccount(const UniValue& params)
     for (auto const& item : pwalletMain->mapAddressBook)
     {
         const CTxDestination& address = item.first;
-        const string& strName = item.second;
+        const string& strName = item.second.name;
         if (strName == strAccount)
             ret.push_back(EncodeDestination(address));
     }
@@ -581,7 +581,7 @@ UniValue listaddressgroupings(const UniValue& params)
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
                 if (pwalletMain->mapAddressBook.find(address) != pwalletMain->mapAddressBook.end())
-                    addressInfo.push_back(pwalletMain->mapAddressBook.find(address)->second);
+                    addressInfo.push_back(pwalletMain->mapAddressBook.find(address)->second.name);
             }
             jsonGrouping.push_back(addressInfo);
         }
@@ -754,7 +754,7 @@ void GetAccountAddresses(string strAccount, set<CTxDestination>& setAddress) EXC
     for (auto const& item : pwalletMain->mapAddressBook)
     {
         const CTxDestination& address = item.first;
-        const string& strName = item.second;
+        const string& strName = item.second.name;
         if (strName == strAccount)
             setAddress.insert(address);
     }
@@ -1562,7 +1562,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts) EXCLUSIVE_LOCKS_
     for (auto const& item : pwalletMain->mapAddressBook)
     {
         const CTxDestination& address = item.first;
-        const string& strAccount = item.second;
+        const string& strAccount = item.second.name;
         map<CTxDestination, tallyitem>::iterator it = mapTally.find(address);
         if (it == mapTally.end() && !fIncludeEmpty)
             continue;
@@ -1779,7 +1779,7 @@ UniValue listreceivedbyaccount(const UniValue& params)
             string account;
 
             if (pwalletMain->mapAddressBook.count(r.destination))
-                account = pwalletMain->mapAddressBook[r.destination];
+                account = pwalletMain->mapAddressBook[r.destination].name;
 
             if (fAllAccounts || (account == strAccount))
             {
@@ -2073,7 +2073,7 @@ UniValue listaccounts(const UniValue& params)
     map<string, int64_t> mapAccountBalances;
     for (auto const& entry : pwalletMain->mapAddressBook) {
        if (IsMine(*pwalletMain, entry.first) & includeWatchonly) // This address belongs to me
-            mapAccountBalances[entry.second] = 0;
+            mapAccountBalances[entry.second.name] = 0;
     }
 
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
@@ -2094,7 +2094,7 @@ UniValue listaccounts(const UniValue& params)
         {
             for (auto const& r : listReceived)
                 if (pwalletMain->mapAddressBook.count(r.destination))
-                    mapAccountBalances[pwalletMain->mapAddressBook[r.destination]] += r.amount;
+                    mapAccountBalances[pwalletMain->mapAddressBook[r.destination].name] += r.amount;
                 else
                     mapAccountBalances[""] += r.amount;
         }
@@ -3166,7 +3166,7 @@ UniValue validateaddress(const UniValue& params)
             ret.pushKVs(detail);
         }
         if (pwalletMain->mapAddressBook.count(dest))
-            ret.pushKV("account", pwalletMain->mapAddressBook[dest]);
+            ret.pushKV("account", pwalletMain->mapAddressBook[dest].name);
         CKeyID* keyID = std::get_if<CKeyID>(&dest);
         if (pwalletMain && keyID && pwalletMain->mapKeyMetadata.count(*keyID) && !pwalletMain->mapKeyMetadata[*keyID].hdKeypath.empty())
         {
@@ -3231,7 +3231,7 @@ UniValue validatepubkey(const UniValue& params)
             ret.pushKVs(detail);
         }
         if (pwalletMain->mapAddressBook.count(dest))
-            ret.pushKV("account", pwalletMain->mapAddressBook[dest]);
+            ret.pushKV("account", pwalletMain->mapAddressBook[dest].name);
     }
     return ret;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1800,7 +1800,7 @@ void CWalletTx::GetAccountAmounts(const string& strAccount, int64_t& nReceived,
             if (pwallet->mapAddressBook.count(r.destination))
             {
                 const auto mi = pwallet->mapAddressBook.find(r.destination);
-                if (mi != pwallet->mapAddressBook.end() && mi->second == strAccount) {
+                if (mi != pwallet->mapAddressBook.end() && mi->second.name == strAccount) {
                     nReceived += r.amount;
                 }
             }
@@ -3460,17 +3460,34 @@ DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx>& vWtx)
 bool CWallet::SetAddressBookName(const CTxDestination& address, const string& strName)
 {
     bool fUpdated = false;
+    std::string strPurpose;
     {
         LOCK(cs_wallet); // mapAddressBook
-        std::map<CTxDestination, std::string>::iterator mi = mapAddressBook.find(address);
+        auto mi = mapAddressBook.find(address);
         fUpdated = mi != mapAddressBook.end();
-        mapAddressBook[address] = strName;
+        mapAddressBook[address].name = strName;
+        strPurpose = mapAddressBook[address].purpose;
     }
     NotifyAddressBookChanged(this, address, strName, (::IsMine(*this, address) != ISMINE_NO),
-                             (fUpdated ? CT_UPDATED : CT_NEW) );
+                             strPurpose, (fUpdated ? CT_UPDATED : CT_NEW) );
     if (!fFileBacked)
         return false;
     return CWalletDB(strWalletFile).WriteName(EncodeDestination(address), strName);
+}
+
+bool CWallet::SetAddressBookPurpose(const CTxDestination& address, const string& strPurpose)
+{
+    std::string strName;
+    {
+        LOCK(cs_wallet); // mapAddressBook
+        mapAddressBook[address].purpose = strPurpose;
+        strName = mapAddressBook[address].name;
+    }
+    NotifyAddressBookChanged(this, address, strName, (::IsMine(*this, address) != ISMINE_NO),
+                             strPurpose, CT_UPDATED);
+    if (!fFileBacked)
+        return false;
+    return CWalletDB(strWalletFile).WritePurpose(EncodeDestination(address), strPurpose);
 }
 
 bool CWallet::DelAddressBookName(const CTxDestination& address)
@@ -3481,11 +3498,19 @@ bool CWallet::DelAddressBookName(const CTxDestination& address)
         mapAddressBook.erase(address);
     }
 
-    NotifyAddressBookChanged(this, address, "", (::IsMine(*this, address) != ISMINE_NO), CT_DELETED);
+    NotifyAddressBookChanged(this, address, "", (::IsMine(*this, address) != ISMINE_NO), "", CT_DELETED);
 
     if (!fFileBacked)
         return false;
-    return CWalletDB(strWalletFile).EraseName(EncodeDestination(address));
+
+    // Erase both records with a single CWalletDB instance and no short-circuit, so a failed
+    // purpose-erase can never skip the load-bearing name-erase (which would leave a ghost
+    // label on disk after the in-memory entry is already gone). Erasing an absent record is
+    // safe -- CDB::Erase returns true on DB_NOTFOUND.
+    CWalletDB walletdb(strWalletFile);
+    bool fErasedPurpose = walletdb.ErasePurpose(EncodeDestination(address));
+    bool fErasedName = walletdb.EraseName(EncodeDestination(address));
+    return fErasedPurpose && fErasedName;
 }
 
 bool CWallet::GetTransaction(const uint256 &hashTx, CWalletTx& wtx)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3477,14 +3477,19 @@ bool CWallet::SetAddressBookName(const CTxDestination& address, const string& st
 
 bool CWallet::SetAddressBookPurpose(const CTxDestination& address, const string& strPurpose)
 {
+    bool fUpdated = false;
     std::string strName;
     {
         LOCK(cs_wallet); // mapAddressBook
+        // Determine new-vs-updated BEFORE operator[] creates the entry, so a purpose set on a
+        // not-yet-known address emits CT_NEW (matching SetAddressBookName) rather than telling a
+        // GUI subscriber to update a row it never inserted.
+        fUpdated = mapAddressBook.count(address);
         mapAddressBook[address].purpose = strPurpose;
         strName = mapAddressBook[address].name;
     }
     NotifyAddressBookChanged(this, address, strName, (::IsMine(*this, address) != ISMINE_NO),
-                             strPurpose, CT_UPDATED);
+                             strPurpose, (fUpdated ? CT_UPDATED : CT_NEW));
     if (!fFileBacked)
         return false;
     return CWalletDB(strWalletFile).WritePurpose(EncodeDestination(address), strPurpose);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -88,6 +88,25 @@ public:
     }
 };
 
+/** Address book data for a destination: the user-facing label plus a purpose tag.
+ *
+ * Mirrors Bitcoin 0.17's CAddressBookData. The two fields persist as two separate
+ * walletdb records ("name" and "purpose") keyed by address and are assembled in memory at
+ * load, so this struct is intentionally not serialized as a unit (no SERIALIZE_METHODS).
+ *
+ * No implicit conversion to std::string is provided: every consumer must read .name
+ * explicitly, so the account/label disentanglement surfaces at compile time rather than
+ * silently converting.
+ */
+class CAddressBookData
+{
+public:
+    std::string name;
+    std::string purpose;
+
+    CAddressBookData() : purpose("unknown") {}
+};
+
 /** A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
  */
@@ -190,7 +209,7 @@ public:
     int64_t nOrderPosNext GUARDED_BY(cs_wallet);
     std::map<uint256, int> mapRequestCount GUARDED_BY(cs_wallet);
 
-    std::map<CTxDestination, std::string> mapAddressBook GUARDED_BY(cs_wallet);
+    std::map<CTxDestination, CAddressBookData> mapAddressBook GUARDED_BY(cs_wallet);
 
     //! Maps spent outpoints to the transaction that spends them.
     //! Multimap because reorgs can temporarily create duplicates.
@@ -461,6 +480,8 @@ public:
 
     bool SetAddressBookName(const CTxDestination& address, const std::string& strName);
 
+    bool SetAddressBookPurpose(const CTxDestination& address, const std::string& strPurpose);
+
     bool DelAddressBookName(const CTxDestination& address);
 
     void Inventory(const uint256 &hash)
@@ -508,9 +529,11 @@ public:
     void StoreLastBackupTime(const int64_t backup_time);
 
     /** Address book entry changed.
-     * @note called with lock cs_wallet held.
+     * @note Emitted with cs_wallet NOT held: the emitters snapshot name/purpose into locals
+     *       inside the lock scope and fire the signal after releasing it, so all arguments are
+     *       passed by value. A subscriber must not assume cs_wallet is held in its handler.
      */
-    boost::signals2::signal<void (CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, ChangeType status)> NotifyAddressBookChanged;
+    boost::signals2::signal<void (CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, const std::string &purpose, ChangeType status)> NotifyAddressBookChanged;
 
     /** Wallet transaction added, removed or updated.
      * @note called with lock cs_wallet held.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -530,8 +530,9 @@ public:
 
     /** Address book entry changed.
      * @note Emitted with cs_wallet NOT held: the emitters snapshot name/purpose into locals
-     *       inside the lock scope and fire the signal after releasing it, so all arguments are
-     *       passed by value. A subscriber must not assume cs_wallet is held in its handler.
+     *       inside the lock scope and fire the signal after releasing it, so the by-reference
+     *       string arguments stay valid for the duration of the call. A subscriber must not
+     *       assume cs_wallet is held in its handler.
      */
     boost::signals2::signal<void (CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, const std::string &purpose, ChangeType status)> NotifyAddressBookChanged;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -34,6 +34,18 @@ bool CWalletDB::EraseName(const string& strAddress)
     return Erase(make_pair(string("name"), strAddress));
 }
 
+bool CWalletDB::WritePurpose(const string& strAddress, const string& strPurpose)
+{
+    nWalletDBUpdated++;
+    return Write(make_pair(string("purpose"), strAddress), strPurpose);
+}
+
+bool CWalletDB::ErasePurpose(const string& strAddress)
+{
+    nWalletDBUpdated++;
+    return Erase(make_pair(string("purpose"), strAddress));
+}
+
 bool CWalletDB::WriteBestBlock(const CBlockLocator& locator)
 {
     nWalletDBUpdated++;
@@ -252,7 +264,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             string strAddress;
             ssKey >> strAddress;
-            ssValue >> pwallet->mapAddressBook[DecodeDestination(strAddress)];
+            ssValue >> pwallet->mapAddressBook[DecodeDestination(strAddress)].name;
+        }
+        else if (strType == "purpose")
+        {
+            string strAddress;
+            ssKey >> strAddress;
+            ssValue >> pwallet->mapAddressBook[DecodeDestination(strAddress)].purpose;
         }
         else if (strType == "tx")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -110,7 +110,11 @@ public:
     bool WriteName(const std::string& strAddress, const std::string& strName);
 
     bool EraseName(const std::string& strAddress);
-    
+
+    bool WritePurpose(const std::string& strAddress, const std::string& strPurpose);
+
+    bool ErasePurpose(const std::string& strAddress);
+
     bool WriteBestBlock(const CBlockLocator& locator);
     bool ReadBestBlock(CBlockLocator& locator);
 


### PR DESCRIPTION
First step of retiring the legacy **accounts** system (#3086), sequenced safely behind a labels disentanglement. **Wallet-local, no consensus impact** — no fork.

## Why
Bitcoin deprecated accounts in 0.17 and removed them in 0.18; crucially 0.17 first introduced the **label** system so labels could survive the account removal. Gridcoin kept accounts and never took the 0.17 label step. In Gridcoin `mapAddressBook` is `std::map<CTxDestination, std::string>` — that one string is *simultaneously* the address-book label (load-bearing: GUI address book, `listreceivedbyaddress`, transaction display) and the legacy account grouping key. They cannot be cleanly separated until the label half is formalized.

## What this PR does (Phase A — storage)
Promotes `mapAddressBook`'s value to a first-class `CAddressBookData{name, purpose}`, mirroring Bitcoin 0.17, so labels become independent of accounts.

- `CAddressBookData` with `name` + `"unknown"`-defaulted `purpose`. No implicit `std::string` conversion and no unit serialization — the two fields persist as separate `name`/`purpose` walletdb records assembled at load, and every consumer must read `.name` explicitly (the disentanglement surfaces at compile time).
- New `SetAddressBookPurpose` + `WritePurpose`/`ErasePurpose`; `ReadKeyValue` loads the new `purpose` record alongside `name`. **Old wallets (name only) default `purpose` to `"unknown"` with no migration write — downgrade-safe.** `DelAddressBookName` erases both records on one `CWalletDB` with no short-circuit.
- `NotifyAddressBookChanged` carries `purpose` (6-arg); emits, the Qt free function, and bind placeholders updated in lockstep. The GUI slot stays 4-arg for now (purpose accepted but not yet surfaced).
- All value-read sites migrated to `.name` across wallet/rpc/qt.

## Tests
New `addressbook_tests`: struct defaults, name/purpose round-trip, legacy name-only compat, del-erases-both, and the new signal arity. `accounting_tests` is unaffected (it exercises only the `CAccountingEntry` ledger).

## Sequence
This is **PR1 of 3**. Phase B (label RPCs `setlabel`/`getaddressesbylabel`/`listlabels`) and Phase C (deprecate the account surface) will follow as stacked PRs. Marked **draft** pending that sequencing.

Refs #3086.