### PR TITLE
scraper: fix spurious zero total credit for no_records projects (v15) + convergencereport diagnostics

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -305,6 +305,7 @@ public:
         consensus.ProjectV2Height = 0;
         consensus.PollMultiAddressHeight = 0;
         consensus.AutoGreylistAuditHeight = 0;
+        consensus.AutoGreylistDeepCopyHeight = 0;
         consensus.AutoGreylistTotalCreditFixHeight = 0;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -78,6 +78,9 @@ public:
         // TBD: set coincident with BlockV15Height when v15 is scheduled. numeric_limits max keeps
         // the deep-copy overlay fix inactive on mainnet until then (mirrors PollMultiAddressHeight).
         consensus.AutoGreylistDeepCopyHeight = std::numeric_limits<int>::max();
+        // TBD: set coincident with BlockV15Height when v15 is scheduled. numeric_limits max keeps the
+        // scraper no_records total-credit fix inactive on mainnet until then (mirrors the deep-copy fix).
+        consensus.AutoGreylistTotalCreditFixHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
@@ -206,6 +209,9 @@ public:
         // Inactive by default; activated on the isolated mesh / public testnet via the
         // -autogreylistdeepcopyheight override ahead of v15.
         consensus.AutoGreylistDeepCopyHeight = std::numeric_limits<int>::max();
+        // Inactive by default; activated on the isolated mesh / public testnet via the
+        // -autogreylisttotalcreditfixheight override ahead of v15.
+        consensus.AutoGreylistTotalCreditFixHeight = std::numeric_limits<int>::max();
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;
@@ -299,6 +305,7 @@ public:
         consensus.ProjectV2Height = 0;
         consensus.PollMultiAddressHeight = 0;
         consensus.AutoGreylistAuditHeight = 0;
+        consensus.AutoGreylistTotalCreditFixHeight = 0;
         consensus.DefaultConstantBlockReward = 10 * COIN;
         consensus.ConstantBlockRewardFloor = 0;
         consensus.ConstantBlockRewardCeiling = 500 * COIN;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -184,6 +184,13 @@ inline bool IsAutoGreylistDeepCopyEnabled(int nHeight)
     return nHeight >= gArgs.GetArg("-autogreylistdeepcopyheight", Params().GetConsensus().AutoGreylistDeepCopyHeight);
 }
 
