### PR TITLE
rpc: PSGT pool RPCs + three-layer notification (#2910 Phase II, PR E)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -498,7 +498,7 @@ void SetupServerArgs()
                                                      "7 days (168 hours)",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::OPTIONS);
     argsman.AddArg("-psgtnotify=<cmd>", "Execute command when the PSGT pool changes (%s1 in cmd is replaced by the multisig "
-                                        "image hash, %s2 by the event: added, updated, expired, replaced, completed, "
+                                        "image hash, %s2 by the event: added, updated, expired, completed, "
                                         "conflict-mempool, conflict-block, removed; %s3 by the unsigned transaction id)",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::OPTIONS);
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2005,7 +2005,8 @@ bool AppInit2(ThreadHandlerPtr threads)
             ReplaceAll(strCmd, "%s1", entry.image.ToString());
             ReplaceAll(strCmd, "%s2", event);
             ReplaceAll(strCmd, "%s3", entry.tx_hash.ToString());
-            boost::thread t(runCommand, strCmd); // thread runs free
+            boost::thread t(runCommand, strCmd);
+            t.detach(); // run free; never let t's destructor join/terminate
         }
 #endif
     };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -30,6 +30,7 @@
 #include "node/coherence.h"
 #include "node/mempool_persist.h"
 #include "node/psgt_pool.h"
+#include <util/string.h>
 #include <util/syserror.h>
 
 #include <openssl/crypto.h>
