### PR TITLE
gui: distinct PSGT removal statuses + MultiSig Txns menu + pool page title

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1991,7 +1991,12 @@ bool AppInit2(ThreadHandlerPtr threads)
             change == PSGTPoolChangeType::ADDED ? CT_NEW :
             change == PSGTPoolChangeType::UPDATED ? CT_UPDATED : CT_DELETED;
 
-        uiInterface.PSGTPoolChanged(entry.revision_hash, status);
+        // Carry the removal reason (as int) on a removal; -1 for add/update.
+        const int reason_code =
+            (change == PSGTPoolChangeType::ADDED || change == PSGTPoolChangeType::UPDATED)
+                ? -1
+                : static_cast<int>(reason.value_or(PSGTRemovalReason::LOCAL_REMOVE));
+        uiInterface.PSGTPoolChanged(entry.revision_hash, status, reason_code);
 
 #if HAVE_SYSTEM
         std::string strCmd = gArgs.GetArg("-psgtnotify", std::string{});

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -84,7 +84,7 @@ void CClientUIInterface::ResearcherChanged() { return g_ui_signals.ResearcherCha
 void CClientUIInterface::AccrualChangedFromStakeOrMRC() { return g_ui_signals.AccrualChangedFromStakeOrMRC(); }
 void CClientUIInterface::MRCChanged() { return g_ui_signals.MRCChanged(); }
 void CClientUIInterface::BeaconChanged() { return g_ui_signals.BeaconChanged(); }
-void CClientUIInterface::PSGTPoolChanged(const uint256& revision_hash, ChangeType status) { return g_ui_signals.PSGTPoolChanged(revision_hash, status); }
+void CClientUIInterface::PSGTPoolChanged(const uint256& revision_hash, ChangeType status, int reason) { return g_ui_signals.PSGTPoolChanged(revision_hash, status, reason); }
 void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signals.NewPollReceived(poll_time); }
 void CClientUIInterface::NewVoteReceived(const uint256& poll_txid) { return g_ui_signals.NewVoteReceived(poll_txid); }
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -136,7 +136,9 @@ public:
     /** PSGT pool changed (#2910): an entry was added (CT_NEW), replaced by a
      * better revision (CT_UPDATED) or removed (CT_DELETED). The revision hash
      * identifies the affected entry; consumers query the pool for details. **/
-    ADD_SIGNALS_DECL_WRAPPER(PSGTPoolChanged, void, const uint256& revision_hash, ChangeType status);
+    // reason is a PSGTRemovalReason (as int) on removal (CT_DELETED), or -1 for
+    // CT_NEW/CT_UPDATED. Kept as int so this header stays decoupled from the pool enum.
+    ADD_SIGNALS_DECL_WRAPPER(PSGTPoolChanged, void, const uint256& revision_hash, ChangeType status, int reason);
 
     /** New poll received **/
     ADD_SIGNALS_DECL_WRAPPER(NewPollReceived, void, int64_t poll_time);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -609,8 +609,9 @@ void BitcoinGUI::createMenuBar()
     QMenu *signMenu = file->addMenu(tr("Sign &message"));
     signMenu->addAction(signMessageAction);
     signMenu->addAction(verifyMessageAction);
-    signMenu->addAction(multisignAction);
-    signMenu->addAction(psgtPoolAction);
+    QMenu *multisigMenu = file->addMenu(tr("MultiSig &Txns"));
+    multisigMenu->addAction(multisignAction);
+    multisigMenu->addAction(psgtPoolAction);
     file->addSeparator();
 
     // Snapshot GUI menu action disabled due to snapshot CDN abuse in 202308.
@@ -1687,8 +1688,12 @@ void BitcoinGUI::gotoPSGTPoolPage()
     disconnect(exportAction, &QAction::triggered, nullptr, nullptr);
 }
 
-void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type)
+void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type, int reason)
 {
+    // The toast fires only on add/update, so the removal reason is unused here;
+    // the table model consumes it (to label the history row).
+    Q_UNUSED(reason);
+
     // Toast only for an entry that newly needs THIS wallet's signature.
     if (change_type == CT_DELETED || !clientModel) {
         return;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -284,7 +284,7 @@ private slots:
     /** Switch to the PSGT pool page (#2910) */
     void gotoPSGTPoolPage();
     /** Toast when a pooled PSGT relevant to this wallet needs a signature */
-    void handlePSGTPoolChanged(QString revision_hash, quint8 change_type);
+    void handlePSGTPoolChanged(QString revision_hash, quint8 change_type, int reason);
     /** Show configuration dialog */
     void optionsClicked();
     /** Switch the active light/dark theme */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -193,9 +193,9 @@ void ClientModel::updateScraper(int scraperEventtype, int status, const QString 
         emit updateScraperStatus(scraperEventtype, status);
 }
 
-void ClientModel::updatePSGTPool(const QString &revision_hash, int status)
+void ClientModel::updatePSGTPool(const QString &revision_hash, int status, int reason)
 {
-    emit psgtPoolChanged(revision_hash, (quint8)status);
+    emit psgtPoolChanged(revision_hash, (quint8)status, reason);
 }
 
 // Requires a lock on cs_ConvergedScraperStatsCache
@@ -349,11 +349,12 @@ static void MinerStatusChanged(ClientModel *clientmodel, bool staking, double co
                               Q_ARG(double, coin_weight));
 }
 
-static void PSGTPoolChanged(ClientModel *clientmodel, const uint256& revision_hash, ChangeType status)
+static void PSGTPoolChanged(ClientModel *clientmodel, const uint256& revision_hash, ChangeType status, int reason)
 {
     QMetaObject::invokeMethod(clientmodel, "updatePSGTPool", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(revision_hash.GetHex())),
-                              Q_ARG(int, status));
+                              Q_ARG(int, status),
+                              Q_ARG(int, reason));
 }
 
 void ClientModel::subscribeToCoreSignals()
