### PR TITLE
qa: harden functional tests against the daemon RPC-startup flake

### DIFF
--- a/.github/workflows/cmake_functional.yml
+++ b/.github/workflows/cmake_functional.yml
@@ -80,3 +80,17 @@ jobs:
       # registered (ctest -R otherwise exits 0 when nothing matches).
       - name: Run functional tests
         run: ctest --test-dir build -R functional_tests --output-on-failure --no-tests=error
+
+      # On failure, keep the per-node datadirs (each holds <chain>/debug.log) so an
+      # intermittent flake -- which often vanishes on the next run -- leaves a
+      # debuggable artifact instead of only the truncated console log. test_runner.py
+      # leaves failed-test datadirs under $TMPDIR/test_runner_* (it only removes them
+      # on success).
+      - name: Upload functional test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: functional-test-logs-${{ github.run_id }}
+          path: /tmp/test_runner_*/**/debug.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,7 +499,7 @@ if(ENABLE_TESTS AND ENABLE_DAEMON)
                 COMMAND ${Python3_EXECUTABLE}
                         "${CMAKE_SOURCE_DIR}/test/functional/test_runner.py"
                         "--configfile=${CMAKE_BINARY_DIR}/test/config.ini"
-                        --ci --quiet --combinedlogslen=4000
+                        --ci --quiet --combinedlogslen=4000 --attempts=3
             )
             set_tests_properties(functional_tests PROPERTIES
                 ENVIRONMENT "${_functional_env}"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1807,7 +1807,9 @@ bool AppInit2(ThreadHandlerPtr threads)
     // net threads is safe.
     g_stake_miner_thread = std::thread(ThreadStakeMiner, pwalletMain);
 
-    if (gArgs.GetBoolArg("-server", false)) StartRPCThreads();
+    const bool fStartRPC = gArgs.GetBoolArg("-server", false);
+    LogPrintf("init: -server=%d, %s RPC server\n", fStartRPC, fStartRPC ? "starting" : "skipping");
+    if (fStartRPC) StartRPCThreads();
 
     // ********************************************************* Step 13: finished
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -44,6 +44,11 @@ static std::string strRPCUserColonPass;
 static ioContext* rpc_io_service = nullptr;
 static ssl::context* rpc_ssl_context = nullptr;
 static boost::thread_group* rpc_worker_group = nullptr;
+// Acceptors created by StartRPCThreads. Retained so (a) startup can log the
+// bound endpoints and (b) StopRPCThreads can close() them before tearing down
+// the io_service, which prevents the shutdown hang on an open keep-alive socket
+// that authproxy.py works around on the client side.
+static std::vector<boost::shared_ptr<boost::asio::ip::tcp::acceptor>> rpc_acceptors;
 
 const UniValue emptyobj(UniValue::VOBJ);
 
@@ -648,6 +653,11 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
 
 void StartRPCThreads()
 {
+    // Logged unconditionally: the absence of this line in a node's debug.log
+    // distinguishes "RPC server never started" from "started but not serving"
+    // when diagnosing functional-test RPC-startup timeouts.
+    LogPrintf("StartRPCThreads: entered\n");
+
     strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");
 
     if ((gArgs.GetArg("-rpcpassword", "") == "" ||
@@ -723,6 +733,8 @@ void StartRPCThreads()
         acceptor->listen(socket_base::max_listen_connections);
 
         RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
+        rpc_acceptors.push_back(acceptor);
+        LogPrintf("RPC: bound and listening on [%s]:%u\n", endpoint.address().to_string(), endpoint.port());
 
         fListening = true;
     }
@@ -746,6 +758,8 @@ void StartRPCThreads()
             acceptor->listen(socket_base::max_listen_connections);
 
             RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
+            rpc_acceptors.push_back(acceptor);
+            LogPrintf("RPC: bound and listening on %s:%u\n", endpoint.address().to_string(), endpoint.port());
 
             fListening = true;
         }
@@ -757,14 +771,22 @@ void StartRPCThreads()
 
     if (!fListening)
     {
+        // Log before the message box: ThreadSafeMessageBox has no UI in daemon
+        // mode, so without this the failure reason never reaches debug.log and
+        // the node exits (via StartShutdown) with no diagnosable cause.
+        LogPrintf("ERROR: StartRPCThreads: RPC server failed to listen: %s\n", strerr);
         uiInterface.ThreadSafeMessageBox(strerr, _("Error"), CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
         StartShutdown();
         return;
     }
 
+    const int nRPCThreads = gArgs.GetArg("-rpcthreads", 4);
     rpc_worker_group = new boost::thread_group();
-    for (int i = 0; i < gArgs.GetArg("-rpcthreads", 4); i++)
+    for (int i = 0; i < nRPCThreads; i++)
         rpc_worker_group->create_thread(boost::bind(&ioContext::run, rpc_io_service));
+
+    LogPrintf("RPC server started: %u acceptor(s), %d worker thread(s)\n",
+              static_cast<unsigned>(rpc_acceptors.size()), nRPCThreads);
 }
 
 void StopRPCThreads()
@@ -775,6 +797,19 @@ void StopRPCThreads()
         LogPrintf("RPC IO server not started\n");
         return;
     }
+
+    // Close the listening acceptors before stopping the io_service. This makes
+    // any pending async_accept complete with operation_aborted (RPCAcceptHandler
+    // then sees !is_open() and does not re-arm), so no newly-accepted connection
+    // can wedge the join_all() below. Without this, an open keep-alive socket can
+    // hang shutdown -- the exact failure authproxy.py works around client-side.
+    for (auto& acc : rpc_acceptors) {
+        if (acc && acc->is_open()) {
+            boost::system::error_code ec;
+            acc->close(ec);
+        }
+    }
+    rpc_acceptors.clear();
 
     rpc_io_service->stop();
     if (rpc_worker_group != nullptr) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -31,6 +31,7 @@
 #include <stdexcept>
 
 #include <memory>
+#include <vector>
 
 using namespace std;
 using namespace boost;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -504,6 +504,11 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
                 start_perf=self.options.perf,
                 use_valgrind=self.options.valgrind,
             )
