### PR TITLE
node: add the PSGT pool — container, acceptance, replacement, eviction (#2910 Phase II, PR C)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,7 @@ add_library(gridcoin_util STATIC
     node/coherence.cpp
     node/mempool_persist.cpp
     node/orphan_blocks.cpp
+    node/psgt_pool.cpp
     node/ui_interface.cpp
     noui.cpp
     pbkdf2.cpp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -29,6 +29,7 @@
 #include "node/blockstorage.h"
 #include "node/coherence.h"
 #include "node/mempool_persist.h"
+#include "node/psgt_pool.h"
 #include <util/syserror.h>
 
 #include <openssl/crypto.h>
@@ -304,6 +305,7 @@ void Shutdown(void* parg)
         // SignalScheduler() earlier in Shutdown() already reset CMainSignals' internals and
         // disconnected every subscriber -- but keeping them makes the subscribers' lifetimes
         // self-contained and load-bearing again if that ordering is ever changed.
+        UnregisterValidationInterface(&g_psgt_pool);
         UnregisterValidationInterface(&g_ui_notification_bridge);
         UnregisterValidationInterface(pwalletMain);
         UnregisterWallet(pwalletMain);
@@ -1969,9 +1971,22 @@ bool AppInit2(ThreadHandlerPtr threads)
     // the Qt models keep receiving them (issue #3030, workstream B3).
     RegisterValidationInterface(&g_ui_notification_bridge);
 
+    // Subscribe the PSGT pool (#2910) to mempool/block events: pooled PSGTs
+    // whose inputs get spent are evicted on mempool admission (fast) and on
+    // block connection (authoritative).
+    RegisterValidationInterface(&g_psgt_pool);
+
     g_scheduler->scheduleEvery([]{
         g_banman->DumpBanlist();
     }, std::chrono::seconds{DUMP_BANS_INTERVAL});
+
+    // Periodically expire stale PSGT pool entries (EXPIRY_SECONDS). The pool's
+    // capacity self-healing -- slots reopen as PSGTs complete or expire -- relies
+    // on this running; without it, entries whose funding is never spent leak their
+    // slot permanently and a full pool would reject all new images indefinitely.
+    g_scheduler->scheduleEvery([]{
+        g_psgt_pool.EraseExpired(GetAdjustedTime());
+    }, std::chrono::minutes{5});
 
     // Periodically rebroadcast the node's own transactions still awaiting initial
     // broadcast (the unbroadcast set). Runs on the scheduler thread, which holds no

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -1,0 +1,592 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <node/psgt_pool.h>
+
+#include <consensus/validation.h>
+#include <dbwrapper.h>
+#include <hash.h>
+#include <index/txindex.h>
+#include <logging.h>
+#include <policy/fees.h>
+#include <tinyformat.h>
+#include <txmempool.h>
+#include <util.h>
+#include <validation.h>
+
+#include <algorithm>
+#include <cassert>
+
+PSGTPool g_psgt_pool;
+
+std::string PSGTRemovalReasonToString(PSGTRemovalReason reason)
+{
+    switch (reason) {
+    case PSGTRemovalReason::EXPIRED:          return "expired";
+    case PSGTRemovalReason::REPLACED:         return "replaced";
+    case PSGTRemovalReason::COMPLETED:        return "completed";
+    case PSGTRemovalReason::CONFLICT_MEMPOOL: return "conflict-mempool";
+    case PSGTRemovalReason::CONFLICT_BLOCK:   return "conflict-block";
+    case PSGTRemovalReason::LOCAL_REMOVE:     return "removed";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+    return "";
+}
+
+std::string PSGTPoolRejectToString(PSGTPoolReject reject)
+{
+    switch (reject) {
+    case PSGTPoolReject::NONE:         return "none";
+    case PSGTPoolReject::TOO_LARGE:    return "too-large";
+    case PSGTPoolReject::MALFORMED:    return "malformed";
+    case PSGTPoolReject::STRUCTURAL:   return "structural";
+    case PSGTPoolReject::INVALID_SIG:  return "invalid-signature";
+    case PSGTPoolReject::NO_VALID_SIG: return "no-valid-signature";
+    case PSGTPoolReject::COMPLETE:     return "complete";
+    case PSGTPoolReject::UTXO_MISSING: return "utxo-missing";
+    case PSGTPoolReject::UTXO_SPENT:   return "utxo-spent";
+    case PSGTPoolReject::FEE_TOO_LOW:  return "fee-too-low";
+    case PSGTPoolReject::FEE_ABSURD:   return "fee-absurd";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+    return "";
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+//! Reject fees above this multiple of the relay minimum as user error.
+static constexpr int MAX_POOL_FEE_MULTIPLIER = 100;
+
+//! Is the funding output available from this node's point of view? The
+//! embedded funding transaction is already hash-authenticated against
+//! prevout.hash, so existence and unspentness are the only chain facts left
+//! to establish: unspent in the transaction index (confirmed funding) or
+//! present in the mempool (unconfirmed funding), and in either case not
+//! spent by a mempool transaction.
+static PSGTPoolReject CheckFundingOutput(const COutPoint& prevout, CTxDB& txdb, std::string& error)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    {
+        LOCK(mempool.cs);
+
+        if (mempool.mapNextTx.count(prevout)) {
+            error = strprintf("funding output %s:%u is spent by a mempool transaction",
+                              prevout.hash.ToString(), prevout.n);
+            return PSGTPoolReject::UTXO_SPENT;
+        }
+
+        if (mempool.exists(prevout.hash)) {
+            return PSGTPoolReject::NONE; // unconfirmed funding, unspent
+        }
+    }
+
+    CTxIndex txindex;
+    if (!txdb.ReadTxIndex(prevout.hash, txindex)) {
+        error = strprintf("funding transaction %s is unknown (not in chain or mempool)",
+                          prevout.hash.ToString());
+        return PSGTPoolReject::UTXO_MISSING;
+    }
+
+    if (prevout.n >= txindex.vSpent.size()) {
+        error = strprintf("funding output %s:%u does not exist on chain",
+                          prevout.hash.ToString(), prevout.n);
+        return PSGTPoolReject::UTXO_MISSING;
+    }
+
+    if (!txindex.vSpent[prevout.n].IsNull()) {
+        error = strprintf("funding output %s:%u is already spent on chain",
+                          prevout.hash.ToString(), prevout.n);
+        return PSGTPoolReject::UTXO_SPENT;
+    }
+
+    return PSGTPoolReject::NONE;
+}
+
+PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
+                                   int64_t now,
+                                   PSGTPoolEntry& out_entry,
+                                   std::string& error)
+{
+    AssertLockHeld(cs_main);
+
+    // Decode into a pristine entry: DecodePSGTBytes fills psgt incrementally,
+    // so state left over from a previous validation of a reused out_entry
+    // (e.g. partial_sigs surviving an inputs.resize to the same count) would
+    // otherwise leak into this one.
+    out_entry = PSGTPoolEntry{};
+
+    if (wire_bytes.size() > MAX_PSGT_WIRE_SIZE) {
+        error = strprintf("PSGT of %zu bytes exceeds the %zu byte limit",
+                          wire_bytes.size(), static_cast<size_t>(MAX_PSGT_WIRE_SIZE));
+        return PSGTPoolReject::TOO_LARGE;
+    }
+
+    PartiallySignedTransaction& psgt = out_entry.psgt;
+    if (!DecodePSGTBytes(psgt, wire_bytes, error)) {
+        return PSGTPoolReject::MALFORMED;
+    }
+
+    const CTransaction tx(psgt.tx);
+
+    if (tx.nVersion < 2) {
+        error = "legacy transaction version";
+        return PSGTPoolReject::STRUCTURAL;
+    }
+
+    CValidationState state;
+    if (!CheckTransaction(tx, state)) {
+        error = "unsigned transaction fails CheckTransaction";
+        return PSGTPoolReject::STRUCTURAL;
+    }
+
+    if (psgt.inputs.size() != tx.vin.size() || psgt.outputs.size() != tx.vout.size()) {
+        error = "PSGT input/output count does not match unsigned transaction";
+        return PSGTPoolReject::STRUCTURAL;
+    }
+
+    for (const PSGTInput& input : psgt.inputs) {
+        if (!input.final_script_sig.empty()) {
+            error = "pool holds partially signed material only; finalized "
+                    "inputs belong in a broadcast transaction";
+            return PSGTPoolReject::STRUCTURAL;
+        }
+    }
+
+    const std::optional<CScriptID> image = GetPSGTImage(psgt);
+    if (!image) {
+        error = "not a single-arrangement P2SH multisig spend (every input "
+                "must carry its matching funding transaction and a redeem "
+                "script committed to by the funded output, all for the same "
+                "multisig arrangement)";
+        return PSGTPoolReject::STRUCTURAL;
+    }
+
+    int sigs_required = 0;
+    int sigs_total = 0;
+    if (!GetPSGTMultisigParams(psgt, sigs_required, sigs_total)) {
+        error = "cannot recover m-of-n multisig parameters";
+        return PSGTPoolReject::STRUCTURAL;
+    }
+
+    if (!VerifyPSGTPartialSigs(psgt, out_entry.valid_keys_per_input, error)) {
+        return PSGTPoolReject::INVALID_SIG;
+    }
+
+    int min_valid_sigs = sigs_total;
+    for (const std::set<CKeyID>& keys : out_entry.valid_keys_per_input) {
+        min_valid_sigs = std::min<int>(min_valid_sigs, keys.size());
+    }
+
+    // The anti-spam floor of #2910: nobody puts a PSGT on the network without
+    // proving they are a party to it (the ValidateMRC principle).
+    if (min_valid_sigs < 1) {
+        error = "every input must carry at least one valid partial signature";
+        return PSGTPoolReject::NO_VALID_SIG;
+    }
+
+    // A PSGT with m valid signatures everywhere needs no co-signers: it should
+    // be finalized and broadcast as a transaction, and nodes must not race to
+    // finalize other people's PSGTs from the pool.
+    if (min_valid_sigs >= sigs_required) {
+        error = "already fully signed; finalize and broadcast as a transaction";
+        return PSGTPoolReject::COMPLETE;
+    }
+
+    // One CTxDB for the whole PSGT rather than constructing one per input.
+    CTxDB txdb("r");
+    for (const CTxIn& txin : tx.vin) {
+        const PSGTPoolReject utxo_result = CheckFundingOutput(txin.prevout, txdb, error);
+        if (utxo_result != PSGTPoolReject::NONE) {
+            return utxo_result;
+        }
+    }
+
+    // Fee sanity. The funding amounts come from the hash-verified embedded
+    // funding transactions, so AnalyzePSGT's fee is trustworthy here; its
+    // estimated final size prices the fully signed transaction.
+    const PSGTAnalysis analysis = AnalyzePSGT(psgt);
+    if (!analysis.fee || !analysis.estimated_final_size) {
+        error = "fee or final size not computable";
+        return PSGTPoolReject::STRUCTURAL;
+    }
+
+    const CAmount min_fee = GetMinFee(tx, 1000, GMF_RELAY, *analysis.estimated_final_size);
+    if (*analysis.fee < min_fee) {
+        error = strprintf("fee %s below the relay minimum %s for an estimated "
+                          "final size of %u bytes",
+                          FormatMoney(*analysis.fee), FormatMoney(min_fee),
+                          *analysis.estimated_final_size);
+        return PSGTPoolReject::FEE_TOO_LOW;
+    }
+
+    if (*analysis.fee > MAX_POOL_FEE_MULTIPLIER * min_fee) {
+        error = strprintf("fee %s is more than %d times the relay minimum %s; "
+                          "rejecting as probable user error",
+                          FormatMoney(*analysis.fee), MAX_POOL_FEE_MULTIPLIER,
+                          FormatMoney(min_fee));
+        return PSGTPoolReject::FEE_ABSURD;
+    }
+
+    out_entry.serialized = wire_bytes;
+    out_entry.revision_hash = Hash(wire_bytes);
+    out_entry.image = *image;
+    out_entry.tx_hash = tx.GetHash();
+    out_entry.time_received = now;
+    out_entry.valid_sigs = min_valid_sigs;
+    out_entry.sigs_required = sigs_required;
+    out_entry.sigs_total = sigs_total;
+    out_entry.fee = *analysis.fee;
+
+    error.clear();
+    return PSGTPoolReject::NONE;
+}
+
+// ---------------------------------------------------------------------------
+// Pool container
+// ---------------------------------------------------------------------------
+
+PSGTPoolAddResult PSGTPool::Add(PSGTPoolEntry&& entry, std::string& reject_reason)
+{
+    std::optional<PSGTPoolEntry> accepted;
+    PSGTPoolChangeType change = PSGTPoolChangeType::ADDED;
+    PSGTPoolAddResult result;
+
+    {
+        LOCK(cs_psgt_pool);
+
+        const int64_t now = entry.time_received;
+
+        if (m_by_revision.count(entry.revision_hash)
+            || m_recently_removed.count(entry.revision_hash)) {
+            reject_reason = "already have this revision";
+            return PSGTPoolAddResult::DUPLICATE;
+        }
+
+        const auto existing_it = m_by_image.find(entry.image);
+
+        if (existing_it == m_by_image.end()) {
+            if (m_by_image.size() >= MAX_ENTRIES) {
+                // Reject, never evict: slots open as PSGTs complete or
+                // expire, and the submitter gets a clear try-again-later
+                // signal instead of silently killing someone else's
+                // in-progress signing session.
+                reject_reason = "PSGT pool is full; try again later";
+                return PSGTPoolAddResult::REJECTED_POOL_FULL;
+            }
+
+            // First entry for this image: whoever holds a valid signature on
+            // it is recorded as the initiator for the image's lifetime.
+            entry.initiator_keys.clear();
+            for (const std::set<CKeyID>& keys : entry.valid_keys_per_input) {
+                entry.initiator_keys.insert(keys.begin(), keys.end());
+            }
+
+            accepted = entry;
+            InsertInternal(std::move(entry));
+            result = PSGTPoolAddResult::ACCEPTED_NEW;
+            change = PSGTPoolChangeType::ADDED;
+        } else {
+            const PSGTPoolEntry& existing = existing_it->second;
+
+            if (entry.tx_hash == existing.tx_hash) {
+                // Same unsigned transaction: accept only signature progress.
+                // Compare valid-signer SETS, not signature bytes -- ECDSA
+                // signatures are malleable and re-signing produces different
+                // bytes for the same authorization.
+                // Same unsigned tx => same input count, so the per-input signer
+                // vectors must match in length. Guard defensively before indexing
+                // existing[i] by entry's size, so a future call-site bug or a
+                // malformed synthetic entry rejects rather than reading OOB.
+                if (existing.valid_keys_per_input.size() != entry.valid_keys_per_input.size()) {
+                    reject_reason = "per-input signer vector size mismatch for same transaction";
+                    return PSGTPoolAddResult::REJECTED_NOT_BETTER;
+                }
+                bool superset = true;
+                bool strictly_larger = false;
+                for (size_t i = 0; i < entry.valid_keys_per_input.size(); ++i) {
+                    const std::set<CKeyID>& have = existing.valid_keys_per_input[i];
+                    const std::set<CKeyID>& offered = entry.valid_keys_per_input[i];
+                    if (!std::includes(offered.begin(), offered.end(),
+                                       have.begin(), have.end())) {
+                        superset = false;
+                        break;
+                    }
+                    if (offered.size() > have.size()) {
+                        strictly_larger = true;
+                    }
+                }
+
+                if (!superset) {
+                    reject_reason = "does not carry every signature of the pooled revision";
+                    return PSGTPoolAddResult::REJECTED_NOT_BETTER;
+                }
+                if (!strictly_larger) {
+                    reject_reason = "no new signatures over the pooled revision";
+                    return PSGTPoolAddResult::DUPLICATE;
+                }
+            } else {
+                // Different unsigned transaction: only the original initiator
+                // may supersede (change destination/amount/fee). Their valid
+                // signature over the NEW transaction on every input is the
+                // authorization; co-signatures legitimately drop off.
+                bool initiator_signed = false;
+                for (const CKeyID& keyid : existing.initiator_keys) {
+                    bool on_every_input = true;
+                    for (const std::set<CKeyID>& keys : entry.valid_keys_per_input) {
+                        if (!keys.count(keyid)) {
+                            on_every_input = false;
+                            break;
+                        }
+                    }
+                    if (on_every_input) {
+                        initiator_signed = true;
+                        break;
+                    }
+                }
+
+                if (!initiator_signed) {
+                    reject_reason = "supersedes the pooled transaction without a "
+                                    "valid signature from its initiator";
+                    return PSGTPoolAddResult::REJECTED_NOT_INITIATOR;
+                }
+            }
+
+            entry.initiator_keys = existing.initiator_keys;
+            EraseInternal(entry.image, now);
+            accepted = entry;
+            InsertInternal(std::move(entry));
+            result = PSGTPoolAddResult::ACCEPTED_REPLACEMENT;
+            change = PSGTPoolChangeType::UPDATED;
+        }
+    }
+
+    if (accepted) {
+        LogPrint(BCLog::LogFlags::MEMPOOL,
+                 "psgtpool: %s image %s revision %s (%d/%d signatures)",
+                 change == PSGTPoolChangeType::ADDED ? "accepted" : "replaced",
+                 accepted->image.ToString(), accepted->revision_hash.ToString(),
+                 accepted->valid_sigs, accepted->sigs_required);
+        Notify(*accepted, change, std::nullopt);
+    }
+
+    reject_reason.clear();
+    return result;
+}
+
+bool PSGTPool::Remove(const CScriptID& image, PSGTRemovalReason reason)
+{
+    std::optional<PSGTPoolEntry> removed;
+
+    {
+        LOCK(cs_psgt_pool);
+        removed = EraseInternal(image, GetAdjustedTime());
+    }
+
+    if (!removed) {
+        return false;
+    }
+
+    LogPrint(BCLog::LogFlags::MEMPOOL, "psgtpool: removed image %s (%s)",
+             image.ToString(), PSGTRemovalReasonToString(reason));
+    Notify(*removed, PSGTPoolChangeType::REMOVED, reason);
+    return true;
+}
+
+std::optional<PSGTPoolEntry> PSGTPool::Get(const CScriptID& image) const
+{
+    LOCK(cs_psgt_pool);
+
+    const auto it = m_by_image.find(image);
+    if (it == m_by_image.end()) return std::nullopt;
+    return it->second;
+}
+
+std::optional<PSGTPoolEntry> PSGTPool::GetByRevision(const uint256& revision_hash) const
+{
+    LOCK(cs_psgt_pool);
+
+    const auto it = m_by_revision.find(revision_hash);
+    if (it == m_by_revision.end()) return std::nullopt;
+    const auto img = m_by_image.find(it->second);
+    if (img == m_by_image.end()) return std::nullopt;
+    return img->second;
+}
+
+std::optional<PSGTPoolEntry> PSGTPool::GetByTxHash(const uint256& tx_hash) const
+{
+    LOCK(cs_psgt_pool);
+
+    const auto it = m_by_txhash.find(tx_hash);
+    if (it == m_by_txhash.end()) return std::nullopt;
+    const auto img = m_by_image.find(it->second);
+    if (img == m_by_image.end()) return std::nullopt;
+    return img->second;
+}
+
+bool PSGTPool::HaveRevision(const uint256& revision_hash) const
+{
+    LOCK(cs_psgt_pool);
+    return m_by_revision.count(revision_hash) || m_recently_removed.count(revision_hash);
+}
+
+std::vector<PSGTPoolEntry> PSGTPool::GetAll() const
+{
+    LOCK(cs_psgt_pool);
+
+    std::vector<PSGTPoolEntry> entries;
+    entries.reserve(m_by_image.size());
+    for (const auto& [image, entry] : m_by_image) {
+        entries.push_back(entry);
+    }
+    return entries;
+}
+
+size_t PSGTPool::EraseExpired(int64_t now)
+{
+    std::vector<PSGTPoolEntry> expired;
+
+    {
+        LOCK(cs_psgt_pool);
+
+        std::vector<CScriptID> images;
+        for (const auto& [image, entry] : m_by_image) {
+            if (now - entry.time_received > EXPIRY_SECONDS) {
+                images.push_back(image);
+            }
+        }
+        for (const CScriptID& image : images) {
+            if (auto entry = EraseInternal(image, now)) {
+                expired.push_back(std::move(*entry));
+            }
+        }
+    }
+
+    for (const PSGTPoolEntry& entry : expired) {
+        LogPrint(BCLog::LogFlags::MEMPOOL, "psgtpool: expired image %s",
+                 entry.image.ToString());
+        Notify(entry, PSGTPoolChangeType::REMOVED, PSGTRemovalReason::EXPIRED);
+    }
+
+    return expired.size();
+}
+
+size_t PSGTPool::Size() const
+{
+    LOCK(cs_psgt_pool);
+    return m_by_image.size();
+}
+
+void PSGTPool::Clear()
+{
+    LOCK(cs_psgt_pool);
+    m_by_image.clear();
+    m_by_revision.clear();
+    m_by_txhash.clear();
+    m_by_prevout.clear();
+    m_recently_removed.clear();
+}
+
+void PSGTPool::TransactionAddedToMempool(const CTransactionRef& tx)
+{
+    EvictConflicts(*tx, PSGTRemovalReason::CONFLICT_MEMPOOL);
+}
+
+void PSGTPool::BlockConnected(const CBlock& block, int /*height*/)
+{
+    for (const CTransaction& tx : block.vtx) {
+        EvictConflicts(tx, PSGTRemovalReason::CONFLICT_BLOCK);
+    }
+}
+
+void PSGTPool::EvictConflicts(const CTransaction& tx, PSGTRemovalReason reason)
+{
+    std::vector<PSGTPoolEntry> evicted;
+
+    {
+        LOCK(cs_psgt_pool);
+
+        const int64_t now = GetAdjustedTime();
+        std::set<CScriptID> images;
+        for (const CTxIn& txin : tx.vin) {
+            const auto it = m_by_prevout.find(txin.prevout);
+            if (it != m_by_prevout.end()) {
+                images.insert(it->second);
+            }
+        }
+        for (const CScriptID& image : images) {
+            if (auto entry = EraseInternal(image, now)) {
+                evicted.push_back(std::move(*entry));
+            }
+        }
+    }
+
+    for (const PSGTPoolEntry& entry : evicted) {
+        LogPrint(BCLog::LogFlags::MEMPOOL,
+                 "psgtpool: evicted image %s (%s, input spent by %s)",
+                 entry.image.ToString(), PSGTRemovalReasonToString(reason),
+                 tx.GetHash().ToString());
+        Notify(entry, PSGTPoolChangeType::REMOVED, reason);
+    }
+}
+
+std::optional<PSGTPoolEntry> PSGTPool::EraseInternal(const CScriptID& image, int64_t now)
+{
+    const auto it = m_by_image.find(image);
+    if (it == m_by_image.end()) {
+        return std::nullopt;
+    }
+
+    PSGTPoolEntry entry = std::move(it->second);
+    m_by_image.erase(it);
+    m_by_revision.erase(entry.revision_hash);
+    m_by_txhash.erase(entry.tx_hash);
+    for (const CTxIn& txin : entry.psgt.tx.vin) {
+        m_by_prevout.erase(txin.prevout);
+    }
+    RecordRemoved(entry.revision_hash, now);
+    return entry;
+}
+
+void PSGTPool::InsertInternal(PSGTPoolEntry&& entry)
+{
+    m_by_revision[entry.revision_hash] = entry.image;
+    m_by_txhash[entry.tx_hash] = entry.image;
+    for (const CTxIn& txin : entry.psgt.tx.vin) {
+        m_by_prevout[txin.prevout] = entry.image;
+    }
+    const CScriptID image = entry.image;
+    m_by_image.insert_or_assign(image, std::move(entry));
+}
+
+void PSGTPool::RecordRemoved(const uint256& revision_hash, int64_t now)
+{
+    // TTL prune, then a hard cap as a safety net (evict oldest).
+    for (auto it = m_recently_removed.begin(); it != m_recently_removed.end();) {
+        if (now - it->second > RECENTLY_REMOVED_TTL) {
+            it = m_recently_removed.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    while (m_recently_removed.size() >= MAX_RECENTLY_REMOVED) {
+        auto oldest = m_recently_removed.begin();
+        for (auto it = m_recently_removed.begin(); it != m_recently_removed.end(); ++it) {
+            if (it->second < oldest->second) oldest = it;
+        }
+        m_recently_removed.erase(oldest);
+    }
+
+    m_recently_removed[revision_hash] = now;
+}
+
+void PSGTPool::Notify(const PSGTPoolEntry& entry, PSGTPoolChangeType change,
+                      std::optional<PSGTRemovalReason> reason) const
+{
+    if (m_notify_hook) {
+        m_notify_hook(entry, change, reason);
+    }
+}

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_NODE_PSGT_POOL_H
+#define GRIDCOIN_NODE_PSGT_POOL_H
+
+#include <amount.h>
+#include <main.h>
+#include <psgt.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <sync.h>
+#include <uint256.h>
+#include <validationinterface.h>
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+//!
+//! \brief The in-band PSGT pool (issue #2910): pending partially signed
+//! multisig transactions relayed through the network so co-signers can find,
+//! review, sign and rebroadcast them without out-of-band coordination.
+//!
+//! Identity model:
+//!  - Every pooled PSGT has an \b image = CScriptID(redeem_script) -- the
+//!    multisig arrangement alone, NOT destinations or amounts. There is at
+//!    most ONE active PSGT per image, so pool capacity is bounded by the
+//!    number of distinct multisig arrangements actually funded on-chain,
+//!    which an attacker cannot inflate for free.
+//!  - The relay identity of a specific revision is its \b revision hash =
+//!    Hash(serialized wire bytes). Adding a co-signature does not change the
+//!    unsigned transaction's hash, so tx-hash inventory would never
+//!    propagate signature progress; every mutation produces a fresh
+//!    revision hash and therefore a fresh inv.
+//!
+
+//! Why a pooled PSGT was removed.
+enum class PSGTRemovalReason
+{
+    EXPIRED,          //!< Older than EXPIRY_SECONDS.
+    REPLACED,         //!< Superseded by a better revision of the same image.
+    COMPLETED,        //!< Finalized locally into a broadcast transaction.
+    CONFLICT_MEMPOOL, //!< An input was spent by a transaction accepted to the mempool.
+    CONFLICT_BLOCK,   //!< An input was confirmed spent by a connected block.
+    LOCAL_REMOVE,     //!< Explicitly removed by the local user (RPC/GUI).
+};
+
+//! Human-readable removal reason (for logs, RPC and notifications).
+std::string PSGTRemovalReasonToString(PSGTRemovalReason reason);
+
+//! How the pool changed, for the notification hook.
+enum class PSGTPoolChangeType
+{
+    ADDED,   //!< New image accepted.
+    UPDATED, //!< Existing image replaced by a better/initiator revision.
+    REMOVED, //!< Entry left the pool (see PSGTRemovalReason).
+};
+
+//! Result of PSGTPool::Add.
+enum class PSGTPoolAddResult
+{
+    ACCEPTED_NEW,          //!< First entry for this image.
+    ACCEPTED_REPLACEMENT,  //!< Replaced the existing entry for this image.
+    DUPLICATE,             //!< Already have this revision (or it was just removed); no-op.
+    REJECTED_POOL_FULL,    //!< Pool at capacity and this is a new image.
+    REJECTED_NOT_BETTER,   //!< Same unsigned tx but not a strict signature superset.
+    REJECTED_NOT_INITIATOR,//!< Different unsigned tx without a valid initiator signature.
+};
+
+//! A pooled PSGT together with everything validation established about it.
+//! Produced by ValidatePSGTForPool in production; outside of unit tests that
+//! exercise container semantics with synthetic entries, do not hand-build one
+//! for Add() (its invariants are otherwise unchecked).
+struct PSGTPoolEntry
+{
+    PartiallySignedTransaction psgt;
+    std::vector<unsigned char> serialized; //!< Exact wire bytes (getdata serving; hashed for revision).
+    uint256 revision_hash;                 //!< Hash(serialized) -- the inv/relay identity.
+    CScriptID image;                       //!< CScriptID(redeem script) -- the pool key.
+    uint256 tx_hash;                       //!< Hash of the unsigned transaction.
+    int64_t time_received = 0;
+
+    //! Key ids holding a cryptographically valid partial signature, per input
+    //! (VerifyPSGTPartialSigs output). Basis of the replacement rules.
+    std::vector<std::set<CKeyID>> valid_keys_per_input;
+
+    //! Key ids that signed the FIRST entry ever accepted for this image.
+    //! Carried forward verbatim across replacements; a valid signature by one
+    //! of these keys over a *different* unsigned tx authorizes the initiator
+    //! to supersede the pending PSGT (change destination/amount/fee) even
+    //! though co-signatures drop off.
+    std::set<CKeyID> initiator_keys;
+
+    int valid_sigs = 0;     //!< Minimum per-input count of valid signatures.
+    int sigs_required = 0;  //!< m of the m-of-n arrangement.
+    int sigs_total = 0;     //!< n of the m-of-n arrangement.
+    CAmount fee = 0;        //!< sum(inputs) - sum(outputs), from the hash-verified funding txs.
+};
+
+//! Why ValidatePSGTForPool rejected a candidate. Ordered roughly by the
+//! validation pipeline. The P2P layer maps these to misbehavior scores; the
+//! RPC layer maps them to error strings.
+enum class PSGTPoolReject
+{
+    NONE,         //!< Valid; out_entry is filled.
+    TOO_LARGE,    //!< Wire size above MAX_PSGT_WIRE_SIZE.
+    MALFORMED,    //!< Does not decode as a PSGT.
+    STRUCTURAL,   //!< Decodes, but is not a well-formed single-image P2SH multisig spend.
+    INVALID_SIG,  //!< Carries a cryptographically invalid or foreign partial signature.
+    NO_VALID_SIG, //!< Some input has no valid partial signature (anti-spam floor).
+    COMPLETE,     //!< Already has m valid signatures on every input; belongs in a tx, not the pool.
+    UTXO_MISSING, //!< A funding transaction is unknown to this node (chain + mempool).
+    UTXO_SPENT,   //!< A funding output is already spent (chain or mempool).
+    FEE_TOO_LOW,  //!< Below the relay minimum for the estimated final size.
+    FEE_ABSURD,   //!< Implausibly high; almost certainly user error.
+};
+
+//! Human-readable reject reason (for logs and RPC errors).
+std::string PSGTPoolRejectToString(PSGTPoolReject reject);
+
+//!
+//! \brief Validate a PSGT received from an untrusted source (network relay or
+//! local submission) and fill a pool entry from it.
+//!
+//! Checks, cheap to expensive: wire size; decode; basic transaction sanity
+//! (CheckTransaction, version >= 2, no finalized inputs); single-image P2SH
+//! multisig structure across ALL inputs (GetPSGTImage's trustworthiness
+//! rules); cryptographic verification of EVERY partial signature with at
+//! least one valid signature on every input, and fewer than m so the pool
+//! only holds material that still needs co-signers; funding outputs exist
+//! unspent in the chain or mempool (the embedded funding transactions are
+//! hash-authenticated by prevout, so existence and unspentness are the only
+//! chain facts to establish); and fee within [relay minimum, 100x relay
+//! minimum] for the estimated final size.
+//!
+//! Requires cs_main (chain/mempool lookups). Does NOT check IsV15Enabled or
+//! sync state -- those are the caller's (P2P handler / RPC) admission gates.
+//!
+PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
+                                   int64_t now,
+                                   PSGTPoolEntry& out_entry,
+                                   std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+//!
+//! \brief Bounded, expiring container of pending PSGTs, one per image.
+//!
+//! Locking: a dedicated leaf mutex. Lock order is cs_main -> cs_psgt_pool;
+//! nothing that takes cs_main, the connection manager's node mutex, or
+//! cs_wallet may be called while holding it. The notification hook and any
+//! relay always fire AFTER the lock is released (though possibly still under
+//! the caller's cs_main, as the eviction callbacks run under it).
+//!
+//! The two CValidationInterface overrides implement the UTXO-conflict
+//! eviction triggers of #2910: mempool admission (fast, near-simultaneous
+//! network-wide) and block connection (authoritative). They are public so
+//! tests can drive them directly; in production they are invoked through
+//! CMainSignals after RegisterValidationInterface in init.
+//!
+class PSGTPool final : public CValidationInterface
+{
+public:
+    //! Maximum entries. Reached only if this many distinct funded multisig
+    //! arrangements have a PSGT in flight at once; new images are REJECTED
+    //! when full (no eviction of someone else's in-progress signing session);
+    //! replacements of existing images are not growth and still accepted.
+    static constexpr size_t MAX_ENTRIES = 100;
+
+    //! Time-based expiry: covers timezone gaps, weekends, travel. The
+    //! initiator can always resubmit (they retain the PSGT locally).
+    static constexpr int64_t EXPIRY_SECONDS = 7 * 24 * 60 * 60;
+
+    //! How long removed revision hashes keep answering "already have" so a
+    //! completed/evicted/replaced revision is neither re-fetched from lagging
+    //! peers nor re-admitted by gossip. A NEW revision of the same image is
+    //! unaffected (keyed by revision, not image).
+    static constexpr int64_t RECENTLY_REMOVED_TTL = 60 * 60;
+
+    //! Hard cap on the recently-removed set (safety net; TTL is the normal bound).
+    static constexpr size_t MAX_RECENTLY_REMOVED = 1000;
+
+    //! Notification hook, fired outside the pool lock for every mutation.
+    //! For REMOVED changes the removal reason is provided. Wired to the
+    //! uiInterface signal and -psgtnotify by the RPC/notification layer;
+    //! unset (and skipped) until then.
+    std::function<void(const PSGTPoolEntry&, PSGTPoolChangeType,
+                       std::optional<PSGTRemovalReason>)> m_notify_hook;
+
+    //! Add a validated entry, applying the one-per-image replacement rules:
+    //!  - unknown image: accepted (unless the pool is full);
+    //!  - same image, same unsigned tx: accepted iff the valid-signer sets
+    //!    are a superset on every input and strictly larger on at least one
+    //!    (signature progress). Signer SETS are compared, not signature
+    //!    bytes: ECDSA signatures are malleable and re-signing produces
+    //!    different bytes for the same authorization.
+    //!  - same image, different unsigned tx: accepted iff some initiator key
+    //!    has a valid signature on EVERY input of the replacement
+    //!    (initiator-privileged supersede).
+    //! initiator_keys are snapshotted from the first accepted entry and
+    //! carried forward on every replacement.
+    PSGTPoolAddResult Add(PSGTPoolEntry&& entry, std::string& reject_reason);
+
+    //! Remove the entry for an image. Returns false if not present.
+    bool Remove(const CScriptID& image, PSGTRemovalReason reason);
+
+    std::optional<PSGTPoolEntry> Get(const CScriptID& image) const;
+    std::optional<PSGTPoolEntry> GetByRevision(const uint256& revision_hash) const;
+    std::optional<PSGTPoolEntry> GetByTxHash(const uint256& tx_hash) const;
+
+    //! True if the revision is pooled OR was recently removed (relay
+    //! damping: recently completed/evicted revisions read as "already have").
+    bool HaveRevision(const uint256& revision_hash) const;
+
+    //! Snapshot of all entries (RPC/GUI listing, connect-time advertisement).
+    std::vector<PSGTPoolEntry> GetAll() const;
+
+    //! Evict entries older than EXPIRY_SECONDS. Returns the number evicted.
+    size_t EraseExpired(int64_t now);
+
+    size_t Size() const;
+    void Clear();
+
+    //! Eviction trigger 1: a transaction entered the local mempool; any
+    //! pooled PSGT spending one of its inputs is dead (locally observed
+    //! double spend -- or, commonly, the completed PSGT itself arriving as a
+    //! transaction, which is how completion propagates network-wide).
+    void TransactionAddedToMempool(const CTransactionRef& tx) override;
+
+    //! Eviction trigger 2 (authoritative): a connected block spent an input.
+    void BlockConnected(const CBlock& block, int height) override;
+
+private:
+    mutable CCriticalSection cs_psgt_pool;
+
+    std::map<CScriptID, PSGTPoolEntry> m_by_image GUARDED_BY(cs_psgt_pool);
+    std::map<uint256, CScriptID> m_by_revision GUARDED_BY(cs_psgt_pool);
+    std::map<uint256, CScriptID> m_by_txhash GUARDED_BY(cs_psgt_pool);
+    //! One image per prevout: a P2SH output belongs to exactly one arrangement
+    //! and each arrangement has at most one pooled PSGT.
+    std::map<COutPoint, CScriptID> m_by_prevout GUARDED_BY(cs_psgt_pool);
+    //! Removed revision hash -> removal time (TTL-pruned, hard-capped).
+    std::map<uint256, int64_t> m_recently_removed GUARDED_BY(cs_psgt_pool);
+
+    //! Erase an entry from every index and record its revision as recently
+    //! removed. Returns the entry (for post-lock notification).
+    std::optional<PSGTPoolEntry> EraseInternal(const CScriptID& image, int64_t now)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_psgt_pool);
+
+    //! Insert an entry into every index (image slot must be free).
+    void InsertInternal(PSGTPoolEntry&& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_psgt_pool);
+
+    //! TTL-prune and cap m_recently_removed, then record a removal.
+    void RecordRemoved(const uint256& revision_hash, int64_t now)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_psgt_pool);
+
+    //! Shared body of the two eviction triggers.
+    void EvictConflicts(const CTransaction& tx, PSGTRemovalReason reason);
+
+    //! Fire m_notify_hook if set (call with the lock RELEASED).
+    void Notify(const PSGTPoolEntry& entry, PSGTPoolChangeType change,
+                std::optional<PSGTRemovalReason> reason) const;
+};
+
+//! Global PSGT pool. Registered as a validation-interface subscriber in init.
+extern PSGTPool g_psgt_pool;
+
+#endif // GRIDCOIN_NODE_PSGT_POOL_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(test_gridcoin
     netbase_tests.cpp
     net_tests.cpp
     orphan_block_tests.cpp
+    psgt_pool_tests.cpp
     psgt_tests.cpp
     # Qt-free transaction filter/sort core (src/qt/txfilter.cpp) + its unit
     # suite. The core has zero Qt dependencies, so it compiles into the

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -1,0 +1,465 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include <key.h>
+#include <keystore.h>
+#include <main.h>
+#include <node/psgt_pool.h>
+#include <policy/fees.h>
+#include <primitives/transaction.h>
+#include <psgt.h>
+#include <test/psgt_test_helpers.h>
+#include <test/test_gridcoin.h>
+#include <txmempool.h>
+
+#include <optional>
+#include <vector>
+
+using namespace psgt_test;
+
+BOOST_AUTO_TEST_SUITE(psgt_pool_tests)
+
+//! Register a transaction with the global mempool so the pool's funding-output
+//! check (chain-or-mempool existence, mapNextTx spentness) can see it. The
+//! mock txdb is empty in unit tests, so mempool residence is how funding
+//! transactions are made visible.
+static void AddToMempool(const CTransaction& tx)
+{
+    LOCK(mempool.cs);
+    mempool.addUnchecked(tx.GetHash(),
+                         CTxMemPoolEntry(tx, 0, 1700000000, 1,
+                                         ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
+}
+
+//! A mempool-funded 2-of-3 P2SH multisig spend: the shape the pool accepts.
+//! The unsigned PSGT is kept pristine; Signed() returns signed copies so one
+//! fixture can produce competing revisions.
+struct FundedMultisig
+{
+    CKey k1, k2, k3;
+    CScript redeem;
+    CTransaction funding;
+    PartiallySignedTransaction unsigned_psgt;
+
+    //! 0.01 GRC fee by default: above the v2 relay minimum (0.001 GRC/kB
+    //! for sub-kB transactions), below the 100x absurd-fee ceiling.
+    explicit FundedMultisig(CAmount fee = 1000000)
+        : k1(MakeKey()), k2(MakeKey()), k3(MakeKey())
+        , redeem(MultisigScript(2, {k1.GetPubKey(), k2.GetPubKey(), k3.GetPubKey()}))
+        , funding(MakePrevTxScript(P2SH(CScriptID(redeem)), 10 * COIN))
+    {
+        AddToMempool(funding);
+
+        CMutableTransaction mtx;
+        mtx.nVersion = 2;
+        mtx.nTime = 1700002000;
+        mtx.vin.resize(1);
+        mtx.vin[0].prevout = COutPoint(funding.GetHash(), 0);
+        mtx.vout.push_back(CTxOut(10 * COIN - fee, P2PKH(MakeKey().GetPubKey().GetID())));
+
+        unsigned_psgt = PartiallySignedTransaction(mtx);
+        unsigned_psgt.inputs[0].non_witness_utxo = funding;
+        unsigned_psgt.inputs[0].redeem_script = redeem;
+    }
+
+    PartiallySignedTransaction Signed(const std::vector<CKey>& keys) const
+    {
+        PartiallySignedTransaction psgt = unsigned_psgt;
+        for (const CKey& key : keys) {
+            CBasicKeyStore keystore;
+            keystore.AddKey(key);
+            keystore.AddCScript(redeem);
+            BOOST_REQUIRE(SignPSGTInput(keystore, psgt, 0));
+        }
+        return psgt;
+    }
+
+    //! A spend of the same funding output to a different destination/amount
+    //! (a superseding transaction the initiator might submit).
+    PartiallySignedTransaction Superseding(CAmount fee, const std::vector<CKey>& keys) const
+    {
+        CMutableTransaction mtx = unsigned_psgt.tx;
+        mtx.vout[0] = CTxOut(10 * COIN - fee, P2PKH(MakeKey().GetPubKey().GetID()));
+
+        PartiallySignedTransaction psgt(mtx);
+        psgt.inputs[0].non_witness_utxo = funding;
+        psgt.inputs[0].redeem_script = redeem;
+
+        PartiallySignedTransaction result = psgt;
+        for (const CKey& key : keys) {
+            CBasicKeyStore keystore;
+            keystore.AddKey(key);
+            keystore.AddCScript(redeem);
+            BOOST_REQUIRE(SignPSGTInput(keystore, result, 0));
+        }
+        return result;
+    }
+};
+
+static PSGTPoolReject Validate(const PartiallySignedTransaction& psgt,
+                               PSGTPoolEntry& entry, std::string& error)
+{
+    LOCK(cs_main);
+    return ValidatePSGTForPool(SerializePSGT(psgt), 1700003000, entry, error);
+}
+
+//! A synthetic entry with a unique image, for container-semantics tests that
+//! do not need the cryptographic pipeline (pool-full, expiry).
+static PSGTPoolEntry SyntheticEntry(int64_t time_received)
+{
+    PSGTPoolEntry entry;
+    entry.revision_hash = InsecureRand256();
+    entry.image = CScriptID(uint160(InsecureRandBytes(20)));
+    entry.tx_hash = InsecureRand256();
+    entry.time_received = time_received;
+    entry.valid_keys_per_input.push_back({CKeyID(uint160(InsecureRandBytes(20)))});
+    entry.valid_sigs = 1;
+    entry.sigs_required = 2;
+    entry.sigs_total = 3;
+    return entry;
+}
+
+// ---------------------------------------------------------------------------
+// ValidatePSGTForPool
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(validate_accepts_partially_signed_multisig)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+
+    PSGTPoolEntry entry;
+    std::string error;
+    BOOST_REQUIRE_MESSAGE(
+        Validate(fixture.Signed({fixture.k1}), entry, error) == PSGTPoolReject::NONE, error);
+
+    BOOST_CHECK(entry.image == CScriptID(fixture.redeem));
+    BOOST_CHECK(entry.tx_hash == CTransaction(fixture.unsigned_psgt.tx).GetHash());
+    BOOST_CHECK_EQUAL(entry.valid_sigs, 1);
+    BOOST_CHECK_EQUAL(entry.sigs_required, 2);
+    BOOST_CHECK_EQUAL(entry.sigs_total, 3);
+    BOOST_CHECK_EQUAL(entry.fee, 1000000);
+    BOOST_CHECK(!entry.serialized.empty());
+    BOOST_CHECK(entry.revision_hash == Hash(entry.serialized));
+}
+
+BOOST_AUTO_TEST_CASE(validate_reject_matrix)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+
+    PSGTPoolEntry entry;
+    std::string error;
+
+    // No signature at all: the anti-spam floor.
+    BOOST_CHECK(Validate(fixture.unsigned_psgt, entry, error) == PSGTPoolReject::NO_VALID_SIG);
+
+    // A corrupted signature poisons the PSGT.
+    {
+        PartiallySignedTransaction corrupted = fixture.Signed({fixture.k1});
+        auto& sig = corrupted.inputs[0].partial_sigs.begin()->second;
+        sig[sig.size() / 2] ^= 0x01;
+        BOOST_CHECK(Validate(corrupted, entry, error) == PSGTPoolReject::INVALID_SIG);
+    }
+
+    // Complete (2-of-3 with 2 valid sigs): belongs in a transaction, not the pool.
+    BOOST_CHECK(Validate(fixture.Signed({fixture.k1, fixture.k2}), entry, error)
+                == PSGTPoolReject::COMPLETE);
+
+    // Not multisig: a plain P2PKH spend has no image.
+    {
+        CKey plain = MakeKey();
+        CTransaction prev = MakePrevTx(plain, 10 * COIN);
+        AddToMempool(prev);
+        PartiallySignedTransaction p2pkh = MakeSpendPSGT(prev, 10 * COIN - 1000000);
+        BOOST_CHECK(Validate(p2pkh, entry, error) == PSGTPoolReject::STRUCTURAL);
+    }
+
+    // Unknown funding transaction (not in mempool, mock txdb is empty).
+    {
+        FundedMultisig unknown;
+        // mempool.remove() takes a const ref and locks mempool.cs internally.
+        mempool.remove(unknown.funding);
+        const PSGTPoolReject r = Validate(unknown.Signed({unknown.k1}), entry, error);
+        BOOST_CHECK_MESSAGE(r == PSGTPoolReject::UTXO_MISSING,
+                            PSGTPoolRejectToString(r) + ": " + error);
+    }
+
+    // Funding output already spent by a mempool transaction.
+    {
+        FundedMultisig spent;
+        CMutableTransaction spender;
+        spender.nVersion = 2;
+        spender.nTime = 1700002500;
+        spender.vin.resize(1);
+        spender.vin[0].prevout = COutPoint(spent.funding.GetHash(), 0);
+        spender.vin[0].scriptSig = CScript() << 0;
+        spender.vout.push_back(CTxOut(10 * COIN - 1000000, P2PKH(MakeKey().GetPubKey().GetID())));
+        AddToMempool(CTransaction(spender));
+        BOOST_CHECK(Validate(spent.Signed({spent.k1}), entry, error)
+                    == PSGTPoolReject::UTXO_SPENT);
+    }
+
+    // Fee bounds.
+    {
+        FundedMultisig cheap(1000); // 0.00001 GRC: below the v2 relay minimum
+        BOOST_CHECK(Validate(cheap.Signed({cheap.k1}), entry, error)
+                    == PSGTPoolReject::FEE_TOO_LOW);
+
+        FundedMultisig lavish(1 * COIN); // 100x the ~0.001 GRC minimum and then some
+        BOOST_CHECK(Validate(lavish.Signed({lavish.k1}), entry, error)
+                    == PSGTPoolReject::FEE_ABSURD);
+    }
+
+    // Oversize and malformed wire bytes.
+    {
+        LOCK(cs_main);
+        std::vector<unsigned char> huge(MAX_PSGT_WIRE_SIZE + 1, 0x00);
+        BOOST_CHECK(ValidatePSGTForPool(huge, 1700003000, entry, error)
+                    == PSGTPoolReject::TOO_LARGE);
+
+        std::vector<unsigned char> garbage = {0xde, 0xad, 0xbe, 0xef};
+        BOOST_CHECK(ValidatePSGTForPool(garbage, 1700003000, entry, error)
+                    == PSGTPoolReject::MALFORMED);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PSGTPool: add / replace / initiator rules
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pool_add_and_signature_progress)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+    PSGTPool pool;
+    std::string error;
+    std::string reject;
+
+    PSGTPoolEntry one_sig;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k1}), one_sig, error) == PSGTPoolReject::NONE);
+    const uint256 first_revision = one_sig.revision_hash;
+
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(one_sig), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+    BOOST_CHECK_EQUAL(pool.Size(), 1u);
+    BOOST_CHECK(pool.Get(one_sig.image).has_value());
+    BOOST_CHECK(pool.GetByRevision(first_revision).has_value());
+    BOOST_CHECK(pool.GetByTxHash(one_sig.tx_hash).has_value());
+    BOOST_CHECK(pool.HaveRevision(first_revision));
+
+    // The first signer is recorded as the initiator.
+    const std::set<CKeyID> expected_initiator{fixture.k1.GetPubKey().GetID()};
+    BOOST_CHECK(pool.Get(one_sig.image)->initiator_keys == expected_initiator);
+
+    // Same revision again: duplicate gossip, no-op.
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(one_sig), reject) == PSGTPoolAddResult::DUPLICATE);
+
+    // A co-signer's revision with k1+k2: strict superset, replaces.
+    // (2-of-3 with both sigs is COMPLETE for validation, so build the entry
+    // for this container test by amending the validated one-sig entry the way
+    // the signing path will: re-validate a k1+k3 pair is still incomplete...
+    // it is not -- any two of three completes. Amend manually instead.)
+    PSGTPoolEntry two_sigs = one_sig;
+    {
+        PartiallySignedTransaction psgt = fixture.Signed({fixture.k1, fixture.k2});
+        two_sigs.psgt = psgt;
+        two_sigs.serialized = SerializePSGT(psgt);
+        two_sigs.revision_hash = Hash(two_sigs.serialized);
+        two_sigs.valid_keys_per_input[0].insert(fixture.k2.GetPubKey().GetID());
+        two_sigs.valid_sigs = 2;
+    }
+
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(two_sigs), reject)
+                == PSGTPoolAddResult::ACCEPTED_REPLACEMENT);
+    BOOST_CHECK_EQUAL(pool.Size(), 1u);
+    BOOST_CHECK_EQUAL(pool.Get(one_sig.image)->valid_sigs, 2);
+
+    // Initiator survives the replacement.
+    BOOST_CHECK(pool.Get(one_sig.image)->initiator_keys == expected_initiator);
+
+    // The replaced revision is remembered: not listed, but "already have",
+    // and re-adding it is a no-op rather than a downgrade fight.
+    BOOST_CHECK(!pool.GetByRevision(first_revision).has_value());
+    BOOST_CHECK(pool.HaveRevision(first_revision));
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(one_sig), reject) == PSGTPoolAddResult::DUPLICATE);
+
+    // A k2-only revision of the same tx is not a superset: rejected.
+    PSGTPoolEntry k2_only;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k2}), k2_only, error) == PSGTPoolReject::NONE);
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(k2_only), reject)
+                == PSGTPoolAddResult::REJECTED_NOT_BETTER);
+}
+
+BOOST_AUTO_TEST_CASE(pool_initiator_supersede)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+    PSGTPool pool;
+    std::string error;
+    std::string reject;
+
+    PSGTPoolEntry original;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k1}), original, error) == PSGTPoolReject::NONE);
+    BOOST_REQUIRE(pool.Add(PSGTPoolEntry(original), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    // A different unsigned tx signed only by a co-signer (k2): not the
+    // initiator, rejected even though the signature is valid.
+    PSGTPoolEntry hijack;
+    BOOST_REQUIRE(Validate(fixture.Superseding(3000000, {fixture.k2}), hijack, error)
+                  == PSGTPoolReject::NONE);
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(hijack), reject)
+                == PSGTPoolAddResult::REJECTED_NOT_INITIATOR);
+
+    // The initiator (k1) revises destination/fee: accepted although it
+    // carries no more signatures than the pooled entry, and the initiator
+    // set is carried forward.
+    PSGTPoolEntry revised;
+    BOOST_REQUIRE(Validate(fixture.Superseding(2000000, {fixture.k1}), revised, error)
+                  == PSGTPoolReject::NONE);
+    BOOST_CHECK(pool.Add(PSGTPoolEntry(revised), reject)
+                == PSGTPoolAddResult::ACCEPTED_REPLACEMENT);
+
+    const auto pooled = pool.Get(original.image);
+    BOOST_REQUIRE(pooled.has_value());
+    BOOST_CHECK(pooled->tx_hash == revised.tx_hash);
+    BOOST_CHECK(pooled->initiator_keys
+                == std::set<CKeyID>{fixture.k1.GetPubKey().GetID()});
+}
+
+// ---------------------------------------------------------------------------
+// PSGTPool: capacity, expiry, eviction
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE(pool_full_rejects_new_images_but_not_replacements)
+{
+    PSGTPool pool;
+    std::string reject;
+
+    PSGTPoolEntry first = SyntheticEntry(1700003000);
+    BOOST_REQUIRE(pool.Add(PSGTPoolEntry(first), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    for (size_t i = 1; i < PSGTPool::MAX_ENTRIES; ++i) {
+        BOOST_REQUIRE(pool.Add(SyntheticEntry(1700003000), reject)
+                      == PSGTPoolAddResult::ACCEPTED_NEW);
+    }
+    BOOST_CHECK_EQUAL(pool.Size(), PSGTPool::MAX_ENTRIES);
+
+    // A new image is rejected -- never evict someone's signing session.
+    BOOST_CHECK(pool.Add(SyntheticEntry(1700003000), reject)
+                == PSGTPoolAddResult::REJECTED_POOL_FULL);
+
+    // A signature-progress replacement of an existing image is not growth
+    // and is still accepted at capacity.
+    PSGTPoolEntry progress = first;
+    progress.revision_hash = InsecureRand256();
+    progress.valid_keys_per_input[0].insert(CKeyID(uint160(InsecureRandBytes(20))));
+    progress.valid_sigs = 2;
+    BOOST_CHECK(pool.Add(std::move(progress), reject)
+                == PSGTPoolAddResult::ACCEPTED_REPLACEMENT);
+    BOOST_CHECK_EQUAL(pool.Size(), PSGTPool::MAX_ENTRIES);
+}
+
+BOOST_AUTO_TEST_CASE(pool_expiry)
+{
+    PSGTPool pool;
+    std::string reject;
+
+    const int64_t now = 1700003000;
+    BOOST_REQUIRE(pool.Add(SyntheticEntry(now - PSGTPool::EXPIRY_SECONDS - 1), reject)
+                  == PSGTPoolAddResult::ACCEPTED_NEW);
+    BOOST_REQUIRE(pool.Add(SyntheticEntry(now - 60), reject)
+                  == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    BOOST_CHECK_EQUAL(pool.EraseExpired(now), 1u);
+    BOOST_CHECK_EQUAL(pool.Size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(pool_utxo_conflict_eviction)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+    PSGTPool pool;
+    std::string error;
+    std::string reject;
+
+    // Capture notifications to check the eviction reason surfaces.
+    std::vector<std::pair<PSGTPoolChangeType, std::optional<PSGTRemovalReason>>> events;
+    pool.m_notify_hook = [&](const PSGTPoolEntry&, PSGTPoolChangeType change,
+                             std::optional<PSGTRemovalReason> reason) {
+        events.emplace_back(change, reason);
+    };
+
+    PSGTPoolEntry entry;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k1}), entry, error) == PSGTPoolReject::NONE);
+    const CScriptID image = entry.image;
+    const uint256 revision = entry.revision_hash;
+    BOOST_REQUIRE(pool.Add(std::move(entry), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    // A transaction spending the PSGT's input enters the mempool (in the
+    // common case, the completed PSGT itself): evict immediately.
+    CMutableTransaction spender;
+    spender.nVersion = 2;
+    spender.nTime = 1700002500;
+    spender.vin.resize(1);
+    spender.vin[0].prevout = COutPoint(fixture.funding.GetHash(), 0);
+    spender.vin[0].scriptSig = CScript() << 0;
+    spender.vout.push_back(CTxOut(10 * COIN - 1000000, P2PKH(MakeKey().GetPubKey().GetID())));
+
+    pool.TransactionAddedToMempool(MakeTransactionRef(CTransaction(spender)));
+
+    BOOST_CHECK_EQUAL(pool.Size(), 0u);
+    BOOST_CHECK(!pool.Get(image).has_value());
+    BOOST_CHECK(pool.HaveRevision(revision)); // recently-removed damping
+
+    BOOST_REQUIRE_EQUAL(events.size(), 2u); // ADDED + REMOVED
+    BOOST_CHECK(events[1].first == PSGTPoolChangeType::REMOVED);
+    BOOST_REQUIRE(events[1].second.has_value());
+    BOOST_CHECK(*events[1].second == PSGTRemovalReason::CONFLICT_MEMPOOL);
+
+    // Block-connect path: fresh entry, same spender confirmed in a block.
+    PSGTPoolEntry again;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k2}), again, error) == PSGTPoolReject::NONE);
+    BOOST_REQUIRE(pool.Add(std::move(again), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    CBlock block;
+    block.vtx.push_back(CTransaction(spender));
+    pool.BlockConnected(block, 100);
+
+    BOOST_CHECK_EQUAL(pool.Size(), 0u);
+    BOOST_REQUIRE_EQUAL(events.size(), 4u);
+    BOOST_REQUIRE(events[3].second.has_value());
+    BOOST_CHECK(*events[3].second == PSGTRemovalReason::CONFLICT_BLOCK);
+
+    // A transaction spending unrelated outputs is a no-op.
+    PSGTPoolEntry third;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k3}), third, error) == PSGTPoolReject::NONE);
+    BOOST_REQUIRE(pool.Add(std::move(third), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    CMutableTransaction unrelated = spender;
+    unrelated.vin[0].prevout = COutPoint(InsecureRand256(), 0);
+    pool.TransactionAddedToMempool(MakeTransactionRef(CTransaction(unrelated)));
+    BOOST_CHECK_EQUAL(pool.Size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(pool_local_remove)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+    PSGTPool pool;
+    std::string error;
+    std::string reject;
+
+    PSGTPoolEntry entry;
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k1}), entry, error) == PSGTPoolReject::NONE);
+    const CScriptID image = entry.image;
+    BOOST_REQUIRE(pool.Add(std::move(entry), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    BOOST_CHECK(pool.Remove(image, PSGTRemovalReason::LOCAL_REMOVE));
+    BOOST_CHECK_EQUAL(pool.Size(), 0u);
+    BOOST_CHECK(!pool.Remove(image, PSGTRemovalReason::LOCAL_REMOVE));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Third PR of the **PSGT Phase II** series (#2910): the pool itself. Stacked on #3113 (A) and #3114 (B) — only the last commit is new. No P2P or RPC surface yet; that's PRs D and E. Nothing constructs or feeds the pool in production code in this PR, so runtime behavior is unchanged (init registers an empty subscriber).

## Design highlights (all per the issue; deviations called out)

- **One PSGT per image** (`CScriptID(redeem_script)`): capacity tracks real funded multisig arrangements. `MAX_ENTRIES = 100`, **reject-when-full** (never evict someone else's in-progress session; replacements are not growth and stay accepted at capacity), **7-day expiry**.
- **Revision-hash relay identity** — one deliberate refinement to the issue text: the inv/getdata identity is `Hash(wire bytes)`, not the unsigned tx hash. Adding a co-signature doesn't change the tx hash, so tx-hash inventory would hit `AlreadyHave == true` everywhere and signature progress could never propagate. The by-txhash index the issue asks for is still there (RPC lookups); by-image stays primary; by-prevout drives eviction.
- **Admission pipeline** (`ValidatePSGTForPool`, cheap→expensive): size cap → decode → `CheckTransaction`/version/no-finalized-inputs → single-image P2SH multisig structure (PR A's trustworthiness rules) → **cryptographic verification of every partial signature** with ≥1 valid per input (the `ValidateMRC` principle) **and fewer than m** (a complete PSGT belongs in a transaction; nodes must not race to finalize other people's PSGTs) → funding outputs exist **unspent** in chain (`CTxIndex.vSpent`) or mempool (`mapNextTx`) — the embedded funding txs are hash-authenticated by prevout, so existence/unspentness are the only chain facts left to establish → fee in `[GetMinFee(GMF_RELAY, est_final_size), 100×]`.
- **Replacement rules**: same-tx → valid-**signer-set** superset per input, strictly larger somewhere (sets, not bytes — ECDSA malleability); different-tx → valid signature by an **initiator key on every input** (initiator set snapshotted at first acceptance, carried forward verbatim). Implicit cancellation per the issue: to change destination/amount/fee the initiator just submits a new PSGT.
- **UTXO-conflict eviction**: `CValidationInterface` subscriber (registered in init next to the wallet) — `TransactionAddedToMempool` (fast; also how a completed PSGT's broadcast cleans up peers' pools network-wide) and `BlockConnected` (authoritative). Both fire the same notification seam with the removal reason.
- **Recently-removed damping** (TTL'd, capped): removed revisions answer "already have" and refuse re-admission, so completed/superseded revisions don't bounce back from lagging peers; a *new* revision of the same image is unaffected (keyed by revision, not image).
- **Locking**: dedicated leaf mutex, order `cs_main → cs_psgt_pool`; nothing that takes cs_main/wallet/net locks runs under it; notifications fire after it's released. The eviction callbacks run under the caller's cs_main per the CValidationInterface contract.

## Testing

7 new unit tests (`psgt_pool_tests`, reusing PR A's `psgt_test_helpers.h`; funding txs live in the test mempool so the real existence/spentness path is exercised): acceptance + entry fields; the reject matrix (no-sig, corrupted sig, complete, non-multisig, unknown funding, mempool-spent funding, fee too low/absurd, oversize, malformed); signature-progress replacement incl. initiator carry-forward, recently-removed re-add, non-superset rejection; initiator supersede vs co-signer hijack; pool-full semantics; expiry boundary; both eviction triggers with notification reasons + unrelated-tx no-op; local remove.

Full `test_gridcoin` suite green; `git diff --check` clean.

One fix surfaced by the tests worth reviewer attention: `ValidatePSGTForPool` resets its output entry before decoding — `DecodePSGTBytes` fills a `PartiallySignedTransaction` incrementally, so validating into a reused object would let prior state (e.g. `partial_sigs` surviving an `inputs.resize()` to the same count) leak into the next validation.

## Series

A #3113 → B #3114 → **C (this)** → D (MSG_PSGT P2P relay) → E (pool RPCs + `-psgtnotify`) → F (Qt Pool view).