### PR TITLE
refactor: remove dead PrintWallets debug wrapper

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,14 +199,6 @@ void UpdatedTransaction(const uint256& hashTx)
         pwallet->UpdatedTransaction(hashTx);
 }
 
-// dump all wallets
-void static PrintWallets(const CBlock& block)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->PrintWallet(block);
-}
-
 
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)
@@ -1304,13 +1296,6 @@ void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                   block.nBits,
                   DateTimeStrFormat("%x %H:%M:%S", block.GetBlockTime()).c_str(),
                   block.vtx.size());
-
-        {
-            // PrintBlockTree is EXCLUSIVE_LOCKS_REQUIRED(cs_main); add the
-            // wallet-registry lock here in the canonical order before dispatch.
-            LOCK(cs_setpwalletRegistered);
-            PrintWallets(block);
-        }
 
         // put the main time-chain first
         vector<CBlockIndex*>& vNext = mapNext[pindex];

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3475,26 +3475,6 @@ bool CWallet::DelAddressBookName(const CTxDestination& address)
     return CWalletDB(strWalletFile).EraseName(EncodeDestination(address));
 }
 
-
-void CWallet::PrintWallet(const CBlock& block)
-{
-    {
-        LOCK(cs_wallet);
-        if (block.IsProofOfWork() && mapWallet.count(block.vtx[0].GetHash()))
-        {
-            CWalletTx& wtx = mapWallet[block.vtx[0].GetHash()];
-            LogPrintf("    mine:  %d  %d  %" PRId64 "", wtx.GetDepthInMainChain(), wtx.GetBlocksToMaturity(), wtx.GetCredit());
-        }
-        if (block.IsProofOfStake() && mapWallet.count(block.vtx[1].GetHash()))
-        {
-            CWalletTx& wtx = mapWallet[block.vtx[1].GetHash()];
-            LogPrintf("    stake: %d  %d  %" PRId64 "", wtx.GetDepthInMainChain(), wtx.GetBlocksToMaturity(), wtx.GetCredit());
-         }
-
-    }
-    LogPrintf("");
-}
-
 bool CWallet::GetTransaction(const uint256 &hashTx, CWalletTx& wtx)
 {
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -459,8 +459,6 @@ public:
 
     void UpdatedTransaction(const uint256 &hashTx);
 
-    void PrintWallet(const CBlock& block);
-
     void Inventory(const uint256 &hash)
     {
         {


### PR DESCRIPTION
## Summary

Follow-up to the `main.cpp`/`main.h` decomposition (#3030). Removes the dead
`PrintWallets` debug wrapper, one of the `setpwalletRegistered` iterate-all-wallets
wrappers slated for retirement.

`PrintWallets(const CBlock&)` (main.cpp) iterated `setpwalletRegistered` to call
`CWallet::PrintWallet`, a debug-only dump of coinbase/stake maturity via `LogPrintf`.
Its sole caller was the `PrintBlockTree` block-tree dump. Bitcoin removed this
`PrintWallet`/`PrintWallets` machinery long ago.

## Changes

- Delete `PrintWallets` and its `PrintBlockTree` call site (main.cpp).
- Delete `CWallet::PrintWallet` (declaration + definition).

Pure deletion of dead debug output; no behavior change to any live path. This drops
one `setpwalletRegistered` consumer, unblocking the eventual removal of the registry.

Part of #3030.