### PR TITLE
p2p: relay PSGT pool entries via MSG_PSGT inv/getdata (#2910 Phase II, PR D)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2145,10 +2145,12 @@ void CConnman::ForEachNodeUnderLock(const std::function<void(CNode*)>& func) con
     }
 }
 
-void CConnman::RelayInventory(const CInv& inv)
+void CConnman::RelayInventory(const CInv& inv, int min_proto_version)
 {
-    ForEachNode([&inv](CNode* pnode) {
-        pnode->PushInventory(inv);
+    ForEachNode([&inv, min_proto_version](CNode* pnode) {
+        if (pnode->nVersion >= min_proto_version) {
+            pnode->PushInventory(inv);
+        }
     });
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -95,6 +95,7 @@ enum
     MSG_BLOCK,
     MSG_PART,
     MSG_SCRAPERINDEX,
+    MSG_PSGT,
 };
 
 
@@ -709,8 +710,10 @@ public:
     void ForEachNodeUnderLock(const std::function<void(CNode*)>& func) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Relay an inventory item to every node (issue #2558 PR 9c; replaces the
-    //! free RelayInventory shim).
-    void RelayInventory(const CInv& inv);
+    //! free RelayInventory shim). When min_proto_version is set, only peers
+    //! whose negotiated protocol version is at least that value are told --
+    //! used for object types older peers cannot handle (e.g. MSG_PSGT, #2910).
+    void RelayInventory(const CInv& inv, int min_proto_version = 0);
 
     //! Relay an address to a deterministic, limited subset of nodes (issue #2558
     //! PR 9c; moved from net_processing's ADDR handler).

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -572,9 +572,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion >= PSGT_PROTO_VERSION
             && WITH_LOCK(cs_main, return IsV15Enabled(nBestHeight) && !OutOfSyncByAge()))
         {
-            for (const auto& entry : g_psgt_pool.GetAll())
+            for (const uint256& revision_hash : g_psgt_pool.GetAllRevisionHashes())
             {
-                pfrom->PushInventory(CInv(MSG_PSGT, entry.revision_hash));
+                pfrom->PushInventory(CInv(MSG_PSGT, revision_hash));
             }
         }
 
@@ -835,12 +835,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // budget so a single getdata cannot force unbounded sends.
                     if (!OutOfSyncByAge() && psgt_served < MAX_PSGT_PER_GETDATA)
                     {
-                        if (const auto entry = g_psgt_pool.GetByRevision(inv.hash))
+                        if (const auto serialized = g_psgt_pool.GetSerializedByRevision(inv.hash))
                         {
                             ++psgt_served;
                             CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                            ss.reserve(entry->serialized.size() + 16);
-                            ss << entry->serialized;
+                            ss.reserve(serialized->size() + 16);
+                            ss << *serialized;
                             pfrom->PushMessage(NetMsgType::PSGT, ss);
                         }
                     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -288,7 +288,7 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
     PSGTPoolEntry entry;
     std::string reason;
     const PSGTPoolReject reject =
-        ValidatePSGTForPool(wire_bytes, GetAdjustedTime(), entry, reason);
+        ValidatePSGTForPool(g_psgt_pool, wire_bytes, GetAdjustedTime(), entry, reason);
 
     switch (reject) {
     case PSGTPoolReject::NONE:
@@ -305,7 +305,14 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
               pfrom->addr.ToString(), PSGTPoolRejectToString(reject), reason);
         return;
 
-    // Policy rejects honest nodes can disagree on: no penalty, no relay.
+    // Policy rejects honest nodes can disagree on, plus the cheap pre-validation
+    // drops (unknown fields and already-known revisions): no penalty, no relay.
+    // HAS_UNKNOWN_FIELDS and DUPLICATE_REVISION are rejected before the
+    // expensive signature verification, so replaying them costs no ECDSA work
+    // and needs no DoS score; scoring them would also risk banning honest peers
+    // in ordinary gossip races or future protocol extensions.
+    case PSGTPoolReject::HAS_UNKNOWN_FIELDS:
+    case PSGTPoolReject::DUPLICATE_REVISION:
     case PSGTPoolReject::COMPLETE:
     case PSGTPoolReject::UTXO_MISSING:
     case PSGTPoolReject::UTXO_SPENT:
@@ -731,6 +738,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         LOCK(cs_main);
+
+        // Bound the PSGT bytes served per getdata. The pool holds at most
+        // PSGTPool::MAX_ENTRIES distinct revisions, so any request for more than
+        // that many is necessarily redundant. This caps a getdata amplification
+        // where a peer packs MAX_INV_SZ (50000) MSG_PSGT entries all naming the
+        // same pooled revision (each up to MAX_PSGT_WIRE_SIZE) to force gigabytes
+        // of repeated sends under cs_main.
+        constexpr size_t MAX_PSGT_PER_GETDATA = PSGTPool::MAX_ENTRIES;
+        size_t psgt_served = 0;
+
         for (auto const& inv : vInv)
         {
             if (fShutdown)
@@ -805,11 +822,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // Serve from the PSGT pool, not mapRelay: pooled PSGTs
                     // live up to 7 days, far beyond mapRelay's 15-minute
                     // expiry. Do not serve while out of sync (mirrors the
-                    // scraper manifest guard below).
-                    if (!OutOfSyncByAge())
+                    // scraper manifest guard below). Bounded by the per-getdata
+                    // budget so a single getdata cannot force unbounded sends.
+                    if (!OutOfSyncByAge() && psgt_served < MAX_PSGT_PER_GETDATA)
                     {
                         if (const auto entry = g_psgt_pool.GetByRevision(inv.hash))
                         {
+                            ++psgt_served;
                             CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                             ss.reserve(entry->serialized.size() + 16);
                             ss << entry->serialized;
@@ -1617,13 +1636,14 @@ public:
         return ::SendMessages(pto, fSendTrickle);
     }
 
-    void StartScheduledTasks(CScheduler& scheduler) override
+    void StartScheduledTasks(CScheduler& /*scheduler*/) override
     {
-        // Sweep expired PSGTs (#2910) so entries whose owners went idle still
-        // expire -- and fire the eviction notification -- even when no pool
-        // traffic triggers the lazy paths.
-        scheduler.scheduleEvery([] { g_psgt_pool.EraseExpired(GetAdjustedTime()); },
-                                std::chrono::minutes{10});
+        // Intentionally empty. The recurring PSGT-pool sweep (EraseExpired,
+        // #2910) is scheduled in AppInit2 alongside the other recurring tasks
+        // (banlist dump, entropy, unbroadcast rebroadcast), so it is NOT
+        // duplicated here -- scheduling it in both places ran two sweeps of the
+        // same pool. This hook remains as the eventual home should those tasks
+        // be consolidated onto PeerManager.
     }
 
     bool Misbehaving(const CAddress& addr, int howmuch) override

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -325,6 +325,15 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
     }
 
     const uint256 revision_hash = entry.revision_hash;
+
+    // Mark the sender as knowing the CANONICAL revision (what we pool and
+    // relay), not just the wire-bytes hash tracked at the top of this function.
+    // The two differ if the peer sent a non-canonical encoding; without this we
+    // would relay inv(revision_hash) straight back to the sender. Re-asking is
+    // already prevented by HaveRevision() once the entry is pooled below, so no
+    // mapAlreadyAskedFor bookkeeping is needed for the canonical hash.
+    pfrom->AddInventoryKnown(CInv(MSG_PSGT, revision_hash));
+
     std::string reject_reason;
     const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -268,7 +268,21 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
         return;
     }
 
-    const CInv inv(MSG_PSGT, Hash(wire_bytes));
+    // Identify the object by its CANONICAL revision hash (the hash of the
+    // SerializePSGT re-serialization) -- the identity we pool and relay -- not
+    // the raw wire-bytes hash, so inventory-known and mapAlreadyAskedFor
+    // bookkeeping match even when a peer sends a non-canonical encoding of the
+    // same content. Decoding here is cheap (no signature work); a decode failure
+    // falls back to the wire hash and is rejected during validation below.
+    uint256 obj_hash = Hash(wire_bytes);
+    {
+        PartiallySignedTransaction decoded;
+        std::string decode_err;
+        if (DecodePSGTBytes(decoded, wire_bytes, decode_err)) {
+            obj_hash = Hash(SerializePSGT(decoded));
+        }
+    }
+    const CInv inv(MSG_PSGT, obj_hash);
 
     // The sender obviously has this revision: suppress the inv echo.
     pfrom->AddInventoryKnown(inv);
@@ -324,15 +338,10 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
         return;
     }
 
+    // The inv tracked at the top of this function is already keyed on the
+    // canonical revision hash (== entry.revision_hash), so the sender is marked
+    // as knowing this revision and we will not echo it back.
     const uint256 revision_hash = entry.revision_hash;
-
-    // Mark the sender as knowing the CANONICAL revision (what we pool and
-    // relay), not just the wire-bytes hash tracked at the top of this function.
-    // The two differ if the peer sent a non-canonical encoding; without this we
-    // would relay inv(revision_hash) straight back to the sender. Re-asking is
-    // already prevented by HaveRevision() once the entry is pooled below, so no
-    // mapAlreadyAskedFor bookkeeping is needed for the canonical hash.
-    pfrom->AddInventoryKnown(CInv(MSG_PSGT, revision_hash));
 
     std::string reject_reason;
     const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -42,7 +42,9 @@
 #include "node/blockstorage.h"
 #include "node/coherence.h"
 #include "node/orphan_blocks.h"
+#include "node/psgt_pool.h"
 #include "policy/fees.h"
+#include "scheduler.h"
 #include "policy/policy.h"
 #include "random.h"
 #include "validation.h"
@@ -226,9 +228,115 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(c
     case MSG_BLOCK:
         return mapBlockIndex.count(inv.hash) ||
                g_orphan_blocks.Contains(inv.hash);
+
+    case MSG_PSGT:
+        // Recently removed revisions read as "have": a completed, superseded
+        // or evicted PSGT must not be re-fetched from lagging peers (#2910).
+        return g_psgt_pool.HaveRevision(inv.hash);
     }
     // Don't know what it is, just say we already got one
     return true;
+}
+
+//! Relay a pooled PSGT revision to peers that can handle it (#2910). Served
+//! from the PSGT pool in the getdata loop, NOT from mapRelay: pooled PSGTs
+//! live up to 7 days, far beyond mapRelay's 15-minute expiry.
+void RelayPSGT(const uint256& revision_hash)
+{
+    if (!g_connman) return;
+
+    g_connman->RelayInventory(CInv(MSG_PSGT, revision_hash), PSGT_PROTO_VERSION);
+}
+
+//! Handle an incoming "psgt" message (#2910): validate against the pool
+//! admission rules and, on acceptance, pool and relay the new revision.
+//!
+//! Misbehavior policy: rejects no compliant node would have relayed
+//! (undecodable, oversize, structural, invalid or missing signatures) score
+//! 20 -- a buggy peer survives a couple of slips, a flooder is banned at
+//! five. Policy rejects honest nodes can disagree on (UTXO races around
+//! confirmation, fee bounds, pool-full, replacement races, completeness)
+//! score 0.
+static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
+{
+    std::vector<unsigned char> wire_bytes;
+    try {
+        vRecv >> wire_bytes;
+    } catch (const std::exception&) {
+        pfrom->Misbehaving(20);
+        error("%s: undecodable psgt message from %s", __func__, pfrom->addr.ToString());
+        return;
+    }
+
+    const CInv inv(MSG_PSGT, Hash(wire_bytes));
+
+    // The sender obviously has this revision: suppress the inv echo.
+    pfrom->AddInventoryKnown(inv);
+
+    // The request is satisfied (or abandoned); stop re-asking either way.
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+        mapAlreadyAskedFor.erase(inv);
+    }
+
+    LOCK(cs_main);
+
+    // Not active, or unable to validate against a current UTXO view yet:
+    // ignore silently, as a pre-v15 node would ignore the unknown message.
+    if (!IsV15Enabled(nBestHeight) || OutOfSyncByAge()) return;
+
+    PSGTPoolEntry entry;
+    std::string reason;
+    const PSGTPoolReject reject =
+        ValidatePSGTForPool(wire_bytes, GetAdjustedTime(), entry, reason);
+
+    switch (reject) {
+    case PSGTPoolReject::NONE:
+        break;
+
+    // Rejects no compliant node would have relayed.
+    case PSGTPoolReject::TOO_LARGE:
+    case PSGTPoolReject::MALFORMED:
+    case PSGTPoolReject::STRUCTURAL:
+    case PSGTPoolReject::INVALID_SIG:
+    case PSGTPoolReject::NO_VALID_SIG:
+        pfrom->Misbehaving(20);
+        error("%s: invalid psgt from %s: %s (%s)", __func__,
+              pfrom->addr.ToString(), PSGTPoolRejectToString(reject), reason);
+        return;
+
+    // Policy rejects honest nodes can disagree on: no penalty, no relay.
+    case PSGTPoolReject::COMPLETE:
+    case PSGTPoolReject::UTXO_MISSING:
+    case PSGTPoolReject::UTXO_SPENT:
+    case PSGTPoolReject::FEE_TOO_LOW:
+    case PSGTPoolReject::FEE_ABSURD:
+        LogPrint(BCLog::LogFlags::MEMPOOL, "%s: psgt from %s not accepted: %s (%s)",
+                 __func__, pfrom->addr.ToString(),
+                 PSGTPoolRejectToString(reject), reason);
+        return;
+    }
+
+    const uint256 revision_hash = entry.revision_hash;
+    std::string reject_reason;
+    const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);
+
+    switch (result) {
+    case PSGTPoolAddResult::ACCEPTED_NEW:
+    case PSGTPoolAddResult::ACCEPTED_REPLACEMENT:
+        RelayPSGT(revision_hash);
+        break;
+
+    case PSGTPoolAddResult::DUPLICATE:
+    case PSGTPoolAddResult::REJECTED_POOL_FULL:
+    case PSGTPoolAddResult::REJECTED_NOT_BETTER:
+    case PSGTPoolAddResult::REJECTED_NOT_INITIATOR:
+        // Normal gossip and replacement races.
+        LogPrint(BCLog::LogFlags::MEMPOOL, "%s: psgt %s from %s not pooled: %s",
+                 __func__, revision_hash.ToString(), pfrom->addr.ToString(),
+                 reject_reason);
+        break;
+    }
 }
 
 
