### PR TITLE
refactor: route mempool-replacement wallet erase through CMainSignals

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,15 +182,6 @@ void static EraseFromWallets(uint256 hash)
         pwallet->EraseFromWallet(hash);
 }
 
-// notify wallets about a new best chain. External linkage: also called from
-// node/chainman.cpp's SetBestChain after the chain-management move (issue #3030 A4).
-void SetBestChain(const CBlockLocator& loc)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->SetBestChain(loc);
-}
-
 
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,15 +174,6 @@ void UnregisterWallet(CWallet* pwalletIn)
 // pattern would otherwise create.
 
 
-// erases transaction with the given hash from all wallets
-void static EraseFromWallets(uint256 hash)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->EraseFromWallet(hash);
-}
-
-
 // ask wallets to resend their transactions
 void ResendWalletTransactions(bool fForce)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered)
@@ -431,11 +422,16 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
     }
 
     // Store transaction in memory
+    CTransactionRef replaced_tx; // copy of the replaced tx, captured before remove() frees it
     {
         LOCK(pool.cs);
         if (ptxOld)
         {
             LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : replacing tx %s with new version", ptxOld->GetHash().ToString());
+            // ptxOld points into the mempool entry that remove() erases below, so
+            // copy the transaction out first; the wallet-erase signal further down
+            // must use this copy, not the dangling ptxOld.
+            replaced_tx = MakeTransactionRef(*ptxOld);
             pool.remove(*ptxOld);
         }
         // entry_time is non-zero only when reloading from unbroadcast.dat: preserve
@@ -471,10 +467,15 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, CValidationState& st
 
     ///// are we sure this is ok when loading transactions or restoring block txes
     // If updated, erase old tx from wallet
-    if (ptxOld)
+    if (replaced_tx)
     {
-        LOCK(cs_setpwalletRegistered);
-        EraseFromWallets(ptxOld->GetHash());
+        // The replaced tx was removed from the mempool above; notify the
+        // validation-signal layer so the wallet drops its now-defunct copy.
+        // Emitted synchronously under cs_main (held on entry), preserving the
+        // cs_main -> signals -> cs_wallet order and replacing the legacy
+        // cs_setpwalletRegistered EraseFromWallets wrapper (issue #3030). Uses the
+        // copy captured before remove() -- ptxOld dangles once the pool entry is gone.
+        GetMainSignals().TransactionReplacedInMempool(replaced_tx);
     }
 
     LogPrint(BCLog::LogFlags::MEMPOOL, "AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")", hash.ToString(), pool.mapTx.size());

--- a/src/main.h
+++ b/src/main.h
@@ -171,9 +171,6 @@ bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
 void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered);
-// Persists the best-block locator to registered wallets. Now also called from
-// node/chainman.cpp's SetBestChain, so it has external linkage (issue #3030 A4).
-void SetBestChain(const CBlockLocator& loc) EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered);
 bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/