+            # Regression guard: every node must inherit the (already
+            # timeout_factor-scaled) self.rpc_timeout. A historical flake had nodes
+            # starting with the unscaled 60s default under --ci, so RPC-startup
+            # timeouts fired 4x too early; assert the scaled value reaches the node.
+            assert_equal(test_node_i.rpc_timeout, self.rpc_timeout)
             self.nodes.append(test_node_i)
             if not test_node_i.version_is_at_least(170000):
                 # adjust conf for pre 17

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -225,6 +225,12 @@ class TestNode():
         """Sets up an RPC connection to the gridcoinresearchd process. Returns False if unable to connect."""
         # Poll at a rate of four times per second
         poll_per_s = 4
+        # Track the most recent connection failure so that, if we time out, the
+        # assertion reports *why* the daemon never answered. The decisive datum
+        # for the RPC-startup flake is ECONNREFUSED (nothing listening on the RPC
+        # port) vs a connect that succeeds but never returns (listening but not
+        # serving) vs -28 in-warmup. See test_runner.py / the hardening notes.
+        last_failure = None
         for _ in range(poll_per_s * self.rpc_timeout):
             if self.process.poll() is not None:
                 raise FailedToStartError(self._node_msg(
@@ -254,13 +260,15 @@ class TestNode():
             except JSONRPCException as e:  # Initialization phase
                 # -28 RPC in warmup
                 # -342 Service unavailable, RPC server started but is shutting down due to error
+                last_failure = "JSONRPC code {}".format(e.error['code'])
                 if e.error['code'] != -28 and e.error['code'] != -342:
                     raise  # unknown JSON RPC exception
             except ConnectionResetError:
                 # This might happen when the RPC server is in warmup, but shut down before the call to getblockcount
                 # succeeds. Try again to properly raise the FailedToStartError
-                pass
+                last_failure = "ConnectionResetError"
             except OSError as e:
+                last_failure = "OSError errno {} ({})".format(e.errno, errno.errorcode.get(e.errno, "?"))
                 if e.errno == errno.ETIMEDOUT:
                     pass  # Treat identical to ConnectionResetError
                 elif e.errno == errno.ECONNREFUSED:
@@ -268,10 +276,13 @@ class TestNode():
                 else:
                     raise  # unknown OS error
             except ValueError as e:  # cookie file not found and no rpcuser or rpcpassword; gridcoinresearchd is still starting
+                last_failure = "ValueError: {}".format(e)
                 if "No RPC credentials" not in str(e):
                     raise
             time.sleep(1.0 / poll_per_s)
-        self._raise_assertion_error("Unable to connect to gridcoinresearchd after {}s".format(self.rpc_timeout))
+        self._raise_assertion_error(
+            "Unable to connect to gridcoinresearchd after {}s (last failure: {})".format(
+                self.rpc_timeout, last_failure))
 
     def wait_for_cookie_credentials(self):
         """Ensures auth cookie credentials can be read, e.g. for testing CLI with -rpcwait before RPC connection is up."""

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -194,6 +194,7 @@ def main():
     parser.add_argument('--extended', action='store_true', help='run the extended test suite in addition to the basic tests')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--attempts', '-a', type=int, default=1, help='how many times to run a script that fails with the known transient daemon RPC-startup signature before marking it failed. Default=1 (no retry). ONLY failures matching that signature are retried -- assertion/logic/build/sync failures are never retried, so real regressions are not masked as flaky.')
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print dots, results summary and failure logs')
     parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
@@ -316,10 +317,18 @@ def main():
         args=passon_args,
         combined_logs_len=args.combinedlogslen,
         failfast=args.failfast,
+        attempts=args.attempts,
         use_term_control=args.ansi,
     )
 
-def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, use_term_control):
+# A script that fails with this signature hit the known transient daemon
+# RPC-startup flake (the daemon comes up but the RPC port never answers). These
+# -- and only these -- are eligible for --attempts retry; every other failure
+# (assertion, build, block-sync timeout, wallet/tx mismatch) is a real failure
+# and is never retried, so retries cannot mask a genuine regression.
+RETRY_SIGNATURE = "Unable to connect to gridcoinresearchd after"
+
+def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, attempts=1, use_term_control):
     args = args or []
 
     # Warn if gridcoinresearchd is already running