@@ -373,7 +374,8 @@ void ClientModel::subscribeToCoreSignals()
     uiInterface.MinerStatusChanged_connect(boost::bind(MinerStatusChanged, this,
                                                      boost::placeholders::_1, boost::placeholders::_2));
     uiInterface.PSGTPoolChanged_connect(boost::bind(PSGTPoolChanged, this,
-                                                    boost::placeholders::_1, boost::placeholders::_2));
+                                                    boost::placeholders::_1, boost::placeholders::_2,
+                                                    boost::placeholders::_3));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -87,8 +87,10 @@ signals:
 
     //! The PSGT pool (#2910) changed. change_type is a ui_interface ChangeType
     //! (CT_NEW / CT_UPDATED / CT_DELETED) narrowed to quint8 for the queued
-    //! connection; the affected revision hash is carried for reference.
-    void psgtPoolChanged(QString revision_hash, quint8 change_type);
+    //! connection; the affected revision hash is carried for reference. reason is
+    //! a PSGTRemovalReason code (as int) on a removal (CT_DELETED) and -1 for
+    //! CT_NEW / CT_UPDATED -- consumers must read it only on CT_DELETED.
+    void psgtPoolChanged(QString revision_hash, quint8 change_type, int reason);
 
     //! Asynchronous error notification
     void error(const QString &title, const QString &message, bool modal);
@@ -101,7 +103,7 @@ public slots:
     void updateAlert(const QString &hash, int status);
     void updateMinerStatus(bool staking, double coin_weight);
     void updateScraper(int scraperEventtype, int status, const QString message);
-    void updatePSGTPool(const QString &revision_hash, int status);
+    void updatePSGTPool(const QString &revision_hash, int status, int reason);
 };
 
 #endif // BITCOIN_QT_CLIENTMODEL_H

--- a/src/qt/psgtpoolpage.cpp
+++ b/src/qt/psgtpoolpage.cpp
@@ -14,6 +14,7 @@
 #include <node/psgt_pool.h>
 #include <sync.h>
 