--- a/src/node/chainman.cpp
+++ b/src/node/chainman.cpp
@@ -526,9 +526,12 @@ bool SetBestChain(CTxDB& txdb, CBlock &blockNew, CBlockIndex* pindexNew) EXCLUSI
 
     if (!fIsInitialDownload) {
         const CBlockLocator locator(pindexNew);
-        // Canonical order: cs_main (held by SetBestChain) -> cs_setpwalletRegistered -> cs_wallet.
-        LOCK(cs_setpwalletRegistered);
-        ::SetBestChain(locator);
+        // Persist the wallet best-block locator. Emitted synchronously under
+        // cs_main (held by SetBestChain), so the CValidationInterface subscriber
+        // (CWallet::ChainStateFlushed) runs in the canonical cs_main -> signals
+        // order -- replacing the legacy cs_setpwalletRegistered wrapper (issue
+        // #3030 setpwalletRegistered retirement).
+        GetMainSignals().ChainStateFlushed(locator);
     }
 
     if (LogInstance().WillLogCategory(BCLog::LogFlags::VERBOSE)) {

--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -152,11 +152,12 @@ const RPCHelpMan& claimhtlc_helpman() { return claimhtlc_help; }
 
 UniValue claimhtlc(const UniValue& params)
 {
-    // Canonical order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
-    // The wallet-registry lock is needed for the transactionAddedToMempool
-    // dispatch after AcceptToMemoryPool below.
+    // Canonical order: cs_main -> cs_wallet. cs_wallet is held for this RPC's
+    // own wallet work; AcceptToMemoryPool's synchronous signal dispatch (the
+    // wallet's TransactionAddedToMempool / TransactionReplacedInMempool
+    // handlers) also takes cs_wallet, recursively, under cs_main. The legacy
+    // cs_setpwalletRegistered hop is gone (issue #3030 retirement).
     LOCK(cs_main);
-    LOCK(cs_setpwalletRegistered);
     LOCK(pwalletMain->cs_wallet);
     EnsureWalletIsUnlocked();
 
@@ -300,11 +301,12 @@ const RPCHelpMan& refundhtlc_helpman() { return refundhtlc_help; }
 
 UniValue refundhtlc(const UniValue& params)
 {
-    // Canonical order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
-    // The wallet-registry lock is needed for the transactionAddedToMempool
-    // dispatch after AcceptToMemoryPool below.
+    // Canonical order: cs_main -> cs_wallet. cs_wallet is held for this RPC's
+    // own wallet work; AcceptToMemoryPool's synchronous signal dispatch (the
+    // wallet's TransactionAddedToMempool / TransactionReplacedInMempool
+    // handlers) also takes cs_wallet, recursively, under cs_main. The legacy
+    // cs_setpwalletRegistered hop is gone (issue #3030 retirement).
     LOCK(cs_main);
-    LOCK(cs_setpwalletRegistered);
     LOCK(pwalletMain->cs_wallet);
     EnsureWalletIsUnlocked();
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2222,12 +2222,12 @@ UniValue sendrawtransaction(const UniValue& params)
 {
     RPCTypeCheck(params, { UniValue::VSTR });
 
-    // Canonical lock order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
-    // Acquired as sequenced LOCKs (rather than a LOCK2 + nested LOCK) so the
-    // analyzer sees the order at acquisition time. The wallet registry lock
-    // is needed for the transactionAddedToMempool dispatch below.
+    // Canonical lock order: cs_main -> cs_wallet, acquired as sequenced LOCKs
+    // (rather than a LOCK2) so the analyzer sees the order at acquisition time.
+    // cs_wallet is held for this RPC's own wallet work; AcceptToMemoryPool's
+    // synchronous signal dispatch also takes cs_wallet recursively under
+    // cs_main. The legacy cs_setpwalletRegistered hop is gone (issue #3030).
     LOCK(cs_main);
-    LOCK(cs_setpwalletRegistered);
     LOCK(pwalletMain->cs_wallet);
 
     // parse hex string from parameter

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -24,6 +24,7 @@ struct ValidationInterfaceConnections {
     boost::signals2::scoped_connection TransactionRemovedFromMempool;
     boost::signals2::scoped_connection BlockConnected;
     boost::signals2::scoped_connection BlockDisconnected;
+    boost::signals2::scoped_connection ChainStateFlushed;
 };
 
 struct MainSignalsInstance {
@@ -38,6 +39,7 @@ public:
     boost::signals2::signal<void (const CTransactionRef&, MemPoolRemovalReason)> TransactionRemovedFromMempool;
     boost::signals2::signal<void (const CBlock&, int height)> BlockConnected;
     boost::signals2::signal<void (const CBlock&, int height)> BlockDisconnected;
+    boost::signals2::signal<void (const CBlockLocator&)> ChainStateFlushed;
 
     //! Serializes background callbacks on the g_scheduler thread.
     SingleThreadedSchedulerClient m_schedulerClient;
@@ -63,6 +65,8 @@ public:
         inserted.first->second.BlockDisconnected = BlockDisconnected.connect(
             std::bind(&CValidationInterface::BlockDisconnected, callbacks,
                       std::placeholders::_1, std::placeholders::_2));
+        inserted.first->second.ChainStateFlushed = ChainStateFlushed.connect(
+            std::bind(&CValidationInterface::ChainStateFlushed, callbacks, std::placeholders::_1));
     }
 
     void Unregister(CValidationInterface* callbacks)
@@ -190,4 +194,10 @@ void CMainSignals::BlockDisconnected(const CBlock& block, int height)
 {
     if (!m_internals) return;
     m_internals->BlockDisconnected(block, height);
+}
+
+void CMainSignals::ChainStateFlushed(const CBlockLocator& locator)
+{
+    if (!m_internals) return;
+    m_internals->ChainStateFlushed(locator);
 }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -22,6 +22,7 @@ struct ValidationInterfaceConnections {
     boost::signals2::scoped_connection UpdatedBlockTip;
     boost::signals2::scoped_connection TransactionAddedToMempool;
     boost::signals2::scoped_connection TransactionRemovedFromMempool;
+    boost::signals2::scoped_connection TransactionReplacedInMempool;
     boost::signals2::scoped_connection BlockConnected;
     boost::signals2::scoped_connection BlockDisconnected;
     boost::signals2::scoped_connection ChainStateFlushed;
@@ -37,6 +38,7 @@ public:
     boost::signals2::signal<void (const CBlockIndex*, const CBlockIndex*, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef&)> TransactionAddedToMempool;
     boost::signals2::signal<void (const CTransactionRef&, MemPoolRemovalReason)> TransactionRemovedFromMempool;
+    boost::signals2::signal<void (const CTransactionRef&)> TransactionReplacedInMempool;
     boost::signals2::signal<void (const CBlock&, int height)> BlockConnected;
     boost::signals2::signal<void (const CBlock&, int height)> BlockDisconnected;
     boost::signals2::signal<void (const CBlockLocator&)> ChainStateFlushed;
@@ -59,6 +61,8 @@ public:
         inserted.first->second.TransactionRemovedFromMempool = TransactionRemovedFromMempool.connect(
             std::bind(&CValidationInterface::TransactionRemovedFromMempool, callbacks,
                       std::placeholders::_1, std::placeholders::_2));
+        inserted.first->second.TransactionReplacedInMempool = TransactionReplacedInMempool.connect(
+            std::bind(&CValidationInterface::TransactionReplacedInMempool, callbacks, std::placeholders::_1));
         inserted.first->second.BlockConnected = BlockConnected.connect(
             std::bind(&CValidationInterface::BlockConnected, callbacks,
                       std::placeholders::_1, std::placeholders::_2));
@@ -182,6 +186,12 @@ void CMainSignals::TransactionRemovedFromMempool(const CTransactionRef& tx, MemP
 {
     if (!m_internals) return;
     m_internals->TransactionRemovedFromMempool(tx, reason);
+}
+
+void CMainSignals::TransactionReplacedInMempool(const CTransactionRef& tx)
+{
+    if (!m_internals) return;
+    m_internals->TransactionReplacedInMempool(tx);
 }
 
 void CMainSignals::BlockConnected(const CBlock& block, int height)

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -83,6 +83,13 @@ protected:
     /** Notifies listeners of a transaction leaving mempool. */
     virtual void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {}
 
+    /**
+     * Notifies listeners that a mempool transaction was replaced by a newer
+     * conflicting transaction and should be discarded (the wallet erases its
+     * now-defunct copy).
+     */
+    virtual void TransactionReplacedInMempool(const CTransactionRef& tx) {}
+
     /** Notifies listeners of a block being connected to the active chain. */
     virtual void BlockConnected(const CBlock& block, int height) {}
 
@@ -124,6 +131,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex*, const CBlockIndex*, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef&);
     void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason);
+    void TransactionReplacedInMempool(const CTransactionRef&);
     void BlockConnected(const CBlock&, int height);
     void BlockDisconnected(const CBlock&, int height);
     void ChainStateFlushed(const CBlockLocator&);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -14,6 +14,7 @@
 
 class CBlock;
 class CBlockIndex;
+class CBlockLocator;
 class CScheduler;
 class CValidationInterface;
 struct MainSignalsInstance;
@@ -88,6 +89,12 @@ protected:
     /** Notifies listeners of a block being disconnected from the active chain. */
     virtual void BlockDisconnected(const CBlock& block, int height) {}
 
+    /**
+     * Notifies listeners that the active-chain best block was flushed, supplying
+     * a locator the subscriber can persist to recover its position on restart.
+     */
+    virtual void ChainStateFlushed(const CBlockLocator& locator) {}
+
     friend class CMainSignals;
     friend struct MainSignalsInstance;
 };
@@ -119,6 +126,7 @@ public:
     void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason);
     void BlockConnected(const CBlock&, int height);
     void BlockDisconnected(const CBlock&, int height);
+    void ChainStateFlushed(const CBlockLocator&);
 };
 
 /** This will have its internals registered with a background signal scheduler in AppInit2. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1191,6 +1191,15 @@ void CWallet::TransactionAddedToMempool(const CTransactionRef& tx)
     SyncTransaction(tx, TxStateInMempool{});
 }
 
+void CWallet::TransactionReplacedInMempool(const CTransactionRef& tx)
+{
+    // The transaction was superseded by a conflicting one accepted to the
+    // mempool. Preserve the legacy EraseFromWallets behavior: drop the defunct
+    // copy entirely (EraseFromWallet takes cs_wallet internally). This replaces
+    // the setpwalletRegistered EraseFromWallets wrapper (issue #3030).
+    EraseFromWallet(tx->GetHash());
+}
+
 void CWallet::BlockConnected(const CBlock& block, int height)
 {
     LOCK(cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -531,7 +531,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
-void CWallet::SetBestChain(const CBlockLocator& loc)
+void CWallet::ChainStateFlushed(const CBlockLocator& loc)
 {
     CWalletDB walletdb(strWalletFile);
     walletdb.WriteBestBlock(loc);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -305,6 +305,8 @@ public:
     void BlockConnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void TransactionRemovedFromMempool(const CTransactionRef& tx,
                                       MemPoolRemovalReason reason) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
+    //! A conflicting tx replaced this one in the mempool; erase the defunct copy.
+    void TransactionReplacedInMempool(const CTransactionRef& tx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void BlockDisconnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     //! Persist the best-block locator so a restored wallet can detect its
     //! position. Writes wallet DB only; takes no cs_wallet.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -296,14 +296,19 @@ public:
 
     // -- CValidationInterface callbacks ---------------------------------------
     // Invoked by the validation/mempool layer through GetMainSignals() with
-    // cs_main held; each acquires cs_wallet internally, so callers must hold
-    // cs_main but not cs_wallet. Override the (UpperCamelCase) CValidationInterface
+    // cs_main held. Lock-order rule for all of these: callers must hold cs_main
+    // and must NOT hold cs_wallet. Most acquire cs_wallet internally;
+    // ChainStateFlushed is the exception -- it only writes the wallet DB and
+    // takes no cs_wallet. Override the (UpperCamelCase) CValidationInterface
     // virtuals.
     void TransactionAddedToMempool(const CTransactionRef& tx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void BlockConnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void TransactionRemovedFromMempool(const CTransactionRef& tx,
                                       MemPoolRemovalReason reason) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
     void BlockDisconnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
+    //! Persist the best-block locator so a restored wallet can detect its
+    //! position. Writes wallet DB only; takes no cs_wallet.
+    void ChainStateFlushed(const CBlockLocator& locator) override EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs_wallet);
 
     // -- Conflict tracking & abandonment -------------------------------------
     /** Return txids that spend the same inputs as @p txid. */
@@ -448,7 +453,6 @@ public:
         }
         return nChange;
     }