@@ -390,10 +399,34 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
 
     max_len_name = len(max(test_list, key=len))
     test_count = len(test_list)
-    for i in range(test_count):
+    # Per-script retry bookkeeping for --attempts. retries_used caps re-runs at
+    # (attempts - 1); retried records which scripts were re-run so a subsequent
+    # pass is reported as "Passed (retried)" rather than a clean pass.
+    retries_used = {}
+    retried = set()
+    i = 0
+    while i < test_count:
         test_result, testdir, stdout, stderr = job_queue.get_next()
+
+        # Retry only the known transient RPC-startup flake, never a real failure.
+        if (test_result.status == "Failed" and attempts > 1
+                and retries_used.get(test_result.name, 0) < (attempts - 1)
+                and RETRY_SIGNATURE in (stdout + stderr)):
+            n = retries_used.get(test_result.name, 0) + 1
+            retries_used[test_result.name] = n
+            retried.add(test_result.name)
+            print("%s[RETRY %d/%d]%s %s failed with the transient RPC-startup signature; re-running" % (
+                BOLD[1], n, attempts - 1, BOLD[0], test_result.name))
+            # Re-enqueue the script and extend the run by one iteration.
+            job_queue.test_list.append(test_result.name)
+            test_count += 1
+            continue
+
+        if test_result.name in retried and test_result.status == "Passed":
+            test_result.retried = True
         test_results.append(test_result)
-        done_str = "{}/{} - {}{}{}".format(i + 1, test_count, BOLD[1], test_result.name, BOLD[0])
+        i += 1
+        done_str = "{}/{} - {}{}{}".format(i, test_count, BOLD[1], test_result.name, BOLD[0])
         if test_result.status == "Passed":
             logging.debug("%s passed, Duration: %s s" % (done_str, test_result.time))
         elif test_result.status == "Skipped":
@@ -557,6 +590,9 @@ class TestResult():
         self.status = status
         self.time = time
         self.padding = 0
+        # Set True when the script passed only after a --attempts re-run, so the
+        # summary flags it instead of reporting an unqualified pass.
+        self.retried = False
 
     def sort_key(self):
         if self.status == "Passed":
@@ -577,7 +613,8 @@ class TestResult():
             color = GREY
             glyph = CIRCLE
 
