### PR TITLE
refactor: name the scheduler thread in logs (grc-scheduler)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1911,7 +1911,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     assert(!g_scheduler);
     g_scheduler = std::make_unique<CScheduler>();
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, g_scheduler.get());
-    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
+    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "grc-scheduler", serviceLoop));
 
     // Register the PeerManager's recurring tasks now that the scheduler exists
     // (issue #2558). This call previously sat next to the PeerManager construction

--- a/src/util.h
+++ b/src/util.h
@@ -30,6 +30,7 @@
 #include <util/strencodings.h>
 #include "util/system.h"
 #include "util/string.h"
+#include <util/threadnames.h>
 
 #ifndef WIN32
 #include <sys/types.h>
@@ -851,6 +852,9 @@ private:
 template <typename Callable> void TraceThread(const char* name,  Callable func)
 {
     RenameThread(name);
+    // RenameThread only sets the OS thread name; also set the internal name so
+    // the log-line thread tag ([<name>]) is populated instead of "[unknown]".
+    util::ThreadSetInternalName(name);
     try
     {
         LogPrintf("%s thread start\n", name);


### PR DESCRIPTION
## Summary

The scheduler thread's log lines show as `[unknown]` instead of a thread name. `TraceThread` (the wrapper the scheduler thread runs under) calls `RenameThread`, which only sets the **OS** thread name (`prctl`), not the **internal** name that `BCLog` reads for its per-line `[<thread>]` tag (`util::ThreadGetInternalName()`). The net threads set both (`RenameThread("grc-msghand")` **and** `util::ThreadSetInternalName("grc-msghand")`), which is why they log correctly.

This became visible after #3112 moved the wallet rebroadcast onto `g_scheduler`: `ResendWalletTransactions` log lines went from `[grc-msghand]` to `[unknown]`. It also affects every other scheduler job — banlist dump, wallet backup, beacon renew, and the #3094 unbroadcast rebroadcast.

## Change

- **`util.h` `TraceThread`**: also call `util::ThreadSetInternalName(name)` so the log tag is populated. The scheduler is the *only* `TraceThread` caller, so this is effectively scoped to it — but it fixes the helper (which is meant to make the thread "recognisable") rather than special-casing the call site.
- **`init.cpp`**: rename the scheduler thread `"scheduler"` → `"grc-scheduler"` to match the `grc-` convention used by the net threads.

Result: scheduler jobs log as `[grc-scheduler]`.

## Testing

Logging-only; no behavior change. Built clean (daemon + tests). Observed live on the isolated mesh during the #3112 soak — the `[unknown]` tag on the scheduler's `ResendWalletTransactions` lines is exactly what this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)