### PR TITLE
psgt: add bytes decoder and partial-signature verification helpers (#2910 Phase II, PR A)

### DIFF
--- a/src/psgt.cpp
+++ b/src/psgt.cpp
@@ -7,6 +7,7 @@
 #include <hash.h>
 #include <keystore.h>
 #include <policy/fees.h>
+#include <policy/policy.h>
 #include <script/interpreter.h>
 #include <script/sign.h>
 #include <script/standard.h>
@@ -530,49 +531,20 @@ std::vector<unsigned char> SerializePSGT(const PartiallySignedTransaction& psgt)
     return result;
 }
 
-// Helper: read a compact size from a stream position.
-static bool ReadCompactSizeFromVec(const std::vector<unsigned char>& data, size_t& pos, uint64_t& nSize)
+// Read a length-prefixed byte string from a PSGT stream. ReadCompactSize bounds
+// the length to MAX_SIZE and rejects non-canonical encodings; the additional
+// remaining-bytes check bounds the allocation to the data actually present, so a
+// small PSGT cannot claim a large length and force an oversized allocation
+// before the read fails on truncation.
+template <typename Stream>
+static void ReadPSGTField(Stream& s, std::vector<unsigned char>& out)
 {
-    if (pos >= data.size()) return false;
-
-    unsigned char chSize = data[pos++];
-    if (chSize < 253)
-    {
-        nSize = chSize;
-    }
-    else if (chSize == 253)
-    {
-        if (pos + 2 > data.size()) return false;
-        nSize = data[pos] | ((uint64_t)data[pos + 1] << 8);
-        pos += 2;
-    }
-    else if (chSize == 254)
-    {
-        if (pos + 4 > data.size()) return false;
-        nSize = 0;
-        for (int i = 0; i < 4; ++i)
-            nSize |= ((uint64_t)data[pos + i] << (8 * i));
-        pos += 4;
-    }
-    else
-    {
-        if (pos + 8 > data.size()) return false;
-        nSize = 0;
-        for (int i = 0; i < 8; ++i)
-            nSize |= ((uint64_t)data[pos + i] << (8 * i));
-        pos += 8;
-    }
-    return true;
-}
-
-// Helper: read N bytes from a vector at a given position.
-static bool ReadBytes(const std::vector<unsigned char>& data, size_t& pos,
-                      std::vector<unsigned char>& out, size_t n)
-{
-    if (pos + n > data.size()) return false;
-    out.assign(data.begin() + pos, data.begin() + pos + n);
-    pos += n;
-    return true;
+    uint64_t len = ReadCompactSize(s);
+    if (len > s.size())
+        throw std::ios_base::failure("PSGT field length exceeds remaining data");
+    out.resize(len);
+    if (len > 0)
+        s.read(AsWritableBytes(Span{out.data(), out.size()}));
 }
 
 bool DecodeRawPSGT(PartiallySignedTransaction& psgt,
@@ -587,6 +559,15 @@ bool DecodeRawPSGT(PartiallySignedTransaction& psgt,
     {
         if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
             cleaned += c;
+    }
+
+    // Bound the input before decoding so a large base64 blob can't force a big
+    // allocation ahead of the byte-level MAX_PSGT_WIRE_SIZE check. Base64 expands
+    // 3 bytes -> 4 chars, so a valid PSGT encodes to at most this many characters.
+    if (cleaned.size() > (MAX_PSGT_WIRE_SIZE / 3 + 1) * 4)
+    {
+        error = "PSGT exceeds maximum size";
+        return false;
     }
 
     bool invalid = false;
@@ -604,6 +585,16 @@ bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
                      const std::vector<unsigned char>& data,
                      std::string& error)
 {
+    // Bound untrusted input before any work: a PSGT from an untrusted source
+    // (the decode RPC/GUI, and the upcoming p2p relay) must not exceed the wire
+    // cap. Together with the range-checked ReadCompactSize used by the stream
+    // reads below, this removes attacker-controlled lengths as a crash vector.
+    if (data.size() > MAX_PSGT_WIRE_SIZE)
+    {
+        error = "PSGT exceeds maximum size";
+        return false;
+    }
+
     // Check magic bytes.
     if (data.size() < PSGT_MAGIC.size() ||
         !std::equal(PSGT_MAGIC.begin(), PSGT_MAGIC.end(), data.begin()))
@@ -612,30 +603,32 @@ bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
         return false;
     }
 
-    size_t pos = PSGT_MAGIC.size();
+    // Parse the key/value maps through the standard serialization framework
+    // instead of hand-rolled index walking: ReadPSGTField reads each
+    // length-prefixed byte string via ReadCompactSize (which rejects
+    // non-canonical and over-MAX_SIZE lengths) and rejects any length beyond the
+    // remaining bytes before allocating -- so a malformed length can neither
+    // overflow, over-read, nor force an oversized allocation.
+    CDataStream ss(std::vector<unsigned char>(data.begin() + PSGT_MAGIC.size(), data.end()),
+                   SER_NETWORK, PROTOCOL_VERSION);
+
+    try {
 
     // Parse global map.
     bool found_tx = false;
     std::set<std::vector<unsigned char>> global_keys;
-    while (pos < data.size())
+    while (!ss.empty())
     {
-        // Check for separator.
-        uint64_t keyLen = 0;
-        size_t savedPos = pos;
-        if (!ReadCompactSizeFromVec(data, pos, keyLen)) { error = "Truncated global key length"; return false; }
-        if (keyLen == 0) break; // Separator
-
         std::vector<unsigned char> key;
-        if (!ReadBytes(data, pos, key, keyLen)) { error = "Truncated global key"; return false; }
+        ReadPSGTField(ss, key);
+        if (key.empty()) break; // Separator
 
-        uint64_t valLen = 0;
-        if (!ReadCompactSizeFromVec(data, pos, valLen)) { error = "Truncated global value length"; return false; }
         std::vector<unsigned char> val;
-        if (!ReadBytes(data, pos, val, valLen)) { error = "Truncated global value"; return false; }
+        ReadPSGTField(ss, val);
 
         if (!global_keys.insert(key).second) { error = "Duplicate key in global map"; return false; }
 
-        if (key.size() >= 1 && key[0] == PSGT_GLOBAL_UNSIGNED_TX && !found_tx)
+        if (key[0] == PSGT_GLOBAL_UNSIGNED_TX && !found_tx)
         {
             CDataStream ssTx(val, SER_NETWORK, PROTOCOL_VERSION);
             try {
@@ -676,19 +669,14 @@ bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
     for (unsigned int i = 0; i < psgt.tx.vin.size(); ++i)
     {
         std::set<std::vector<unsigned char>> input_keys;
-        while (pos < data.size())
+        while (!ss.empty())
         {
-            uint64_t keyLen = 0;
-            if (!ReadCompactSizeFromVec(data, pos, keyLen)) { error = "Truncated input key length"; return false; }
-            if (keyLen == 0) break; // Separator
-
             std::vector<unsigned char> key;
-            if (!ReadBytes(data, pos, key, keyLen)) { error = "Truncated input key"; return false; }
+            ReadPSGTField(ss, key);
+            if (key.empty()) break; // Separator
 
-            uint64_t valLen = 0;
-            if (!ReadCompactSizeFromVec(data, pos, valLen)) { error = "Truncated input value length"; return false; }
             std::vector<unsigned char> val;
-            if (!ReadBytes(data, pos, val, valLen)) { error = "Truncated input value"; return false; }
+            ReadPSGTField(ss, val);
 
             if (!input_keys.insert(key).second) { error = "Duplicate key in input map"; return false; }
 
@@ -697,8 +685,8 @@ bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
             {
             case PSGT_IN_NON_WITNESS_UTXO:
             {
-                CDataStream ss(val, SER_NETWORK, PROTOCOL_VERSION);
-                try { ss >> psgt.inputs[i].non_witness_utxo; }
+                CDataStream ssu(val, SER_NETWORK, PROTOCOL_VERSION);
+                try { ssu >> psgt.inputs[i].non_witness_utxo; }
                 catch (...) { error = "Failed to decode non-witness UTXO"; return false; }
                 break;
             }
@@ -752,19 +740,14 @@ bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
     for (unsigned int i = 0; i < psgt.tx.vout.size(); ++i)
     {
         std::set<std::vector<unsigned char>> output_keys;
-        while (pos < data.size())
+        while (!ss.empty())
         {
-            uint64_t keyLen = 0;
-            if (!ReadCompactSizeFromVec(data, pos, keyLen)) { error = "Truncated output key length"; return false; }
-            if (keyLen == 0) break; // Separator
-
             std::vector<unsigned char> key;
-            if (!ReadBytes(data, pos, key, keyLen)) { error = "Truncated output key"; return false; }
+            ReadPSGTField(ss, key);
+            if (key.empty()) break; // Separator
 
-            uint64_t valLen = 0;
-            if (!ReadCompactSizeFromVec(data, pos, valLen)) { error = "Truncated output value length"; return false; }
             std::vector<unsigned char> val;
-            if (!ReadBytes(data, pos, val, valLen)) { error = "Truncated output value"; return false; }
+            ReadPSGTField(ss, val);
 
             if (!output_keys.insert(key).second) { error = "Duplicate key in output map"; return false; }
 
@@ -796,6 +779,13 @@ bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
                 break;
             }
         }
+    }
+
+    } catch (const std::exception& e) {
+        // Any truncated/over-long length field or malformed embedded object
+        // surfaces here as a stream exception rather than a crash.
+        error = std::string("Malformed PSGT: ") + e.what();
+        return false;
     }
 
     return true;
@@ -1176,7 +1166,15 @@ bool VerifyPSGTPartialSigs(const PartiallySignedTransaction& psgt,
                 return false;
             }
 
-            if (sig.empty() || !CheckSig(sig, member->second, sign_script, tx, i))
+            // Enforce the signature encoding the finalized transaction will have to
+            // satisfy (strict DER + low-S + STRICTENC), not just ECDSA validity:
+            // CheckSig verifies through the lax parser + S-normalization, so a
+            // malleated (high-S / non-canonical-DER) copy would verify here yet be
+            // rejected by the network's mandatory DERSIG on broadcast. Reject it now
+            // so the pool never vouches for an un-finalizable PSGT.
+            if (sig.empty()
+                || !CheckSignatureEncoding(sig, STANDARD_SCRIPT_VERIFY_FLAGS)
+                || !CheckSig(sig, member->second, sign_script, tx, i))
             {
                 error = strprintf("input %u: invalid partial signature", i);
                 return false;
@@ -1221,7 +1219,11 @@ bool PSGTSignedBy(const SigningProvider& provider,
             if (it == input.partial_sigs.end() || it->second.empty())
                 continue;
 
-            if (CheckSig(it->second, vSolutions[j], sign_script, tx, i))
+            // Same encoding-strictness gate as VerifyPSGTPartialSigs: a malleated
+            // copy of an own signature would verify but not finalize, so it must
+            // not be reported as the provider having signed.
+            if (CheckSignatureEncoding(it->second, STANDARD_SCRIPT_VERIFY_FLAGS)
+                && CheckSig(it->second, vSolutions[j], sign_script, tx, i))
                 return true;
         }
     }

--- a/src/psgt.cpp
+++ b/src/psgt.cpp
@@ -597,6 +597,13 @@ bool DecodeRawPSGT(PartiallySignedTransaction& psgt,
         return false;
     }
 
+    return DecodePSGTBytes(psgt, data, error);
+}
+
+bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
+                     const std::vector<unsigned char>& data,
+                     std::string& error)
+{
     // Check magic bytes.
     if (data.size() < PSGT_MAGIC.size() ||
         !std::equal(PSGT_MAGIC.begin(), PSGT_MAGIC.end(), data.begin()))
@@ -1000,4 +1007,224 @@ PSGTAnalysis AnalyzePSGT(const PartiallySignedTransaction& psgtx)
     }
 
     return result;
+}
+
+/**
+ * Resolve the script the partial signatures of input `index` are made over
+ * (the P2SH-unwrapped redeem script), requiring the carried previous
+ * transaction to actually match prevout and, for P2SH, the redeem script to
+ * hash to the script hash the funded output commits to. Returns false when
+ * the input's signing context cannot be established trustworthily.
+ */
+static bool GetPSGTInputSignScript(const PartiallySignedTransaction& psgt,
+                                   unsigned int index, CScript& sign_script)
+{
+    if (index >= psgt.inputs.size() || index >= psgt.tx.vin.size())
+        return false;
+
+    const PSGTInput& input = psgt.inputs[index];
+    const COutPoint& prevout = psgt.tx.vin[index].prevout;
+
+    if (input.non_witness_utxo.IsNull()
+        || prevout.n >= input.non_witness_utxo.vout.size()
+        || input.non_witness_utxo.GetHash() != prevout.hash)
+        return false;
+
+    const CScript& scriptPubKey = input.non_witness_utxo.vout[prevout.n].scriptPubKey;
+    if (!scriptPubKey.IsPayToScriptHash())
+    {
+        sign_script = scriptPubKey;
+        return true;
+    }
+
+    if (input.redeem_script.empty())
+        return false;
+
+    const CScriptID expected(uint160(std::vector<unsigned char>(
+        scriptPubKey.begin() + 2, scriptPubKey.begin() + 22)));
+    if (CScriptID(input.redeem_script) != expected)
+        return false;
+
+    sign_script = input.redeem_script;
+    return true;
+}
+
+std::optional<CScriptID> GetPSGTInputImage(const PartiallySignedTransaction& psgt,
+                                           unsigned int index)
+{
+    if (index >= psgt.inputs.size() || index >= psgt.tx.vin.size())
+        return std::nullopt;
+
+    const PSGTInput& input = psgt.inputs[index];
+    const COutPoint& prevout = psgt.tx.vin[index].prevout;
+
+    if (input.non_witness_utxo.IsNull()
+        || prevout.n >= input.non_witness_utxo.vout.size()
+        || input.non_witness_utxo.GetHash() != prevout.hash)
+        return std::nullopt;
+
+    // Only P2SH-wrapped multisig arrangements have an image.
+    if (!input.non_witness_utxo.vout[prevout.n].scriptPubKey.IsPayToScriptHash())
+        return std::nullopt;
+
+    CScript sign_script;
+    if (!GetPSGTInputSignScript(psgt, index, sign_script))
+        return std::nullopt;
+
+    txnouttype script_type;
+    std::vector<std::vector<unsigned char>> vSolutions;
+    if (!Solver(sign_script, script_type, vSolutions) || script_type != TX_MULTISIG)
+        return std::nullopt;
+
+    return CScriptID(sign_script);
+}
+
+std::optional<CScriptID> GetPSGTImage(const PartiallySignedTransaction& psgt)
+{
+    if (psgt.inputs.empty() || psgt.inputs.size() != psgt.tx.vin.size())
+        return std::nullopt;
+
+    std::optional<CScriptID> image = GetPSGTInputImage(psgt, 0);
+    if (!image)
+        return std::nullopt;
+
+    for (unsigned int i = 1; i < psgt.inputs.size(); ++i)
+    {
+        const std::optional<CScriptID> other = GetPSGTInputImage(psgt, i);
+        if (!other || *other != *image)
+            return std::nullopt;
+    }
+
+    return image;
+}
+
+bool GetPSGTMultisigParams(const PartiallySignedTransaction& psgt,
+                           int& required, int& total)
+{
+    if (!GetPSGTImage(psgt))
+        return false;
+
+    // GetPSGTImage established that input 0's redeem script is present,
+    // committed to by the funded output, and TX_MULTISIG.
+    txnouttype script_type;
+    std::vector<std::vector<unsigned char>> vSolutions;
+    if (!Solver(psgt.inputs[0].redeem_script, script_type, vSolutions)
+        || script_type != TX_MULTISIG)
+        return false;
+
+    required = vSolutions.front()[0];
+    total = vSolutions.size() - 2;
+    return true;
+}
+
+bool VerifyPSGTPartialSigs(const PartiallySignedTransaction& psgt,
+                           std::vector<std::set<CKeyID>>& valid_keys_per_input,
+                           std::string& error)
+{
+    valid_keys_per_input.assign(psgt.inputs.size(), {});
+
+    if (psgt.inputs.size() != psgt.tx.vin.size())
+    {
+        error = "PSGT input count does not match unsigned transaction input count";
+        return false;
+    }
+
+    const CTransaction tx(psgt.tx);
+
+    for (unsigned int i = 0; i < psgt.inputs.size(); ++i)
+    {
+        const PSGTInput& input = psgt.inputs[i];
+        if (input.partial_sigs.empty())
+            continue;
+
+        CScript sign_script;
+        if (!GetPSGTInputSignScript(psgt, i, sign_script))
+        {
+            error = strprintf("input %u: carries partial signatures but its signing "
+                              "context cannot be verified (missing or mismatched "
+                              "previous transaction or redeem script)", i);
+            return false;
+        }
+
+        txnouttype script_type;
+        std::vector<std::vector<unsigned char>> vSolutions;
+        if (!Solver(sign_script, script_type, vSolutions) || script_type != TX_MULTISIG)
+        {
+            // Phase I only accumulates partial_sigs for multisig scripts;
+            // anything else carrying them is malformed or crafted.
+            error = strprintf("input %u: partial signatures on a non-multisig script", i);
+            return false;
+        }
+
+        // Map the redeem script's pubkeys by key id so each partial_sigs
+        // entry (keyed by CKeyID only) can be verified.
+        std::map<CKeyID, std::vector<unsigned char>> member_pubkeys;
+        for (unsigned int j = 1; j + 1 < vSolutions.size(); ++j)
+        {
+            const CPubKey pubkey(vSolutions[j]);
+            if (pubkey.IsValid())
+                member_pubkeys[pubkey.GetID()] = vSolutions[j];
+        }
+
+        for (const auto& [keyid, sig] : input.partial_sigs)
+        {
+            const auto member = member_pubkeys.find(keyid);
+            if (member == member_pubkeys.end())
+            {
+                error = strprintf("input %u: partial signature by a key that is not "
+                                  "part of the multisig arrangement", i);
+                return false;
+            }
+
+            if (sig.empty() || !CheckSig(sig, member->second, sign_script, tx, i))
+            {
+                error = strprintf("input %u: invalid partial signature", i);
+                return false;
+            }
+
+            valid_keys_per_input[i].insert(keyid);
+        }
+    }
+
+    return true;
+}
+
+bool PSGTSignedBy(const SigningProvider& provider,
+                  const PartiallySignedTransaction& psgt)
+{
+    const CTransaction tx(psgt.tx);
+
+    for (unsigned int i = 0; i < psgt.inputs.size() && i < psgt.tx.vin.size(); ++i)
+    {
+        const PSGTInput& input = psgt.inputs[i];
+        if (input.partial_sigs.empty())
+            continue;
+
+        // Tolerant per-input skip (not a hard failure like
+        // VerifyPSGTPartialSigs): only provider-owned entries decide.
+        CScript sign_script;
+        if (!GetPSGTInputSignScript(psgt, i, sign_script))
+            continue;
+
+        txnouttype script_type;
+        std::vector<std::vector<unsigned char>> vSolutions;
+        if (!Solver(sign_script, script_type, vSolutions) || script_type != TX_MULTISIG)
+            continue;
+
+        for (unsigned int j = 1; j + 1 < vSolutions.size(); ++j)
+        {
+            const CPubKey pubkey(vSolutions[j]);
+            if (!pubkey.IsValid() || !provider.HaveKey(pubkey.GetID()))
+                continue;
+
+            const auto it = input.partial_sigs.find(pubkey.GetID());
+            if (it == input.partial_sigs.end() || it->second.empty())
+                continue;
+
+            if (CheckSig(it->second, vSolutions[j], sign_script, tx, i))
+                return true;
+        }
+    }
+
+    return false;
 }

--- a/src/psgt.h
+++ b/src/psgt.h
@@ -192,10 +192,18 @@ PSGTAnalysis AnalyzePSGT(const PartiallySignedTransaction& psgtx);
 /**
  * The multisig "image" of one PSGT input: the hash of its redeem script
  * (CScriptID), the key a PSGT pool indexes on (#2910). Returns a value only
- * when the input is trustworthily P2SH multisig: the carried previous
+ * when the input is a self-consistent P2SH multisig: the carried previous
  * transaction matches prevout, the funded output is P2SH, the redeem script
  * is present and hashes to the script hash the output commits to, and the
  * redeem script decomposes as m-of-n CHECKMULTISIG.
+ *
+ * IMPORTANT — this establishes INTERNAL CONSISTENCY only, not on-chain reality.
+ * The non_witness_utxo is attacker-supplied; these checks prove the carried
+ * previous transaction commits to this redeem script, NOT that it is confirmed
+ * or a live UTXO. A caller that trusts the image to gate real resources (the
+ * #2910/#3115 pool) MUST additionally verify each input's prevout against the
+ * live UTXO set (exists AND unspent) before trusting it; otherwise an image can
+ * be fabricated for a multisig that was never funded on-chain.
  */
 std::optional<CScriptID> GetPSGTInputImage(const PartiallySignedTransaction& psgt,
                                            unsigned int index);

--- a/src/psgt.h
+++ b/src/psgt.h
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -32,6 +33,12 @@ static constexpr uint8_t PSGT_OUT_BIP32_DERIVATION = 0x02;
 
 // Magic bytes: "psgt" + 0xff separator
 static const std::vector<unsigned char> PSGT_MAGIC = {0x70, 0x73, 0x67, 0x74, 0xff};
+
+// Upper bound on the serialized (binary) size of a PSGT accepted from
+// untrusted sources (network relay, pool submission). Generous for a
+// multisig spend of a few dozen inputs, each carrying its full previous
+// transaction, while bounding per-object memory.
+static constexpr size_t MAX_PSGT_WIRE_SIZE = 100000;
 
 /** HD key origin information: fingerprint + derivation path. */
 struct KeyOriginInfo
@@ -108,12 +115,22 @@ bool CombinePSGTs(PartiallySignedTransaction& out,
                    const std::vector<PartiallySignedTransaction>& psgts);
 
 /**
- * Decode a PSGT from a binary stream.
+ * Decode a PSGT from base64 text (whitespace tolerated).
  * @return true on success.
  */
 bool DecodeRawPSGT(PartiallySignedTransaction& psgt,
                     const std::string& base64_tx,
                     std::string& error);
+
+/**
+ * Decode a PSGT from raw binary bytes (the SerializePSGT format). This is
+ * the transport-agnostic core of DecodeRawPSGT, exposed for callers that
+ * receive PSGT bytes directly (e.g. network relay) rather than base64 text.
+ * @return true on success.
+ */
+bool DecodePSGTBytes(PartiallySignedTransaction& psgt,
+                     const std::vector<unsigned char>& data,
+                     std::string& error);
 
 /**
  * Serialize a PSGT to a binary byte vector.
@@ -171,5 +188,57 @@ struct PSGTAnalysis
  * Pure function of the PSGT; does not consult the wallet or mutate anything.
  */
 PSGTAnalysis AnalyzePSGT(const PartiallySignedTransaction& psgtx);
+
+/**
+ * The multisig "image" of one PSGT input: the hash of its redeem script
+ * (CScriptID), the key a PSGT pool indexes on (#2910). Returns a value only
+ * when the input is trustworthily P2SH multisig: the carried previous
+ * transaction matches prevout, the funded output is P2SH, the redeem script
+ * is present and hashes to the script hash the output commits to, and the
+ * redeem script decomposes as m-of-n CHECKMULTISIG.
+ */
+std::optional<CScriptID> GetPSGTInputImage(const PartiallySignedTransaction& psgt,
+                                           unsigned int index);
+
+/**
+ * The single multisig image shared by ALL inputs of the PSGT, or nullopt if
+ * any input lacks an image or two inputs disagree. One image per PSGT is the
+ * pool's identity model: multi-input spends from the same multisig address
+ * qualify; mixed-arrangement PSGTs do not.
+ */
+std::optional<CScriptID> GetPSGTImage(const PartiallySignedTransaction& psgt);
+
+/**
+ * Recover the m-of-n parameters of the PSGT's (single) multisig image.
+ * @return false if GetPSGTImage would return nullopt.
+ */
+bool GetPSGTMultisigParams(const PartiallySignedTransaction& psgt,
+                           int& required, int& total);
+
+/**
+ * Cryptographically verify EVERY partial signature carried by the PSGT.
+ * For each input, each (key id, signature) entry must map to a pubkey of the
+ * input's multisig redeem script and pass CheckSig over the unsigned
+ * transaction. Any unknown key or invalid signature fails the whole PSGT —
+ * partial_sigs are untrusted after transport and CombinePSGTs (which merges
+ * without verifying).
+ *
+ * On success, valid_keys_per_input[i] holds the key ids with a verified
+ * signature on input i (the per-input m-of-n progress).
+ */
+bool VerifyPSGTPartialSigs(const PartiallySignedTransaction& psgt,
+                           std::vector<std::set<CKeyID>>& valid_keys_per_input,
+                           std::string& error);
+
+/**
+ * True iff some input carries a cryptographically valid partial signature
+ * from a key the provider holds — verified against the input's sighash, not
+ * merely present under an owned key id. Tolerant of other signers' invalid
+ * or unverifiable material (unlike VerifyPSGTPartialSigs): only the
+ * provider-owned entries decide the result. This is the ">=1 valid own
+ * signature" precondition for submitting a PSGT to the pool (#2910).
+ */
+bool PSGTSignedBy(const SigningProvider& provider,
+                  const PartiallySignedTransaction& psgt);
 
 #endif // GRIDCOIN_PSGT_H

--- a/src/qt/multisigndialog.cpp
+++ b/src/qt/multisigndialog.cpp
@@ -262,57 +262,9 @@ void MultisignPSGTDialog::setWorking(const PartiallySignedTransaction& psgt)
 
 bool MultisignPSGTDialog::walletHasSignature(const PartiallySignedTransaction& psgt) const
 {
-    if (!pwalletMain)
-        return false;
-
-    for (unsigned int i = 0; i < psgt.inputs.size() && i < psgt.tx.vin.size(); ++i)
-    {
-        const PSGTInput& input = psgt.inputs[i];
-        if (input.partial_sigs.empty())
-            continue;
-
-        // We must know what was signed, so require the provided previous
-        // transaction to actually match the prevout (the AnalyzePSGT guard) and
-        // verify against the real scriptPubKey.
-        const COutPoint& prevout = psgt.tx.vin[i].prevout;
-        if (input.non_witness_utxo.IsNull()
-            || prevout.n >= input.non_witness_utxo.vout.size()
-            || input.non_witness_utxo.GetHash() != prevout.hash)
-            continue;
-
-        // P2SH multisig signatures are made over the redeem script.
-        CScript signScript = input.non_witness_utxo.vout[prevout.n].scriptPubKey;
-        if (signScript.IsPayToScriptHash())
-        {
-            if (input.redeem_script.empty())
-                continue;
-            signScript = input.redeem_script;
-        }
-
-        // Map each partial signature back to its multisig pubkey and verify the
-        // bytes cryptographically. Presence under an owned CKeyID is not enough:
-        // a crafted or combined PSGT could carry arbitrary bytes under our key id,
-        // and Phase II's pool-acceptance precondition (#2910) is >=1 *valid* sig.
-        txnouttype scriptType;
-        std::vector<std::vector<unsigned char>> vSolutions;
-        if (!Solver(signScript, scriptType, vSolutions) || scriptType != TX_MULTISIG)
-            continue;
-
-        for (unsigned int j = 1; j + 1 < vSolutions.size(); ++j)
-        {
-            const CPubKey pubkey(vSolutions[j]);
-            if (!pubkey.IsValid() || !pwalletMain->HaveKey(pubkey.GetID()))
-                continue;
-
-            auto it = input.partial_sigs.find(pubkey.GetID());
-            if (it == input.partial_sigs.end())
-                continue;
-
-            if (CheckSig(it->second, vSolutions[j], signScript, CTransaction(psgt.tx), i))
-                return true;
-        }
-    }
-    return false;
+    // Hoisted into the core PSGT library as PSGTSignedBy so the Phase II pool
+    // (#2910) can gate on the same ">=1 valid own signature" precondition.
+    return pwalletMain && PSGTSignedBy(*pwalletMain, psgt);
 }
 
 void MultisignPSGTDialog::showDecoded(const PartiallySignedTransaction& psgt)

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -13,6 +13,7 @@ class CTransaction;
 bool EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script, unsigned int flags, const CTransaction& txTo, unsigned int nIn);
 uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 bool CheckSig(std::vector<unsigned char> vchSig, std::vector<unsigned char> vchPubKey, CScript scriptCode, const CTransaction& txTo, unsigned int nIn);
+bool CheckSignatureEncoding(const std::vector<unsigned char>& vchSig, unsigned int flags);
 bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, unsigned int flags, const CTransaction& txTo, unsigned int nIn);
 bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int flags, unsigned int nIn, int nHashType);
 