-        return color[1] + "%s | %s%s | %s s\n" % (self.name.ljust(self.padding), glyph, self.status.ljust(7), self.time) + color[0]
+        status = self.status + (" (retried)" if self.retried else "")
+        return color[1] + "%s | %s%s | %s s\n" % (self.name.ljust(self.padding), glyph, status.ljust(7), self.time) + color[0]
 
     @property
     def was_successful(self):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -517,13 +517,22 @@ class TestHandler:
         self.num_running = 0
         self.jobs = []
         self.use_term_control = use_term_control
+        # Monotonic per-spawn portseed source. A --attempts retry re-enqueues the
+        # script name; deriving portseed from len(self.test_list) could then hand the
+        # retry the same portseed its failed run used, colliding with that run's kept
+        # testdir (created with exist_ok=False) and risking a port clash with a still-
+        # running job. A never-reused counter avoids both. util.p2p_port takes portseed
+        # modulo the port range, so an unbounded counter stays in range, and consecutive
+        # values keep concurrent jobs' port blocks non-overlapping just as before.
+        self.next_portseed = 0
 
     def get_next(self):
         while self.num_running < self.num_jobs and self.test_list:
             # Add tests
             self.num_running += 1
             test = self.test_list.pop(0)
-            portseed = len(self.test_list)
+            portseed = self.next_portseed
+            self.next_portseed += 1
             portseed_arg = ["--portseed={}".format(portseed)]
             log_stdout = tempfile.SpooledTemporaryFile(max_size=2**16)
             log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)


### PR DESCRIPTION
## Problem

Intermittent functional-test CI failures ("flaky, nothing to fix") all share one signature — `Unable to connect to gridcoinresearchd after Ns` — landing on a random single-node script (`rpc_blockchain`, `rpc_multisig`, `feature_regtest_staking`, `rpc_help`). Mining ~3–4 weeks of the **CMake Functional Tests** workflow confirmed it as the dominant failure mode.

**Root cause:** the daemon finishes init in ~127 ms (`Done loading`) and **stays alive**, but the legacy boost::asio RPC server intermittently never serves the port — and there is **no log line** to diagnose it. Ruled out along the way: PoS determinism (those tests are quarantined and never appear), the `--ci` timeout scaling (already correct), and a bind failure (a failed `bind()` actually *exits* the daemon, which would surface as `FailedToStartError`, not a 60s timeout). The daemon always sets `-server`, so `StartRPCThreads()` is always entered — narrowing it to a post-bind servicing race.

## What this does

Make the failure self-diagnosing and harden the surrounding paths (no consensus/runtime behavior change):

- **Instrumentation (primary):** `rpc/server.cpp` + `init.cpp` log the RPC startup path — the `-server` value, `StartRPCThreads: entered`, each bound/listening endpoint, and a final `RPC server started` line; plus the bind-failure reason before the (headless) message box. Their presence/absence on the next CI repro distinguishes "RPC never started" from "started but not serving." `test_node.py` records the per-attempt errno and reports it in the connect timeout (`last failure: ...`) — ECONNREFUSED vs a connect that never returns vs `-28` in-warmup.
- **Shutdown fix:** `StopRPCThreads()` now `close()`s the listening acceptors before stopping the io_service, so an open keep-alive socket can't wedge `join_all()` (the hang `authproxy.py` works around client-side).
- **Retry, guarded:** `test_runner.py` gains `--attempts` (=3 under CI), retrying **only** scripts that failed with the RPC-startup signature. Assertion/build/sync failures are never retried, and a recovered run reports `Passed (retried)` so retries can't mask a real regression.
- **CI artifact:** `cmake_functional.yml` uploads per-node `debug.log` on failure, so a flake that vanishes on re-run still leaves something to debug.
- **Regression guard:** assert each node inherits the `timeout_factor`-scaled `rpc_timeout`.

## Testing

- Daemon builds clean; `feature_hello` + `rpc_blockchain` pass with `--attempts=3`; new instrumentation lines verified in `debug.log` (binds both `[::1]` and `127.0.0.1`).
- All fork CI workflows green (Functional Tests, Quality Gate/lint, Compatibility, Distribution, Production).

## Deferred (separate follow-ups)

- Narrowing `cs_main` around `StartRPCThreads` — defensive only, not the flake, and risky given wallet ops still run under the lock.
- `setmocktime`/`invalidateblock`/`disconnectnode` RPCs to make `feature_reorg`/`feature_stakelimit` deterministic and re-promote them from `EXTENDED_SCRIPTS`.

Refs #2932.