### PR TITLE
refactor: self-schedule wallet rebroadcast, retire ResendWalletTransactions wrapper

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -308,6 +308,11 @@ void Shutdown(void* parg)
         UnregisterValidationInterface(pwalletMain);
         UnregisterWallet(pwalletMain);
         delete pwalletMain;
+        // Null the global so any late/defensive `if (pwalletMain)` guard (e.g. the
+        // scheduled wallet-rebroadcast job) is load-bearing rather than seeing a
+        // dangling pointer. Safe today only because the scheduler thread is already
+        // joined above; nulling hardens against future teardown reordering.
+        pwalletMain = nullptr;
         // close transaction database to prevent lock issue on restart
         // This causes issues on daemons where it tries to create a second
         // lock file.
@@ -1951,6 +1956,26 @@ bool AppInit2(ThreadHandlerPtr threads)
     g_scheduler->scheduleEvery([]{
         ResendUnbroadcastTransactions();
     }, std::chrono::minutes{12});
+
+    // Periodically rebroadcast the wallet's own unconfirmed transactions. This
+    // was previously driven per-pass from net_processing::SendMessages via the
+    // setpwalletRegistered ResendWalletTransactions wrapper; it now self-
+    // schedules here, retiring that wrapper (issue #3030).
+    // CWallet::ResendWalletTransactions self-rate-limits (random ~10x block
+    // spacing, gated on IBD / OutOfSyncByAge / new-block-seen), so a 60s poll
+    // reproduces the old cadence. TRY_LOCK(cs_main) matches the other
+    // wallet-touching scheduled jobs (RunBackupJob, RunRenewBeaconJob): when
+    // cs_main is busy (reorg/IBD) the cycle is skipped rather than stalling the
+    // shared scheduler thread, and the next poll is 60s away. Shutdown-safe: the
+    // scheduler thread is joined (threadGroup.join_all(), see Shutdown()) before
+    // g_connman and pwalletMain
+    // are torn down, so this can never deref freed state.
+    g_scheduler->scheduleEvery([]{
+        if (!pwalletMain) return;
+        TRY_LOCK(cs_main, locked_main);
+        if (!locked_main) return;
+        pwalletMain->ResendWalletTransactions();
+    }, std::chrono::seconds{60});
 
     GRC::ScheduleBackgroundJobs(*g_scheduler);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,24 +163,13 @@ void UnregisterWallet(CWallet* pwalletIn)
     }
 }
 
-// Canonical lock order: cs_main -> cs_setpwalletRegistered -> cs_wallet.
-// Each wrapper iterates setpwalletRegistered (GUARDED_BY cs_setpwalletRegistered)
-// and dispatches into pwallet methods that take pwallet->cs_wallet. Callers
-// MUST hold cs_setpwalletRegistered before invoking these wrappers; this is
-// enforced by EXCLUSIVE_LOCKS_REQUIRED. Holding the lock at the call site
-// (rather than taking it inside the wrapper) lets callers that also hold
-// cs_wallet establish the canonical order at acquisition time and avoids
-// the cs_setpwalletRegistered <-> cs_wallet inversion the inside-lock
-// pattern would otherwise create.
-
-
-// ask wallets to resend their transactions
-void ResendWalletTransactions(bool fForce)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->ResendWalletTransactions(fForce);
-}
+// The setpwalletRegistered dispatch wrappers (EraseFromWallets, SetBestChain,
+// UpdatedTransaction, PrintWallets, ResendWalletTransactions) have been retired
+// under issue #3030: wallet notifications now flow through CMainSignals and the
+// wallet rebroadcast self-schedules on g_scheduler. cs_setpwalletRegistered now
+// guards only the registry set itself (RegisterWallet/UnregisterWallet above) and
+// the net-half Inventory/GetTransaction wrappers (tracked separately). The
+// canonical lock order remains cs_main -> cs_setpwalletRegistered -> cs_wallet.
 
 
 double CoinToDouble(double surrogate)

--- a/src/main.h
+++ b/src/main.h
@@ -170,7 +170,6 @@ int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
-void ResendWalletTransactions(bool fForce = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_setpwalletRegistered);
 bool OutOfSyncByAge();
 
 /** (try to) add transaction to memory pool **/

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1245,14 +1245,10 @@ static bool SendMessages(CNode* pto, bool fSendTrickle)
         pto->PushMessage(NetMsgType::PING, nonce);
     }
 