--- a/src/test/psgt_test_helpers.h
+++ b/src/test/psgt_test_helpers.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_TEST_PSGT_TEST_HELPERS_H
+#define GRIDCOIN_TEST_PSGT_TEST_HELPERS_H
+
+#include <key.h>
+#include <primitives/transaction.h>
+#include <psgt.h>
+#include <script/script.h>
+#include <script/standard.h>
+
+#include <vector>
+
+//! Shared builders for PSGT unit tests (psgt_tests, psgt_pool_tests).
+
+inline CKey MakeKey()
+{
+    CKey key;
+    key.MakeNewKey(true);
+    return key;
+}
+
+inline CScript P2PKH(const CKeyID& id)
+{
+    CScript s;
+    s << OP_DUP << OP_HASH160 << id << OP_EQUALVERIFY << OP_CHECKSIG;
+    return s;
+}
+
+inline CScript P2SH(const CScriptID& id)
+{
+    CScript s;
+    s << OP_HASH160 << id << OP_EQUAL;
+    return s;
+}
+
+inline CScript MultisigScript(int required, const std::vector<CPubKey>& pubkeys)
+{
+    CScript s;
+    s << (int64_t)required;
+    for (const CPubKey& pubkey : pubkeys)
+        s << pubkey;
+    s << (int64_t)pubkeys.size() << OP_CHECKMULTISIG;
+    return s;
+}
+
+inline CScript Multisig1of2(const CKey& key1, const CKey& key2)
+{
+    return MultisigScript(1, {key1.GetPubKey(), key2.GetPubKey()});
+}
+
+//! Build a fake previous transaction that pays to the given key.
+inline CTransaction MakePrevTx(const CKey& key, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.nTime = 1700000000;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout.SetNull(); // coinbase-like
+    mtx.vin[0].scriptSig = CScript() << 0;
+    mtx.vout.push_back(CTxOut(amount, P2PKH(key.GetPubKey().GetID())));
+    return CTransaction(mtx);
+}
+
+//! Build a fake previous transaction with an arbitrary scriptPubKey.
+inline CTransaction MakePrevTxScript(const CScript& scriptPubKey, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.nTime = 1700000000;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout.SetNull();
+    mtx.vin[0].scriptSig = CScript() << 0;
+    mtx.vout.push_back(CTxOut(amount, scriptPubKey));
+    return CTransaction(mtx);
+}
+
+//! Build an unsigned one-input spend of prevTx:0 paying amount to a fresh key.
+inline PartiallySignedTransaction MakeSpendPSGT(const CTransaction& prevTx, CAmount amount)
+{
+    CMutableTransaction mtx;
+    mtx.nVersion = 2;
+    mtx.nTime = 1700002000;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(prevTx.GetHash(), 0);
+    mtx.vout.push_back(CTxOut(amount, P2PKH(MakeKey().GetPubKey().GetID())));
+
+    PartiallySignedTransaction psgt(mtx);
+    psgt.inputs[0].non_witness_utxo = prevTx;
+    return psgt;
+}
+
+#endif // GRIDCOIN_TEST_PSGT_TEST_HELPERS_H

