### PR TITLE
net: protocol 180330 + per-fork disconnect grace ladder (PSGT Phase II, PR B)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -50,6 +50,7 @@
 #include <boost/thread.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <ctime>
+#include <limits>
 #include <math.h>
 #include "wallet/wallet.h"
 
@@ -277,16 +278,30 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             return false;
         }
 
-        // Disconnect peers on old protocol versions after a grace period past the
-        // BlockV14Height activation height. Skip entirely if that fork is not yet
-        // activated (height == INT_MAX) to avoid signed integer overflow UB in the addition.
+        // Disconnect peers on protocol versions older than the newest activated
+        // block-version fork requires, after a grace period past that fork's
+        // activation height. A per-fork ladder rather than a single
+        // PROTOCOL_VERSION comparison so that bumping PROTOCOL_VERSION for a
+        // future fork (v15) neither cuts off peers that satisfy every activated
+        // fork nor loses the staged enforcement of earlier ones (v14). Each
+        // fork is skipped entirely while unscheduled (height == INT_MAX), also
+        // avoiding signed integer overflow UB in the addition.
         const int nLocalBestHeight = WITH_LOCK(cs_main, return pindexBest ? pindexBest->nHeight : 0);
+        const Consensus::Params& consensus = Params().GetConsensus();
+        const auto past_fork_grace = [&](int fork_height) {
+            // int64_t arithmetic: fork_height can come from a user-supplied
+            // -blockv15height near INT_MAX, where fork_height + grace would
+            // overflow signed int (UB). The != max() guard handles "unscheduled".
+            return fork_height != std::numeric_limits<int>::max()
+                && nLocalBestHeight > (int64_t)fork_height + consensus.ProtocolVersionGracePeriod;
+        };
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION
             || (DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD
-                && pfrom->nVersion < PROTOCOL_VERSION
-                && Params().GetConsensus().BlockV14Height != std::numeric_limits<int>::max()
-                && nLocalBestHeight > Params().GetConsensus().BlockV14Height
-                                             + Params().GetConsensus().ProtocolVersionGracePeriod
+                && ((pfrom->nVersion < V14_MIN_PROTO_VERSION && past_fork_grace(consensus.BlockV14Height))
+                    // Use GetBlockV15Height() (not the raw consensus field) so the
+                    // -blockv15height override that activates v15 early on
+                    // isolated-testnet/regtest also drives this disconnect rung.
+                    || (pfrom->nVersion < PROTOCOL_VERSION && past_fork_grace(GetBlockV15Height())))
                 )
             ) {
             // disconnect from peers older than this proto version

--- a/src/version.h
+++ b/src/version.h
@@ -9,12 +9,27 @@
 // network protocol versioning
 //
 //! The current protocol version
-static const int PROTOCOL_VERSION = 180329;
+static const int PROTOCOL_VERSION = 180330;
+
+//! Minimum protocol version required to gate PSGT pool relay (MSG_PSGT, #2910).
+//! The relay itself lands in a later PR of the Phase II chain; peers below this
+//! version will never be sent PSGT inventory once it does. This is a FIXED
+//! marker equal to the PROTOCOL_VERSION of the release that adds PSGT relay
+//! (180330, the block v15 minimum) and must NOT be changed to track future
+//! PROTOCOL_VERSION bumps -- a 180330 peer still supports PSGT relay regardless
+//! of later protocol versions. Hence the literal rather than an alias.
+static const int PSGT_PROTO_VERSION = 180330;
+
+//! Minimum protocol version required once the block v14 hard fork grace
+//! period has elapsed. Kept when PROTOCOL_VERSION moved on to 180330 (v15)
+//! so the staged v14 transition still disconnects pre-v14 peers without
+//! cutting off 180329 (v14-capable) peers.
+static const int V14_MIN_PROTO_VERSION = 180329;
 
 //! Note that there may be special logic implemented for
 //! a hard fork that actually disconnects nodes less than
-//! PROTOCOL_VERSION after grace period above the hard
-//! fork height. This is activated by setting the
+//! the version its fork height requires after a grace period above that
+//! height. This is activated by setting the
 //! DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD to true.
 static const bool DISCONNECT_OLD_VERSION_AFTER_GRACE_PERIOD = true;
 


### PR DESCRIPTION
Second PR of the **PSGT Phase II** series (#2910). Consensus/protocol scaffolding, **inert until v15 is scheduled**. Stacked on #3113 (PR A) — only the last commit is new here.

## What

- **`Consensus::Params::BlockV15Height`** — `INT_MAX` on mainnet/testnet (unscheduled), `0` on regtest so functional tests exercise v15 features immediately. The two AutoGreylist heights whose comments say *"TBD: set coincident with BlockV15Height"* stay as they are — scheduling all three together remains the future v15 fork omnibus's job (as does the miner/block `CURRENT_VERSION` bump — deliberately **not** in this series).
- **`IsV15Enabled(nHeight)`** with a `-blockv15height` hidden debug override (the `IsAutoGreylistDeepCopyEnabled` pattern) for isolated/public testnet testing ahead of activation; startup log line added.
- **Block-version enforcement ladder** in AcceptBlock extended with v15 on both branches (too-old and too-new). Inert: nothing mints `nVersion=15` blocks yet, and `IsV15Enabled` is false everywhere but regtest.
- **`PROTOCOL_VERSION` → 180330** and **`PSGT_PROTO_VERSION` = 180330** — the version PSGT inventory relay will be gated on (PR D): v15 nodes only announce `MSG_PSGT` to peers ≥ 180330.
- **Grace-period disconnect generalized to a per-fork ladder.** This is the subtle one. The existing check disconnects peers `< PROTOCOL_VERSION` past `BlockV14Height + grace`. Bumping `PROTOCOL_VERSION` alone would therefore have made upgraded nodes disconnect **180329 peers — the v14-mandatory version — once v14 activates**; re-anchoring the single check to v15 instead would have silently dropped the staged v14 enforcement. The ladder keeps both: `< V14_MIN_PROTO_VERSION (180329)` disconnects past v14+grace, `< PROTOCOL_VERSION` past v15+grace (unscheduled ⇒ skipped, same INT_MAX overflow guard as before).

## Testing

- Full `test_gridcoin` suite green; `test/functional/p2p_version_handshake.py` green with the bumped version.
- Behavior identical to `development` on mainnet/testnet params by inspection: v15 clauses all gate on `IsV15Enabled` = false / `INT_MAX` skip; v14 disconnect clause is byte-for-byte the old condition with 180329 in place of `PROTOCOL_VERSION` (same value today).

## Series

A #3113 → **B (this)** → C (PSGT pool node module) → D (MSG_PSGT P2P relay) → E (pool RPCs + `-psgtnotify`) → F (Qt Pool view).