### PR TITLE
refactor: route wallet best-block flush through CMainSignals::ChainStateFlushed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,15 +182,6 @@ void static EraseFromWallets(uint256 hash)
         pwallet->EraseFromWallet(hash);
 }
 
-// notify wallets about a new best chain. External linkage: also called from
-// node/chainman.cpp's SetBestChain after the chain-management move (issue #3030 A4).
-void SetBestChain(const CBlockLocator& loc)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->SetBestChain(loc);
-}
-
 
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)

--- a/src/main.h
+++ b/src/main.h
@@ -171,9 +171,6 @@ bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
 void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered);
-// Persists the best-block locator to registered wallets. Now also called from
-// node/chainman.cpp's SetBestChain, so it has external linkage (issue #3030 A4).
-void SetBestChain(const CBlockLocator& loc) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
 bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -526,9 +526,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
 
     if (!fIsInitialDownload) {
         const CBlockLocator locator(pindexNew);
-        // Canonical order: cs_main (held by SetBestChain) -> cs_setpwalletRegistered -> cs_wallet.
-        LOCK(cs_setpwalletRegistered);
-        ::SetBestChain(locator);
+        // Persist the wallet best-block locator. Emitted synchronously under
+        // cs_main (held by SetBestChain), so the CValidationInterface subscriber
+        // (CWallet::ChainStateFlushed) runs in the canonical cs_main -> signals
+        // order -- replacing the legacy cs_setpwalletRegistered wrapper (issue
+        // #3030 setpwalletRegistered retirement).
+        GetMainSignals().ChainStateFlushed(locator);
     }
 
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) {

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -24,6 +24,7 @@ struct ValidationInterfaceConnections {
     boost::signals2::scoped_connection TransactionRemovedFromMempool;
     boost::signals2::scoped_connection BlockConnected;
     boost::signals2::scoped_connection BlockDisconnected;
+    boost::signals2::scoped_connection ChainStateFlushed;
 };
 
 struct MainSignalsInstance {
@@ -38,6 +39,7 @@ public:
     boost::signals2::signal<void (const CTransactionRef&, MemPoolRemovalReason)> TransactionRemovedFromMempool;
     boost::signals2::signal<void (const CBlock&, int height)> BlockConnected;
     boost::signals2::signal<void (const CBlock&, int height)> BlockDisconnected;
+    boost::signals2::signal<void (const CBlockLocator&)> ChainStateFlushed;
 
     //! Serializes background callbacks on the g_scheduler thread.
     SingleThreadedSchedulerClient m_schedulerClient;
@@ -63,6 +65,8 @@ public:
         inserted.first->second.BlockDisconnected = BlockDisconnected.connect(
             std::bind(&CValidationInterface::BlockDisconnected, callbacks,
                       std::placeholders::_1, std::placeholders::_2));
+        inserted.first->second.ChainStateFlushed = ChainStateFlushed.connect(
+            std::bind(&CValidationInterface::ChainStateFlushed, callbacks, std::placeholders::_1));
     }
 
     void Unregister(CValidationInterface* callbacks)
@@ -190,4 +194,10 @@ void CMainSignals::BlockDisconnected(const CBlock& block, int height)
 {
     if (!m_internals) return;
     m_internals->BlockDisconnected(block, height);
+}
+
+void CMainSignals::ChainStateFlushed(const CBlockLocator& locator)
+{
+    if (!m_internals) return;
+    m_internals->ChainStateFlushed(locator);
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -14,6 +14,7 @@
 
 class CBlock;
 class CBlockIndex;
+class CBlockLocator;
 class CScheduler;
 class CValidationInterface;
 struct MainSignalsInstance;
@@ -88,6 +89,12 @@ protected:
     /** Notifies listeners of a block being disconnected from the active chain. */
     virtual void BlockDisconnected(const CBlock& block, int height) {}
 
+    /**
+     * Notifies listeners that the active-chain best block was flushed, supplying
+     * a locator the subscriber can persist to recover its position on restart.
+     */
+    virtual void ChainStateFlushed(const CBlockLocator& locator) {}
+
     friend class CMainSignals;
     friend struct MainSignalsInstance;
 };
@@ -119,6 +126,7 @@ public:
     void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason);
     void BlockConnected(const CBlock&, int height);
     void BlockDisconnected(const CBlock&, int height);
+    void ChainStateFlushed(const CBlockLocator&);
 };
 
 /** This will have its internals registered with a background signal scheduler in AppInit2. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -531,7 +531,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
-void CWallet::SetBestChain(const CBlockLocator& loc)
+void CWallet::ChainStateFlushed(const CBlockLocator& loc)
 {
     CWalletDB walletdb(strWalletFile);
     walletdb.WriteBestBlock(loc);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -296,14 +296,19 @@ public:
 
     // -- CValidationInterface callbacks ---------------------------------------
     // Invoked by the validation/mempool layer through GetMainSignals() with
-    // cs_main held; each acquires cs_wallet internally, so callers must hold
-    // cs_main but not cs_wallet. Override the (UpperCamelCase) CValidationInterface
+    // cs_main held. Lock-order rule for all of these: callers must hold cs_main
+    // and must NOT hold cs_wallet. Most acquire cs_wallet internally;
+    // ChainStateFlushed is the exception -- it only writes the wallet DB and
+    // takes no cs_wallet. Override the (UpperCamelCase) CValidationInterface
     // virtuals.
     void TransactionAddedToMempool(const CTransactionRef& tx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void BlockConnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void TransactionRemovedFromMempool(const CTransactionRef& tx,
                                       MemPoolRemovalReason reason) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void BlockDisconnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
+    //! Persist the best-block locator so a restored wallet can detect its
+    //! position. Writes wallet DB only; takes no cs_wallet.
+    void ChainStateFlushed(const CBlockLocator& locator) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
 
     // -- Conflict tracking & abandonment -------------------------------------
     /** Return txids that spend the same inputs as @p txid. */
@@ -448,7 +453,6 @@ public:
         }
         return nChange;
     }
-    void SetBestChain(const CBlockLocator& loc);
 
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);


### PR DESCRIPTION
## Summary

Follow-up to #3030. Retires the legacy `setpwalletRegistered` `SetBestChain(const CBlockLocator&)`
wrapper in favour of a `CValidationInterface` signal.

## Changes

- Add `ChainStateFlushed(const CBlockLocator&)` to `CValidationInterface` and `CMainSignals`
  (`validationinterface.{h,cpp}`), wired like the existing `UpdatedBlockTip`/`BlockConnected` signals.
- `CWallet::SetBestChain` becomes a `CWallet::ChainStateFlushed` override (body unchanged: it only
  writes the best-block locator to the wallet DB and takes no `cs_wallet`).
- `node/chainman.cpp` emits `GetMainSignals().ChainStateFlushed(locator)` in place of
  `LOCK(cs_setpwalletRegistered)` + `::SetBestChain(locator)`. Emission stays **inside the existing
  `!fIsInitialDownload` guard** and under `cs_main`, so IBD gating and the canonical
  `cs_main -> signals -> cs_wallet` order are preserved. Because `boost::signals2` releases its
  internal mutex before invoking slots, this removes the intermediate `cs_setpwalletRegistered` hold
  rather than adding one.
- Delete the free `SetBestChain(const CBlockLocator&)` wrapper (`main.{h,cpp}`).

Pure move to the signal layer; the wallet is registered symmetrically via `RegisterValidationInterface`,
so the notified set is unchanged. No behavior change.

Part of #3030.