### PR TITLE
qt: refresh NotAccepted/Conflicted records to fix post-send transaction-list freeze

### DIFF
--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -56,9 +56,24 @@ GRC::SortKey projectKeys(const TransactionRecord& r)
         r.address};
 }
 
-//! Per-tip status volatility (PR4-fix A): a record whose displayed status still
-//! advances as blocks connect. Terminal states never re-render, so they are
-//! excluded from the per-block refresh set.
+//! Per-tip status volatility (PR4-fix A): a record whose displayed status can
+//! still change as blocks connect, so it must stay in the per-block refresh set
+//! until it reaches a terminal state. Only Confirmed and Offline are terminal.
+//!
+//! Conflicted and NotAccepted are NOT terminal — a record can land in one of
+//! these states transiently and later resolve to an accepted/active state (a
+//! coinstake whose block depth/acceptance is not yet established, or a tx that
+//! briefly conflicts after a large send consumes overlapping UTXOs). The default
+//! detailed/overview filter masks inactive (Conflicted/NotAccepted) rows
+//! (show_orphans=false), so such a record is excluded from the view while in that
+//! state. If it were ALSO excluded from the refresh set, its cached status would
+//! never be re-evaluated and it could never reappear once it resolved — the row
+//! would stay hidden permanently. This surfaced as the transaction list
+//! "freezing" after a send: staking/sidestake rows show normally until a send,
+//! after which the send and the coinstakes that follow it land
+//! Conflicted/NotAccepted, get masked, and (without this) never come back.
+//! Keeping them volatile lets applyChainTipRefresh -> applyStatusUpdate flip
+//! them back into the view once they resolve.
 bool recordStatusIsVolatile(const TransactionRecord& r)
 {
     switch (r.status.status) {
@@ -68,11 +83,11 @@ bool recordStatusIsVolatile(const TransactionRecord& r)
     case TransactionStatus::Confirming:
     case TransactionStatus::Immature:
     case TransactionStatus::MaturesWarning:
+    case TransactionStatus::Conflicted:
+    case TransactionStatus::NotAccepted:
         return true;
     case TransactionStatus::Confirmed:
     case TransactionStatus::Offline:
-    case TransactionStatus::Conflicted:
-    case TransactionStatus::NotAccepted:
         return false;
     }
     return false;


### PR DESCRIPTION
## Problem

In the windowed transaction model (the #2944 follow-ups / PR1–5), staking and sidestake rows **display normally** — until a **send** is performed, after which the transaction list **freezes**: new staking/sidestake entries stop appearing on both the Overview and Detail views. Reported on a staking node after a send.

## Root cause

Confirmed by instrumentation captured during the freeze:

- The send — and the coinstakes that follow it — insert with status **Conflicted/NotAccepted** and are masked by the default filter (`show_orphans = false`), so they're excluded from the view while in that state.
- `recordStatusIsVolatile()` treated `NotAccepted` and `Conflicted` as **terminal**, so such a record was never added to the per-tip refresh set. `applyChainTipRefresh()` never re-evaluated it, its cached status stayed masked, and it could **never reappear once it resolved** — so the list stayed frozen.

(The trigger is that a send pushes the following coinstakes into the masked Conflicted/NotAccepted state — UTXO contention with the stake miner after the spend; on the isolated mesh, large multi-input sends reproducibly insert as Conflicted. The bug this fixes is the **missing refresh** that turns a *transient* masked state into a *permanent* one.)

## Fix

`NotAccepted` and `Conflicted` are **not** terminal — a record can land in one of them transiently (a coinstake before its block depth is established; a tx that briefly conflicts after a large send) and later resolve to an accepted/active state. Mark them volatile so `applyChainTipRefresh` → `applyStatusUpdate` flips them back into the view once they resolve. Only `Confirmed` and `Offline` remain terminal. One-function change.

## Validation

Isolated 4-node staking testnet: **before**, the list froze after a send and stopped showing new staking/sidestake entries; **after**, the rows reappear as the records resolve/mature (cross-checked via `gettransaction` — the hidden rows were confirming/immature on-chain). Currently soaking across the mesh in both Release and ASan builds.

## Testing notes

The downstream flip-in mechanism (a masked Conflicted/NotAccepted row going active → inserted) is already covered by `qt_cursor_tests::status_update_flip_out_then_in`. A dedicated unit test for the *store-side* volatility classification would require extracting it into a Qt-free core, since the `qt_*` test cores are deliberately Qt/wallet-free (GUI-OFF in CI) and `recordStatusIsVolatile` lives in wallet-coupled `wallettxstore.cpp`. Flagged as a possible follow-up.

## Minor consideration

A record that stays Conflicted/NotAccepted indefinitely (rare) now remains in the per-block refresh set rather than dropping out. Per-block cost is O(volatile count) and such records normally mature or are pruned (CT_DELETED on reorg → dropped via the vanished-from-wallet check), so the practical impact is negligible; revisit with a terminal-after-N-blocks prune if needed.

## Related

A separate, still-unreproduced **duplicate-row** issue for large multi-input sends is tracked in #3101 (distinct from this freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
