### PR TITLE
qa: fix --attempts retry over-run that crashes test_runner with IndexError

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -418,9 +418,16 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
             retried.add(test_result.name)
             print("%s[RETRY %d/%d]%s %s failed with the transient RPC-startup signature; re-running" % (
                 BOLD[1], n, attempts - 1, BOLD[0], test_result.name))
-            # Re-enqueue the script and extend the run by one iteration.
+            # Re-enqueue the script (test_count += 1 schedules the extra run) AND
+            # advance i: this branch has already consumed one get_next() result, and
+            # the loop is `while i < test_count`. Bumping only test_count would leave
+            # the loop expecting one more result than there are jobs once everything
+            # drains, so it would call get_next() with no jobs left and hit the
+            # "pop from empty list" guard. i and test_count must both advance so the
+            # loop counts every consumed result against every scheduled job.
             job_queue.test_list.append(test_result.name)
             test_count += 1
+            i += 1
             continue
 
         if test_result.name in retried and test_result.status == "Passed":


### PR DESCRIPTION
## Problem
The functional `--attempts` retry path (introduced in #3103) crashes the whole test run with `IndexError: pop from empty list` whenever a flaked test is actually retried — turning a *transient* flake into a *hard* CI failure, the opposite of what `--attempts` is for.

Observed on gridcoin-community CI (under the `jobs=1` fallback):
```
[RETRY 1/2] rpc_net_connman.py failed with the transient RPC-startup signature; re-running
...
  File ".../test/functional/test_runner.py", line 411, in run_tests
    test_result, testdir, stdout, stderr = job_queue.get_next()
  File ".../test/functional/test_runner.py", line 553, in get_next
    raise IndexError('pop from empty list')
IndexError: pop from empty list
```

## Root cause
The main loop is `while i < test_count`, and every consumed result does `i += 1`. The retry branch re-enqueues the script and does `test_count += 1` but `continue`s **without** advancing `i`. So each retry raises the loop's upper bound by one without counting the result it just consumed. Once all jobs (originals + re-enqueued retries) actually drain, the loop has run one extra iteration **per retry** and calls `TestHandler.get_next()` with no jobs left, tripping its `if not self.jobs: raise IndexError(...)` guard.

Trace (1 test, flakes once):
- **Buggy:** iter1 flaky (`test_count=2`, `i=0`) → iter2 re-run passes (`i=1`) → `1<2` → iter3 `get_next()` with nothing left → **crash**.
- **Fixed:** iter1 flaky (`test_count=2`, **`i=1`**) → iter2 passes (`i=2`) → `2<2` false → clean exit.

## Fix
Advance `i` alongside `test_count` in the retry branch, so the loop counts every consumed result against every scheduled (including re-enqueued) job and terminates exactly when all jobs have drained. One line + an explanatory comment; no other behavior change. `--attempts` retries now re-run as intended instead of crashing the suite.

Follow-up to #3103.