--- a/src/test/psgt_test_helpers.h
+++ b/src/test/psgt_test_helpers.h
@@ -14,6 +14,9 @@
 #include <vector>
 
 //! Shared builders for PSGT unit tests (psgt_tests, psgt_pool_tests).
+//! Namespaced so the very generic names (MakeKey/P2PKH/P2SH/...) do not leak
+//! into the global namespace of every translation unit that includes this.
+namespace psgt_test {
 
 inline CKey MakeKey()
 {
@@ -91,5 +94,7 @@ inline PartiallySignedTransaction MakeSpendPSGT(const CTransaction& prevTx, CAmo
     psgt.inputs[0].non_witness_utxo = prevTx;
     return psgt;
 }
+
+} // namespace psgt_test
 
 #endif // GRIDCOIN_TEST_PSGT_TEST_HELPERS_H

--- a/src/test/psgt_tests.cpp
+++ b/src/test/psgt_tests.cpp
@@ -18,6 +18,8 @@
 #include <util/strencodings.h>
 #include <version.h>
 
+using namespace psgt_test;
+
 BOOST_AUTO_TEST_SUITE(psgt_tests)
 
 // ---------------------------------------------------------------------------
@@ -322,6 +324,50 @@ BOOST_AUTO_TEST_CASE(wrong_magic_rejected)
     std::string error;
     BOOST_CHECK(!DecodeRawPSGT(psgt, b64, error));
     BOOST_CHECK(error.find("magic") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Test 10b: a crafted over-long compact-size length is rejected, not crashed.
+// The first global key length is a 0xFF-prefixed 2^64-1 compact size. The old
+// hand-rolled reader let pos+n wrap past its bounds check (OOB); the framework's
+// ReadCompactSize rejects it (> MAX_SIZE). Must return false without crashing.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(decode_overlong_length_rejected)
+{
+    std::vector<unsigned char> data = {0x70, 0x73, 0x67, 0x74, 0xff}; // PSGT magic
+    data.push_back(0xff);                                             // compact-size 8-byte marker
+    for (int i = 0; i < 8; ++i) data.push_back(0xff);                 // length = 2^64-1
+    PartiallySignedTransaction psgt;
+    std::string error;
+    BOOST_CHECK(!DecodePSGTBytes(psgt, data, error)); // no crash, no OOB
+}
+
+// ---------------------------------------------------------------------------
+// Test 10c: input larger than MAX_PSGT_WIRE_SIZE is rejected up front.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(decode_oversize_rejected)
+{
+    std::vector<unsigned char> data = {0x70, 0x73, 0x67, 0x74, 0xff}; // PSGT magic
+    data.resize(MAX_PSGT_WIRE_SIZE + 1, 0x00);
+    PartiallySignedTransaction psgt;
+    std::string error;
+    BOOST_CHECK(!DecodePSGTBytes(psgt, data, error));
+    BOOST_CHECK(error.find("maximum size") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Test 10d: a field length under ReadCompactSize's MAX_SIZE but larger than the
+// remaining data is rejected before any oversized allocation.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(decode_field_length_exceeds_data_rejected)
+{
+    std::vector<unsigned char> data = {0x70, 0x73, 0x67, 0x74, 0xff}; // PSGT magic
+    data.push_back(0xfe);                                             // 4-byte compact-size marker
+    data.push_back(0x00); data.push_back(0x00);
+    data.push_back(0x00); data.push_back(0x01);                      // length = 0x01000000 (~16 MB)
+    PartiallySignedTransaction psgt;
+    std::string error;
+    BOOST_CHECK(!DecodePSGTBytes(psgt, data, error)); // rejected, no ~16 MB allocation
 }
 
 // ---------------------------------------------------------------------------
@@ -1100,6 +1146,28 @@ BOOST_AUTO_TEST_CASE(verify_partial_sigs)
         auto& sig = corrupted.inputs[0].partial_sigs[fixture.k1.GetPubKey().GetID()];
         sig[sig.size() / 2] ^= 0x01;
         BOOST_CHECK(!VerifyPSGTPartialSigs(corrupted, valid, error));
+    }
+
+    // A signature that is valid ECDSA but non-canonically encoded (a superfluous
+    // leading zero on S) is accepted by CheckSig's lax DER parser yet fails
+    // strict DER, so the network's mandatory DERSIG would reject the finalized
+    // tx. VerifyPSGTPartialSigs must reject it (it would pass without the
+    // CheckSignatureEncoding gate).
+    {
+        PartiallySignedTransaction malleated = fixture.psgt;
+        auto& sig = malleated.inputs[0].partial_sigs[fixture.k1.GetPubKey().GetID()];
+        BOOST_REQUIRE(sig.size() > 6 && sig[0] == 0x30); // DER || hashtype
+        unsigned char hashtype = sig.back();
+        std::vector<unsigned char> der(sig.begin(), sig.end() - 1);
+        size_t rlen = der[3];
+        size_t s_len_pos = 4 + rlen + 1; // index of the S length byte
+        BOOST_REQUIRE(s_len_pos < der.size() && der[s_len_pos - 1] == 0x02);
+        der[1] += 1;                                     // total length += 1
+        der[s_len_pos] += 1;                             // S length += 1
+        der.insert(der.begin() + s_len_pos + 1, 0x00);  // superfluous leading zero on S
+        der.push_back(hashtype);
+        sig = der;
+        BOOST_CHECK(!VerifyPSGTPartialSigs(malleated, valid, error));
     }
 
     // An entry keyed by a non-member key fails.

--- a/src/test/psgt_tests.cpp
+++ b/src/test/psgt_tests.cpp
@@ -14,37 +14,11 @@
 #include <script/sign.h>
 #include <script/standard.h>
 #include <streams.h>
+#include <test/psgt_test_helpers.h>
 #include <util/strencodings.h>
 #include <version.h>
 
 BOOST_AUTO_TEST_SUITE(psgt_tests)
-
-static CKey MakeKey()
-{
-    CKey key;
-    key.MakeNewKey(true);
-    return key;
-}
-
-static CScript P2PKH(const CKeyID& id)
-{
-    CScript s;
-    s << OP_DUP << OP_HASH160 << id << OP_EQUALVERIFY << OP_CHECKSIG;
-    return s;
-}
-
-// Build a fake previous transaction that pays to the given key.
-static CTransaction MakePrevTx(const CKey& key, CAmount amount)
-{
-    CMutableTransaction mtx;
-    mtx.nVersion = 2;
-    mtx.nTime = 1700000000;
-    mtx.vin.resize(1);
-    mtx.vin[0].prevout.SetNull(); // coinbase-like
-    mtx.vin[0].scriptSig = CScript() << 0;
-    mtx.vout.push_back(CTxOut(amount, P2PKH(key.GetPubKey().GetID())));
-    return CTransaction(mtx);
-}
 
 // ---------------------------------------------------------------------------
 // Test 1: Create a PSGT, serialize, deserialize, verify round-trip.
@@ -742,48 +716,6 @@ BOOST_AUTO_TEST_CASE(hd_keypaths_roundtrip)
 // AnalyzePSGT tests.
 // ---------------------------------------------------------------------------
 
-static CScript P2SH(const CScriptID& id)
-{
-    CScript s;
-    s << OP_HASH160 << id << OP_EQUAL;
-    return s;
-}
-
-static CScript Multisig1of2(const CKey& key1, const CKey& key2)
-{
-    CScript s;
-    s << OP_1 << key1.GetPubKey() << key2.GetPubKey() << OP_2 << OP_CHECKMULTISIG;
-    return s;
-}
-
-// Build a fake previous transaction with an arbitrary scriptPubKey.
-static CTransaction MakePrevTxScript(const CScript& scriptPubKey, CAmount amount)
-{
-    CMutableTransaction mtx;
-    mtx.nVersion = 2;
-    mtx.nTime = 1700000000;
-    mtx.vin.resize(1);
-    mtx.vin[0].prevout.SetNull();
-    mtx.vin[0].scriptSig = CScript() << 0;
-    mtx.vout.push_back(CTxOut(amount, scriptPubKey));
-    return CTransaction(mtx);
-}
-
-// Build an unsigned one-input spend of prevTx:0 paying amount to a fresh key.
-static PartiallySignedTransaction MakeSpendPSGT(const CTransaction& prevTx, CAmount amount)
-{
-    CMutableTransaction mtx;
-    mtx.nVersion = 2;
-    mtx.nTime = 1700002000;
-    mtx.vin.resize(1);
-    mtx.vin[0].prevout = COutPoint(prevTx.GetHash(), 0);
-    mtx.vout.push_back(CTxOut(amount, P2PKH(MakeKey().GetPubKey().GetID())));
-
-    PartiallySignedTransaction psgt(mtx);
-    psgt.inputs[0].non_witness_utxo = prevTx;
-    return psgt;
-}
-
 // Test: unsigned P2PKH input — signer's turn, missing sig and pubkey,
 // fee/size/min-fee all computable.
 BOOST_AUTO_TEST_CASE(analyze_p2pkh_unsigned)
@@ -1004,6 +936,214 @@ BOOST_AUTO_TEST_CASE(analyze_error_precedence)
 
     BOOST_CHECK_EQUAL(analysis.error,
         "Input 0 spends a non-standard or unspendable output");
+}
+
+// ---------------------------------------------------------------------------
+// Phase II groundwork (#2910): bytes decoder, image helpers, partial-sig
+// verification.
+// ---------------------------------------------------------------------------
+
+// A funded 2-of-3 P2SH multisig spend with the redeem script attached --
+// the shape the PSGT pool operates on.
+struct Multisig2of3PSGT
+{
+    CKey k1, k2, k3;
+    CScript redeem;
+    PartiallySignedTransaction psgt;
+
+    Multisig2of3PSGT()
+        : k1(MakeKey()), k2(MakeKey()), k3(MakeKey())
+        , redeem(MultisigScript(2, {k1.GetPubKey(), k2.GetPubKey(), k3.GetPubKey()}))
+    {
+        CTransaction prevTx = MakePrevTxScript(P2SH(CScriptID(redeem)), 10 * COIN);
+        psgt = MakeSpendPSGT(prevTx, 9 * COIN);
+        psgt.inputs[0].redeem_script = redeem;
+    }
+
+    void Sign(const CKey& key)
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(key);
+        keystore.AddCScript(redeem);
+        BOOST_REQUIRE(SignPSGTInput(keystore, psgt, 0));
+    }
+};
+
+// Test: DecodePSGTBytes accepts what SerializePSGT produced, agrees with the
+// base64 path, and rejects corrupted magic.
+BOOST_AUTO_TEST_CASE(decode_bytes_matches_base64)
+{
+    Multisig2of3PSGT fixture;
+    fixture.Sign(fixture.k1);
+
+    const std::vector<unsigned char> data = SerializePSGT(fixture.psgt);
+
+    PartiallySignedTransaction from_bytes;
+    PartiallySignedTransaction from_base64;
+    std::string error;
+
+    BOOST_REQUIRE_MESSAGE(DecodePSGTBytes(from_bytes, data, error), error);
+    BOOST_REQUIRE_MESSAGE(
+        DecodeRawPSGT(from_base64, EncodeBase64(data.data(), data.size()), error), error);
+
+    BOOST_CHECK(SerializePSGT(from_bytes) == data);
+    BOOST_CHECK(SerializePSGT(from_base64) == data);
+
+    std::vector<unsigned char> bad_magic = data;
+    bad_magic[0] ^= 0x01;
+    PartiallySignedTransaction rejected;
+    BOOST_CHECK(!DecodePSGTBytes(rejected, bad_magic, error));
+    BOOST_CHECK_EQUAL(error, "Invalid PSGT magic bytes");
+}
+
+// Test: image = CScriptID(redeem_script) for a trustworthy P2SH multisig
+// input; non-P2SH inputs and untrustworthy redeem scripts have none.
+BOOST_AUTO_TEST_CASE(image_and_multisig_params)
+{
+    Multisig2of3PSGT fixture;
+
+    const std::optional<CScriptID> image = GetPSGTImage(fixture.psgt);
+    BOOST_REQUIRE(image.has_value());
+    BOOST_CHECK(*image == CScriptID(fixture.redeem));
+
+    int required = 0;
+    int total = 0;
+    BOOST_REQUIRE(GetPSGTMultisigParams(fixture.psgt, required, total));
+    BOOST_CHECK_EQUAL(required, 2);
+    BOOST_CHECK_EQUAL(total, 3);
+
+    // A P2PKH input has no image.
+    CKey plain = MakeKey();
+    PartiallySignedTransaction p2pkh = MakeSpendPSGT(MakePrevTx(plain, 10 * COIN), 9 * COIN);
+    BOOST_CHECK(!GetPSGTInputImage(p2pkh, 0).has_value());
+    BOOST_CHECK(!GetPSGTImage(p2pkh).has_value());
+
+    // A redeem script that does not hash to the funded script hash is not
+    // trusted, so the input has no image.
+    Multisig2of3PSGT lying;
+    lying.psgt.inputs[0].redeem_script = Multisig1of2(MakeKey(), MakeKey());
+    BOOST_CHECK(!GetPSGTInputImage(lying.psgt, 0).has_value());
+}
+
+// Test: a multi-input spend from the SAME multisig shares one image; inputs
+// from different multisig arrangements do not.
+BOOST_AUTO_TEST_CASE(image_multi_input)
+{
+    CKey k1 = MakeKey();
+    CKey k2 = MakeKey();
+    CKey k3 = MakeKey();
+    const CScript redeem_a = MultisigScript(2, {k1.GetPubKey(), k2.GetPubKey(), k3.GetPubKey()});
+    const CScript redeem_b = Multisig1of2(MakeKey(), MakeKey());
+
+    // Distinct amounts so the two funding transactions hash differently.
+    CTransaction prev1 = MakePrevTxScript(P2SH(CScriptID(redeem_a)), 10 * COIN);
+    CTransaction prev2 = MakePrevTxScript(P2SH(CScriptID(redeem_a)), 20 * COIN);
+    CTransaction prev_b = MakePrevTxScript(P2SH(CScriptID(redeem_b)), 30 * COIN);
+
+    const auto make_two_input_psgt = [](const CTransaction& first, const CTransaction& second,
+                                        const CScript& first_redeem, const CScript& second_redeem) {
+        CMutableTransaction mtx;
+        mtx.nVersion = 2;
+        mtx.nTime = 1700002000;
+        mtx.vin.resize(2);
+        mtx.vin[0].prevout = COutPoint(first.GetHash(), 0);
+        mtx.vin[1].prevout = COutPoint(second.GetHash(), 0);
+        mtx.vout.push_back(CTxOut(25 * COIN, P2PKH(MakeKey().GetPubKey().GetID())));
+
+        PartiallySignedTransaction psgt(mtx);
+        psgt.inputs[0].non_witness_utxo = first;
+        psgt.inputs[0].redeem_script = first_redeem;
+        psgt.inputs[1].non_witness_utxo = second;
+        psgt.inputs[1].redeem_script = second_redeem;
+        return psgt;
+    };
+
+    // Same arrangement on both inputs: one image.
+    PartiallySignedTransaction same = make_two_input_psgt(prev1, prev2, redeem_a, redeem_a);
+    const std::optional<CScriptID> image = GetPSGTImage(same);
+    BOOST_REQUIRE(image.has_value());
+    BOOST_CHECK(*image == CScriptID(redeem_a));
+
+    // Mixed arrangements: both inputs have an image, the PSGT does not.
+    PartiallySignedTransaction mixed = make_two_input_psgt(prev1, prev_b, redeem_a, redeem_b);
+    BOOST_CHECK(GetPSGTInputImage(mixed, 0).has_value());
+    BOOST_CHECK(GetPSGTInputImage(mixed, 1).has_value());
+    BOOST_CHECK(!GetPSGTImage(mixed).has_value());
+}
+
+// Test: VerifyPSGTPartialSigs verifies every signature cryptographically and
+// reports per-input signer sets; any invalid or foreign entry fails the whole
+// PSGT.
+BOOST_AUTO_TEST_CASE(verify_partial_sigs)
+{
+    Multisig2of3PSGT fixture;
+    fixture.Sign(fixture.k1);
+
+    std::vector<std::set<CKeyID>> valid;
+    std::string error;
+
+    BOOST_REQUIRE_MESSAGE(VerifyPSGTPartialSigs(fixture.psgt, valid, error), error);
+    BOOST_REQUIRE_EQUAL(valid.size(), 1u);
+    BOOST_CHECK_EQUAL(valid[0].size(), 1u);
+    BOOST_CHECK(valid[0].count(fixture.k1.GetPubKey().GetID()));
+
+    // Second signer: both keys now verify.
+    fixture.Sign(fixture.k2);
+    BOOST_REQUIRE_MESSAGE(VerifyPSGTPartialSigs(fixture.psgt, valid, error), error);
+    BOOST_CHECK_EQUAL(valid[0].size(), 2u);
+    BOOST_CHECK(valid[0].count(fixture.k2.GetPubKey().GetID()));
+
+    // A corrupted signature poisons the whole PSGT (CombinePSGTs would merge
+    // it silently; the pool must not).
+    {
+        PartiallySignedTransaction corrupted = fixture.psgt;
+        auto& sig = corrupted.inputs[0].partial_sigs[fixture.k1.GetPubKey().GetID()];
+        sig[sig.size() / 2] ^= 0x01;
+        BOOST_CHECK(!VerifyPSGTPartialSigs(corrupted, valid, error));
+    }
+
+    // An entry keyed by a non-member key fails.
+    {
+        PartiallySignedTransaction foreign = fixture.psgt;
+        foreign.inputs[0].partial_sigs[MakeKey().GetPubKey().GetID()] =
+            fixture.psgt.inputs[0].partial_sigs.begin()->second;
+        BOOST_CHECK(!VerifyPSGTPartialSigs(foreign, valid, error));
+    }
+
+    // Signatures without a verifiable signing context (no matching previous
+    // transaction) fail rather than being skipped.
+    {
+        PartiallySignedTransaction no_utxo = fixture.psgt;
+        no_utxo.inputs[0].non_witness_utxo = CTransaction();
+        BOOST_CHECK(!VerifyPSGTPartialSigs(no_utxo, valid, error));
+    }
+}
+
+// Test: PSGTSignedBy is keyed to the provider's own keys and tolerant of
+// other signers' garbage.
+BOOST_AUTO_TEST_CASE(psgt_signed_by)
+{
+    Multisig2of3PSGT fixture;
+    fixture.Sign(fixture.k1);
+
+    CBasicKeyStore holder1;
+    holder1.AddKey(fixture.k1);
+    CBasicKeyStore holder2;
+    holder2.AddKey(fixture.k2);
+
+    BOOST_CHECK(PSGTSignedBy(holder1, fixture.psgt));
+    BOOST_CHECK(!PSGTSignedBy(holder2, fixture.psgt));
+
+    // k2 signs; now both holders pass.
+    fixture.Sign(fixture.k2);
+    BOOST_CHECK(PSGTSignedBy(holder2, fixture.psgt));
+
+    // Corrupt k1's signature: holder1 no longer passes (presence under an
+    // owned key id is not enough), holder2 is unaffected.
+    auto& sig = fixture.psgt.inputs[0].partial_sigs[fixture.k1.GetPubKey().GetID()];
+    sig[sig.size() / 2] ^= 0x01;
+    BOOST_CHECK(!PSGTSignedBy(holder1, fixture.psgt));
+    BOOST_CHECK(PSGTSignedBy(holder2, fixture.psgt));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
First PR of the **PSGT Phase II** series (#2910 — in-band P2P relay for collaborative multisig signing). Pure library additions with **no behavior change** for existing callers; no P2P, no pool, no gating yet.

## What

- **`DecodePSGTBytes`** — splits `DecodeRawPSGT` so its transport-agnostic core (magic check + map parsing) is callable with raw bytes; the base64 entry point becomes a thin wrapper over it. The upcoming `psgt` network message carries raw `SerializePSGT` bytes, not base64. Adds `MAX_PSGT_WIRE_SIZE` (100 KB) as the size bound for untrusted sources.
- **`GetPSGTInputImage` / `GetPSGTImage`** — the multisig **image** = `CScriptID(redeem_script)` that #2910 keys the pool on. Returned only when the input context is trustworthy: the carried `non_witness_utxo` matches `prevout`, the funded output is P2SH, the redeem script hashes to the script hash that output commits to, and it decomposes as `CHECKMULTISIG`. The whole-PSGT variant requires **all inputs to share one arrangement** (multi-input spends from the same multisig address qualify; mixed-arrangement PSGTs stay on the Phase I out-of-band path).
- **`GetPSGTMultisigParams`** — m-of-n of the (single) image.
- **`VerifyPSGTPartialSigs`** — cryptographically verifies **every** carried partial signature via `CheckSig` and reports per-input valid-signer sets (the m-of-n progress). `partial_sigs` are untrusted after transport and `CombinePSGTs` (which merges without verifying), so pool acceptance must verify all of them — any unknown-key or invalid entry fails the whole PSGT.
- **`PSGTSignedBy`** — "some input carries a valid signature from a provider-owned key", tolerant of other signers' garbage. This hoists the Multisign dialog's `walletHasSignature` (the only in-tree cryptographic partial-sig check) into the core library, exactly as its doc comment anticipated (#3054 review); the dialog is now a thin call to it. It is the ">=1 valid own signature" gate the pool submit path (#2910) will use.
- **`src/test/psgt_test_helpers.h`** — the psgt_tests builders (keys, P2PKH/P2SH/multisig scripts, funded PSGTs), factored out verbatim for reuse by the upcoming `psgt_pool_tests`.

## Why the strict image rules

Per the revised #2910 design (after feedback in bitcoin/bitcoin#34968): the image is the redeem script **alone**, so pool capacity tracks real on-chain multisig usage. These helpers enforce that an attacker can't fake an image with a lying `non_witness_utxo` or an uncommitted redeem script.

## Testing

- 6 new unit tests: bytes/base64 decoder parity + corrupted magic; image extraction (valid 2-of-3, P2PKH has none, lying redeem script has none); multi-input same-image vs mixed-image; `VerifyPSGTPartialSigs` (1 then 2 signers, bit-flipped sig fails whole PSGT, non-member key fails, unverifiable context fails); `PSGTSignedBy` (owned-key keyed, tolerant of others' corruption).
- Full `test_gridcoin` and `test_gridcoin-qt` suites green; `test/functional/rpc_psgt.py` green; `git diff --check` clean.

## Series

PR A of the #2910 chain: **A (this)** → B (BlockV15Height + protocol 180330) → C (PSGT pool node module) → D (MSG_PSGT P2P relay) → E (pool RPCs + `-psgtnotify`) → F (Qt Pool view).