-    // Resend wallet transactions that haven't gotten in a block yet.
-    // No outer locks held here in SendMessages; acquire in canonical order
-    // cs_main -> cs_setpwalletRegistered -> cs_wallet. cs_main is required
-    // for the wallet method's mapBlockIndex / pindexBest reads.
-    {
-        LOCK2(cs_main, cs_setpwalletRegistered);
-        ResendWalletTransactions();
-    }
+    // Wallet rebroadcast of unconfirmed transactions now self-schedules on
+    // g_scheduler (see AppInit2) rather than running per SendMessages pass,
+    // retiring the setpwalletRegistered ResendWalletTransactions wrapper
+    // (issue #3030).
 
     // (The node's own unbroadcast transactions are rebroadcast from a scheduler
     // job, ResendUnbroadcastTransactions(), not here -- relaying from inside

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3421,8 +3421,8 @@ const RPCHelpMan& resendtx_helpman() { return resendtx_help; }
 UniValue resendtx(const UniValue& params)
 {
     {
-        LOCK2(cs_main, cs_setpwalletRegistered);
-        ResendWalletTransactions(true);
+        LOCK(cs_main);
+        pwalletMain->ResendWalletTransactions(true);
     }
 
     return NullUniValue;


### PR DESCRIPTION
## Summary

Follow-up to #3030. The wallet's periodic rebroadcast of its own unconfirmed transactions was driven
per-pass from `net_processing::SendMessages` through the `setpwalletRegistered`
`ResendWalletTransactions` wrapper. Move it onto `g_scheduler` so that wrapper — and its hold of
`cs_setpwalletRegistered` in the message loop — can go away.

## Changes

- **`init.cpp`:** register a `g_scheduler->scheduleEvery(60s)` task that calls
  `pwalletMain->ResendWalletTransactions()`. It uses `TRY_LOCK(cs_main)` with skip-on-contention,
  matching the other wallet-touching scheduled jobs (`RunBackupJob`, `RunRenewBeaconJob`), so a busy
  `cs_main` (reorg/IBD) skips the cycle instead of stalling the single shared scheduler thread. The
  wallet method self-rate-limits (random ~10× block spacing, gated on IBD / `OutOfSyncByAge` /
  new-block-seen), and that throttle is **timestamp-based, not caller-count-based**, so a fixed 60s poll
  reproduces the old per-pass cadence.
- **`init.cpp`:** set `pwalletMain = nullptr;` after `delete pwalletMain;` so the job's `if (pwalletMain)`
  guard is load-bearing. (Teardown is already safe because the scheduler thread is joined via
  `threadGroup.join_all()` before `g_connman.reset()` and `delete pwalletMain`.)
- **`rpcwallet.cpp`:** `resendtx` calls `pwalletMain->ResendWalletTransactions(true)` directly under
  `cs_main`; `fForce` semantics (immediate, gate-bypass) unchanged.
- **`net_processing.cpp`:** remove the `SendMessages` resend block (`LOCK2(cs_main,
  cs_setpwalletRegistered)` + call).
- **`main.{h,cpp}`:** delete the free `ResendWalletTransactions` wrapper.

Relay stays thread-safe off the message-handler thread (`RelayTransaction` null-guards `g_connman`;
`RelayInventory`/`PushInventory` take their own locks) and introduces no new lock-order inversion
(`cs_main -> cs_wallet` is a subset of the old path's order). Does **not** delete
`cs_setpwalletRegistered` — the net-half `Inventory`/`GetTransaction` wrappers still use it (#3108).

## Behavior notes

- Trigger moves from the message-handler thread to the scheduler thread, and from opportunistic
  per-`SendMessages`-pass to a fixed 60s poll. Because the internal `nNextTime`/new-block gate is the
  real throttle (minutes granularity), effective relay events are unchanged; first-relay latency gains at
  most ~60s, swamped by the existing random timer.
- The historical `doc/thread_safety_phase1_report.md` wrapper inventory is a point-in-time snapshot and
  is intentionally not edited per-PR across this retirement series; a consolidated refresh belongs with
  the final `cs_setpwalletRegistered` deletion (#3108).

## Testing

Behavior-equivalence of the thread/cadence move was verified against source (relay lock-safety off the
message-handler thread, timestamp-based throttle, teardown join-before-free, `fForce` preservation). CI
covers compilation + the existing suite. There is no automated rebroadcast/resendtx coverage today
(only a help-text registration check), so a dedicated functional test — submit an unconfirmed tx, call
`resendtx`, assert re-INV — is a sensible follow-up; the rebroadcast path is otherwise manually
verifiable via the `resendtx` RPC.

Part of #3030.