@@ -495,6 +496,10 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::OPTIONS);
     argsman.AddArg("-pollexpirewarningtime=<hours>", "Hours before poll expiration to execute notification command. Default is "
                                                      "7 days (168 hours)",
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::OPTIONS);
+    argsman.AddArg("-psgtnotify=<cmd>", "Execute command when the PSGT pool changes (%s1 in cmd is replaced by the multisig "
+                                        "image hash, %s2 by the event: added, updated, expired, replaced, completed, "
+                                        "conflict-mempool, conflict-block, removed; %s3 by the unsigned transaction id)",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::OPTIONS);
 #endif
     argsman.AddArg("-confchange", "Require confirmations for change (default: 0)",
@@ -1975,6 +1980,35 @@ bool AppInit2(ThreadHandlerPtr threads)
     // whose inputs get spent are evicted on mempool admission (fast) and on
     // block connection (authoritative).
     RegisterValidationInterface(&g_psgt_pool);
+
+    // Three-layer PSGT pool notification (#2910), the -pollnotify pattern:
+    // the pool fires this hook outside its lock for every mutation; it fans
+    // out to the uiInterface signal (Qt models/toasts) and the -psgtnotify
+    // external command (headless workflows: email, SMS, webhook).
+    g_psgt_pool.m_notify_hook = [](const PSGTPoolEntry& entry, PSGTPoolChangeType change,
+                                   std::optional<PSGTRemovalReason> reason) {
+        const ChangeType status =
+            change == PSGTPoolChangeType::ADDED ? CT_NEW :
+            change == PSGTPoolChangeType::UPDATED ? CT_UPDATED : CT_DELETED;
+
+        uiInterface.PSGTPoolChanged(entry.revision_hash, status);
+
+#if HAVE_SYSTEM
+        std::string strCmd = gArgs.GetArg("-psgtnotify", std::string{});
+
+        if (!strCmd.empty()) {
+            const std::string event =
+                change == PSGTPoolChangeType::ADDED ? "added" :
+                change == PSGTPoolChangeType::UPDATED ? "updated" :
+                PSGTRemovalReasonToString(reason.value_or(PSGTRemovalReason::LOCAL_REMOVE));
+
+            ReplaceAll(strCmd, "%s1", entry.image.ToString());
+            ReplaceAll(strCmd, "%s2", event);
+            ReplaceAll(strCmd, "%s3", entry.tx_hash.ToString());
+            boost::thread t(runCommand, strCmd); // thread runs free
+        }
+#endif
+    };
 
     g_scheduler->scheduleEvery([]{
         g_banman->DumpBanlist();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2145,10 +2145,12 @@ void CConnman::ForEachNodeUnderLock(const std::function<void(CNode*)>& func) con
     }
 }
 
-void CConnman::RelayInventory(const CInv& inv)
+void CConnman::RelayInventory(const CInv& inv, int min_proto_version)
 {
-    ForEachNode([&inv](CNode* pnode) {
-        pnode->PushInventory(inv);
+    ForEachNode([&inv, min_proto_version](CNode* pnode) {
+        if (pnode->nVersion >= min_proto_version) {
+            pnode->PushInventory(inv);
+        }
     });
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -95,6 +95,7 @@ enum
     MSG_BLOCK,
     MSG_PART,
     MSG_SCRAPERINDEX,
+    MSG_PSGT,
 };
 
 
@@ -709,8 +710,10 @@ public:
     void ForEachNodeUnderLock(const std::function<void(CNode*)>& func) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Relay an inventory item to every node (issue #2558 PR 9c; replaces the
-    //! free RelayInventory shim).
-    void RelayInventory(const CInv& inv);
+    //! free RelayInventory shim). When min_proto_version is set, only peers
+    //! whose negotiated protocol version is at least that value are told --
+    //! used for object types older peers cannot handle (e.g. MSG_PSGT, #2910).
+    void RelayInventory(const CInv& inv, int min_proto_version = 0);
 
     //! Relay an address to a deterministic, limited subset of nodes (issue #2558
     //! PR 9c; moved from net_processing's ADDR handler).

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -572,9 +572,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->nVersion >= PSGT_PROTO_VERSION
             && WITH_LOCK(cs_main, return IsV15Enabled(nBestHeight) && !OutOfSyncByAge()))
         {
-            for (const auto& entry : g_psgt_pool.GetAll())
+            for (const uint256& revision_hash : g_psgt_pool.GetAllRevisionHashes())
             {
-                pfrom->PushInventory(CInv(MSG_PSGT, entry.revision_hash));
+                pfrom->PushInventory(CInv(MSG_PSGT, revision_hash));
             }
         }
 
@@ -835,12 +835,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // budget so a single getdata cannot force unbounded sends.
                     if (!OutOfSyncByAge() && psgt_served < MAX_PSGT_PER_GETDATA)
                     {
-                        if (const auto entry = g_psgt_pool.GetByRevision(inv.hash))
+                        if (const auto serialized = g_psgt_pool.GetSerializedByRevision(inv.hash))
                         {
                             ++psgt_served;
                             CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                            ss.reserve(entry->serialized.size() + 16);
-                            ss << entry->serialized;
+                            ss.reserve(serialized->size() + 16);
+                            ss << *serialized;
                             pfrom->PushMessage(NetMsgType::PSGT, ss);
                         }
                     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -288,7 +288,7 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
     PSGTPoolEntry entry;
     std::string reason;
     const PSGTPoolReject reject =
-        ValidatePSGTForPool(wire_bytes, GetAdjustedTime(), entry, reason);
+        ValidatePSGTForPool(g_psgt_pool, wire_bytes, GetAdjustedTime(), entry, reason);
 
     switch (reject) {
     case PSGTPoolReject::NONE:
@@ -305,7 +305,14 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
               pfrom->addr.ToString(), PSGTPoolRejectToString(reject), reason);
         return;
 
-    // Policy rejects honest nodes can disagree on: no penalty, no relay.
+    // Policy rejects honest nodes can disagree on, plus the cheap pre-validation
+    // drops (unknown fields and already-known revisions): no penalty, no relay.
+    // HAS_UNKNOWN_FIELDS and DUPLICATE_REVISION are rejected before the
+    // expensive signature verification, so replaying them costs no ECDSA work
+    // and needs no DoS score; scoring them would also risk banning honest peers
+    // in ordinary gossip races or future protocol extensions.
+    case PSGTPoolReject::HAS_UNKNOWN_FIELDS:
+    case PSGTPoolReject::DUPLICATE_REVISION:
     case PSGTPoolReject::COMPLETE:
     case PSGTPoolReject::UTXO_MISSING:
     case PSGTPoolReject::UTXO_SPENT:
@@ -731,6 +738,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         LOCK(cs_main);
+
+        // Bound the PSGT bytes served per getdata. The pool holds at most
+        // PSGTPool::MAX_ENTRIES distinct revisions, so any request for more than
+        // that many is necessarily redundant. This caps a getdata amplification
+        // where a peer packs MAX_INV_SZ (50000) MSG_PSGT entries all naming the
+        // same pooled revision (each up to MAX_PSGT_WIRE_SIZE) to force gigabytes
+        // of repeated sends under cs_main.
+        constexpr size_t MAX_PSGT_PER_GETDATA = PSGTPool::MAX_ENTRIES;
+        size_t psgt_served = 0;
+
         for (auto const& inv : vInv)
         {
             if (fShutdown)
@@ -805,11 +822,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     // Serve from the PSGT pool, not mapRelay: pooled PSGTs
                     // live up to 7 days, far beyond mapRelay's 15-minute
                     // expiry. Do not serve while out of sync (mirrors the
-                    // scraper manifest guard below).
-                    if (!OutOfSyncByAge())
+                    // scraper manifest guard below). Bounded by the per-getdata
+                    // budget so a single getdata cannot force unbounded sends.
+                    if (!OutOfSyncByAge() && psgt_served < MAX_PSGT_PER_GETDATA)
                     {
                         if (const auto entry = g_psgt_pool.GetByRevision(inv.hash))
                         {
+                            ++psgt_served;
                             CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                             ss.reserve(entry->serialized.size() + 16);
                             ss << entry->serialized;
@@ -1617,13 +1636,14 @@ public:
         return ::SendMessages(pto, fSendTrickle);
     }
 
-    void StartScheduledTasks(CScheduler& scheduler) override
+    void StartScheduledTasks(CScheduler& /*scheduler*/) override
     {
-        // Sweep expired PSGTs (#2910) so entries whose owners went idle still
-        // expire -- and fire the eviction notification -- even when no pool
-        // traffic triggers the lazy paths.
-        scheduler.scheduleEvery([] { g_psgt_pool.EraseExpired(GetAdjustedTime()); },
-                                std::chrono::minutes{10});
+        // Intentionally empty. The recurring PSGT-pool sweep (EraseExpired,
+        // #2910) is scheduled in AppInit2 alongside the other recurring tasks
+        // (banlist dump, entropy, unbroadcast rebroadcast), so it is NOT
+        // duplicated here -- scheduling it in both places ran two sweeps of the
+        // same pool. This hook remains as the eventual home should those tasks
+        // be consolidated onto PeerManager.
     }
 
     bool Misbehaving(const CAddress& addr, int howmuch) override

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -325,6 +325,15 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
     }
 
     const uint256 revision_hash = entry.revision_hash;
+
+    // Mark the sender as knowing the CANONICAL revision (what we pool and
+    // relay), not just the wire-bytes hash tracked at the top of this function.
+    // The two differ if the peer sent a non-canonical encoding; without this we
+    // would relay inv(revision_hash) straight back to the sender. Re-asking is
+    // already prevented by HaveRevision() once the entry is pooled below, so no
+    // mapAlreadyAskedFor bookkeeping is needed for the canonical hash.
+    pfrom->AddInventoryKnown(CInv(MSG_PSGT, revision_hash));
+
     std::string reject_reason;
     const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -268,7 +268,21 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
         return;
     }
 
-    const CInv inv(MSG_PSGT, Hash(wire_bytes));
+    // Identify the object by its CANONICAL revision hash (the hash of the
+    // SerializePSGT re-serialization) -- the identity we pool and relay -- not
+    // the raw wire-bytes hash, so inventory-known and mapAlreadyAskedFor
+    // bookkeeping match even when a peer sends a non-canonical encoding of the
+    // same content. Decoding here is cheap (no signature work); a decode failure
+    // falls back to the wire hash and is rejected during validation below.
+    uint256 obj_hash = Hash(wire_bytes);
+    {
+        PartiallySignedTransaction decoded;
+        std::string decode_err;
+        if (DecodePSGTBytes(decoded, wire_bytes, decode_err)) {
+            obj_hash = Hash(SerializePSGT(decoded));
+        }
+    }
+    const CInv inv(MSG_PSGT, obj_hash);
 
     // The sender obviously has this revision: suppress the inv echo.
     pfrom->AddInventoryKnown(inv);
@@ -324,15 +338,10 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
         return;
     }
 
+    // The inv tracked at the top of this function is already keyed on the
+    // canonical revision hash (== entry.revision_hash), so the sender is marked
+    // as knowing this revision and we will not echo it back.
     const uint256 revision_hash = entry.revision_hash;
-
-    // Mark the sender as knowing the CANONICAL revision (what we pool and
-    // relay), not just the wire-bytes hash tracked at the top of this function.
-    // The two differ if the peer sent a non-canonical encoding; without this we
-    // would relay inv(revision_hash) straight back to the sender. Re-asking is
-    // already prevented by HaveRevision() once the entry is pooled below, so no
-    // mapAlreadyAskedFor bookkeeping is needed for the canonical hash.
-    pfrom->AddInventoryKnown(CInv(MSG_PSGT, revision_hash));
 
     std::string reject_reason;
     const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -42,7 +42,9 @@
 #include "node/blockstorage.h"
 #include "node/coherence.h"
 #include "node/orphan_blocks.h"
+#include "node/psgt_pool.h"
 #include "policy/fees.h"
+#include "scheduler.h"
 #include "policy/policy.h"
 #include "random.h"
 #include "validation.h"
@@ -226,9 +228,115 @@ bool static AlreadyHave(CTxDB& txdb, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(c
     case MSG_BLOCK:
         return mapBlockIndex.count(inv.hash) ||
                g_orphan_blocks.Contains(inv.hash);
+
+    case MSG_PSGT:
+        // Recently removed revisions read as "have": a completed, superseded
+        // or evicted PSGT must not be re-fetched from lagging peers (#2910).
+        return g_psgt_pool.HaveRevision(inv.hash);
     }
     // Don't know what it is, just say we already got one
     return true;
+}
+
+//! Relay a pooled PSGT revision to peers that can handle it (#2910). Served
+//! from the PSGT pool in the getdata loop, NOT from mapRelay: pooled PSGTs
+//! live up to 7 days, far beyond mapRelay's 15-minute expiry.
+void RelayPSGT(const uint256& revision_hash)
+{
+    if (!g_connman) return;
+
+    g_connman->RelayInventory(CInv(MSG_PSGT, revision_hash), PSGT_PROTO_VERSION);
+}
+
+//! Handle an incoming "psgt" message (#2910): validate against the pool
+//! admission rules and, on acceptance, pool and relay the new revision.
+//!
+//! Misbehavior policy: rejects no compliant node would have relayed
+//! (undecodable, oversize, structural, invalid or missing signatures) score
+//! 20 -- a buggy peer survives a couple of slips, a flooder is banned at
+//! five. Policy rejects honest nodes can disagree on (UTXO races around
+//! confirmation, fee bounds, pool-full, replacement races, completeness)
+//! score 0.
+static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
+{
+    std::vector<unsigned char> wire_bytes;
+    try {
+        vRecv >> wire_bytes;
+    } catch (const std::exception&) {
+        pfrom->Misbehaving(20);
+        error("%s: undecodable psgt message from %s", __func__, pfrom->addr.ToString());
+        return;
+    }
+
+    const CInv inv(MSG_PSGT, Hash(wire_bytes));
+
+    // The sender obviously has this revision: suppress the inv echo.
+    pfrom->AddInventoryKnown(inv);
+
+    // The request is satisfied (or abandoned); stop re-asking either way.
+    {
+        LOCK(cs_mapAlreadyAskedFor);
+        mapAlreadyAskedFor.erase(inv);
+    }
+
+    LOCK(cs_main);
+
+    // Not active, or unable to validate against a current UTXO view yet:
+    // ignore silently, as a pre-v15 node would ignore the unknown message.
+    if (!IsV15Enabled(nBestHeight) || OutOfSyncByAge()) return;
+
+    PSGTPoolEntry entry;
+    std::string reason;
+    const PSGTPoolReject reject =
+        ValidatePSGTForPool(wire_bytes, GetAdjustedTime(), entry, reason);
+
+    switch (reject) {
+    case PSGTPoolReject::NONE:
+        break;
+
+    // Rejects no compliant node would have relayed.
+    case PSGTPoolReject::TOO_LARGE:
+    case PSGTPoolReject::MALFORMED:
+    case PSGTPoolReject::STRUCTURAL:
+    case PSGTPoolReject::INVALID_SIG:
+    case PSGTPoolReject::NO_VALID_SIG:
+        pfrom->Misbehaving(20);
+        error("%s: invalid psgt from %s: %s (%s)", __func__,
+              pfrom->addr.ToString(), PSGTPoolRejectToString(reject), reason);
+        return;
+
+    // Policy rejects honest nodes can disagree on: no penalty, no relay.
+    case PSGTPoolReject::COMPLETE:
+    case PSGTPoolReject::UTXO_MISSING:
+    case PSGTPoolReject::UTXO_SPENT:
+    case PSGTPoolReject::FEE_TOO_LOW:
+    case PSGTPoolReject::FEE_ABSURD:
+        LogPrint(BCLog::LogFlags::MEMPOOL, "%s: psgt from %s not accepted: %s (%s)",
+                 __func__, pfrom->addr.ToString(),
+                 PSGTPoolRejectToString(reject), reason);
+        return;
+    }
+
+    const uint256 revision_hash = entry.revision_hash;
+    std::string reject_reason;
+    const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);
+
+    switch (result) {
+    case PSGTPoolAddResult::ACCEPTED_NEW:
+    case PSGTPoolAddResult::ACCEPTED_REPLACEMENT:
+        RelayPSGT(revision_hash);
+        break;
+
+    case PSGTPoolAddResult::DUPLICATE:
+    case PSGTPoolAddResult::REJECTED_POOL_FULL:
+    case PSGTPoolAddResult::REJECTED_NOT_BETTER:
+    case PSGTPoolAddResult::REJECTED_NOT_INITIATOR:
+        // Normal gossip and replacement races.
+        LogPrint(BCLog::LogFlags::MEMPOOL, "%s: psgt %s from %s not pooled: %s",
+                 __func__, revision_hash.ToString(), pfrom->addr.ToString(),
+                 reject_reason);
+        break;
+    }
 }
 
 
@@ -442,6 +550,18 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 item.second.RelayTo(pfrom);
         }
 
+        // Notify the peer about pooled PSGTs (#2910): only peers that
+        // understand MSG_PSGT, and only when the fork is active and this
+        // node is in sync enough to serve what it advertises.
+        if (pfrom->nVersion >= PSGT_PROTO_VERSION
+            && WITH_LOCK(cs_main, return IsV15Enabled(nBestHeight) && !OutOfSyncByAge()))
+        {
+            for (const auto& entry : g_psgt_pool.GetAll())
+            {
+                pfrom->PushInventory(CInv(MSG_PSGT, entry.revision_hash));
+            }
+        }
+
         /* Notify the peer about statsscraper blobs we have */
         LOCK2(CScraperManifest::cs_mapManifest, CSplitBlob::cs_mapParts);
 
@@ -563,7 +683,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             {
                 LOCK(cs_main);
 
-                if (!fAlreadyHave)
+                // PSGTs (#2910) are only fetched once the v15 gate is active
+                // and this node is in sync -- validation needs a current UTXO
+                // view, and the pool does not operate pre-activation.
+                const bool skip_psgt = inv.type == MSG_PSGT
+                    && (!IsV15Enabled(nBestHeight) || OutOfSyncByAge());
+
+                if (!fAlreadyHave && !skip_psgt)
                     pfrom->AskFor(inv);
                 else if (inv.type == MSG_BLOCK && g_orphan_blocks.Contains(inv.hash)) {
                     const CBlock* pblock_root = g_orphan_blocks.GetRootBlock(inv.hash);
@@ -674,6 +800,22 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     LOCK(CSplitBlob::cs_mapParts);
 
                     CSplitBlob::SendPartTo(pfrom, inv.hash);
+                }
+                else if (!pushed && inv.type == MSG_PSGT) {
+                    // Serve from the PSGT pool, not mapRelay: pooled PSGTs
+                    // live up to 7 days, far beyond mapRelay's 15-minute
+                    // expiry. Do not serve while out of sync (mirrors the
+                    // scraper manifest guard below).
+                    if (!OutOfSyncByAge())
+                    {
+                        if (const auto entry = g_psgt_pool.GetByRevision(inv.hash))
+                        {
+                            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                            ss.reserve(entry->serialized.size() + 16);
+                            ss << entry->serialized;
+                            pfrom->PushMessage(NetMsgType::PSGT, ss);
+                        }
+                    }
                 }
                 else if(!pushed &&  inv.type == MSG_SCRAPERINDEX)
                 {
@@ -1060,6 +1202,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (strCommand == NetMsgType::PART)
     {
         CSplitBlob::RecvPart(pfrom, vRecv);
+    }
+    else if (strCommand == NetMsgType::PSGT)
+    {
+        ProcessPSGTMessage(pfrom, vRecv);
     }
 
 
@@ -1471,9 +1617,13 @@ public:
         return ::SendMessages(pto, fSendTrickle);
     }
 
-    void StartScheduledTasks(CScheduler& /*scheduler*/) override
+    void StartScheduledTasks(CScheduler& scheduler) override
     {
-        // No recurring tasks yet (issue #2558 PR 8a shell).
+        // Sweep expired PSGTs (#2910) so entries whose owners went idle still
+        // expire -- and fire the eviction notification -- even when no pool
+        // traffic triggers the lazy paths.
+        scheduler.scheduleEvery([] { g_psgt_pool.EraseExpired(GetAdjustedTime()); },
+                                std::chrono::minutes{10});
     }
 
     bool Misbehaving(const CAddress& addr, int howmuch) override

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -24,6 +24,10 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
 //! see the definition for the lock-order rationale).
 void ResendUnbroadcastTransactions();
 
+//! Relay a pooled PSGT revision (#2910) to peers on PSGT_PROTO_VERSION or
+//! later. The object itself is served from the PSGT pool by the getdata loop.
+void RelayPSGT(const uint256& revision_hash);
+
 //! Message-processing manager (issue #2558 PR 8a). Abstract interface; the
 //! implementation (PeerManagerImpl) lives in net_processing.cpp and also
 //! implements NetEventsInterface (ProcessMessages/SendMessages). The

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -37,9 +37,11 @@ std::string PSGTRemovalReasonToString(PSGTRemovalReason reason)
 std::string PSGTPoolRejectToString(PSGTPoolReject reject)
 {
     switch (reject) {
-    case PSGTPoolReject::NONE:         return "none";
-    case PSGTPoolReject::TOO_LARGE:    return "too-large";
-    case PSGTPoolReject::MALFORMED:    return "malformed";
+    case PSGTPoolReject::NONE:               return "none";
+    case PSGTPoolReject::TOO_LARGE:          return "too-large";
+    case PSGTPoolReject::MALFORMED:          return "malformed";
+    case PSGTPoolReject::HAS_UNKNOWN_FIELDS: return "unknown-fields";
+    case PSGTPoolReject::DUPLICATE_REVISION: return "duplicate-revision";
     case PSGTPoolReject::STRUCTURAL:   return "structural";
     case PSGTPoolReject::INVALID_SIG:  return "invalid-signature";
     case PSGTPoolReject::NO_VALID_SIG: return "no-valid-signature";
@@ -105,7 +107,25 @@ static PSGTPoolReject CheckFundingOutput(const COutPoint& prevout, CTxDB& txdb, 
     return PSGTPoolReject::NONE;
 }
 
-PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
+//! True if the PSGT carries any unknown (extension) key-value pairs in its
+//! global, per-input, or per-output maps. The relay pool understands only the
+//! fields it needs and rejects extension fields (see ValidatePSGTForPool):
+//! they are a free revision-hash malleability vector and serve no pooling
+//! purpose. Cheap -- iterates the already-decoded maps, no allocation.
+static bool PSGTHasUnknownFields(const PartiallySignedTransaction& psgt)
+{
+    if (!psgt.unknown.empty()) return true;
+    for (const PSGTInput& input : psgt.inputs) {
+        if (!input.unknown.empty()) return true;
+    }
+    for (const PSGTOutput& output : psgt.outputs) {
+        if (!output.unknown.empty()) return true;
+    }
+    return false;
+}
+
+PSGTPoolReject ValidatePSGTForPool(const PSGTPool& pool,
+                                   const std::vector<unsigned char>& wire_bytes,
                                    int64_t now,
                                    PSGTPoolEntry& out_entry,
                                    std::string& error)
@@ -127,6 +147,37 @@ PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
     PartiallySignedTransaction& psgt = out_entry.psgt;
     if (!DecodePSGTBytes(psgt, wire_bytes, error)) {
         return PSGTPoolReject::MALFORMED;
+    }
+
+    // Unknown (extension) fields serve no purpose for a relay pool and are a
+    // free malleability vector: appending one mints a fresh wire encoding for
+    // otherwise-identical content. Reject them so the canonical revision hash
+    // computed below is stable. Cheap check, done before any signature work.
+    if (PSGTHasUnknownFields(psgt)) {
+        error = "PSGT carries unknown extension fields; not eligible for the pool";
+        return PSGTPoolReject::HAS_UNKNOWN_FIELDS;
+    }
+
+    // Canonical revision identity. Hash a re-serialization (SerializePSGT emits
+    // sorted maps) rather than the received wire bytes, so map reordering cannot
+    // mint a fresh identity for the same content either. Combined with #3113's
+    // strict DER / low-S encoding -- exactly one valid signature per (keyid,
+    // sighash) -- this makes the revision hash canonical for a given (unsigned
+    // tx, valid-signer-set). Storing the canonical bytes means getdata serves,
+    // and peers converge on, that single canonical form.
+    out_entry.serialized = SerializePSGT(psgt);
+    out_entry.revision_hash = Hash(out_entry.serialized);
+
+    // Duplicate short-circuit BEFORE the expensive per-signature ECDSA
+    // verification below: if we already hold (or recently held) this exact
+    // canonical revision, drop it cheaply. This is what stops a peer replaying
+    // one valid PSGT under an ever-changing hash to burn signature checks under
+    // cs_main (the deferred #3115/#3116 DoS). Correctness does not depend on it
+    // -- Add() re-checks under cs_psgt_pool -- so the read here is a pure
+    // optimization; a race merely means we do work we would have done anyway.
+    if (pool.HaveRevision(out_entry.revision_hash)) {
+        error = "revision already present in or recently removed from the pool";
+        return PSGTPoolReject::DUPLICATE_REVISION;
     }
 
     const CTransaction tx(psgt.tx);
@@ -230,8 +281,8 @@ PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
         return PSGTPoolReject::FEE_ABSURD;
     }
 
-    out_entry.serialized = wire_bytes;
-    out_entry.revision_hash = Hash(wire_bytes);
+    // out_entry.serialized / revision_hash were set from the canonical
+    // re-serialization above (before the duplicate short-circuit).
     out_entry.image = *image;
     out_entry.tx_hash = tx.GetHash();
     out_entry.time_received = now;

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -686,7 +686,7 @@ PSGTSignResult SignAndAdvancePSGT(const CScriptID& image, std::string& error,
     const std::optional<PSGTPoolEntry> pooled = g_psgt_pool.Get(image);
     if (!pooled) {
         error = "PSGT not found in the pool";
-        return PSGTSignResult::FAILED;
+        return PSGTSignResult::NOT_FOUND;
     }
 
     PartiallySignedTransaction psgt = pooled->psgt;

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -747,6 +747,17 @@ PSGTSignResult SignAndAdvancePSGT(const CScriptID& image, std::string& error,
         return PSGTSignResult::COMPLETED_AND_BROADCAST;
     }
 
+    if (reject == PSGTPoolReject::DUPLICATE_REVISION) {
+        // The wallet's signature reproduced a revision the pool already holds or
+        // recently held: another co-signer holding the same key signed
+        // identically first (deterministic low-S ECDSA yields identical bytes),
+        // or this exact revision was pooled before. The contribution is already
+        // known to the network -- there is nothing to add or relay, and it is
+        // not a failure. Report the unsigned-tx id like the SIGNED path does.
+        if (txid_out) *txid_out = pooled->tx_hash;
+        return PSGTSignResult::ALREADY_KNOWN;
+    }
+
     if (reject != PSGTPoolReject::NONE) {
         error = strprintf("signed PSGT failed revalidation: %s (%s)",
                           PSGTPoolRejectToString(reject), validate_error);

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -495,6 +495,30 @@ std::vector<PSGTPoolEntry> PSGTPool::GetAll() const
     return entries;
 }
 
+std::vector<uint256> PSGTPool::GetAllRevisionHashes() const
+{
+    LOCK(cs_psgt_pool);
+
+    std::vector<uint256> hashes;
+    hashes.reserve(m_by_revision.size());
+    for (const auto& [revision_hash, image] : m_by_revision) {
+        hashes.push_back(revision_hash);
+    }
+    return hashes;
+}
+
+std::optional<std::vector<unsigned char>>
+PSGTPool::GetSerializedByRevision(const uint256& revision_hash) const
+{
+    LOCK(cs_psgt_pool);
+
+    const auto it = m_by_revision.find(revision_hash);
+    if (it == m_by_revision.end()) return std::nullopt;
+    const auto img = m_by_image.find(it->second);
+    if (img == m_by_image.end()) return std::nullopt;
+    return img->second.serialized;
+}
+
 size_t PSGTPool::EraseExpired(int64_t now)
 {
     std::vector<PSGTPoolEntry> expired;

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -713,7 +713,7 @@ PSGTSignResult SignAndAdvancePSGT(const CScriptID& image, std::string& error,
     PSGTPoolEntry replacement;
     std::string validate_error;
     const PSGTPoolReject reject =
-        ValidatePSGTForPool(wire, GetAdjustedTime(), replacement, validate_error);
+        ValidatePSGTForPool(g_psgt_pool, wire, GetAdjustedTime(), replacement, validate_error);
 
     if (reject == PSGTPoolReject::COMPLETE) {
         PartiallySignedTransaction to_extract = psgt;

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -8,12 +8,15 @@
 #include <dbwrapper.h>
 #include <hash.h>
 #include <index/txindex.h>
+#include <init.h>
 #include <logging.h>
+#include <net_processing.h>
 #include <policy/fees.h>
 #include <tinyformat.h>
 #include <txmempool.h>
 #include <util.h>
 #include <validation.h>
+#include <wallet/wallet.h>
 
 #include <algorithm>
 #include <cassert>
@@ -664,4 +667,103 @@ void PSGTPool::Notify(const PSGTPoolEntry& entry, PSGTPoolChangeType change,
     if (m_notify_hook) {
         m_notify_hook(entry, change, reason);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Signing workflow
+// ---------------------------------------------------------------------------
+
+PSGTSignResult SignAndAdvancePSGT(const CScriptID& image, std::string& error,
+                                  uint256* txid_out)
+{
+    if (!pwalletMain) {
+        error = "wallet is not loaded";
+        return PSGTSignResult::FAILED;
+    }
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    const std::optional<PSGTPoolEntry> pooled = g_psgt_pool.Get(image);
+    if (!pooled) {
+        error = "PSGT not found in the pool";
+        return PSGTSignResult::FAILED;
+    }
+
+    PartiallySignedTransaction psgt = pooled->psgt;
+
+    // SignPSGTInput's multisig return value means "any signature present",
+    // not "this wallet signed", so count partial_sigs growth instead.
+    bool added_any = false;
+    for (unsigned int i = 0; i < psgt.inputs.size(); ++i) {
+        const size_t before = psgt.inputs[i].partial_sigs.size();
+        SignPSGTInput(*pwalletMain, psgt, i);
+        if (psgt.inputs[i].partial_sigs.size() > before) {
+            added_any = true;
+        }
+    }
+
+    if (!added_any) {
+        error = "this wallet holds no key that can add a signature";
+        return PSGTSignResult::NO_NEW_SIGNATURES;
+    }
+
+    // Revalidate the enriched PSGT exactly as the network would; COMPLETE
+    // means our signature(s) finished the job.
+    const std::vector<unsigned char> wire = SerializePSGT(psgt);
+    PSGTPoolEntry replacement;
+    std::string validate_error;
+    const PSGTPoolReject reject =
+        ValidatePSGTForPool(wire, GetAdjustedTime(), replacement, validate_error);
+
+    if (reject == PSGTPoolReject::COMPLETE) {
+        PartiallySignedTransaction to_extract = psgt;
+        CMutableTransaction final_mtx;
+        if (!FinalizeAndExtractPSGT(to_extract, final_mtx)) {
+            error = "PSGT has enough signatures but could not be finalized";
+            return PSGTSignResult::FAILED;
+        }
+
+        // Free the slot as COMPLETED before broadcasting: mempool admission
+        // fires this pool's own conflict eviction, which would otherwise get
+        // there first and report the completion as a conflict.
+        g_psgt_pool.Remove(image, PSGTRemovalReason::COMPLETED);
+
+        CTransaction final_tx(final_mtx);
+        CValidationState state;
+        if (!AcceptToMemoryPool(mempool, final_tx, state, nullptr)) {
+            // The local slot is already freed, but peers still carry the
+            // PSGT and the initiator can always resubmit.
+            error = "finalized transaction was rejected by the mempool";
+            return PSGTSignResult::FAILED;
+        }
+
+        RelayTransaction(final_tx, final_tx.GetHash());
+
+        if (txid_out) *txid_out = final_tx.GetHash();
+
+        LogPrint(BCLog::LogFlags::MEMPOOL,
+                 "psgtpool: completed image %s -> broadcast tx %s",
+                 image.ToString(), final_tx.GetHash().ToString());
+        return PSGTSignResult::COMPLETED_AND_BROADCAST;
+    }
+
+    if (reject != PSGTPoolReject::NONE) {
+        error = strprintf("signed PSGT failed revalidation: %s (%s)",
+                          PSGTPoolRejectToString(reject), validate_error);
+        return PSGTSignResult::FAILED;
+    }
+
+    const uint256 revision_hash = replacement.revision_hash;
+    std::string reject_reason;
+    const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(replacement), reject_reason);
+    if (result != PSGTPoolAddResult::ACCEPTED_REPLACEMENT
+        && result != PSGTPoolAddResult::ACCEPTED_NEW) {
+        error = strprintf("signed PSGT was not pooled: %s", reject_reason);
+        return PSGTSignResult::FAILED;
+    }
+
+    if (txid_out) *txid_out = pooled->tx_hash;
+
+    RelayPSGT(revision_hash);
+    return PSGTSignResult::SIGNED_AND_RELAYED;
 }

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -207,6 +207,15 @@ public:
     //! For REMOVED changes the removal reason is provided. Wired to the
     //! uiInterface signal and -psgtnotify by the RPC/notification layer;
     //! unset (and skipped) until then.
+    //!
+    //! Consumer constraint: the hook may fire while the caller still holds
+    //! cs_main (and sometimes cs_wallet) -- e.g. from Add/Remove inside
+    //! SignAndAdvancePSGT, or from the synchronous EvictConflicts callback
+    //! during AcceptToMemoryPool/BlockConnected. It must therefore behave as a
+    //! LEAF: do not synchronously take cs_main, cs_wallet, or cs_psgt_pool, and
+    //! do not block. The existing sinks comply (a Qt queued signal and a
+    //! detached runCommand); a future subscriber that violates this would
+    //! deadlock or invert lock order.
     std::function<void(const PSGTPoolEntry&, PSGTPoolChangeType,
                        std::optional<PSGTRemovalReason>)> m_notify_hook;
 
@@ -317,6 +326,7 @@ enum class PSGTSignResult
     SIGNED_AND_RELAYED,      //!< Added signature(s); still incomplete; new revision pooled and relayed.
     COMPLETED_AND_BROADCAST, //!< Signature(s) completed the PSGT; final transaction broadcast; pool slot freed.
     NO_NEW_SIGNATURES,       //!< The wallet holds no key that could add a signature.
+    ALREADY_KNOWN,           //!< Added signature(s), but the resulting revision is already in (or was recently in) the pool; nothing to relay.
     FAILED,                  //!< See error.
 };
 

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -327,6 +327,7 @@ enum class PSGTSignResult
     COMPLETED_AND_BROADCAST, //!< Signature(s) completed the PSGT; final transaction broadcast; pool slot freed.
     NO_NEW_SIGNATURES,       //!< The wallet holds no key that could add a signature.
     ALREADY_KNOWN,           //!< Added signature(s), but the resulting revision is already in (or was recently in) the pool; nothing to relay.
+    NOT_FOUND,               //!< The image is not in the pool (never was, or was removed/expired before signing).
     FAILED,                  //!< See error.
 };
 

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -246,8 +246,20 @@ public:
     //! damping: recently completed/evicted revisions read as "already have").
     bool HaveRevision(const uint256& revision_hash) const;
 
-    //! Snapshot of all entries (RPC/GUI listing, connect-time advertisement).
+    //! Snapshot of all entries (RPC/GUI listing).
     std::vector<PSGTPoolEntry> GetAll() const;
+
+    //! Revision hashes of all pooled entries, for the connect-time inventory
+    //! push. Copies only the 32-byte hashes, not the full entries -- the push
+    //! runs on every inbound connection, so a peer must not be able to force
+    //! repeated multi-megabyte entry copies just by reconnecting.
+    std::vector<uint256> GetAllRevisionHashes() const;
+
+    //! Canonical serialized bytes of a pooled revision, if present, for the
+    //! getdata serve. Copies only the wire bytes, not the decoded PSGT, on this
+    //! peer-controlled hot path.
+    std::optional<std::vector<unsigned char>>
+        GetSerializedByRevision(const uint256& revision_hash) const;
 
     //! Evict entries older than EXPIRY_SECONDS. Returns the number evicted.
     size_t EraseExpired(int64_t now);

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -311,4 +311,31 @@ private:
 //! Global PSGT pool. Registered as a validation-interface subscriber in init.
 extern PSGTPool g_psgt_pool;
 
+//! What SignAndAdvancePSGT did.
+enum class PSGTSignResult
+{
+    SIGNED_AND_RELAYED,      //!< Added signature(s); still incomplete; new revision pooled and relayed.
+    COMPLETED_AND_BROADCAST, //!< Signature(s) completed the PSGT; final transaction broadcast; pool slot freed.
+    NO_NEW_SIGNATURES,       //!< The wallet holds no key that could add a signature.
+    FAILED,                  //!< See error.
+};
+
+//!
+//! \brief Sign a pooled PSGT with the local wallet and advance the workflow
+//! (#2910 lifecycle steps 6-9): if the added signature(s) complete it,
+//! finalize, broadcast the extracted transaction through the normal relay
+//! path and free the image slot (peers' pools clean themselves up when the
+//! transaction reaches their mempools); otherwise pool and relay the
+//! signature-superset revision.
+//!
+//! Shared by the signpsgtinpool RPC and the GUI Sign action. Takes cs_main
+//! and the wallet lock internally; the wallet must be unlocked.
+//!
+//! On COMPLETED_AND_BROADCAST, txid_out receives the FINAL transaction id
+//! (signing changes the id: the hash covers scriptSigs); on
+//! SIGNED_AND_RELAYED it receives the unchanged unsigned transaction id.
+//!
+PSGTSignResult SignAndAdvancePSGT(const CScriptID& image, std::string& error,
+                                  uint256* txid_out = nullptr);
+
 #endif // GRIDCOIN_NODE_PSGT_POOL_H

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -33,9 +33,12 @@
 //!    number of distinct multisig arrangements actually funded on-chain,
 //!    which an attacker cannot inflate for free.
 //!  - The relay identity of a specific revision is its \b revision hash =
-//!    Hash(serialized wire bytes). Adding a co-signature does not change the
-//!    unsigned transaction's hash, so tx-hash inventory would never
-//!    propagate signature progress; every mutation produces a fresh
+//!    Hash(canonical serialization). ValidatePSGTForPool hashes a
+//!    SerializePSGT re-serialization (sorted maps, unknown fields rejected),
+//!    NOT the received wire bytes, so reordering or padding cannot mint a
+//!    fresh identity for the same content. Adding a co-signature does not
+//!    change the unsigned transaction's hash, so tx-hash inventory would never
+//!    propagate signature progress; every genuine mutation produces a fresh
 //!    revision hash and therefore a fresh inv.
 //!
 
@@ -79,7 +82,7 @@ enum class PSGTPoolAddResult
 struct PSGTPoolEntry
 {
     PartiallySignedTransaction psgt;
-    std::vector<unsigned char> serialized; //!< Exact wire bytes (getdata serving; hashed for revision).
+    std::vector<unsigned char> serialized; //!< Canonical SerializePSGT bytes (getdata serving; hashed for revision).
     uint256 revision_hash;                 //!< Hash(serialized) -- the inv/relay identity.
     CScriptID image;                       //!< CScriptID(redeem script) -- the pool key.
     uint256 tx_hash;                       //!< Hash of the unsigned transaction.
@@ -107,9 +110,11 @@ struct PSGTPoolEntry
 //! RPC layer maps them to error strings.
 enum class PSGTPoolReject
 {
-    NONE,         //!< Valid; out_entry is filled.
-    TOO_LARGE,    //!< Wire size above MAX_PSGT_WIRE_SIZE.
-    MALFORMED,    //!< Does not decode as a PSGT.
+    NONE,               //!< Valid; out_entry is filled.
+    TOO_LARGE,          //!< Wire size above MAX_PSGT_WIRE_SIZE.
+    MALFORMED,          //!< Does not decode as a PSGT.
+    HAS_UNKNOWN_FIELDS, //!< Decodes, but carries unknown (extension) key-value pairs; not relayed.
+    DUPLICATE_REVISION, //!< Canonically identical to a revision already pooled or recently removed.
     STRUCTURAL,   //!< Decodes, but is not a well-formed single-image P2SH multisig spend.
     INVALID_SIG,  //!< Carries a cryptographically invalid or foreign partial signature.
     NO_VALID_SIG, //!< Some input has no valid partial signature (anti-spam floor).
@@ -123,13 +128,16 @@ enum class PSGTPoolReject
 //! Human-readable reject reason (for logs and RPC errors).
 std::string PSGTPoolRejectToString(PSGTPoolReject reject);
 
+class PSGTPool;
+
 //!
 //! \brief Validate a PSGT received from an untrusted source (network relay or
 //! local submission) and fill a pool entry from it.
 //!
-//! Checks, cheap to expensive: wire size; decode; basic transaction sanity
-//! (CheckTransaction, version >= 2, no finalized inputs); single-image P2SH
-//! multisig structure across ALL inputs (GetPSGTImage's trustworthiness
+//! Checks, cheap to expensive: wire size; decode; unknown-field rejection;
+//! CANONICAL revision identity + duplicate short-circuit; basic transaction
+//! sanity (CheckTransaction, version >= 2, no finalized inputs); single-image
+//! P2SH multisig structure across ALL inputs (GetPSGTImage's trustworthiness
 //! rules); cryptographic verification of EVERY partial signature with at
 //! least one valid signature on every input, and fewer than m so the pool
 //! only holds material that still needs co-signers; funding outputs exist
@@ -138,10 +146,22 @@ std::string PSGTPoolRejectToString(PSGTPoolReject reject);
 //! chain facts to establish); and fee within [relay minimum, 100x relay
 //! minimum] for the estimated final size.
 //!
+//! Identity note (anti-DoS): the revision hash is computed over a CANONICAL
+//! re-serialization (SerializePSGT), not the received wire bytes, and PSGTs
+//! carrying unknown extension fields are rejected. Together with #3113's strict
+//! DER / low-S signature encoding this makes the revision hash canonical for a
+//! given (unsigned tx, valid-signer-set): map reordering and unknown-field
+//! padding can no longer mint a fresh identity for the same content. This lets
+//! the duplicate short-circuit run BEFORE the expensive per-signature ECDSA
+//! verification, so a peer cannot cheaply replay one valid PSGT under an
+//! ever-changing hash to burn CPU under cs_main (the deferred #3115/#3116 DoS).
+//! `pool` is consulted read-only for that HaveRevision short-circuit.
+//!
 //! Requires cs_main (chain/mempool lookups). Does NOT check IsV15Enabled or
 //! sync state -- those are the caller's (P2P handler / RPC) admission gates.
 //!
-PSGTPoolReject ValidatePSGTForPool(const std::vector<unsigned char>& wire_bytes,
+PSGTPoolReject ValidatePSGTForPool(const PSGTPool& pool,
+                                   const std::vector<unsigned char>& wire_bytes,
                                    int64_t now,
                                    PSGTPoolEntry& out_entry,
                                    std::string& error) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -202,6 +222,17 @@ public:
     //!    (initiator-privileged supersede).
     //! initiator_keys are snapshotted from the first accepted entry and
     //! carried forward on every replacement.
+    //!
+    //! Caller contract (funding-unspent invariant): an entry produced by
+    //! ValidatePSGTForPool was checked unspent against the UTXO view under
+    //! cs_main. To keep that guarantee at insertion, such a caller MUST hold
+    //! cs_main continuously from validation through this call, so no block or
+    //! mempool tx spending a funding output can land in the gap. The P2P
+    //! handler (ProcessPSGTMessage) does exactly this. Add itself takes only
+    //! cs_psgt_pool (a leaf); the cs_main requirement is the caller's, which is
+    //! why it is documented here rather than annotated -- unit tests that insert
+    //! synthetic entries never validated against a UTXO set have no such
+    //! invariant to preserve and legitimately call Add without cs_main.
     PSGTPoolAddResult Add(PSGTPoolEntry&& entry, std::string& reject_reason);
 
     //! Remove the entry for an image. Returns false if not present.

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -25,6 +25,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::AccrualChangedFromStakeOrMRCSig> AccrualChangedFromStakeOrMRC;
     boost::signals2::signal<CClientUIInterface::MRCChangedSig> MRCChanged;
     boost::signals2::signal<CClientUIInterface::BeaconChangedSig> BeaconChanged;
+    boost::signals2::signal<CClientUIInterface::PSGTPoolChangedSig> PSGTPoolChanged;
     boost::signals2::signal<CClientUIInterface::NewPollReceivedSig> NewPollReceived;
     boost::signals2::signal<CClientUIInterface::NewVoteReceivedSig> NewVoteReceived;
     boost::signals2::signal<CClientUIInterface::NotifyScraperEventSig> NotifyScraperEvent;
@@ -55,6 +56,7 @@ ADD_SIGNALS_IMPL_WRAPPER(ResearcherChanged);
 ADD_SIGNALS_IMPL_WRAPPER(AccrualChangedFromStakeOrMRC);
 ADD_SIGNALS_IMPL_WRAPPER(MRCChanged);
 ADD_SIGNALS_IMPL_WRAPPER(BeaconChanged);
+ADD_SIGNALS_IMPL_WRAPPER(PSGTPoolChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NewPollReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NewVoteReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyScraperEvent);
@@ -82,6 +84,7 @@ void CClientUIInterface::ResearcherChanged() { return g_ui_signals.ResearcherCha
 void CClientUIInterface::AccrualChangedFromStakeOrMRC() { return g_ui_signals.AccrualChangedFromStakeOrMRC(); }
 void CClientUIInterface::MRCChanged() { return g_ui_signals.MRCChanged(); }
 void CClientUIInterface::BeaconChanged() { return g_ui_signals.BeaconChanged(); }
+void CClientUIInterface::PSGTPoolChanged(const uint256& revision_hash, ChangeType status) { return g_ui_signals.PSGTPoolChanged(revision_hash, status); }
 void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signals.NewPollReceived(poll_time); }
 void CClientUIInterface::NewVoteReceived(const uint256& poll_txid) { return g_ui_signals.NewVoteReceived(poll_txid); }
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -133,6 +133,11 @@ public:
     /** Beacon changed */
     ADD_SIGNALS_DECL_WRAPPER(BeaconChanged, void);
 
+    /** PSGT pool changed (#2910): an entry was added (CT_NEW), replaced by a
+     * better revision (CT_UPDATED) or removed (CT_DELETED). The revision hash
+     * identifies the affected entry; consumers query the pool for details. **/
+    ADD_SIGNALS_DECL_WRAPPER(PSGTPoolChanged, void, const uint256& revision_hash, ChangeType status);
+
     /** New poll received **/
     ADD_SIGNALS_DECL_WRAPPER(NewPollReceived, void, int64_t poll_time);
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -37,8 +37,10 @@ namespace NetMsgType {
     // Gridcoin specific
     const char *SCRAPERINDEX="scraperindex";
     const char *PART="part";
+    const char *PSGT="psgt";
 }
 
+// Index-aligned with the inv-type enum in net.h (MSG_TX = 1, ...).
 static const char* ppszTypeName[] =
 {
     "ERROR", // Should never occur
@@ -46,6 +48,7 @@ static const char* ppszTypeName[] =
     NetMsgType::BLOCK,
     NetMsgType::PART,
     NetMsgType::SCRAPERINDEX,
+    NetMsgType::PSGT,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -76,6 +79,7 @@ const static std::string allNetMessageTypes[] = {
     // Gridcoin specific
     NetMsgType::SCRAPERINDEX,
     NetMsgType::PART,
+    NetMsgType::PSGT,
 };
 
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -254,6 +254,12 @@ namespace NetMsgType {
     extern const char *PART;
 
     /**
+    * Gridcoin specific message: a partially signed transaction for the
+    * PSGT pool (#2910). Payload is the raw binary PSGT wire bytes.
+    */
+    extern const char *PSGT;
+
+    /**
     * Gridcoin alias for version message (will be removed)
     */
     extern const char *ARIES;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -205,6 +205,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "walletcreatefundedpsgt"          , 1 },
     { "walletcreatefundedpsgt"          , 2 },
     { "walletcreatefundedpsgt"          , 3 },
+    { "listpsgtpool"                    , 0 },
     { "upgradewallet"          , 0 },
     { "walletpassphrase"       , 1 },
     { "walletpassphrase"       , 2 },

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -1083,7 +1083,7 @@ UniValue submitpsgt(const UniValue& params)
     const int64_t now = GetAdjustedTime();
     PSGTPoolEntry entry;
     std::string error;
-    const PSGTPoolReject reject = ValidatePSGTForPool(wire_bytes, now, entry, error);
+    const PSGTPoolReject reject = ValidatePSGTForPool(g_psgt_pool, wire_bytes, now, entry, error);
     if (reject != PSGTPoolReject::NONE) {
         throw JSONRPCError(RPC_INVALID_PARAMETER,
                            strprintf("PSGT rejected (%s): %s",

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -1227,10 +1227,13 @@ UniValue signpsgtinpool(const UniValue& params)
 
     case PSGTSignResult::SIGNED_AND_RELAYED:
     {
-        const auto entry = g_psgt_pool.Get(image);
         obj.pushKV("complete", false);
+        // txid is always available from the sign result (the unsigned tx id) and
+        // the schema documents it as always present. The pool-derived fields are
+        // optional: the entry can race away (removed/expired) after signing.
+        obj.pushKV("txid", txid.ToString());
+        const auto entry = g_psgt_pool.Get(image);
         if (entry) {
-            obj.pushKV("txid", entry->tx_hash.ToString());
             obj.pushKV("revision", entry->revision_hash.ToString());
             obj.pushKV("sigs_valid", entry->valid_sigs);
             obj.pushKV("sigs_required", entry->sigs_required);

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -1092,6 +1092,10 @@ UniValue submitpsgt(const UniValue& params)
 
     const uint256 revision_hash = entry.revision_hash;
     const CScriptID image = entry.image;
+    // Keep a copy for the response: the pool takes cs_psgt_pool, not cs_main, so
+    // removepsgtfrompool or the expiry sweep can erase this image between Add and
+    // the Get below. Without a fallback that Get would dereference nullopt.
+    const PSGTPoolEntry submitted = entry;
 
     std::string reject_reason;
     const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);
@@ -1110,7 +1114,10 @@ UniValue submitpsgt(const UniValue& params)
                            strprintf("PSGT not pooled: %s", reject_reason));
     }
 
-    UniValue obj = PoolEntryToJSON(*g_psgt_pool.Get(image), now);
+    // Prefer the freshly-pooled entry (reflects any carried-forward initiator
+    // keys on replacement); fall back to the submitted copy if it raced away.
+    const auto pooled = g_psgt_pool.Get(image);
+    UniValue obj = PoolEntryToJSON(pooled ? *pooled : submitted, now);
     obj.pushKV("replaced", result == PSGTPoolAddResult::ACCEPTED_REPLACEMENT);
     return obj;
 }
@@ -1243,6 +1250,11 @@ UniValue signpsgtinpool(const UniValue& params)
 
     case PSGTSignResult::NO_NEW_SIGNATURES:
         throw JSONRPCError(RPC_WALLET_ERROR, error);
+
+    case PSGTSignResult::NOT_FOUND:
+        // Never pooled, or removed/expired between resolve and signing -- a
+        // normal race/user condition, not an internal fault.
+        throw JSONRPCError(RPC_INVALID_PARAMETER, error);
 
     case PSGTSignResult::FAILED:
         throw JSONRPCError(RPC_INTERNAL_ERROR, error);

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -1183,6 +1183,7 @@ static const RPCHelpMan signpsgtinpool_help{
     RPCResult{RPCResult::Type::OBJ, "", "",
         {
             {RPCResult::Type::BOOL, "complete", "Whether the transaction reached m-of-n and was broadcast."},
+            {RPCResult::Type::BOOL, "already_known", /*optional=*/true, "Present and true when the signed revision was already in (or recently in) the pool; the signature is present network-wide and nothing was re-relayed."},
             {RPCResult::Type::STR_HEX, "txid", "Transaction id (final id when complete)."},
             {RPCResult::Type::STR_HEX, "revision", /*optional=*/true, "New pooled revision (incomplete case only)."},
             {RPCResult::Type::NUM, "sigs_valid", /*optional=*/true, "Valid signatures after signing (incomplete case only)."},
@@ -1229,6 +1230,16 @@ UniValue signpsgtinpool(const UniValue& params)
         }
         return obj;
     }
+
+    case PSGTSignResult::ALREADY_KNOWN:
+        // The signature was added, but the resulting revision is one the network
+        // already has (an identical-key co-signer got there first, or it was
+        // pooled before). Report success: the contribution is present, nothing
+        // more to do.
+        obj.pushKV("complete", false);
+        obj.pushKV("already_known", true);
+        obj.pushKV("txid", txid.ToString());
+        return obj;
 
     case PSGTSignResult::NO_NEW_SIGNATURES:
         throw JSONRPCError(RPC_WALLET_ERROR, error);

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -4,8 +4,11 @@
 
 #include <psgt.h>
 
+#include <chainparams.h>
 #include <key_io.h>
 #include <main.h>
+#include <net_processing.h>
+#include <node/psgt_pool.h>
 #include <rpc/server.h>
 #include <rpc/protocol.h>
 #include <rpc/util.h>
@@ -908,4 +911,387 @@ UniValue walletcreatefundedpsgt(const UniValue& params)
     result.pushKV("fee", ValueFromAmount(nFeeRequired));
 
     return result;
+}
+
+// ---------------------------------------------------------------------------
+// PSGT pool RPCs (#2910 Phase II)
+// ---------------------------------------------------------------------------
+
+//! Throw unless the PSGT pool is active on this node (v15 gate + sync state).
+static void EnsurePSGTPoolActive() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (!IsV15Enabled(nBestHeight)) {
+        throw JSONRPCError(RPC_INVALID_REQUEST,
+                           "The PSGT pool is not active: block v15 has not activated on this network");
+    }
+    if (OutOfSyncByAge()) {
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                           "The PSGT pool is unavailable while the node is syncing");
+    }
+}
+
+//! Resolve an RPC "hash" argument to a pooled entry: the 40-hex-char multisig
+//! image, or a 64-hex-char unsigned transaction id or revision hash.
+static PSGTPoolEntry ResolvePoolEntry(const std::string& hash)
+{
+    if (IsHex(hash)) {
+        if (hash.size() == 40) {
+            // SetHex, not the byte-vector constructor: ToString() renders
+            // base_blob hex byte-reversed, and this must round-trip it.
+            uint160 image_bits;
+            image_bits.SetHex(hash);
+            if (const auto entry = g_psgt_pool.Get(CScriptID(image_bits))) {
+                return *entry;
+            }
+        } else if (hash.size() == 64) {
+            const uint256 h = uint256S(hash);
+            if (const auto entry = g_psgt_pool.GetByTxHash(h)) {
+                return *entry;
+            }
+            if (const auto entry = g_psgt_pool.GetByRevision(h)) {
+                return *entry;
+            }
+        }
+    }
+
+    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
+                       "No PSGT in the pool matches this image, transaction id or revision hash");
+}
+
+//! Does the local wallet hold a key of the entry's multisig arrangement?
+static bool PoolEntryIsMine(const PSGTPoolEntry& entry)
+{
+    if (!pwalletMain || entry.psgt.inputs.empty()) return false;
+
+    txnouttype script_type;
+    std::vector<std::vector<unsigned char>> vSolutions;
+    if (!Solver(entry.psgt.inputs[0].redeem_script, script_type, vSolutions)
+        || script_type != TX_MULTISIG) {
+        return false;
+    }
+
+    LOCK(pwalletMain->cs_wallet);
+    for (unsigned int i = 1; i + 1 < vSolutions.size(); ++i) {
+        const CPubKey pubkey(vSolutions[i]);
+        if (pubkey.IsValid() && pwalletMain->HaveKey(pubkey.GetID())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+//! Render a pool entry for listpsgtpool/submitpsgt output.
+static UniValue PoolEntryToJSON(const PSGTPoolEntry& entry, int64_t now)
+{
+    UniValue obj(UniValue::VOBJ);
+
+    obj.pushKV("image", entry.image.ToString());
+    obj.pushKV("image_address", EncodeDestination(entry.image));
+    obj.pushKV("txid", entry.tx_hash.ToString());
+    obj.pushKV("revision", entry.revision_hash.ToString());
+    obj.pushKV("psgt", EncodeBase64(entry.serialized.data(), entry.serialized.size()));
+    obj.pushKV("time", entry.time_received);
+    obj.pushKV("expires_in", std::max<int64_t>(0, entry.time_received
+                                                      + PSGTPool::EXPIRY_SECONDS - now));
+    obj.pushKV("fee", ValueFromAmount(entry.fee));
+    obj.pushKV("sigs_valid", entry.valid_sigs);
+    obj.pushKV("sigs_required", entry.sigs_required);
+    obj.pushKV("sigs_total", entry.sigs_total);
+
+    UniValue destinations(UniValue::VARR);
+    for (const CTxOut& txout : entry.psgt.tx.vout) {
+        UniValue dest_obj(UniValue::VOBJ);
+        CTxDestination dest;
+        dest_obj.pushKV("address", ExtractDestination(txout.scriptPubKey, dest)
+                                       ? EncodeDestination(dest) : "(nonstandard)");
+        dest_obj.pushKV("amount", ValueFromAmount(txout.nValue));
+        destinations.push_back(dest_obj);
+    }
+    obj.pushKV("destinations", destinations);
+
+    UniValue initiators(UniValue::VARR);
+    for (const CKeyID& keyid : entry.initiator_keys) {
+        initiators.push_back(keyid.ToString());
+    }
+    obj.pushKV("initiator_keyids", initiators);
+
+    const bool is_mine = PoolEntryIsMine(entry);
+    obj.pushKV("ismine", is_mine);
+    obj.pushKV("awaiting_my_signature",
+               is_mine && pwalletMain
+                   && !WITH_LOCK(pwalletMain->cs_wallet,
+                                 return PSGTSignedBy(*pwalletMain, entry.psgt)));
+
+    return obj;
+}
+
+static const RPCHelpMan submitpsgt_help{
+    "submitpsgt",
+    "Submit a partially signed multisig transaction to the network PSGT pool (#2910)\n"
+    "so co-signers are notified and can sign in-band. The PSGT must be a single-\n"
+    "arrangement P2SH multisig spend carrying at least one valid signature (yours)\n"
+    "on every input, with known unspent funding outputs and a sane fee. One PSGT is\n"
+    "pooled per multisig arrangement; resubmitting with a different destination,\n"
+    "amount or fee supersedes your earlier PSGT (initiator privilege).",
+    {
+        {"psgt", RPCArg::Type::STR, RPCArg::Optional::NO, "The base64-encoded PSGT."},
+    },
+    RPCResult{RPCResult::Type::OBJ, "", "",
+        {
+            {RPCResult::Type::STR_HEX, "image", "Multisig image (redeem script hash) the pool keys on."},
+            {RPCResult::Type::STR, "image_address", "The multisig arrangement as a P2SH address."},
+            {RPCResult::Type::STR_HEX, "txid", "Unsigned transaction id."},
+            {RPCResult::Type::STR_HEX, "revision", "Relay identity of this revision (hash of the wire bytes)."},
+            {RPCResult::Type::STR, "psgt", "The pooled PSGT, base64-encoded."},
+            {RPCResult::Type::NUM_TIME, "time", "Time the entry entered the pool."},
+            {RPCResult::Type::NUM, "expires_in", "Seconds until pool expiry."},
+            {RPCResult::Type::STR_AMOUNT, "fee", "Transaction fee."},
+            {RPCResult::Type::NUM, "sigs_valid", "Valid signatures present (minimum across inputs)."},
+            {RPCResult::Type::NUM, "sigs_required", "Signatures required (m of m-of-n)."},
+            {RPCResult::Type::NUM, "sigs_total", "Keys in the arrangement (n of m-of-n)."},
+            {RPCResult::Type::ARR, "destinations", "Where the transaction pays.",
+                {{RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "address", "Destination address."},
+                        {RPCResult::Type::STR_AMOUNT, "amount", "Amount."},
+                    }}}},
+            {RPCResult::Type::ARR, "initiator_keyids", "Key ids that signed the first pooled revision.",
+                {{RPCResult::Type::STR_HEX, "", "Key id."}}},
+            {RPCResult::Type::BOOL, "ismine", "This wallet holds a key of the arrangement."},
+            {RPCResult::Type::BOOL, "awaiting_my_signature", "This wallet can still add a signature."},
+            {RPCResult::Type::BOOL, "replaced", "Whether an earlier revision was superseded."},
+        }},
+    RPCExamples{
+        HelpExampleCli("submitpsgt", "\"psgt\"") +
+        HelpExampleRpc("submitpsgt", "\"psgt\"")},
+};
+const RPCHelpMan& submitpsgt_helpman() { return submitpsgt_help; }
+
+UniValue submitpsgt(const UniValue& params)
+{
+    bool invalid = false;
+    const std::vector<unsigned char> wire_bytes =
+        DecodeBase64(params[0].get_str().c_str(), &invalid);
+    if (invalid) {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Invalid base64");
+    }
+
+    LOCK(cs_main);
+
+    EnsurePSGTPoolActive();
+
+    const int64_t now = GetAdjustedTime();
+    PSGTPoolEntry entry;
+    std::string error;
+    const PSGTPoolReject reject = ValidatePSGTForPool(wire_bytes, now, entry, error);
+    if (reject != PSGTPoolReject::NONE) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           strprintf("PSGT rejected (%s): %s",
+                                     PSGTPoolRejectToString(reject), error));
+    }
+
+    const uint256 revision_hash = entry.revision_hash;
+    const CScriptID image = entry.image;
+
+    std::string reject_reason;
+    const PSGTPoolAddResult result = g_psgt_pool.Add(std::move(entry), reject_reason);
+
+    switch (result) {
+    case PSGTPoolAddResult::ACCEPTED_NEW:
+    case PSGTPoolAddResult::ACCEPTED_REPLACEMENT:
+        RelayPSGT(revision_hash);
+        break;
+
+    case PSGTPoolAddResult::DUPLICATE:
+    case PSGTPoolAddResult::REJECTED_POOL_FULL:
+    case PSGTPoolAddResult::REJECTED_NOT_BETTER:
+    case PSGTPoolAddResult::REJECTED_NOT_INITIATOR:
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                           strprintf("PSGT not pooled: %s", reject_reason));
+    }
+
+    UniValue obj = PoolEntryToJSON(*g_psgt_pool.Get(image), now);
+    obj.pushKV("replaced", result == PSGTPoolAddResult::ACCEPTED_REPLACEMENT);
+    return obj;
+}
+
+static const RPCHelpMan listpsgtpool_help{
+    "listpsgtpool",
+    "List the partially signed multisig transactions currently in the PSGT pool (#2910).",
+    {
+        {"ismineonly", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED,
+            "Only list PSGTs whose multisig arrangement includes a key of this wallet. Default: false."},
+    },
+    RPCResult{RPCResult::Type::ARR, "", "",
+        {
+            {RPCResult::Type::OBJ, "", "",
+                {
+                    {RPCResult::Type::STR_HEX, "image", "Multisig image (redeem script hash) the pool keys on."},
+                    {RPCResult::Type::STR, "image_address", "The multisig arrangement as a P2SH address."},
+                    {RPCResult::Type::STR_HEX, "txid", "Unsigned transaction id."},
+                    {RPCResult::Type::STR_HEX, "revision", "Relay identity of this revision (hash of the wire bytes)."},
+                    {RPCResult::Type::STR, "psgt", "The pooled PSGT, base64-encoded."},
+                    {RPCResult::Type::NUM_TIME, "time", "Time the entry entered the pool."},
+                    {RPCResult::Type::NUM, "expires_in", "Seconds until pool expiry."},
+                    {RPCResult::Type::STR_AMOUNT, "fee", "Transaction fee."},
+                    {RPCResult::Type::NUM, "sigs_valid", "Valid signatures present (minimum across inputs)."},
+                    {RPCResult::Type::NUM, "sigs_required", "Signatures required (m of m-of-n)."},
+                    {RPCResult::Type::NUM, "sigs_total", "Keys in the arrangement (n of m-of-n)."},
+                    {RPCResult::Type::ARR, "destinations", "Where the transaction pays.",
+                        {{RPCResult::Type::OBJ, "", "",
+                            {
+                                {RPCResult::Type::STR, "address", "Destination address."},
+                                {RPCResult::Type::STR_AMOUNT, "amount", "Amount."},
+                            }}}},
+                    {RPCResult::Type::ARR, "initiator_keyids", "Key ids that signed the first pooled revision.",
+                        {{RPCResult::Type::STR_HEX, "", "Key id."}}},
+                    {RPCResult::Type::BOOL, "ismine", "This wallet holds a key of the arrangement."},
+                    {RPCResult::Type::BOOL, "awaiting_my_signature", "This wallet can still add a signature."},
+                }},
+        }},
+    RPCExamples{
+        HelpExampleCli("listpsgtpool", "true") +
+        HelpExampleRpc("listpsgtpool", "true")},
+};
+const RPCHelpMan& listpsgtpool_helpman() { return listpsgtpool_help; }
+
+UniValue listpsgtpool(const UniValue& params)
+{
+    const bool mine_only = !params.empty() && !params[0].isNull() && params[0].get_bool();
+    const int64_t now = GetAdjustedTime();
+
+    UniValue result(UniValue::VARR);
+    for (const PSGTPoolEntry& entry : g_psgt_pool.GetAll()) {
+        if (mine_only && !PoolEntryIsMine(entry)) continue;
+        result.push_back(PoolEntryToJSON(entry, now));
+    }
+    return result;
+}
+
+static const RPCHelpMan signpsgtinpool_help{
+    "signpsgtinpool",
+    "Sign a pooled PSGT with this wallet's keys and advance the workflow (#2910):\n"
+    "if your signature(s) complete the m-of-n requirement, the transaction is\n"
+    "finalized and broadcast and the pool slot is freed; otherwise the enriched\n"
+    "PSGT replaces the pooled revision and is relayed to co-signers.\n"
+    "Requires the wallet passphrase to be set with walletpassphrase first if\n"
+    "the wallet is encrypted.",
+    {
+        {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+            "The multisig image, unsigned transaction id, or revision hash of the pooled PSGT."},
+    },
+    RPCResult{RPCResult::Type::OBJ, "", "",
+        {
+            {RPCResult::Type::BOOL, "complete", "Whether the transaction reached m-of-n and was broadcast."},
+            {RPCResult::Type::STR_HEX, "txid", "Transaction id (final id when complete)."},
+            {RPCResult::Type::STR_HEX, "revision", /*optional=*/true, "New pooled revision (incomplete case only)."},
+            {RPCResult::Type::NUM, "sigs_valid", /*optional=*/true, "Valid signatures after signing (incomplete case only)."},
+            {RPCResult::Type::NUM, "sigs_required", /*optional=*/true, "Signatures required (incomplete case only)."},
+        }},
+    RPCExamples{
+        HelpExampleCli("signpsgtinpool", "\"image\"") +
+        HelpExampleRpc("signpsgtinpool", "\"image\"")},
+};
+const RPCHelpMan& signpsgtinpool_helpman() { return signpsgtinpool_help; }
+
+UniValue signpsgtinpool(const UniValue& params)
+{
+    if (!pwalletMain) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is not loaded");
+    }
+
+    EnsureWalletIsUnlocked();
+
+    const CScriptID image = WITH_LOCK(cs_main, EnsurePSGTPoolActive();
+                                      return ResolvePoolEntry(params[0].get_str()).image);
+
+    std::string error;
+    uint256 txid;
+    const PSGTSignResult result = SignAndAdvancePSGT(image, error, &txid);
+
+    UniValue obj(UniValue::VOBJ);
+
+    switch (result) {
+    case PSGTSignResult::COMPLETED_AND_BROADCAST:
+        obj.pushKV("complete", true);
+        obj.pushKV("txid", txid.ToString());
+        return obj;
+
+    case PSGTSignResult::SIGNED_AND_RELAYED:
+    {
+        const auto entry = g_psgt_pool.Get(image);
+        obj.pushKV("complete", false);
+        if (entry) {
+            obj.pushKV("txid", entry->tx_hash.ToString());
+            obj.pushKV("revision", entry->revision_hash.ToString());
+            obj.pushKV("sigs_valid", entry->valid_sigs);
+            obj.pushKV("sigs_required", entry->sigs_required);
+        }
+        return obj;
+    }
+
+    case PSGTSignResult::NO_NEW_SIGNATURES:
+        throw JSONRPCError(RPC_WALLET_ERROR, error);
+
+    case PSGTSignResult::FAILED:
+        throw JSONRPCError(RPC_INTERNAL_ERROR, error);
+    }
+
+    CHECK_NONFATAL(false); // all PSGTSignResult cases return above
+    return NullUniValue;
+}
+
+static const RPCHelpMan removepsgtfrompool_help{
+    "removepsgtfrompool",
+    "Remove a PSGT from this node's pool (local only: other nodes keep their\n"
+    "copies, and a NEW revision from the network would still be accepted).",
+    {
+        {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO,
+            "The multisig image, unsigned transaction id, or revision hash of the pooled PSGT."},
+    },
+    RPCResult{RPCResult::Type::BOOL, "", "Whether an entry was removed."},
+    RPCExamples{
+        HelpExampleCli("removepsgtfrompool", "\"image\"") +
+        HelpExampleRpc("removepsgtfrompool", "\"image\"")},
+};
+const RPCHelpMan& removepsgtfrompool_helpman() { return removepsgtfrompool_help; }
+
+UniValue removepsgtfrompool(const UniValue& params)
+{
+    const PSGTPoolEntry entry = ResolvePoolEntry(params[0].get_str());
+    return g_psgt_pool.Remove(entry.image, PSGTRemovalReason::LOCAL_REMOVE);
+}
+
+static const RPCHelpMan getpsgtpoolinfo_help{
+    "getpsgtpoolinfo",
+    "Returns PSGT pool status (#2910).",
+    {},
+    RPCResult{RPCResult::Type::OBJ, "", "",
+        {
+            {RPCResult::Type::BOOL, "active", "Whether the pool is active (block v15 live and node in sync)."},
+            {RPCResult::Type::NUM, "size", "Entries currently pooled."},
+            {RPCResult::Type::NUM, "maxsize", "Pool capacity (new images are rejected when full)."},
+            {RPCResult::Type::NUM, "expiry", "Entry lifetime in seconds."},
+            {RPCResult::Type::NUM, "psgtprotocolversion", "Minimum peer protocol version PSGT inventory is relayed to."},
+        }},
+    RPCExamples{
+        HelpExampleCli("getpsgtpoolinfo", "") +
+        HelpExampleRpc("getpsgtpoolinfo", "")},
+};
+const RPCHelpMan& getpsgtpoolinfo_helpman() { return getpsgtpoolinfo_help; }
+
+UniValue getpsgtpoolinfo(const UniValue& params)
+{
+    UniValue obj(UniValue::VOBJ);
+
+    {
+        LOCK(cs_main);
+        obj.pushKV("active", IsV15Enabled(nBestHeight) && !OutOfSyncByAge());
+    }
+    obj.pushKV("size", (int64_t)g_psgt_pool.Size());
+    obj.pushKV("maxsize", (int64_t)PSGTPool::MAX_ENTRIES);
+    obj.pushKV("expiry", PSGTPool::EXPIRY_SECONDS);
+    obj.pushKV("psgtprotocolversion", PSGT_PROTO_VERSION);
+
+    return obj;
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -407,6 +407,13 @@ static const CRPCCommand vRPCCommands[] =
     { "converttopsgt",           &converttopsgt,           cat_wallet, &converttopsgt_helpman        },
     { "walletcreatefundedpsgt",  &walletcreatefundedpsgt,  cat_wallet, &walletcreatefundedpsgt_helpman        },
 
+  // PSGT pool commands (#2910 Phase II)
+    { "submitpsgt",              &submitpsgt,              cat_wallet, &submitpsgt_helpman        },
+    { "listpsgtpool",            &listpsgtpool,            cat_wallet, &listpsgtpool_helpman        },
+    { "signpsgtinpool",          &signpsgtinpool,          cat_wallet, &signpsgtinpool_helpman        },
+    { "removepsgtfrompool",      &removepsgtfrompool,      cat_wallet, &removepsgtfrompool_helpman        },
+    { "getpsgtpoolinfo",         &getpsgtpoolinfo,         cat_wallet, &getpsgtpoolinfo_helpman        },
+
   // Staking commands
     { "advertisebeacon",         &advertisebeacon,         cat_staking, &advertisebeacon_helpman        },
     { "advertisebeaconv3",       &advertisebeaconv3,       cat_staking, &advertisebeaconv3_helpman        },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -212,6 +212,13 @@ extern UniValue utxoupdatepsgt(const UniValue& params);
 extern UniValue converttopsgt(const UniValue& params);
 extern UniValue walletcreatefundedpsgt(const UniValue& params);
 
+// PSGT pool (#2910 Phase II)
+extern UniValue submitpsgt(const UniValue& params);
+extern UniValue listpsgtpool(const UniValue& params);
+extern UniValue signpsgtinpool(const UniValue& params);
+extern UniValue removepsgtfrompool(const UniValue& params);
+extern UniValue getpsgtpoolinfo(const UniValue& params);
+
 // Staking
 extern UniValue advertisebeacon(const UniValue& params);
 extern UniValue advertisebeaconv3(const UniValue& params);
@@ -389,6 +396,11 @@ extern const RPCHelpMan& inspectwalletstate_helpman();
 extern const RPCHelpMan& utxoupdatepsgt_helpman();
 extern const RPCHelpMan& walletcreatefundedpsgt_helpman();
 extern const RPCHelpMan& walletprocesspsgt_helpman();
+extern const RPCHelpMan& submitpsgt_helpman();
+extern const RPCHelpMan& listpsgtpool_helpman();
+extern const RPCHelpMan& signpsgtinpool_helpman();
+extern const RPCHelpMan& removepsgtfrompool_helpman();
+extern const RPCHelpMan& getpsgtpoolinfo_helpman();
 extern const RPCHelpMan& currenttime_helpman();
 extern const RPCHelpMan& debug_helpman();
 extern const RPCHelpMan& decoderawtransaction_helpman();

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -103,7 +103,11 @@ static PSGTPoolReject Validate(const PartiallySignedTransaction& psgt,
                                PSGTPoolEntry& entry, std::string& error)
 {
     LOCK(cs_main);
-    return ValidatePSGTForPool(SerializePSGT(psgt), 1700003000, entry, error);
+    // Validate against an empty pool: HaveRevision is always false here, so the
+    // duplicate short-circuit never fires and this exercises the full pipeline.
+    // Duplicate-revision behaviour has its own dedicated test with a real pool.
+    const PSGTPool empty_pool;
+    return ValidatePSGTForPool(empty_pool, SerializePSGT(psgt), 1700003000, entry, error);
 }
 
 //! A synthetic entry with a unique image, for container-semantics tests that
@@ -217,14 +221,80 @@ BOOST_AUTO_TEST_CASE(validate_reject_matrix)
     // Oversize and malformed wire bytes.
     {
         LOCK(cs_main);
+        const PSGTPool empty_pool;
         std::vector<unsigned char> huge(MAX_PSGT_WIRE_SIZE + 1, 0x00);
-        BOOST_CHECK(ValidatePSGTForPool(huge, 1700003000, entry, error)
+        BOOST_CHECK(ValidatePSGTForPool(empty_pool, huge, 1700003000, entry, error)
                     == PSGTPoolReject::TOO_LARGE);
 
         std::vector<unsigned char> garbage = {0xde, 0xad, 0xbe, 0xef};
-        BOOST_CHECK(ValidatePSGTForPool(garbage, 1700003000, entry, error)
+        BOOST_CHECK(ValidatePSGTForPool(empty_pool, garbage, 1700003000, entry, error)
                     == PSGTPoolReject::MALFORMED);
     }
+}
+
+BOOST_AUTO_TEST_CASE(validate_rejects_unknown_fields)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+
+    PSGTPoolEntry entry;
+    std::string error;
+
+    // Baseline: the same PSGT with no extension fields is accepted.
+    BOOST_REQUIRE(Validate(fixture.Signed({fixture.k1}), entry, error)
+                  == PSGTPoolReject::NONE);
+
+    // An unknown GLOBAL field makes it ineligible: it is a free revision-hash
+    // malleability vector and serves no pooling purpose.
+    {
+        PartiallySignedTransaction psgt = fixture.Signed({fixture.k1});
+        psgt.unknown[{0xff}] = {0x01, 0x02};
+        BOOST_CHECK(Validate(psgt, entry, error) == PSGTPoolReject::HAS_UNKNOWN_FIELDS);
+    }
+
+    // An unknown per-INPUT field is rejected the same way.
+    {
+        PartiallySignedTransaction psgt = fixture.Signed({fixture.k1});
+        psgt.inputs[0].unknown[{0xfe}] = {0x03};
+        BOOST_CHECK(Validate(psgt, entry, error) == PSGTPoolReject::HAS_UNKNOWN_FIELDS);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(validate_short_circuits_duplicate_revision)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+
+    LOCK(cs_main);
+    PSGTPool pool;
+    const std::vector<unsigned char> wire = SerializePSGT(fixture.Signed({fixture.k1}));
+
+    // First sighting: full validation, accepted, added to the pool.
+    PSGTPoolEntry first;
+    std::string error;
+    BOOST_REQUIRE(ValidatePSGTForPool(pool, wire, 1700003000, first, error)
+                  == PSGTPoolReject::NONE);
+    const uint256 revision = first.revision_hash;
+    const std::vector<unsigned char> canonical = first.serialized;
+    std::string reject;
+    BOOST_REQUIRE(pool.Add(std::move(first), reject) == PSGTPoolAddResult::ACCEPTED_NEW);
+
+    // Second sighting of the SAME revision short-circuits as a duplicate -- this
+    // is the branch that returns BEFORE the expensive per-signature ECDSA
+    // verification, so a peer cannot replay a valid PSGT to burn CPU.
+    PSGTPoolEntry second;
+    BOOST_CHECK(ValidatePSGTForPool(pool, wire, 1700003000, second, error)
+                == PSGTPoolReject::DUPLICATE_REVISION);
+
+    // The revision identity is the hash of the CANONICAL re-serialization, and
+    // that canonical form is a fixed point: decoding and re-serializing the
+    // stored bytes reproduces them. Hence any alternate encoding (reordered
+    // maps) of the same content decodes to this same identity.
+    BOOST_CHECK(revision == Hash(canonical));
+    PartiallySignedTransaction round;
+    std::string decode_error;
+    BOOST_REQUIRE(DecodePSGTBytes(round, canonical, decode_error));
+    BOOST_CHECK(SerializePSGT(round) == canonical);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -33,6 +33,7 @@ import time
 from test_framework.messages import (
     CInv,
     MSG_PSGT,
+    PSGT_PROTO_VERSION,
     hash256,
     msg_getdata,
     msg_psgt,
@@ -63,7 +64,7 @@ class OldVersionInvCollector(InvCollector):
 
     def peer_connect_send_version(self):
         super().peer_connect_send_version()
-        self.on_connection_send_msg.nVersion = 180329
+        self.on_connection_send_msg.nVersion = PSGT_PROTO_VERSION - 1
 
 
 class P2PPsgtRelayTest(GridcoinTestFramework):

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -91,8 +91,11 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
     def add_spaced_p2p(self, node, peer):
         """add_p2p_connection with the daemon's inbound rate limit respected:
         at most one inbound per 5 seconds per IP (net.cpp AcceptConnection),
-        and every scripted peer here is 127.0.0.1."""
-        time.sleep(5)
+        and every scripted peer here is 127.0.0.1. The limit compares integer
+        second deltas from GetAdjustedTime(), so sleep a full 6 s -- sleeping
+        exactly 5 can land two connects in the same second boundary (delta 4)
+        and get the second one dropped / misbehavior-scored."""
+        time.sleep(6)
         return node.add_p2p_connection(peer)
 
     def setup_network(self):

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""PSGT pool P2P relay (#2910 Phase II): MSG_PSGT inv/getdata/psgt end to end.
+
+Two connected regtest nodes (v15 active at height 0) plus scripted peers.
+node0's wallet builds a genuinely partially signed 2-of-3 multisig PSGT via
+the Phase I RPCs (one wallet-owned key, two node1-owned keys, so
+walletprocesspsgt contributes exactly one of the two required signatures).
+A scripted peer then injects the raw bytes into node1 with the new `psgt`
+message and we assert, in order:
+
+- node1 validates, pools and relays: a watcher peer on node1 receives
+  inv(MSG_PSGT, revision-hash) where the revision hash is hash256 of the
+  wire bytes (NOT the unsigned tx hash);
+- getdata(MSG_PSGT) is answered byte-exactly from the pool;
+- node0 learns the PSGT daemon-to-daemon, and a peer connecting to node0
+  afterwards receives the pooled inventory in the connect-time push;
+- a peer that handshook with the pre-PSGT protocol version receives no
+  MSG_PSGT inventory anywhere in the run;
+- re-sending the same revision is a quiet no-op (no second inv);
+- garbage and corrupted psgt messages are rejected without relay and
+  without disturbing the node. (The misbehavior score they earn cannot
+  be observed from a functional test: PeerManager::Misbehaving exempts
+  local addresses, and every scripted peer here is 127.0.0.1. The
+  scoring itself is covered by inspection of the ProcessPSGTMessage
+  reject mapping.)
+"""
+
+import time
+
+from test_framework.messages import (
+    CInv,
+    MSG_PSGT,
+    hash256,
+    msg_getdata,
+    msg_psgt,
+    uint256_from_str,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+from base64 import b64decode
+
+
+class InvCollector(P2PInterface):
+    """Records every MSG_PSGT inventory hash it is announced."""
+
+    def __init__(self):
+        super().__init__()
+        self.psgt_invs = []
+
+    def on_inv(self, message):
+        for inv in message.inv:
+            if inv.type == MSG_PSGT:
+                self.psgt_invs.append(inv.hash)
+
+
+class OldVersionInvCollector(InvCollector):
+    """An InvCollector that handshakes with the pre-PSGT protocol version."""
+
+    def peer_connect_send_version(self):
+        super().peer_connect_send_version()
+        self.on_connection_send_msg.nVersion = 180329
+
+
+class P2PPsgtRelayTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        self.extra_args = [["-staking=0"], ["-staking=0"]]
+
+    def confirm_funding(self, txid):
+        """Confirm a just-sent funding transaction. PoS block timestamps are
+        masked down to 16-second boundaries (STAKE_TIMESTAMP_MASK) and the
+        miner excludes transactions with nTime > block.nTime, so wait for the
+        next boundary before mining the confirmation block. Returns False if
+        the transaction vanished instead (double-spent by the staker's own
+        coinstake -- the wallet does not track raw spends)."""
+        node0 = self.nodes[0]
+        time.sleep(16 - (int(time.time()) % 16) + 1)
+        node0.generatetoaddress(1, node0.getnewaddress())
+        try:
+            return node0.getrawtransaction(txid, True).get("confirmations", 0) >= 1
+        except Exception:
+            return False
+
+    def add_spaced_p2p(self, node, peer):
+        """add_p2p_connection with the daemon's inbound rate limit respected:
+        at most one inbound per 5 seconds per IP (net.cpp AcceptConnection),
+        and every scripted peer here is 127.0.0.1."""
+        time.sleep(5)
+        return node.add_p2p_connection(peer)
+
+    def setup_network(self):
+        # Bring the nodes up without the base-class createwallet path (the
+        # daemon rejects its named params), then connect them: daemon-to-daemon
+        # PSGT propagation is part of what this test asserts.
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+        self.connect_nodes(1, 0)
+        self.sync_blocks()
+
+    def make_partially_signed_psgt(self):
+        """Fund a 2-of-3 multisig (1 node0 key, 2 node1 keys) and have node0
+        sign its one key: a valid, incomplete PSGT the pool must accept."""
+        node0, node1 = self.nodes[0], self.nodes[1]
+
+        pub_mine = node0.validateaddress(node0.getnewaddress())["pubkey"]
+        pub_other1 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        pub_other2 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        ms_address = node0.addmultisigaddress(2, [pub_mine, pub_other1, pub_other2])
+
+        # Fund the multisig from a raw spend of a consensus-mature UTXO
+        # (coinstakes need >10 confirmations on regtest; wallet sends are not
+        # an option -- wallet balance accounting treats young coinstakes as
+        # immature far longer). The wallet does not track raw spends, so the
+        # staker can race us for the same UTXO when mining the confirmation
+        # block and double-spend the funding away: verify and retry.
+        txid = None
+        ms_amount = None
+        tried = set()
+        for _ in range(5):
+            candidates = [u for u in node0.listunspent(11)
+                          if (u["txid"], u["vout"]) not in tried]
+            assert candidates, "no mature UTXO left to fund the multisig"
+            utxo = candidates[0]
+            tried.add((utxo["txid"], utxo["vout"]))
+
+            ms_amount = round(float(utxo["amount"]) - 1.0, 8)  # ~1 GRC fee
+            raw = node0.createrawtransaction(
+                [{"txid": utxo["txid"], "vout": utxo["vout"]}], {ms_address: ms_amount})
+            signed = node0.signrawtransactionwithwallet(raw)
+            assert signed.get("complete"), signed
+            candidate_txid = node0.sendrawtransaction(signed["hex"])
+
+            if self.confirm_funding(candidate_txid):
+                txid = candidate_txid
+                break
+        assert txid, "could not confirm the multisig funding transaction"
+        self.sync_blocks()
+
+        funding = node0.getrawtransaction(txid, True)
+        vout = next(o["n"] for o in funding["vout"]
+                    if ms_address in o["scriptPubKey"].get("addresses", []))
+
+        # 0.01 GRC fee: above the relay floor, below the absurd-fee ceiling.
+        dest = node0.getnewaddress()
+        psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
+                                {dest: round(ms_amount - 0.01, 8)})
+        psgt = node0.utxoupdatepsgt(psgt)
+        processed = node0.walletprocesspsgt(psgt)
+        assert not processed["complete"], "expected a PARTIALLY signed PSGT"
+        return b64decode(processed["psgt"])
+
+    def run_test(self):
+        node0, node1 = self.nodes[0], self.nodes[1]
+
+        # Consensus-mature coins (>10 confirmations on regtest) and a current
+        # tip so both nodes are in sync (the pool neither accepts nor serves
+        # while OutOfSyncByAge).
+        node0.generatetoaddress(12, node0.getnewaddress())
+        self.sync_blocks()
+
+        wire = self.make_partially_signed_psgt()
+        revision = uint256_from_str(hash256(wire))
+
+        sender = node1.add_p2p_connection(P2PInterface())
+        watcher = self.add_spaced_p2p(node1, InvCollector())
+        old_peer = self.add_spaced_p2p(node1, OldVersionInvCollector())
+
+        # --- inject: node1 must validate, pool, and announce the revision ---
+        sender.send_message(msg_psgt(wire))
+        watcher.wait_until(lambda: revision in watcher.psgt_invs)
+        self.log.info("psgt accepted by node1 and announced as inv(MSG_PSGT)")
+
+        # --- getdata is served byte-exactly from the pool ---
+        watcher.send_message(msg_getdata([CInv(MSG_PSGT, revision)]))
+        watcher.wait_until(lambda: "psgt" in watcher.last_message
+                           and watcher.last_message["psgt"].psgt_bytes == wire)
+        self.log.info("getdata(MSG_PSGT) served the exact wire bytes")
+
+        # --- daemon-to-daemon relay + connect-time push: node0 fetched the
+        # PSGT from node1, and advertises it to fresh v15 peers on connect ---
+        late_peer = self.add_spaced_p2p(node0, InvCollector())
+        late_peer.wait_until(lambda: revision in late_peer.psgt_invs)
+        self.log.info("node0 pooled the PSGT and pushed it to a connecting peer")
+
+        # --- duplicate revision: a quiet no-op, not a re-announcement ---
+        announced_before = watcher.psgt_invs.count(revision)
+        sender.send_message(msg_psgt(wire))
+        sender.sync_with_ping()
+        time.sleep(1)  # allow any (wrong) re-announcement to arrive
+        assert_equal(watcher.psgt_invs.count(revision), announced_before)
+        self.log.info("duplicate psgt message did not re-announce")
+
+        # --- version gating: the 180329 peer saw nothing throughout ---
+        old_peer.sync_with_ping()
+        assert_equal(old_peer.psgt_invs, [])
+        self.log.info("pre-PSGT protocol peer received no MSG_PSGT inventory")
+
+        # --- invalid psgt messages: rejected without relay, node unfazed ---
+        bad_peer = self.add_spaced_p2p(node1, P2PInterface())
+        announced_before = len(watcher.psgt_invs)
+        bad_peer.send_message(msg_psgt(b"not a psgt"))
+        corrupted = bytearray(wire)
+        corrupted[len(corrupted) // 2] ^= 0x01
+        bad_peer.send_message(msg_psgt(bytes(corrupted)))
+        bad_peer.sync_with_ping()
+        time.sleep(1)  # allow any (wrong) relay to arrive
+        assert_equal(len(watcher.psgt_invs), announced_before)
+        assert_equal(node1.getbestblockhash(), node0.getbestblockhash())
+        self.log.info("garbage/corrupted psgt messages rejected without relay")
+
+
+if __name__ == "__main__":
+    P2PPsgtRelayTest().main()

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -71,7 +71,7 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         self.num_nodes = 2
         self.chain = "regtest"
         self.setup_clean_chain = True
-        self.extra_args = [["-staking=0"], ["-staking=0"]]
+        self.extra_args = [["-staking=0", "-blockv15height=0"], ["-staking=0", "-blockv15height=0"]]
 
     def confirm_funding(self, txid):
         """Confirm a just-sent funding transaction. PoS block timestamps are

--- a/test/functional/rpc_psgtpool.py
+++ b/test/functional/rpc_psgtpool.py
@@ -40,7 +40,7 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
 
     def setup_network(self):
         self.notify_file = os.path.join(self.options.tmpdir, "psgt_events.txt")
-        self.extra_args[1].append("-psgtnotify=echo %s2 %s1 >> " + self.notify_file)
+        self.extra_args[1].append("-psgtnotify=echo %s2 %s1 >> '" + self.notify_file + "'")
         self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
         self.connect_nodes(1, 0)

--- a/test/functional/rpc_psgtpool.py
+++ b/test/functional/rpc_psgtpool.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""PSGT pool RPC lifecycle (#2910 Phase II): the full collaborative signing
+workflow driven entirely through RPC, plus the -psgtnotify hook.
+
+Two connected regtest nodes share a 2-of-3 multisig: node0 holds one key
+(the initiator), node1 holds two (a co-signer able to complete alone).
+
+  - node0 builds and partially signs a spend via the Phase I RPCs, then
+    submitpsgt pools and relays it;
+  - node1's pool learns it over P2P; listpsgtpool reports ismine and
+    awaiting_my_signature from the co-signer's perspective;
+  - signpsgtinpool on node1 completes m-of-n: the finalized transaction is
+    broadcast, and BOTH pools drain (node1 via completion, node0 via the
+    mempool-conflict eviction when the transaction arrives) -- the network-
+    wide completion signal;
+  - the initiator supersedes a pending PSGT (different destination) with
+    submitpsgt: replaced=true, same image, one pool slot;
+  - removepsgtfrompool is local-only: node0 keeps its entry;
+  - -psgtnotify on node1 records added/updated/completed events to a file.
+"""
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+import os
+import time
+
+
+class RpcPsgtPoolTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        # extra_args are finalized in setup_network (the notify file path
+        # needs the test tmpdir, unknown at set_test_params time).
+        self.extra_args = [["-staking=0"], ["-staking=0"]]
+
+    def setup_network(self):
+        self.notify_file = os.path.join(self.options.tmpdir, "psgt_events.txt")
+        self.extra_args[1].append("-psgtnotify=echo %s2 %s1 >> " + self.notify_file)
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+        self.connect_nodes(1, 0)
+        self.sync_blocks()
+
+    def fund_multisig(self, ms_address):
+        """Fund the multisig from a raw spend of a consensus-mature UTXO
+        (>10 confirmations) and confirm it. The wallet does not track raw
+        spends, so the staker can race us for the same UTXO when mining the
+        confirmation block and double-spend the funding away: verify the
+        funding confirmed and retry with a fresh UTXO if not.
+        Returns (txid, vout, amount)."""
+        node0 = self.nodes[0]
+        tried = set()
+        for _ in range(5):
+            candidates = [u for u in node0.listunspent(11)
+                          if (u["txid"], u["vout"]) not in tried]
+            assert candidates, "no mature UTXO left to fund the multisig"
+            utxo = candidates[0]
+            tried.add((utxo["txid"], utxo["vout"]))
+
+            amount = round(float(utxo["amount"]) - 1.0, 8)  # ~1 GRC fee
+            raw = node0.createrawtransaction(
+                [{"txid": utxo["txid"], "vout": utxo["vout"]}], {ms_address: amount})
+            signed = node0.signrawtransactionwithwallet(raw)
+            assert signed.get("complete"), signed
+            txid = node0.sendrawtransaction(signed["hex"])
+
+            # PoS block timestamps are masked down to 16-second boundaries
+            # (STAKE_TIMESTAMP_MASK) and the miner excludes transactions with
+            # nTime > block.nTime: wait for the next boundary before mining
+            # the confirmation block.
+            time.sleep(16 - (int(time.time()) % 16) + 1)
+            node0.generatetoaddress(1, node0.getnewaddress())
+
+            try:
+                funding = node0.getrawtransaction(txid, True)
+                if funding.get("confirmations", 0) >= 1:
+                    self.sync_blocks()
+                    vout = next(o["n"] for o in funding["vout"]
+                                if ms_address in o["scriptPubKey"].get("addresses", []))
+                    return txid, vout, amount
+            except Exception:
+                pass  # double-spent by the staker's coinstake: retry
+
+        raise AssertionError("could not confirm the multisig funding transaction")
+
+    def initiator_psgt(self, txid, vout, amount, fee):
+        """node0 builds and partially signs a spend of the multisig UTXO."""
+        node0 = self.nodes[0]
+        dest = node0.getnewaddress()
+        psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
+                                {dest: round(amount - fee, 8)})
+        psgt = node0.utxoupdatepsgt(psgt)
+        processed = node0.walletprocesspsgt(psgt)
+        assert not processed["complete"], "expected a PARTIALLY signed PSGT"
+        return processed["psgt"]
+
+    def run_test(self):
+        node0, node1 = self.nodes[0], self.nodes[1]
+
+        # Consensus-mature coins: coinstakes are spendable >10 blocks deep.
+        node0.generatetoaddress(12, node0.getnewaddress())
+        self.sync_blocks()
+
+        # 2-of-3: node0 one key (initiator), node1 two (can complete alone).
+        pub_initiator = node0.validateaddress(node0.getnewaddress())["pubkey"]
+        pub_cosigner1 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        pub_cosigner2 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        ms_address = node0.addmultisigaddress(
+            2, [pub_initiator, pub_cosigner1, pub_cosigner2])
+
+        info = node0.getpsgtpoolinfo()
+        assert_equal(info["active"], True)  # regtest activates v15 at height 0
+        assert_equal(info["size"], 0)
+
+        # --- initiate: submitpsgt pools and relays ---
+        txid, vout, amount = self.fund_multisig(ms_address)
+        submitted = node0.submitpsgt(self.initiator_psgt(txid, vout, amount, 0.01))
+        assert_equal(submitted["sigs_valid"], 1)
+        assert_equal(submitted["sigs_required"], 2)
+        assert_equal(submitted["sigs_total"], 3)
+        assert_equal(submitted["ismine"], True)
+        assert_equal(submitted["awaiting_my_signature"], False)  # initiator signed
+        assert_equal(submitted["replaced"], False)
+        assert_equal(submitted["image_address"], ms_address)
+        image = submitted["image"]
+        self.log.info("submitpsgt pooled the initiator's PSGT (image %s)", image)
+
+        # --- the co-signer's node learns it over P2P ---
+        self.wait_until(lambda: len(node1.listpsgtpool()) == 1)
+        pooled = node1.listpsgtpool(True)[0]  # ismineonly: node1 holds keys
+        assert_equal(pooled["image"], image)
+        assert_equal(pooled["ismine"], True)
+        assert_equal(pooled["awaiting_my_signature"], True)
+        self.log.info("co-signer node pooled the PSGT and awaits a signature")
+
+        # --- co-sign to completion: finalize, broadcast, pools drain ---
+        result = node1.signpsgtinpool(image)
+        assert_equal(result["complete"], True)
+        final_txid = result["txid"]
+
+        self.wait_until(lambda: final_txid in node0.getrawmempool()
+                        and final_txid in node1.getrawmempool())
+        self.wait_until(lambda: not node0.listpsgtpool() and not node1.listpsgtpool())
+        self.log.info("signpsgtinpool completed -> %s in both mempools, pools drained",
+                      final_txid)
+
+        # Confirm the spend so the next funding round starts clean.
+        node0.generatetoaddress(1, node0.getnewaddress())
+        self.sync_blocks()
+
+        # --- initiator supersede: new destination replaces the pooled PSGT ---
+        txid2, vout2, amount2 = self.fund_multisig(ms_address)
+        first = node0.submitpsgt(self.initiator_psgt(txid2, vout2, amount2, 0.01))
+        assert_equal(first["replaced"], False)
+
+        revised = node0.submitpsgt(self.initiator_psgt(txid2, vout2, amount2, 0.02))
+        assert_equal(revised["replaced"], True)
+        assert_equal(revised["image"], image)  # same arrangement, same slot
+        assert revised["txid"] != first["txid"]
+        assert_equal(len(node0.listpsgtpool()), 1)
+        self.log.info("initiator superseded the pending PSGT in place")
+
+        # --- removepsgtfrompool is local ---
+        self.wait_until(
+            lambda: any(e["revision"] == revised["revision"] for e in node1.listpsgtpool()))
+        assert_equal(node1.removepsgtfrompool(image), True)
+        assert_equal(node1.listpsgtpool(), [])
+        assert_equal(len(node0.listpsgtpool()), 1)
+        self.log.info("removepsgtfrompool removed locally; the initiator's node kept it")
+
+        # --- -psgtnotify recorded the pool lifecycle on node1 ---
+        # The hook runs runCommand in a detached thread, so the appended lines
+        # arrive asynchronously: poll the file until every expected event lands
+        # rather than reading once.
+        def notify_events():
+            if not os.path.exists(self.notify_file):
+                return []
+            with open(self.notify_file, encoding="utf8") as f:
+                return [line.split()[0] for line in f if line.strip()]
+
+        self.wait_until(lambda: {"added", "completed", "removed"}.issubset(notify_events()))
+        self.log.info("-psgtnotify hook recorded: %s", notify_events())
+
+
+if __name__ == "__main__":
+    RpcPsgtPoolTest().main()

--- a/test/functional/rpc_psgtpool.py
+++ b/test/functional/rpc_psgtpool.py
@@ -36,7 +36,7 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
         self.setup_clean_chain = True
         # extra_args are finalized in setup_network (the notify file path
         # needs the test tmpdir, unknown at set_test_params time).
-        self.extra_args = [["-staking=0"], ["-staking=0"]]
+        self.extra_args = [["-staking=0", "-blockv15height=0"], ["-staking=0", "-blockv15height=0"]]
 
     def setup_network(self):
         self.notify_file = os.path.join(self.options.tmpdir, "psgt_events.txt")

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -43,9 +43,10 @@ MAX_BLOCK_BASE_SIZE = 1000000
 COIN = 100000000  # 1 GRC in halflings
 
 # Protocol constants (src/version.h)
-MY_VERSION = 180329          # PROTOCOL_VERSION
+MY_VERSION = 180330          # PROTOCOL_VERSION
 MIN_PEER_PROTO_VERSION = 180327
 INIT_PROTO_VERSION = 180275
+PSGT_PROTO_VERSION = 180330  # peers below this never receive MSG_PSGT invs
 
 MY_SUBVERSION = "/python-mininode-tester:0.0.3/"
 MY_RELAY = 1  # placeholder; Gridcoin's version message has no relay field
@@ -59,9 +60,12 @@ MAGIC_BYTES = {
     "regtest": b"\xfa\xbf\xb5\xda",
 }
 
-# Inv/getdata type codes (src/protocol.h GetDataMsg). No witness variants.
+# Inv/getdata type codes (src/net.h inv-type enum). No witness variants.
 MSG_TX = 1
 MSG_BLOCK = 2
+MSG_PART = 3
+MSG_SCRAPERINDEX = 4
+MSG_PSGT = 5
 
 
 # Serialization/deserialization tools
@@ -210,7 +214,8 @@ def _ip_to_int(ip):
 
 
 class CInv:
-    typemap = {0: "Error", MSG_TX: "TX", MSG_BLOCK: "Block"}
+    typemap = {0: "Error", MSG_TX: "TX", MSG_BLOCK: "Block", MSG_PART: "Part",
+               MSG_SCRAPERINDEX: "ScraperIndex", MSG_PSGT: "PSGT"}
 
     def __init__(self, t=0, h=0):
         self.type = t
@@ -880,6 +885,31 @@ class msg_pong:
         return "msg_pong(nonce=%08x)" % self.nonce
 
 
+class msg_psgt:
+    """A PSGT pool message (#2910): CompactSize-prefixed raw PSGT wire bytes.
+
+    The inv identity of a revision is hash256 of the raw bytes (the
+    "revision hash"), NOT the unsigned transaction's hash.
+    """
+    __slots__ = ("psgt_bytes",)
+    command = b"psgt"
+
+    def __init__(self, psgt_bytes=b""):
+        self.psgt_bytes = psgt_bytes
+
+    def deserialize(self, f):
+        self.psgt_bytes = deser_string(f)
+
+    def serialize(self):
+        return ser_string(self.psgt_bytes)
+
+    def revision_hash(self):
+        return uint256_from_str(hash256(self.psgt_bytes))
+
+    def __repr__(self):
+        return "msg_psgt(len=%i)" % len(self.psgt_bytes)
+
+
 class msg_notfound:
     __slots__ = ("vec",)
     command = b"notfound"
@@ -917,5 +947,6 @@ MESSAGEMAP = {
     b"mempool": msg_mempool,
     b"ping": msg_ping,
     b"pong": msg_pong,
+    b"psgt": msg_psgt,
     b"notfound": msg_notfound,
 }

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -888,8 +888,13 @@ class msg_pong:
 class msg_psgt:
     """A PSGT pool message (#2910): CompactSize-prefixed raw PSGT wire bytes.
 
-    The inv identity of a revision is hash256 of the raw bytes (the
-    "revision hash"), NOT the unsigned transaction's hash.
+    The inv identity of a revision is the "revision hash", NOT the unsigned
+    transaction's hash. Core computes it as hash256 of the CANONICAL
+    re-serialization (SerializePSGT: sorted maps, unknown fields rejected), not
+    of arbitrary received bytes. Nodes serve/relay those canonical bytes, so a
+    test should hash the canonical on-wire encoding it sent (which a wallet- or
+    SerializePSGT-produced PSGT already is); hashing a non-canonical encoding
+    would chase a revision hash the node never advertises.
     """
     __slots__ = ("psgt_bytes",)
     command = b"psgt"

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -296,6 +296,9 @@ class P2PInterface(P2PConnection):
     def on_notfound(self, message):
         pass
 
+    def on_psgt(self, message):
+        pass
+
     def on_tx(self, message):
         pass
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -147,6 +147,7 @@ BASE_SCRIPTS = [
     'feature_regtest_staking.py',
     'p2p_version_handshake.py',
     'p2p_block_tx_relay.py',
+    'p2p_psgt_relay.py',
     'p2p_ping.py',
     'rpc_help.py',
     'rpc_signmessage.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -153,6 +153,7 @@ BASE_SCRIPTS = [
     'rpc_signmessage.py',
     'rpc_rawtransaction.py',
     'rpc_psgt.py',
+    'rpc_psgtpool.py',
     'rpc_htlc.py',
     'rpc_txoutproof.py',
     'rpc_blockchain.py',


### PR DESCRIPTION
Fifth PR of the **PSGT Phase II** series (#2910): the user-facing half. Stacked on #3113 → #3114 → #3115 → #3116; only the last commit is new. After this PR the full #2910 lifecycle works headless end to end; the Qt Pool view (PR F) is the remaining piece.

## RPCs

| RPC | What |
|---|---|
| `submitpsgt "psgt"` | Validate + pool + relay a base64 PSGT. Returns image, revision, m-of-n progress, destinations, initiator key ids, `replaced`. Rejects carry the machine-readable class (`fee-too-low`, `no-valid-signature`, …) plus the explanation. |
| `listpsgtpool [ismineonly]` | Pool listing with `ismine` (wallet holds an arrangement key) and `awaiting_my_signature` (it hasn't validly signed yet — the cryptographic check, not key-id presence). |
| `signpsgtinpool "hash"` | Resolves image / unsigned txid / revision, signs with wallet keys via the new **`SignAndAdvancePSGT`** core helper (shared with PR F's GUI Sign): reaching m-of-n finalizes, broadcasts and frees the slot — peers' pools then clean themselves up via the mempool-conflict eviction, which is how completion propagates network-wide; otherwise the signature-superset revision is pooled and relayed. Returns the **final** txid on completion (signing changes the id pre-segwit). |
| `removepsgtfrompool "hash"` | Local-only remove; gossip won't restore the removed revision, but a NEW revision is still accepted. |
| `getpsgtpoolinfo` | active / size / capacity / expiry / PSGT proto version. |

All RPCHelpMan schemas complete per the mempool-diagnostic conventions (#3092 follow-up standard).

## Notification (the `-pollnotify` three-layer pattern, #2804)

- **Core → GUI**: `uiInterface.PSGTPoolChanged(revision, CT_NEW/CT_UPDATED/CT_DELETED)`, consumed by PR F.
- **External**: `-psgtnotify=<cmd>` (`%s1` image, `%s2` event **including the eviction reason** — `added|updated|expired|replaced|completed|conflict-mempool|conflict-block|removed` — `%s3` txid), registered next to `-pollnotify` with `IMMEDIATE_EFFECT`, `#if HAVE_SYSTEM`.
- Wired in init as the pool's notify hook, which fires outside the pool lock.

## Two fixes worth reviewer attention

- **Static-init segfault**: RPC help descriptions are static objects; calling `HelpRequiringPassphrase()` in one dereferences the not-yet-created `pwalletMain` and crashes before `main()`. The passphrase note is literal text now. (Existing RPCs only call it at runtime — worth knowing for future help authors.)
- **Endianness round-trip**: `base_blob::ToString()` renders byte-reversed hex, so the `hash` argument parses with `SetHex`, not the byte-vector constructor.

## Testing

New functional test `rpc_psgtpool.py` (two nodes, initiator holds 1 key of a 2-of-3, co-signer node holds 2): submit → P2P propagation → co-signer's `listpsgtpool` shows `awaiting_my_signature` → `signpsgtinpool` completes → final tx in **both** mempools and **both** pools drain (completion locally, conflict eviction remotely) → initiator supersede in place (`replaced: true`, same image) → local-only remove → `-psgtnotify` event file contains `added`/`completed`/`removed`. Funding uses the hardened confirm-and-retry recipe from #3116's flake fix (stake-timestamp mask + staker double-spend races).

Full unit suite, Qt tests, and three consecutive full functional-runner passes (26/26) locally; `git diff --check` clean.

## Series

A #3113 → B #3114 → C #3115 → D #3116 → **E (this)** → F (Qt Pool view + Multisign-dialog graft).