### PR TITLE
qa: retry the wait_until-timeout flake under --attempts (tightly scoped)

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -322,12 +322,25 @@ def main():
         use_term_control=args.ansi,
     )
 
-# A script that fails with this signature hit the known transient daemon
-# RPC-startup flake (the daemon comes up but the RPC port never answers). These
-# -- and only these -- are eligible for --attempts retry; every other failure
-# (assertion, build, block-sync timeout, wallet/tx mismatch) is a real failure
-# and is never retried, so retries cannot mask a genuine regression.
-RETRY_SIGNATURE = "Unable to connect to gridcoinresearchd after"
+# A script that fails with one of these signatures hit a known transient
+# slow-node flake on loaded CI, NOT a logic/assertion/build failure. Only these --
+# and only these -- are eligible for --attempts retry; every other failure (a real
+# assertion mismatch, build error, RPC error, wallet/tx mismatch) is never retried,
+# so retries cannot mask a genuine regression.
+#
+# Keep this list TIGHTLY scoped: each entry must be a string that only a transient
+# slow-node timeout produces, never a deterministic failure. Do NOT add bare
+# "AssertionError" or "timeout" -- they would swallow real bugs.
+#   - "Unable to connect to gridcoinresearchd after": the daemon came up but its
+#     RPC port never answered within the (timeout-factor-scaled) budget.
+#   - "not true after": the exact phrasing of wait_until_helper()'s timeout
+#     (util.py: 'Predicate <x> not true after <n> {attempts|seconds}') -- emitted
+#     ONLY by a wait_until()/wait_until_stopped() timeout (a node too slow to reach
+#     a state / shut down), never by assert_equal or other assertions.
+RETRY_SIGNATURES = (
+    "Unable to connect to gridcoinresearchd after",
+    "not true after",
+)
 
 def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, attempts=1, use_term_control):
     args = args or []
@@ -409,10 +422,10 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
     while i < test_count:
         test_result, testdir, stdout, stderr = job_queue.get_next()
 
-        # Retry only the known transient RPC-startup flake, never a real failure.
+        # Retry only the known transient slow-node flakes, never a real failure.
         if (test_result.status == "Failed" and attempts > 1
                 and retries_used.get(test_result.name, 0) < (attempts - 1)
-                and RETRY_SIGNATURE in (stdout + stderr)):
+                and any(sig in (stdout + stderr) for sig in RETRY_SIGNATURES)):
             n = retries_used.get(test_result.name, 0) + 1
             retries_used[test_result.name] = n
             retried.add(test_result.name)


### PR DESCRIPTION
## Motivation
`--attempts` (#3103, crash-fixed in #3105) only retried the `"Unable to connect to gridcoinresearchd after"` RPC-startup flake. The **other** dominant slow-CI flake — a `wait_until()` / `wait_until_stopped()` predicate timing out because the node was slow to reach a state (or shut down) on a loaded runner — was **not** retried, so it failed the run hard and forced manual re-runs across random platforms (seen repeatedly while landing the mempool stack: OpenSUSE/Arch/etc. functional jobs failing on `AssertionError: Predicate '...' not true after N seconds`).

## Change
Convert `RETRY_SIGNATURE` (single string) → a `RETRY_SIGNATURES` tuple, matched with `any(...)`, and add the wait_until-timeout signature.

**Kept deliberately tight** — the added substring is `"not true after"`, the exact phrasing of `wait_until_helper()`'s timeout (`util.py`: `"Predicate {} not true after {} {attempts|seconds}"`). That string is emitted **only** by a `wait_until`/`wait_until_stopped` timeout, never by `assert_equal` or other logic assertions. So:
- A genuinely transient slow-node timeout is absorbed (re-runs).
- A **real, repeatable** hang/deadlock still fails — it would time out on every retry too, exhausting `--attempts` and failing the run.
- Assertion mismatches, build errors, RPC errors, and wallet/tx mismatches remain non-retryable (unchanged).

The in-code comment explicitly warns against adding bare `"AssertionError"`/`"timeout"`, which would swallow real bugs.

Follow-up to #3103 / #3105.