-    void SetBestChain(const CBlockLocator& loc);
 
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);


### PR DESCRIPTION
## Summary

Follow-up to #3030. Retires the `setpwalletRegistered` `EraseFromWallets` wrapper — the last of the
**validation-half** registry wrappers.

> **Stacked on #3109** (ChainStateFlushed). Review/merge after it; the first commit here is #3109's.
> Until #3109 merges, the diff shows both commits.

When `AcceptToMemoryPool` replaces a conflicting mempool tx (`ptxOld`), it erased the now-defunct tx
from wallets via the `setpwalletRegistered` `EraseFromWallets` wrapper. Route that through a
`CValidationInterface` signal instead.

## Changes

- Add `TransactionReplacedInMempool(const CTransactionRef&)` to `CValidationInterface` / `CMainSignals`
  (`validationinterface.{h,cpp}`).
- `CWallet::TransactionReplacedInMempool` overrides it and calls `EraseFromWallet(hash)`, preserving the
  exact **destructive-delete** semantics. This deliberately does **not** reuse
  `TransactionRemovedFromMempool`, whose handler marks a tx inactive (`TxStateInactive`) rather than
  erasing it — reusing it would be a behavior change (and that handler is currently never emitted).
- `AcceptToMemoryPool` emits `GetMainSignals().TransactionReplacedInMempool(...)` in place of
  `LOCK(cs_setpwalletRegistered)` + `EraseFromWallets()`. Emitted synchronously under `cs_main` (held on
  entry); the wallet handler takes `cs_wallet` internally, preserving `cs_main -> signals -> cs_wallet`.
  `main.cpp` stays wallet-decoupled (no `pwalletMain` reference).
- Delete the free `EraseFromWallets` wrapper (`CWallet::EraseFromWallet` stays; it is still called
  directly from `chainman.cpp` and within the wallet).
- `AcceptToMemoryPool` no longer acquires `cs_setpwalletRegistered` internally, so the pre-acquired
  `LOCK(cs_setpwalletRegistered)` in `claimhtlc`/`refundhtlc` (`rpc/htlc.cpp`) and `sendrawtransaction`
  (`rpc/rawtransaction.cpp`) — held only to keep canonical order across that internal acquisition — is
  removed, leaving `cs_main -> cs_wallet`.

No behavior change.

Part of #3030.