+#include <QFont>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
@@ -26,6 +27,17 @@ PSGTPoolPage::PSGTPoolPage(QWidget* parent)
     : QWidget(parent)
 {
     auto* layout = new QVBoxLayout(this);
+
+    auto* title = new QLabel(tr("PSGT Pool"), this);
+    QFont title_font = title->font();
+    title_font.setPointSize(title_font.pointSize() + 4);
+    title_font.setBold(true);
+    title->setFont(title_font);
+    layout->addWidget(title);
+
+    auto* subtitle = new QLabel(tr("Multisig transactions awaiting signatures."), this);
+    subtitle->setWordWrap(true);
+    layout->addWidget(subtitle);
 
     m_banner = new QLabel(this);
     m_banner->setWordWrap(true);
@@ -102,8 +114,8 @@ void PSGTPoolPage::setClientModel(ClientModel* client_model)
     // Deliver the core PSGTPoolChanged signal (marshalled onto the GUI thread
     // by ClientModel) to the table model so its rows track the pool live.
     connect(client_model, &ClientModel::psgtPoolChanged, this,
-            [this](const QString& revision_hash, quint8 change_type) {
-                if (m_table_model) m_table_model->handlePoolChanged(revision_hash, change_type);
+            [this](const QString& revision_hash, quint8 change_type, int reason) {
+                if (m_table_model) m_table_model->handlePoolChanged(revision_hash, change_type, reason);
                 updateButtons();
             });
 

--- a/src/qt/psgtpooltablemodel.cpp
+++ b/src/qt/psgtpooltablemodel.cpp
@@ -9,6 +9,7 @@
 #include "walletmodel.h"
 
 #include <key_io.h>
+#include <node/psgt_pool.h>
 #include <psgt.h>
 #include <script/standard.h>
 #include <util.h>
@@ -133,7 +134,7 @@ void PSGTPoolTableModel::refresh()
     endResetModel();
 }
 
-void PSGTPoolTableModel::handlePoolChanged(const QString& revision_hash, quint8 change_type)
+void PSGTPoolTableModel::handlePoolChanged(const QString& revision_hash, quint8 change_type, int reason)
 {
     // On a removal, capture the wallet-relevant entry as history before it is
     // gone from the view. CT_DELETED is the removal case (see ui_interface
@@ -149,7 +150,15 @@ void PSGTPoolTableModel::handlePoolChanged(const QString& revision_hash, quint8 
         for (const Row& row : m_rows) {
             if (row.in_pool && row.is_mine && row.revision == removed) {
                 Row completed = row;
-                completed.status = RowStatus::Complete;
+                // Map the pool's removal reason (int, see ui_interface) to a
+                // specific terminal status so the history row is meaningful.
+                switch (static_cast<PSGTRemovalReason>(reason)) {
+                case PSGTRemovalReason::EXPIRED:          completed.status = RowStatus::Expired;    break;
+                case PSGTRemovalReason::COMPLETED:        completed.status = RowStatus::Completed;   break;
+                case PSGTRemovalReason::CONFLICT_MEMPOOL:
+                case PSGTRemovalReason::CONFLICT_BLOCK:   completed.status = RowStatus::Conflicted;  break;
+                default:                                  completed.status = RowStatus::Removed;     break;
+                }
                 completed.in_pool = false;
                 // Newest first; dedupe by image; bound the length.
                 for (int i = m_history.size() - 1; i >= 0; --i) {
@@ -179,10 +188,11 @@ QVariant PSGTPoolTableModel::data(const QModelIndex& index, int role) const
             switch (row.status) {
             case RowStatus::AwaitingYourSignature: return tr("Awaiting your signature");
             case RowStatus::AwaitingOthers:        return tr("Awaiting others");
-            // Rows land here on ANY removal (completed, expired, conflicted, or
-            // locally removed) -- the Qt signal carries no reason -- so use a
-            // neutral label rather than implying the multisig completed.
-            case RowStatus::Complete:              return tr("No longer pending");
+            // History rows, labelled from the pool's removal reason.
+            case RowStatus::Expired:               return tr("Expired");
+            case RowStatus::Completed:             return tr("Completed");
+            case RowStatus::Conflicted:            return tr("Conflict");
+            case RowStatus::Removed:               return tr("Removed");
             }
             return QVariant();
         case Destination:

--- a/src/qt/psgtpooltablemodel.h
+++ b/src/qt/psgtpooltablemodel.h
@@ -42,7 +42,11 @@ public:
     enum class RowStatus {
         AwaitingYourSignature,
         AwaitingOthers,
-        Complete, //!< Recently completed/removed (history only).
+        // History-only terminal states, mapped from the pool's removal reason.
+        Expired,
+        Completed,
+        Conflicted,
+        Removed,
     };
 
     struct Row {
@@ -76,7 +80,7 @@ public Q_SLOTS:
     //! Slot bound to the core PSGTPoolChanged signal via QueuedConnection.
     //! On a removal that this wallet had a stake in, promote the row identified
     //! by revision_hash to the recently-completed history before it vanishes.
-    void handlePoolChanged(const QString& revision_hash, quint8 change_type);
+    void handlePoolChanged(const QString& revision_hash, quint8 change_type, int reason);
 
 private:
     WalletModel* m_wallet_model;


### PR DESCRIPTION
Bundles three small PSGT/multisig GUI follow-ups surfaced during the #3116–#3118 review.

### ② Distinct pool-removal statuses
The pool history showed one neutral **"No longer pending"** for every removal because `PSGTPoolChanged` dropped the reason. This threads the pool's `PSGTRemovalReason` (as an `int`, so `ui_interface.h` stays decoupled from the pool enum) through `uiInterface.PSGTPoolChanged` → `ClientModel` → `PSGTPoolTableModel`, and splits `RowStatus` into **Expired / Completed / Conflict / Removed**. Reason is read only on removal (`CT_DELETED`); add/update pass `-1`.

### ④ "MultiSig Txns" menu
The hamburger **"Sign message"** submenu conflated arbitrary-message signing with the multisig/PSGT flow. Multisign + PSGT pool now live in a new peer-level **"MultiSig Txns"** submenu; message sign/verify stay under "Sign message".

### ⑤ PSGT Pool page title
Added a title + subtitle to `PSGTPoolPage` so it's clear which screen you're on.

### Testing
Qt6 GUI + daemon build clean; whitespace lint clean; adversarial self-review clean (signal arity consistent end-to-end, reason read only on removal, switch total over `PSGTRemovalReason`). ④/⑤ are static GUI; ②'s labels are best eyeballed in a live v15 pool scenario (Expired via sweep, Completed via co-sign, Conflict via a competing spend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)