@@ -442,6 +550,18 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 item.second.RelayTo(pfrom);
         }
 
+        // Notify the peer about pooled PSGTs (#2910): only peers that
+        // understand MSG_PSGT, and only when the fork is active and this
+        // node is in sync enough to serve what it advertises.
+        if (pfrom->nVersion >= PSGT_PROTO_VERSION
+            && WITH_LOCK(cs_main, return IsV15Enabled(nBestHeight) && !OutOfSyncByAge()))
+        {
+            for (const auto& entry : g_psgt_pool.GetAll())
+            {
+                pfrom->PushInventory(CInv(MSG_PSGT, entry.revision_hash));
+            }
+        }
+
         /* Notify the peer about statsscraper blobs we have */
         LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
 
@@ -563,7 +683,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             {
                 LOCK(cs_main);
 
-                if (!fAlreadyHave)
+                // PSGTs (#2910) are only fetched once the v15 gate is active
+                // and this node is in sync -- validation needs a current UTXO
+                // view, and the pool does not operate pre-activation.
+                const bool skip_psgt = inv.type == MSG_PSGT
+                    && (!IsV15Enabled(nBestHeight) || OutOfSyncByAge());
+
+                if (!fAlreadyHave && !skip_psgt)
                     pfrom->AskFor(inv);
                 else if (inv.type == MSG_BLOCK && g_orphan_blocks.Contains(inv.hash)) {
                     const CBlock* pblock_root = g_orphan_blocks.GetRootBlock(inv.hash);
@@ -674,6 +800,22 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     LOCK(CSplitBlob::cs_mapParts);
 
                     CSplitBlob::SendPartTo(pfrom, inv.hash);
+                }
+                else if (!pushed && inv.type == MSG_PSGT) {
+                    // Serve from the PSGT pool, not mapRelay: pooled PSGTs
+                    // live up to 7 days, far beyond mapRelay's 15-minute
+                    // expiry. Do not serve while out of sync (mirrors the
+                    // scraper manifest guard below).
+                    if (!OutOfSyncByAge())
+                    {
+                        if (const auto entry = g_psgt_pool.GetByRevision(inv.hash))
+                        {
+                            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                            ss.reserve(entry->serialized.size() + 16);
+                            ss << entry->serialized;
+                            pfrom->PushMessage(NetMsgType::PSGT, ss);
+                        }
+                    }
                 }
                 else if(!pushed &&  inv.type == MSG_SCRAPERINDEX)
                 {
@@ -1060,6 +1202,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (strCommand == NetMsgType::PART)
     {
         CSplitBlob::RecvPart(pfrom, vRecv);
+    }
+    else if (strCommand == NetMsgType::PSGT)
+    {
+        ProcessPSGTMessage(pfrom, vRecv);
     }
 
 
@@ -1471,9 +1617,13 @@ public:
         return ::SendMessages(pto, fSendTrickle);
     }
 
-    void StartScheduledTasks(CScheduler& /*scheduler*/) override
+    void StartScheduledTasks(CScheduler& scheduler) override
     {
-        // No recurring tasks yet (issue #2558 PR 8a shell).
+        // Sweep expired PSGTs (#2910) so entries whose owners went idle still
+        // expire -- and fire the eviction notification -- even when no pool
+        // traffic triggers the lazy paths.
+        scheduler.scheduleEvery([] { g_psgt_pool.EraseExpired(GetAdjustedTime()); },
+                                std::chrono::minutes{10});
     }
 
     bool Misbehaving(const CAddress& addr, int howmuch) override

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -24,6 +24,10 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
 //! see the definition for the lock-order rationale).
 void ResendUnbroadcastTransactions();
 
+//! Relay a pooled PSGT revision (#2910) to peers on PSGT_PROTO_VERSION or
+//! later. The object itself is served from the PSGT pool by the getdata loop.
+void RelayPSGT(const uint256& revision_hash);
+
 //! Message-processing manager (issue #2558 PR 8a). Abstract interface; the
 //! implementation (PeerManagerImpl) lives in net_processing.cpp and also
 //! implements NetEventsInterface (ProcessMessages/SendMessages). The

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -37,9 +37,11 @@ std::string PSGTRemovalReasonToString(PSGTRemovalReason reason)
 std::string PSGTPoolRejectToString(PSGTPoolReject reject)
 {
     switch (reject) {
-    case PSGTPoolReject::NONE:         return "none";
-    case PSGTPoolReject::TOO_LARGE:    return "too-large";
-    case PSGTPoolReject::MALFORMED:    return "malformed";
+    case PSGTPoolReject::NONE:               return "none";
+    case PSGTPoolReject::TOO_LARGE:          return "too-large";
+    case PSGTPoolReject::MALFORMED:          return "malformed";
+    case PSGTPoolReject::HAS_UNKNOWN_FIELDS: return "unknown-fields";
+    case PSGTPoolReject::DUPLICATE_REVISION: return "duplicate-revision";
     case PSGTPoolReject::STRUCTURAL:   return "structural";
     case PSGTPoolReject::INVALID_SIG:  return "invalid-signature";
     case PSGTPoolReject::NO_VALID_SIG: return "no-valid-signature";
@@ -105,7 +107,25 @@ static PSGTPoolReject CheckFundingOutput(const COutPoint& prevout, CTxDB& txdb, 
     return PSGTPoolReject::NONE;
 }
 
-PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
+//! True if the PSGT carries any unknown (extension) key-value pairs in its
+//! global, per-input, or per-output maps. The relay pool understands only the
+//! fields it needs and rejects extension fields (see ValidatePSGTForPool):
+//! they are a free revision-hash malleability vector and serve no pooling
+//! purpose. Cheap -- iterates the already-decoded maps, no allocation.
+static bool PSGTHasUnknownFields(const PartiallySignedTransaction& psgt)
+{
+    if (!psgt.unknown.empty()) return true;
+    for (const PSGTInput& input : psgt.inputs) {
+        if (!input.unknown.empty()) return true;
+    }
+    for (const PSGTOutput& output : psgt.outputs) {
+        if (!output.unknown.empty()) return true;
+    }
+    return false;
+}
+
+PSGTPoolReject ValidatePSGTForPool(const PSGTPool& pool,
+                                   const std::vector<unsigned char>& wire_bytes,
                                    int64_t now,
                                    PSGTPoolEntry& out_entry,
                                    std::string& error)
@@ -127,6 +147,37 @@ PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
     PartiallySignedTransaction& psgt = out_entry.psgt;
     if (!DecodePSGTBytes(psgt, wire_bytes, error)) {
         return PSGTPoolReject::MALFORMED;
+    }
+
+    // Unknown (extension) fields serve no purpose for a relay pool and are a
+    // free malleability vector: appending one mints a fresh wire encoding for
+    // otherwise-identical content. Reject them so the canonical revision hash
+    // computed below is stable. Cheap check, done before any signature work.
+    if (PSGTHasUnknownFields(psgt)) {
+        error = "PSGT carries unknown extension fields; not eligible for the pool";
+        return PSGTPoolReject::HAS_UNKNOWN_FIELDS;
+    }
+
+    // Canonical revision identity. Hash a re-serialization (SerializePSGT emits
+    // sorted maps) rather than the received wire bytes, so map reordering cannot
+    // mint a fresh identity for the same content either. Combined with #3113's
+    // strict DER / low-S encoding -- exactly one valid signature per (keyid,
+    // sighash) -- this makes the revision hash canonical for a given (unsigned
+    // tx, valid-signer-set). Storing the canonical bytes means getdata serves,
+    // and peers converge on, that single canonical form.
+    out_entry.serialized = SerializePSGT(psgt);
+    out_entry.revision_hash = Hash(out_entry.serialized);
+
+    // Duplicate short-circuit BEFORE the expensive per-signature ECDSA
+    // verification below: if we already hold (or recently held) this exact
+    // canonical revision, drop it cheaply. This is what stops a peer replaying
+    // one valid PSGT under an ever-changing hash to burn signature checks under
+    // cs_main (the deferred #3115/#3116 DoS). Correctness does not depend on it
+    // -- Add() re-checks under cs_psgt_pool -- so the read here is a pure
+    // optimization; a race merely means we do work we would have done anyway.
+    if (pool.HaveRevision(out_entry.revision_hash)) {
+        error = "revision already present in or recently removed from the pool";
+        return PSGTPoolReject::DUPLICATE_REVISION;
     }
 
     const CTransaction tx(psgt.tx);
@@ -230,8 +281,8 @@ PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
         return PSGTPoolReject::FEE_ABSURD;
     }
 
-    out_entry.serialized = wire_bytes;
-    out_entry.revision_hash = Hash(wire_bytes);
+    // out_entry.serialized / revision_hash were set from the canonical
+    // re-serialization above (before the duplicate short-circuit).
     out_entry.image = *image;
     out_entry.tx_hash = tx.GetHash();
     out_entry.time_received = now;

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -495,6 +495,30 @@ std::vector<PSGTPoolEntry> PSGTPool::GetAll() const
     return entries;
 }
 
+std::vector<uint256> PSGTPool::GetAllRevisionHashes() const
+{
+    LOCK(cs_psgt_pool);
+
+    std::vector<uint256> hashes;
+    hashes.reserve(m_by_revision.size());
+    for (const auto& [revision_hash, image] : m_by_revision) {
+        hashes.push_back(revision_hash);
+    }
+    return hashes;
+}
+
+std::optional<std::vector<unsigned char>>
+PSGTPool::GetSerializedByRevision(const uint256& revision_hash) const
+{
+    LOCK(cs_psgt_pool);
+
+    const auto it = m_by_revision.find(revision_hash);
+    if (it == m_by_revision.end()) return std::nullopt;
+    const auto img = m_by_image.find(it->second);
+    if (img == m_by_image.end()) return std::nullopt;
+    return img->second.serialized;
+}
+
 size_t PSGTPool::EraseExpired(int64_t now)
 {
     std::vector<PSGTPoolEntry> expired;

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -246,8 +246,20 @@ public:
     //! damping: recently completed/evicted revisions read as "already have").
     bool HaveRevision(const uint256& revision_hash) const;
 
-    //! Snapshot of all entries (RPC/GUI listing, connect-time advertisement).
+    //! Snapshot of all entries (RPC/GUI listing).
     std::vector<PSGTPoolEntry> GetAll() const;
+
+    //! Revision hashes of all pooled entries, for the connect-time inventory
+    //! push. Copies only the 32-byte hashes, not the full entries -- the push
+    //! runs on every inbound connection, so a peer must not be able to force
+    //! repeated multi-megabyte entry copies just by reconnecting.
+    std::vector<uint256> GetAllRevisionHashes() const;
+
+    //! Canonical serialized bytes of a pooled revision, if present, for the
+    //! getdata serve. Copies only the wire bytes, not the decoded PSGT, on this
+    //! peer-controlled hot path.
+    std::optional<std::vector<unsigned char>>
+        GetSerializedByRevision(const uint256& revision_hash) const;
 
     //! Evict entries older than EXPIRY_SECONDS. Returns the number evicted.
     size_t EraseExpired(int64_t now);

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -33,9 +33,12 @@
 //!    number of distinct multisig arrangements actually funded on-chain,
 //!    which an attacker cannot inflate for free.
 //!  - The relay identity of a specific revision is its \b revision hash =
-//!    Hash(serialized wire bytes). Adding a co-signature does not change the
-//!    unsigned transaction's hash, so tx-hash inventory would never
-//!    propagate signature progress; every mutation produces a fresh
+//!    Hash(canonical serialization). ValidatePSGTForPool hashes a
+//!    SerializePSGT re-serialization (sorted maps, unknown fields rejected),
+//!    NOT the received wire bytes, so reordering or padding cannot mint a
+//!    fresh identity for the same content. Adding a co-signature does not
+//!    change the unsigned transaction's hash, so tx-hash inventory would never
+//!    propagate signature progress; every genuine mutation produces a fresh
 //!    revision hash and therefore a fresh inv.
 //!
 
@@ -79,7 +82,7 @@ enum class PSGTPoolAddResult
 struct PSGTPoolEntry
 {
     PartiallySignedTransaction psgt;
-    std::vector<unsigned char> serialized; //!< Exact wire bytes (getdata serving; hashed for revision).
+    std::vector<unsigned char> serialized; //!< Canonical SerializePSGT bytes (getdata serving; hashed for revision).
     uint256 revision_hash;                 //!< Hash(serialized) -- the inv/relay identity.
     CScriptID image;                       //!< CScriptID(redeem script) -- the pool key.
     uint256 tx_hash;                       //!< Hash of the unsigned transaction.
@@ -107,9 +110,11 @@ struct PSGTPoolEntry
 //! RPC layer maps them to error strings.
 enum class PSGTPoolReject
 {
-    NONE,         //!< Valid; out_entry is filled.
-    TOO_LARGE,    //!< Wire size above MAX_PSGT_WIRE_SIZE.
-    MALFORMED,    //!< Does not decode as a PSGT.
+    NONE,               //!< Valid; out_entry is filled.
+    TOO_LARGE,          //!< Wire size above MAX_PSGT_WIRE_SIZE.
+    MALFORMED,          //!< Does not decode as a PSGT.
+    HAS_UNKNOWN_FIELDS, //!< Decodes, but carries unknown (extension) key-value pairs; not relayed.
+    DUPLICATE_REVISION, //!< Canonically identical to a revision already pooled or recently removed.
     STRUCTURAL,   //!< Decodes, but is not a well-formed single-image P2SH multisig spend.
     INVALID_SIG,  //!< Carries a cryptographically invalid or foreign partial signature.
     NO_VALID_SIG, //!< Some input has no valid partial signature (anti-spam floor).
@@ -123,13 +128,16 @@ enum class PSGTPoolReject
 //! Human-readable reject reason (for logs and RPC errors).
 std::string PSGTPoolRejectToString(PSGTPoolReject reject);
 
+class PSGTPool;
+
 //!
 //! \brief Validate a PSGT received from an untrusted source (network relay or
 //! local submission) and fill a pool entry from it.
 //!
-//! Checks, cheap to expensive: wire size; decode; basic transaction sanity
-//! (CheckTransaction, version >= 2, no finalized inputs); single-image P2SH
-//! multisig structure across ALL inputs (GetPSGTImage's trustworthiness
+//! Checks, cheap to expensive: wire size; decode; unknown-field rejection;
+//! CANONICAL revision identity + duplicate short-circuit; basic transaction
+//! sanity (CheckTransaction, version >= 2, no finalized inputs); single-image
+//! P2SH multisig structure across ALL inputs (GetPSGTImage's trustworthiness
 //! rules); cryptographic verification of EVERY partial signature with at
 //! least one valid signature on every input, and fewer than m so the pool
 //! only holds material that still needs co-signers; funding outputs exist
@@ -138,10 +146,22 @@ std::string PSGTPoolRejectToString(PSGTPoolReject reject);
 //! chain facts to establish); and fee within [relay minimum, 100x relay
 //! minimum] for the estimated final size.
 //!
+//! Identity note (anti-DoS): the revision hash is computed over a CANONICAL
+//! re-serialization (SerializePSGT), not the received wire bytes, and PSGTs
+//! carrying unknown extension fields are rejected. Together with #3113's strict
+//! DER / low-S signature encoding this makes the revision hash canonical for a
+//! given (unsigned tx, valid-signer-set): map reordering and unknown-field
+//! padding can no longer mint a fresh identity for the same content. This lets
+//! the duplicate short-circuit run BEFORE the expensive per-signature ECDSA
+//! verification, so a peer cannot cheaply replay one valid PSGT under an
+//! ever-changing hash to burn CPU under cs_main (the deferred #3115/#3116 DoS).
+//! `pool` is consulted read-only for that HaveRevision short-circuit.
+//!
 //! Requires cs_main (chain/mempool lookups). Does NOT check IsV15Enabled or
 //! sync state -- those are the caller's (P2P handler / RPC) admission gates.
 //!
-PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
+PSGTPoolReject ValidatePSGTForPool(const PSGTPool& pool,
+                                   const std::vector<unsigned char>& wire_bytes,
                                    int64_t now,
                                    PSGTPoolEntry& out_entry,
                                    std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -202,6 +222,17 @@ public:
     //!    (initiator-privileged supersede).
     //! initiator_keys are snapshotted from the first accepted entry and
     //! carried forward on every replacement.
+    //!
+    //! Caller contract (funding-unspent invariant): an entry produced by
+    //! ValidatePSGTForPool was checked unspent against the UTXO view under
+    //! cs_main. To keep that guarantee at insertion, such a caller MUST hold
+    //! cs_main continuously from validation through this call, so no block or
+    //! mempool tx spending a funding output can land in the gap. The P2P
+    //! handler (ProcessPSGTMessage) does exactly this. Add itself takes only
+    //! cs_psgt_pool (a leaf); the cs_main requirement is the caller's, which is
+    //! why it is documented here rather than annotated -- unit tests that insert
+    //! synthetic entries never validated against a UTXO set have no such
+    //! invariant to preserve and legitimately call Add without cs_main.
     PSGTPoolAddResult Add(PSGTPoolEntry&& entry, std::string& reject_reason);
 
     //! Remove the entry for an image. Returns false if not present.

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -37,8 +37,10 @@ namespace NetMsgType {
     // Gridcoin specific
     const char *SCRAPERINDEX="scraperindex";
     const char *PART="part";
+    const char *PSGT="psgt";
 }
 
+// Index-aligned with the inv-type enum in net.h (MSG_TX = 1, ...).
 static const char* ppszTypeName[] =
 {
     "ERROR", // Should never occur
@@ -46,6 +48,7 @@ static const char* ppszTypeName[] =
     NetMsgType::BLOCK,
     NetMsgType::PART,
     NetMsgType::SCRAPERINDEX,
+    NetMsgType::PSGT,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -76,6 +79,7 @@ const static std::string allNetMessageTypes[] = {
     // Gridcoin specific
     NetMsgType::SCRAPERINDEX,
     NetMsgType::PART,
+    NetMsgType::PSGT,
 };
 
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -254,6 +254,12 @@ namespace NetMsgType {
     extern const char *PART;
 
     /**
+    * Gridcoin specific message: a partially signed transaction for the
+    * PSGT pool (#2910). Payload is the raw binary PSGT wire bytes.
+    */
+    extern const char *PSGT;
+
+    /**
     * Gridcoin alias for version message (will be removed)
     */
     extern const char *ARIES;

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -103,7 +103,11 @@ static PSGTPoolReject Validate(const PartiallySignedTransaction& psgt,
                                PSGTPoolEntry& entry, std::string& error)
 {
     LOCK(cs_main);
-    return ValidatePSGTForPool(SerializePSGT(psgt), 1700003000, entry, error);
+    // Validate against an empty pool: HaveRevision is always false here, so the
+    // duplicate short-circuit never fires and this exercises the full pipeline.
+    // Duplicate-revision behaviour has its own dedicated test with a real pool.
+    const PSGTPool empty_pool;
+    return ValidatePSGTForPool(empty_pool, SerializePSGT(psgt), 1700003000, entry, error);
 }
 
 //! A synthetic entry with a unique image, for container-semantics tests that
@@ -217,14 +221,80 @@ BOOST_AUTO_TEST_CASE(validate_reject_matrix)
     // Oversize and malformed wire bytes.
     {
         LOCK(cs_main);
+        const PSGTPool empty_pool;
         std::vector<unsigned char> huge(MAX_PSGT_WIRE_SIZE + 1, 0x00);
-        BOOST_CHECK(ValidatePSGTForPool(huge, 1700003000, entry, error)
+        BOOST_CHECK(ValidatePSGTForPool(empty_pool, huge, 1700003000, entry, error)
                     == PSGTPoolReject::TOO_LARGE);
 
         std::vector<unsigned char> garbage = {0xde, 0xad, 0xbe, 0xef};
-        BOOST_CHECK(ValidatePSGTForPool(garbage, 1700003000, entry, error)
+        BOOST_CHECK(ValidatePSGTForPool(empty_pool, garbage, 1700003000, entry, error)
                     == PSGTPoolReject::MALFORMED);
     }
+}
+
+BOOST_AUTO_TEST_CASE(validate_rejects_unknown_fields)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+
+    PSGTPoolEntry entry;
+    std::string error;
+
+    // Baseline: the same PSGT with no extension fields is accepted.
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k1}), entry, error)
+                  == PSGTPoolReject::NONE);
+
+    // An unknown GLOBAL field makes it ineligible: it is a free revision-hash
+    // malleability vector and serves no pooling purpose.
+    {
+        PartiallySignedTransaction psgt = fixture.Signed({fixture.k1});
+        psgt.unknown[{0xff}] = {0x01, 0x02};
+        BOOST_CHECK(Validate(psgt, entry, error) == PSGTPoolReject::HAS_UNKNOWN_FIELDS);
+    }
+
+    // An unknown per-INPUT field is rejected the same way.
+    {
+        PartiallySignedTransaction psgt = fixture.Signed({fixture.k1});
+        psgt.inputs[0].unknown[{0xfe}] = {0x03};
+        BOOST_CHECK(Validate(psgt, entry, error) == PSGTPoolReject::HAS_UNKNOWN_FIELDS);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(validate_short_circuits_duplicate_revision)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+
+    LOCK(cs_main);
+    PSGTPool pool;
+    const std::vector<unsigned char> wire = SerializePSGT(fixture.Signed({fixture.k1}));
+
+    // First sighting: full validation, accepted, added to the pool.
+    PSGTPoolEntry first;
+    std::string error;
+    BOOST_REQUIRE(ValidatePSGTForPool(pool, wire, 1700003000, first, error)
+                  == PSGTPoolReject::NONE);
+    const uint256 revision = first.revision_hash;
+    const std::vector<unsigned char> canonical = first.serialized;
+    std::string reject;
+    BOOST_REQUIRE(pool.Add(std::move(first), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    // Second sighting of the SAME revision short-circuits as a duplicate -- this
+    // is the branch that returns BEFORE the expensive per-signature ECDSA
+    // verification, so a peer cannot replay a valid PSGT to burn CPU.
+    PSGTPoolEntry second;
+    BOOST_CHECK(ValidatePSGTForPool(pool, wire, 1700003000, second, error)
+                == PSGTPoolReject::DUPLICATE_REVISION);
+
+    // The revision identity is the hash of the CANONICAL re-serialization, and
+    // that canonical form is a fixed point: decoding and re-serializing the
+    // stored bytes reproduces them. Hence any alternate encoding (reordered
+    // maps) of the same content decodes to this same identity.
+    BOOST_CHECK(revision == Hash(canonical));
+    PartiallySignedTransaction round;
+    std::string decode_error;
+    BOOST_REQUIRE(DecodePSGTBytes(round, canonical, decode_error));
+    BOOST_CHECK(SerializePSGT(round) == canonical);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -33,6 +33,7 @@ import time
 from test_framework.messages import (
     CInv,
     MSG_PSGT,
+    PSGT_PROTO_VERSION,
     hash256,
     msg_getdata,
     msg_psgt,
@@ -63,7 +64,7 @@ class OldVersionInvCollector(InvCollector):
 
     def peer_connect_send_version(self):
         super().peer_connect_send_version()
-        self.on_connection_send_msg.nVersion = 180329
+        self.on_connection_send_msg.nVersion = PSGT_PROTO_VERSION - 1
 
 
 class P2PPsgtRelayTest(GridcoinTestFramework):

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -91,8 +91,11 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
     def add_spaced_p2p(self, node, peer):
         """add_p2p_connection with the daemon's inbound rate limit respected:
         at most one inbound per 5 seconds per IP (net.cpp AcceptConnection),
-        and every scripted peer here is 127.0.0.1."""
-        time.sleep(5)
+        and every scripted peer here is 127.0.0.1. The limit compares integer
+        second deltas from GetAdjustedTime(), so sleep a full 6 s -- sleeping
+        exactly 5 can land two connects in the same second boundary (delta 4)
+        and get the second one dropped / misbehavior-scored."""
+        time.sleep(6)
         return node.add_p2p_connection(peer)
 
     def setup_network(self):

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""PSGT pool P2P relay (#2910 Phase II): MSG_PSGT inv/getdata/psgt end to end.
+
+Two connected regtest nodes (v15 active at height 0) plus scripted peers.
+node0's wallet builds a genuinely partially signed 2-of-3 multisig PSGT via
+the Phase I RPCs (one wallet-owned key, two node1-owned keys, so
+walletprocesspsgt contributes exactly one of the two required signatures).
+A scripted peer then injects the raw bytes into node1 with the new `psgt`
+message and we assert, in order:
+
+- node1 validates, pools and relays: a watcher peer on node1 receives
+  inv(MSG_PSGT, revision-hash) where the revision hash is hash256 of the
+  wire bytes (NOT the unsigned tx hash);
+- getdata(MSG_PSGT) is answered byte-exactly from the pool;
+- node0 learns the PSGT daemon-to-daemon, and a peer connecting to node0
+  afterwards receives the pooled inventory in the connect-time push;
+- a peer that handshook with the pre-PSGT protocol version receives no
+  MSG_PSGT inventory anywhere in the run;
+- re-sending the same revision is a quiet no-op (no second inv);
+- garbage and corrupted psgt messages are rejected without relay and
+  without disturbing the node. (The misbehavior score they earn cannot
+  be observed from a functional test: PeerManager::Misbehaving exempts
+  local addresses, and every scripted peer here is 127.0.0.1. The
+  scoring itself is covered by inspection of the ProcessPSGTMessage
+  reject mapping.)
+"""
+
+import time
+
+from test_framework.messages import (
+    CInv,
+    MSG_PSGT,
+    hash256,
+    msg_getdata,
+    msg_psgt,
+    uint256_from_str,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+from base64 import b64decode
+
+
+class InvCollector(P2PInterface):
+    """Records every MSG_PSGT inventory hash it is announced."""
+
+    def __init__(self):
+        super().__init__()
+        self.psgt_invs = []
+
+    def on_inv(self, message):
+        for inv in message.inv:
+            if inv.type == MSG_PSGT:
+                self.psgt_invs.append(inv.hash)
+
+
+class OldVersionInvCollector(InvCollector):
+    """An InvCollector that handshakes with the pre-PSGT protocol version."""
+
+    def peer_connect_send_version(self):
+        super().peer_connect_send_version()
+        self.on_connection_send_msg.nVersion = 180329
+
+
+class P2PPsgtRelayTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.extra_args = [["-staking=0"], ["-staking=0"]]
+
+    def confirm_funding(self, txid):
+        """Confirm a just-sent funding transaction. PoS block timestamps are
+        masked down to 16-second boundaries (STAKE_TIMESTAMP_MASK) and the
+        miner excludes transactions with nTime > block.nTime, so wait for the
+        next boundary before mining the confirmation block. Returns False if
+        the transaction vanished instead (double-spent by the staker's own
+        coinstake -- the wallet does not track raw spends)."""
+        node0 = self.nodes[0]
+        time.sleep(16 - (int(time.time()) % 16) + 1)
+        node0.generatetoaddress(1, node0.getnewaddress())
+        try:
+            return node0.getrawtransaction(txid, True).get("confirmations", 0) >= 1
+        except Exception:
+            return False
+
+    def add_spaced_p2p(self, node, peer):
+        """add_p2p_connection with the daemon's inbound rate limit respected:
+        at most one inbound per 5 seconds per IP (net.cpp AcceptConnection),
+        and every scripted peer here is 127.0.0.1."""
+        time.sleep(5)
+        return node.add_p2p_connection(peer)
+
+    def setup_network(self):
+        # Bring the nodes up without the base-class createwallet path (the
+        # daemon rejects its named params), then connect them: daemon-to-daemon
+        # PSGT propagation is part of what this test asserts.
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+        self.connect_nodes(1, 0)
+        self.sync_blocks()
+
+    def make_partially_signed_psgt(self):
+        """Fund a 2-of-3 multisig (1 node0 key, 2 node1 keys) and have node0
+        sign its one key: a valid, incomplete PSGT the pool must accept."""
+        node0, node1 = self.nodes[0], self.nodes[1]
+
+        pub_mine = node0.validateaddress(node0.getnewaddress())["pubkey"]
+        pub_other1 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        pub_other2 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        ms_address = node0.addmultisigaddress(2, [pub_mine, pub_other1, pub_other2])
+
+        # Fund the multisig from a raw spend of a consensus-mature UTXO
+        # (coinstakes need >10 confirmations on regtest; wallet sends are not
+        # an option -- wallet balance accounting treats young coinstakes as
+        # immature far longer). The wallet does not track raw spends, so the
+        # staker can race us for the same UTXO when mining the confirmation
+        # block and double-spend the funding away: verify and retry.
+        txid = None
+        ms_amount = None
+        tried = set()
+        for _ in range(5):
+            candidates = [u for u in node0.listunspent(11)
+                          if (u["txid"], u["vout"]) not in tried]
+            assert candidates, "no mature UTXO left to fund the multisig"
+            utxo = candidates[0]
+            tried.add((utxo["txid"], utxo["vout"]))
+
+            ms_amount = round(float(utxo["amount"]) - 1.0, 8)  # ~1 GRC fee
+            raw = node0.createrawtransaction(
+                [{"txid": utxo["txid"], "vout": utxo["vout"]}], {ms_address: ms_amount})
+            signed = node0.signrawtransactionwithwallet(raw)
+            assert signed.get("complete"), signed
+            candidate_txid = node0.sendrawtransaction(signed["hex"])
+
+            if self.confirm_funding(candidate_txid):
+                txid = candidate_txid
+                break
+        assert txid, "could not confirm the multisig funding transaction"
+        self.sync_blocks()
+
+        funding = node0.getrawtransaction(txid, True)
+        vout = next(o["n"] for o in funding["vout"]
+                    if ms_address in o["scriptPubKey"].get("addresses", []))
+
+        # 0.01 GRC fee: above the relay floor, below the absurd-fee ceiling.
+        dest = node0.getnewaddress()
+        psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
+                                {dest: round(ms_amount - 0.01, 8)})
+        psgt = node0.utxoupdatepsgt(psgt)
+        processed = node0.walletprocesspsgt(psgt)
+        assert not processed["complete"], "expected a PARTIALLY signed PSGT"
+        return b64decode(processed["psgt"])
+
+    def run_test(self):
+        node0, node1 = self.nodes[0], self.nodes[1]
+
+        # Consensus-mature coins (>10 confirmations on regtest) and a current
+        # tip so both nodes are in sync (the pool neither accepts nor serves
+        # while OutOfSyncByAge).
+        node0.generatetoaddress(12, node0.getnewaddress())
+        self.sync_blocks()
+
+        wire = self.make_partially_signed_psgt()
+        revision = uint256_from_str(hash256(wire))
+
+        sender = node1.add_p2p_connection(P2PInterface())
+        watcher = self.add_spaced_p2p(node1, InvCollector())
+        old_peer = self.add_spaced_p2p(node1, OldVersionInvCollector())
+
+        # --- inject: node1 must validate, pool, and announce the revision ---
+        sender.send_message(msg_psgt(wire))
+        watcher.wait_until(lambda: revision in watcher.psgt_invs)
+        self.log.info("psgt accepted by node1 and announced as inv(MSG_PSGT)")
+
+        # --- getdata is served byte-exactly from the pool ---
+        watcher.send_message(msg_getdata([CInv(MSG_PSGT, revision)]))
+        watcher.wait_until(lambda: "psgt" in watcher.last_message
+                           and watcher.last_message["psgt"].psgt_bytes == wire)
+        self.log.info("getdata(MSG_PSGT) served the exact wire bytes")
+
+        # --- daemon-to-daemon relay + connect-time push: node0 fetched the
+        # PSGT from node1, and advertises it to fresh v15 peers on connect ---
+        late_peer = self.add_spaced_p2p(node0, InvCollector())
+        late_peer.wait_until(lambda: revision in late_peer.psgt_invs)
+        self.log.info("node0 pooled the PSGT and pushed it to a connecting peer")
+
+        # --- duplicate revision: a quiet no-op, not a re-announcement ---
+        announced_before = watcher.psgt_invs.count(revision)
+        sender.send_message(msg_psgt(wire))
+        sender.sync_with_ping()
+        time.sleep(1)  # allow any (wrong) re-announcement to arrive
+        assert_equal(watcher.psgt_invs.count(revision), announced_before)
+        self.log.info("duplicate psgt message did not re-announce")
+
+        # --- version gating: the 180329 peer saw nothing throughout ---
+        old_peer.sync_with_ping()
+        assert_equal(old_peer.psgt_invs, [])
+        self.log.info("pre-PSGT protocol peer received no MSG_PSGT inventory")
+
+        # --- invalid psgt messages: rejected without relay, node unfazed ---
+        bad_peer = self.add_spaced_p2p(node1, P2PInterface())
+        announced_before = len(watcher.psgt_invs)
+        bad_peer.send_message(msg_psgt(b"not a psgt"))
+        corrupted = bytearray(wire)
+        corrupted[len(corrupted) // 2] ^= 0x01
+        bad_peer.send_message(msg_psgt(bytes(corrupted)))
+        bad_peer.sync_with_ping()
+        time.sleep(1)  # allow any (wrong) relay to arrive
+        assert_equal(len(watcher.psgt_invs), announced_before)
+        assert_equal(node1.getbestblockhash(), node0.getbestblockhash())
+        self.log.info("garbage/corrupted psgt messages rejected without relay")
+
+
+if __name__ == "__main__":
+    P2PPsgtRelayTest().main()

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -71,7 +71,7 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         self.num_nodes = 2
         self.chain = "regtest"
         self.setup_clean_chain = True
-        self.extra_args = [["-staking=0"], ["-staking=0"]]
+        self.extra_args = [["-staking=0", "-blockv15height=0"], ["-staking=0", "-blockv15height=0"]]
 
     def confirm_funding(self, txid):
         """Confirm a just-sent funding transaction. PoS block timestamps are

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -43,9 +43,10 @@ MAX_BLOCK_BASE_SIZE = 1000000
 COIN = 100000000  # 1 GRC in halflings
 
 # Protocol constants (src/version.h)
-MY_VERSION = 180329          # PROTOCOL_VERSION
+MY_VERSION = 180330          # PROTOCOL_VERSION
 MIN_PEER_PROTO_VERSION = 180327
 INIT_PROTO_VERSION = 180275
+PSGT_PROTO_VERSION = 180330  # peers below this never receive MSG_PSGT invs
 
 MY_SUBVERSION = "/python-mininode-tester:0.0.3/"
 MY_RELAY = 1  # placeholder; Gridcoin's version message has no relay field
@@ -59,9 +60,12 @@ MAGIC_BYTES = {
     "regtest": b"\xfa\xbf\xb5\xda",
 }
 
-# Inv/getdata type codes (src/protocol.h GetDataMsg). No witness variants.
+# Inv/getdata type codes (src/net.h inv-type enum). No witness variants.
 MSG_TX = 1
 MSG_BLOCK = 2
+MSG_PART = 3
+MSG_SCRAPERINDEX = 4
+MSG_PSGT = 5
 
 
 # Serialization/deserialization tools
@@ -210,7 +214,8 @@ def _ip_to_int(ip):
 
 
 class CInv:
-    typemap = {0: "Error", MSG_TX: "TX", MSG_BLOCK: "Block"}
+    typemap = {0: "Error", MSG_TX: "TX", MSG_BLOCK: "Block", MSG_PART: "Part",
+               MSG_SCRAPERINDEX: "ScraperIndex", MSG_PSGT: "PSGT"}
 
     def __init__(self, t=0, h=0):
         self.type = t
@@ -880,6 +885,31 @@ class msg_pong:
         return "msg_pong(nonce=%08x)" % self.nonce
 
 
+class msg_psgt:
+    """A PSGT pool message (#2910): CompactSize-prefixed raw PSGT wire bytes.
+
+    The inv identity of a revision is hash256 of the raw bytes (the
+    "revision hash"), NOT the unsigned transaction's hash.
+    """
+    __slots__ = ("psgt_bytes",)
+    command = b"psgt"
+
+    def __init__(self, psgt_bytes=b""):
+        self.psgt_bytes = psgt_bytes
+
+    def deserialize(self, f):
+        self.psgt_bytes = deser_string(f)
+
+    def serialize(self):
+        return ser_string(self.psgt_bytes)
+
+    def revision_hash(self):
+        return uint256_from_str(hash256(self.psgt_bytes))
+
+    def __repr__(self):
+        return "msg_psgt(len=%i)" % len(self.psgt_bytes)
+
+
 class msg_notfound:
     __slots__ = ("vec",)
     command = b"notfound"
@@ -917,5 +947,6 @@ MESSAGEMAP = {
     b"mempool": msg_mempool,
     b"ping": msg_ping,
     b"pong": msg_pong,
+    b"psgt": msg_psgt,
     b"notfound": msg_notfound,
 }

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -888,8 +888,13 @@ class msg_pong:
 class msg_psgt:
     """A PSGT pool message (#2910): CompactSize-prefixed raw PSGT wire bytes.
 
-    The inv identity of a revision is hash256 of the raw bytes (the
-    "revision hash"), NOT the unsigned transaction's hash.
+    The inv identity of a revision is the "revision hash", NOT the unsigned
+    transaction's hash. Core computes it as hash256 of the CANONICAL
+    re-serialization (SerializePSGT: sorted maps, unknown fields rejected), not
+    of arbitrary received bytes. Nodes serve/relay those canonical bytes, so a
+    test should hash the canonical on-wire encoding it sent (which a wallet- or
+    SerializePSGT-produced PSGT already is); hashing a non-canonical encoding
+    would chase a revision hash the node never advertises.
     """
     __slots__ = ("psgt_bytes",)
     command = b"psgt"

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -296,6 +296,9 @@ class P2PInterface(P2PConnection):
     def on_notfound(self, message):
         pass
 
+    def on_psgt(self, message):
+        pass
+
     def on_tx(self, message):
         pass
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -147,6 +147,7 @@ BASE_SCRIPTS = [
     'feature_regtest_staking.py',
     'p2p_version_handshake.py',
     'p2p_block_tx_relay.py',
+    'p2p_psgt_relay.py',
     'p2p_ping.py',
     'rpc_help.py',
     'rpc_signmessage.py',


### PR DESCRIPTION
Fourth PR of the **PSGT Phase II** series (#2910): the network half. Stacked on #3113 → #3114 → #3115; only the last commit is new.

## What

- **`MSG_PSGT`** inv type (index-aligned `ppszTypeName`) + **`psgt`** wire command carrying raw binary PSGT bytes. The inv identity is the **revision hash** = `Hash(wire bytes)` — adding a co-signature doesn't change the unsigned tx hash, so tx-hash invs would read as already-have everywhere and signature progress could never propagate (see #3115's design notes).
- **`AlreadyHave`**: pooled *or recently-removed* revisions answer "have" — completed/superseded revisions aren't re-fetched from lagging peers.
- **getdata** serves `MSG_PSGT` from the pool, not `mapRelay` (7-day pool life vs 15-minute relay cache), behind the same in-sync guard as scraper manifests.
- **`ProcessPSGTMessage`**: validate (`ValidatePSGTForPool`, under cs_main) → pool → relay. Misbehavior mapping: rejects **no compliant node would relay** (undecodable/oversize/structural/invalid-or-missing signatures) score 20 — a buggy peer survives a couple of slips, a flooder bans at five; **policy rejects honest nodes can disagree on** (UTXO races around confirmation, fee bounds, pool-full, replacement races, completeness) score 0. Inbound is processed regardless of the peer's advertised version; `IsV15Enabled` + `OutOfSyncByAge` gate acceptance.
- **Version-gated fan-out**: `CConnman::RelayInventory` gains a defaulted `min_proto_version`; `RelayPSGT` (exported for PR E's submit RPC) announces only to peers ≥ `PSGT_PROTO_VERSION` (180330). Pre-PSGT peers never see the inventory — the v15 overlay forms naturally.
- **Connect-time push** (the `CScraperManifest::PushInvTo` pattern): pooled revisions are announced to newly connected v15 peers, so a restarted node relearns the network's pool from any upgraded peer — this is why pool persistence can stay a non-goal.
- **`PeerManagerImpl::StartScheduledTasks`** (the #2558 PR 8a shell) gets its first recurring task: a 10-minute `EraseExpired` sweep.

## Testing

New functional test **`test/functional/p2p_psgt_relay.py`** drives the full lifecycle against two connected regtest nodes (v15 active at height 0) with scripted peers, using a **wallet-built, genuinely partially signed 2-of-3 multisig PSGT** (one node0 key, two node1 keys — Phase I RPCs end to end):
1. inject via `psgt` message → validated, pooled, announced as `inv(MSG_PSGT, revision)`;
2. `getdata` answered **byte-exactly** from the pool;
3. daemon-to-daemon propagation + connect-time push to a late-joining peer on the *other* node;
4. a 180329-handshake peer receives no `MSG_PSGT` inventory anywhere in the run;
5. duplicate revision → quiet no-op (no re-announcement);
6. garbage and corrupted-signature payloads rejected without relay, node undisturbed. (The misbehavior *score* can't be observed from a functional test — `Misbehaving()` exempts local addresses and every scripted peer is 127.0.0.1.)

Framework: `msg_psgt`/`MSG_PSGT`/`PSGT_PROTO_VERSION` added to `messages.py` (+`on_psgt` dispatch); `MY_VERSION` → 180330; scripted peers now space their connections to respect the daemon's per-IP inbound rate limit (one per 5 s), which any future multi-peer test on one node will also need.

Full unit suite, Qt tests, and the complete functional runner (25/25, including the new test) green locally; `git diff --check` clean.

## Series

A #3113 → B #3114 → C #3115 → **D (this)** → E (pool RPCs + `-psgtnotify` + uiInterface signal) → F (Qt Pool view).