+inline bool IsAutoGreylistTotalCreditFixEnabled(int nHeight)
+{
+    // The argument driven override temporarily here to facilitate isolated/public testnet testing
+    // ahead of the v15 activation height.
+    return nHeight >= gArgs.GetArg("-autogreylisttotalcreditfixheight", Params().GetConsensus().AutoGreylistTotalCreditFixHeight);
+}
+
 inline bool IsSuperblockV3Enabled(int nHeight)
 {
     return nHeight >= Params().GetConsensus().SuperblockV3Height;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -58,6 +58,14 @@ struct Params {
       * activation is scheduled; overridable via -autogreylistdeepcopyheight for testnet
       * rollout. */
     int AutoGreylistDeepCopyHeight;
+    /** Height at which the scraper stops emitting a (spurious zero) total-credit entry for a project
+      * whose user-statistics export returned no usable records this cycle (the "no_records" condition).
+      * Before this height the legacy behavior is preserved (a no_records project still gets a zero entry
+      * in ProjectsAllCpidTotalCredits) so historical superblocks remain bit-identical; at/after it the
+      * entry is omitted, so the auto-greylist baseline records nullopt (benefit-of-doubt) instead of a
+      * hard zero that collapses WAS. Set to std::numeric_limits<int>::max() on main/testnet until
+      * activation is scheduled; overridable via -autogreylisttotalcreditfixheight for testnet rollout. */
+    int AutoGreylistTotalCreditFixHeight;
     /**
       * @brief The default GRC paid for a constant block reward.
       *

--- a/src/gridcoin/scraper/fwd.h
+++ b/src/gridcoin/scraper/fwd.h
@@ -277,6 +277,10 @@ typedef std::map<std::string, ScraperPendingBeaconEntry> ScraperPendingBeaconMap
 struct BeaconConsensus
 {
     uint256 nBlockHash;
+    //! Height of the consensus block (nBlockHash). Carried alongside the hash so the scraper can
+    //! evaluate height-gated emit behavior (e.g. IsAutoGreylistTotalCreditFixEnabled) at manifest
+    //! construction time without re-acquiring cs_main. Not serialized; in-memory only.
+    int nBlockHeight {0};
     ScraperBeaconMap mBeaconMap;
     ScraperPendingBeaconMap mPendingMap;
 

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -627,6 +627,7 @@ BeaconConsensus GetConsensusBeaconList()
         const CBlockIndex* pMaxConsensusLadder = GetBeaconConsensusHeight();
 
         consensus.nBlockHash = pMaxConsensusLadder->GetBlockHash();
+        consensus.nBlockHeight = pMaxConsensusLadder->nHeight;
         max_time = pMaxConsensusLadder->nTime;
 
         const auto& beacon_registry = GetBeaconRegistry();
@@ -3274,6 +3275,7 @@ bool StoreBeaconList(const fs::path& file)
         LOCK(cs_StructScraperFileManifest);
 
         StructScraperFileManifest.nConsensusBlockHash = Consensus.nBlockHash;
+        StructScraperFileManifest.nConsensusBlockHeight = Consensus.nBlockHeight;
     }
 
     if (fs::exists(file))
@@ -4900,14 +4902,30 @@ EXCLUSIVE_LOCKS_REQUIRED(cs_StructScraperFileManifest, CScraperManifest::cs_mapM
         std::map<std::string, double> total_credit_map;
         int64_t total_credit_map_timestamp = 0;
 
+        // v15 gate (consensus-block-height anchored so all scrapers flip together): at/after the activation
+        // height, exclude a project whose user-statistics export had no usable records this cycle (no_records)
+        // from the ProjectsAllCpidTotalCredits map. Such a project's all_cpid_total_credit is a spurious zero
+        // (the user-stats part itself is already excluded below at the no_records check), and emitting it as a
+        // zero total-credit entry poisons the auto-greylist WAS baseline (a zero baseline bookmark is never
+        // greater than any historical total credit, so all deltas are skipped and WAS collapses to 0). Omitting
+        // it makes the superblock carry no entry for the project, so the auto-greylist records nullopt at the
+        // baseline (benefit-of-doubt) and computes WAS from real history. Before the gate the legacy behavior
+        // is preserved so historical superblocks remain bit-identical. NOTE: a legitimately scraped zero
+        // (no_records == false) is still emitted — only the no-records case is suppressed.
+        const bool exclude_no_records_tc =
+                IsAutoGreylistTotalCreditFixEnabled(StructScraperFileManifest.nConsensusBlockHeight);
+
         for (auto const& entry : StructScraperFileManifest.mScraperFileManifest)
         {
             auto scraper_cmanifest_include_noncurrent_proj_files =
                     []() { LOCK(cs_ScraperGlobals); return SCRAPER_CMANIFEST_INCLUDE_NONCURRENT_PROJ_FILES; };
 
             // Populate the all cpid total credit map from current entries only. Keep track of the timestamps and assign
-            // the latest manifest file entry timestamp to the total_credit_map_timestamp.
-            if (entry.second.current && !entry.second.excludefromcsmanifest) {
+            // the latest manifest file entry timestamp to the total_credit_map_timestamp. Past the v15 gate, a
+            // no_records project is excluded here too (see exclude_no_records_tc above), matching the user-stats
+            // file-part exclusion in the no_records check below.
+            if (entry.second.current && !entry.second.excludefromcsmanifest
+                    && !(exclude_no_records_tc && entry.second.no_records)) {
                 total_credit_map.insert(std::make_pair(entry.second.project, entry.second.all_cpid_total_credit));
 
                 total_credit_map_timestamp = std::max(entry.second.timestamp, total_credit_map_timestamp);
@@ -6595,6 +6613,32 @@ UniValue convergencereport(const UniValue& params)
         }
 
         result.pushKV("scrapers_not_publishing", ScrapersNotPublishing);
+
+        // The list of projects that actually have a converged user-statistics part in the current convergence.
+        // This is the part-pointer map keyed by project, MINUS the four special side-channel parts (BeaconList,
+        // VerifiedBeacons, ProjectsAllCpidTotalCredits, ProjectPublicKeys), which are not BOINC projects.
+        //
+        // This is the airtight discriminator for the auto-greylist "no records" condition: a project that appears
+        // in the superblock's ProjectsAllCpidTotalCredits map (i.e. has a total-credit entry) but is ABSENT from
+        // this list had its user-statistics export come back with no usable records this cycle. Such a project's
+        // total credit is a spurious zero (its part was excluded from the manifest, but the total-credit entry was
+        // still emitted), and the greylist mitigation service uses the (PACTC-present, part-absent) signature to
+        // distinguish it from a legitimately scraped zero and pin it Active-by-Override.
+        UniValue ConvergedProjects(UniValue::VARR);
+
+        for (const auto& entry : ConvergedScraperStatsCache.Convergence.ConvergedManifestPartPtrsMap)
+        {
+            if (entry.first == "BeaconList"
+                || entry.first == "VerifiedBeacons"
+                || entry.first == "ProjectsAllCpidTotalCredits"
+                || entry.first == "ProjectPublicKeys") {
+                continue;
+            }
+
+            ConvergedProjects.push_back(entry.first);
+        }
+
+        result.pushKV("converged_projects", ConvergedProjects);
     }
 
     return result;

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -107,8 +107,9 @@ struct ScraperFileManifest
     uint256 nFileManifestMapHash;
     uint256 nConsensusBlockHash;
     //! Height of nConsensusBlockHash. In-memory only (refreshed each cycle in StoreBeaconList alongside
-    //! nConsensusBlockHash); not part of the persisted file-manifest CSV. Read lock-free under
-    //! cs_StructScraperFileManifest at manifest emit time to drive height-gated emit behavior.
+    //! nConsensusBlockHash); not part of the persisted file-manifest CSV. Read under
+    //! cs_StructScraperFileManifest at manifest emit time -- no cs_main reacquire needed -- to drive
+    //! height-gated emit behavior.
     int nConsensusBlockHeight {0};
     int64_t timestamp = 0;
 };

--- a/src/gridcoin/scraper/scraper.h
+++ b/src/gridcoin/scraper/scraper.h
@@ -106,6 +106,10 @@ struct ScraperFileManifest
     ScraperFileManifestMap mScraperFileManifest;
     uint256 nFileManifestMapHash;
     uint256 nConsensusBlockHash;
+    //! Height of nConsensusBlockHash. In-memory only (refreshed each cycle in StoreBeaconList alongside
+    //! nConsensusBlockHash); not part of the persisted file-manifest CSV. Read lock-free under
+    //! cs_StructScraperFileManifest at manifest emit time to drive height-gated emit behavior.
+    int nConsensusBlockHeight {0};
     int64_t timestamp = 0;
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -712,6 +712,7 @@ void SetupServerArgs()
     // height via the override.
     hidden_args.emplace_back("-pollmultiaddressheight");
     hidden_args.emplace_back("-autogreylistdeepcopyheight");
+    hidden_args.emplace_back("-autogreylisttotalcreditfixheight");
 
     // This puts hidden options in the form of -clear<type>history, where <type> is the contract types that have a
     // registry with a backing db. This is currently beacon, project, protocol, and scraper, with sidestakes starting

--- a/src/test/gridcoin/project_tests.cpp
+++ b/src/test/gridcoin/project_tests.cpp
@@ -1484,6 +1484,114 @@ BOOST_AUTO_TEST_CASE(it_auto_greylists_correctly)
 }
 
 //!
+//! \brief Consumer-side proof of the scraper "no_records" total-credit fix (v15,
+//! IsAutoGreylistTotalCreditFixEnabled).
+//!
+//! A whitelisted project with a long, healthy, steadily-increasing total-credit history is given a single
+//! head/baseline superblock in two shapes that the scraper produces for a project whose user-statistics
+//! export returned no usable records that cycle:
+//!
+//!   * PRESENT-WITH-ZERO (pre-fix emit): the project appears in the superblock's ProjectsAllCpidTotalCredits
+//!     map with total credit 0. The auto-greylist baseline bookmark becomes 0, which is never greater than any
+//!     historical total credit, so every WAS delta is skipped and WAS collapses to 0 -> the project spuriously
+//!     meets the greylist criteria.
+//!
+//!   * ABSENT (post-fix emit): the project is omitted from the map entirely. The baseline records nullopt
+//!     (benefit-of-doubt) and WAS is computed from the real history -> the project does NOT meet the criteria.
+//!
+//! The only difference between the two runs is present-with-0 vs absent for the head superblock -- exactly the
+//! distinction the scraper gate controls. A legitimately scraped zero (no_records == false) is unaffected by
+//! the fix and is out of scope here; this test isolates the no-records pathology and its remedy.
+//!
+BOOST_AUTO_TEST_CASE(no_records_zero_baseline_does_not_collapse_was)
+{
+    // Drive the auto-greylist over a total-credit sequence (oldest first; the last entry is the baseline/head).
+    // A nullopt entry models a project omitted from ProjectsAllCpidTotalCredits; a value models a present entry.
+    // Returns {WAS as double, meets_greylist_criteria} for the head/baseline.
+    auto run = [](const std::vector<std::optional<uint64_t>>& tc_sequence) {
+        GRC::Whitelist& whitelist = GRC::GetWhitelist();
+        std::shared_ptr<GRC::AutoGreylist> auto_greylist = GRC::GetAutoGreylistCache();
+
+        whitelist.Reset();
+
+        int height = 0;
+        int64_t time = 0;
+
+        auto unit_test_blocks = std::make_shared<std::map<int, std::pair<CBlockIndex*, GRC::SuperblockPtr>>>();
+
+        AddProjectEntry(3, "autogreylist_test", "http://autogreylist.test", false, height, time, true);
+
+        CBlockIndex* whitelist_index_entry = new CBlockIndex;
+        ++height;
+        ++time;
+
+        CBlockIndex* index_ptr = whitelist_index_entry;
+        CBlockIndex* index_ptr_prev = nullptr;
+
+        for (const auto& tc : tc_sequence) {
+            auto_greylist->Reset();
+
+            index_ptr_prev = index_ptr;
+            index_ptr = new CBlockIndex;
+            index_ptr->nHeight = height;
+            index_ptr->nTime = time;
+            index_ptr->MarkAsSuperblock();
+            index_ptr->pprev = index_ptr_prev;
+
+            GRC::Superblock superblock = GRC::Superblock();
+
+            // nullopt -> omitted from the map (post-fix); a value (including 0) -> present (pre-fix when 0).
+            if (tc) {
+                superblock.m_projects_all_cpids_total_credits.m_projects_all_cpid_total_credits
+                    .insert(std::make_pair("autogreylist_test", *tc));
+            }
+
+            GRC::SuperblockPtr superblock_ptr = GRC::SuperblockPtr();
+            superblock_ptr.Replace(superblock);
+            superblock_ptr.Rebind(index_ptr);
+
+            unit_test_blocks->insert(std::make_pair(height, std::make_pair(index_ptr, superblock_ptr)));
+            auto_greylist->RefreshWithSuperblock(superblock_ptr, unit_test_blocks);
+
+            ++height;
+            ++time;
+        }
+
+        auto candidate = auto_greylist->begin()->second;
+        std::pair<double, bool> result(candidate.GetWAS().ToDouble(), candidate.m_meets_greylisting_crit);
+
+        for (auto& it : *unit_test_blocks) delete it.second.first;
+        unit_test_blocks->clear();
+        delete whitelist_index_entry;
+
+        return result;
+    };
+
+    // A healthy, steadily-increasing total-credit history: no zero-credit days, strong WAS, well past the
+    // 7-superblock grace period.
+    std::vector<std::optional<uint64_t>> healthy;
+    for (uint64_t i = 1; i <= 12; ++i) healthy.push_back(i * 1000);
+
+    // Variant A -- PRESENT-WITH-ZERO head (pre-fix): WAS collapses to 0 and the project spuriously meets the
+    // greylist criteria.
+    auto with_zero_head = healthy;
+    with_zero_head.push_back(std::optional<uint64_t>(0));
+    const auto zero_head = run(with_zero_head);
+
+    BOOST_CHECK(zero_head.first == 0.0);
+    BOOST_CHECK(zero_head.second == true);
+
+    // Variant B -- ABSENT head (post-fix): WAS is computed from the real history and the project does NOT meet
+    // the greylist criteria.
+    auto with_absent_head = healthy;
+    with_absent_head.push_back(std::optional<uint64_t>());
+    const auto absent_head = run(with_absent_head);
+
+    BOOST_CHECK(absent_head.first > 0.0);
+    BOOST_CHECK(absent_head.second == false);
+}
+
+//!
 //! \brief Snapshot's auto-greylist overlay must NOT mutate the underlying registry entries.
 //!
 //! Reproduces the consensus bug in Whitelist::Snapshot(): the override working copy at


### PR DESCRIPTION
## Problem

When a BOINC project's user-statistics export returns no usable records for a scraper cycle (the scraper-local `no_records` condition), the scraper still emits a **spurious zero** entry for that project in the superblock's `ProjectsAllCpidTotalCredits` (PACTC) map. The AutoGreylist records that zero as a hard baseline total-credit. Because a `0` baseline is never greater than any historical TC, every Work Availability Score (WAS) delta is skipped → `TC_40_SB_avg` collapses to zero → WAS collapses → the project is spuriously auto-greylisted.

This is live on mainnet: **World Community Grid** is currently auto-greylisted because the most recent superblock recorded a `0` total credit for it (`getautogreylist true true` shows `total_credit: 0` at the current-day baseline).

## Root cause

`ScraperSendFileManifestContents` builds the PACTC map filtered only on `current && !excludefromcsmanifest` — it does **not** honor `no_records`, even though the user-statistics part a few lines below does. A `no_records` project therefore emits `all_cpid_total_credit == 0` into PACTC.

A legitimately scraped `0` and a `no_records` `0` are indistinguishable downstream at superblock-construction time — only the scraper-local `no_records` flag tells them apart, and it is lost before the superblock is built. **So the fix must live in the scraper**, where `no_records` is still known.

## Fix (mandatory, gated on v15)

- New consensus param `AutoGreylistTotalCreditFixHeight` + `IsAutoGreylistTotalCreditFixEnabled()` helper + `-autogreylisttotalcreditfixheight` testnet override (mirrors the `AutoGreylistDeepCopyHeight` pattern). `std::numeric_limits<int>::max()` on main/testnet keeps it **inert** until a v15 activation height is scheduled; `0` on regtest.
- At/after the gate, the PACTC builder skips `no_records` projects, so the AutoGreylist baseline records `nullopt` (benefit-of-doubt) instead of a hard zero. Before the gate the legacy behavior is preserved, so **historical superblocks remain bit-identical**.
- The gate is anchored on the **manifest consensus-block height** (deterministic and shared across scrapers), so all scrapers flip together; a brief boundary-cycle non-convergence is harmless and self-heals. The height is plumbed lock-free via a new in-memory field on `ScraperFileManifest`/`BeaconConsensus` (set under `cs_main`, read at emit) — no CSV/serialization change.

## RPC diagnostics (not gated, no consensus impact)

`convergencereport` gains a `converged_projects` array (the converged manifest's project parts, minus the four special parts). This is the discriminator a mitigation service uses to detect a no-records project (present in the published superblock's PACTC but absent from `converged_projects`).

## Testing

- Unit test `Whitelist/no_records_zero_baseline_does_not_collapse_was`: a present `0` head collapses WAS and meets greylist criteria; an omitted (gap) head keeps WAS healthy and does **not** meet criteria. Passes.
- Build clean (daemon + `test_gridcoin`); full `Whitelist` suite green.
- Isolated mainnet-data testnet mesh: all four nodes rolled onto the gated build with the override active. End-to-end superblock-level confirmation (a no-records project omitted from the next gated superblock, WAS recovery) is being captured at the next superblock.

## Activation

The scraper fix is **mandatory** and ships inert; set `AutoGreylistTotalCreditFixHeight` coincident with `BlockV15Height` when v15 is scheduled. The `convergencereport` change is active immediately.
