### PR TITLE
refactor: drop redundant UpdatedTransaction wallet-registry notify

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,14 +191,6 @@ void SetBestChain(const CBlockLocator& loc)
         pwallet->SetBestChain(loc);
 }
 
-// notify wallets about an updated transaction
-void UpdatedTransaction(const uint256& hashTx)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->UpdatedTransaction(hashTx);
-}
-
 
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)

--- a/src/main.h
+++ b/src/main.h
@@ -108,7 +108,6 @@ class CTxIndex;
 
 void RegisterWallet(CWallet* pwalletIn);
 void UnregisterWallet(CWallet* pwalletIn);
-void UpdatedTransaction(const uint256& hashTx) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 // Block-file I/O helpers (CheckDiskSpace, OpenBlockFile, AppendBlockFile,
 // LoadExternalBlockFile) live in node/blockstorage.h, included above.

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -752,13 +752,12 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
     //       definition in main.cpp, not the header declaration — so the
     //       requirement is verified here by hand, not by the compiler.)
     //
-    //   All five CT_NEW / CT_UPDATED callsites hold both locks, verified by
+    //   All four CT_NEW / CT_UPDATED callsites hold both locks, verified by
     //   audit:
     //     wallet.cpp:572  AddToWallet            — EXCLUSIVE_LOCKS_REQUIRED(cs_main); LOCK(cs_wallet)
     //     wallet.cpp:2400 CommitTransaction      — LOCK2(cs_main, cs_wallet)
     //     wallet.cpp:458  WalletUpdateSpent      — caller AddToWallet / AddToWalletIfInvolvingMe, both EXCLUSIVE_LOCKS_REQUIRED(cs_main); LOCK(cs_wallet)
     //     wallet.cpp:475  WalletUpdateSpent      — same
-    //     wallet.cpp:3057 UpdatedTransaction     — reached via validation.cpp (cs_main required on entry); LOCK(cs_wallet)
     //   This function is annotated EXCLUSIVE_LOCKS_REQUIRED(cs_main,
     //   wallet->cs_wallet) so the Clang thread-safety analyzer accepts the
     //   AssertLockHeld() calls and the mapWallet reads in the CT_NEW /

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1172,17 +1172,11 @@ bool AddToBlockIndex(CBlock& block, unsigned int nFile, unsigned int nBlockPos, 
         if (!SetBestChain(txdb, block, pindexNew))
             return error("%s: SetBestChain failed", __func__);
 
-    if (pindexNew == pindexBest)
-    {
-        // Notify UI to display prev block's coinbase if it was ours.
-        // Canonical order: cs_main (required on entry) -> cs_setpwalletRegistered.
-        static uint256 hashPrevBestCoinBase;
-        {
-            LOCK(cs_setpwalletRegistered);
-            UpdatedTransaction(hashPrevBestCoinBase);
-        }
-        hashPrevBestCoinBase = block.vtx[0].GetHash();
-    }
+    // The previous-best coinbase's confirmation display is refreshed by the
+    // per-tip Qt refresh (UpdatedBlockTip -> NotifyBlocksChanged ->
+    // applyChainTipRefresh, which re-scans all height-volatile records), so the
+    // legacy UpdatedTransaction(hashPrevBestCoinBase) wallet-registry notify is
+    // redundant and has been dropped (issue #3030 setpwalletRegistered retirement).
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3952,17 +3952,6 @@ void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress) const
     }
 }
 
-void CWallet::UpdatedTransaction(const uint256 &hashTx)
-{
-    {
-        LOCK(cs_wallet);
-        // Only notify UI if this transaction is in this wallet
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
-        if (mi != mapWallet.end())
-            NotifyTransactionChanged(this, hashTx, CT_UPDATED);
-    }
-}
-
 void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_wallet)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -457,8 +457,6 @@ public:
 
     bool DelAddressBookName(const CTxDestination& address);
 
-    void UpdatedTransaction(const uint256 &hashTx);
-
     void Inventory(const uint256 &hash)
     {
         {


### PR DESCRIPTION
## Summary

Follow-up to #3030. Removes the `setpwalletRegistered` `UpdatedTransaction` wrapper, which was
redundant.

`AddToBlockIndex` fired `UpdatedTransaction(hashPrevBestCoinBase)` on each new best block so the GUI
would re-display the previous coinbase's confirmation count. That refresh is already delivered by the
per-tip Qt path installed in workstream B3: `UpdatedBlockTip -> uiInterface.NotifyBlocksChanged ->
NotifyBlocksChangedForWallet -> WalletTxStore::applyChainTipRefresh()`, which re-scans every
height-volatile record (a newly-confirmed coinbase is one) and runs
`TransactionTableModel::updateConfirmations()` on each tip advance. The targeted notify fired just
after `SetBestChain`'s `UpdatedBlockTip`, so the refresh had already happened; in the daemon it was
inert (no GUI subscriber).

## Changes

- Delete the whole `if (pindexNew == pindexBest)` block in `validation.cpp` (its only purpose was to
  feed `UpdatedTransaction`; the static `hashPrevBestCoinBase` had no other consumer) and its
  `LOCK(cs_setpwalletRegistered)`.
- Delete the free `UpdatedTransaction` wrapper (`main.{h,cpp}`) and `CWallet::UpdatedTransaction`
  (`wallet.{h,cpp}`).
- Update the `walletmodel.cpp` CT_UPDATED lock-audit comment (five -> four sites).

No behavior change: the GUI confirmation refresh is unchanged.

Part of #3030.