### PR TITLE
p2p: hold PSGTs pending unconfirmed funding (orphan-PSGT pool)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -325,10 +325,25 @@ static void ProcessPSGTMessage(CNode* pfrom, CDataStream& vRecv)
     // expensive signature verification, so replaying them costs no ECDSA work
     // and needs no DoS score; scoring them would also risk banning honest peers
     // in ordinary gossip races or future protocol extensions.
+    // Funding not yet visible to this node -- the unconfirmed-funding relay
+    // race: a peer relayed the PSGT before its funding transaction reached our
+    // mempool. Hold it rather than drop it; PSGTPool::TransactionAddedToMempool /
+    // BlockConnected re-validate and pool+relay it once the funding arrives.
+    // ValidatePSGTForPool decoded entry.psgt before the UTXO check, so its input
+    // prevouts are available to key the orphan on.
+    case PSGTPoolReject::UTXO_MISSING: {
+        std::vector<COutPoint> prevouts;
+        prevouts.reserve(entry.psgt.tx.vin.size());
+        for (const CTxIn& txin : entry.psgt.tx.vin) prevouts.push_back(txin.prevout);
+        g_psgt_pool.AddOrphan(wire_bytes, obj_hash, prevouts, GetAdjustedTime());
+        LogPrint(BCLog::LogFlags::MEMPOOL, "%s: psgt from %s held pending funding: %s",
+                 __func__, pfrom->addr.ToString(), reason);
+        return;
+    }
+
     case PSGTPoolReject::HAS_UNKNOWN_FIELDS:
     case PSGTPoolReject::DUPLICATE_REVISION:
     case PSGTPoolReject::COMPLETE:
-    case PSGTPoolReject::UTXO_MISSING:
     case PSGTPoolReject::UTXO_SPENT:
     case PSGTPoolReject::FEE_TOO_LOW:
     case PSGTPoolReject::FEE_ABSURD:

--- a/src/node/psgt_pool.cpp
+++ b/src/node/psgt_pool.cpp
@@ -540,6 +540,8 @@ size_t PSGTPool::EraseExpired(int64_t now)
                 expired.push_back(std::move(*entry));
             }
         }
+
+        EraseExpiredOrphans(now);
     }
 
     for (const PSGTPoolEntry& entry : expired) {
@@ -565,17 +567,22 @@ void PSGTPool::Clear()
     m_by_txhash.clear();
     m_by_prevout.clear();
     m_recently_removed.clear();
+    m_orphans.clear();
+    m_orphans_by_prevout.clear();
 }
 
 void PSGTPool::TransactionAddedToMempool(const CTransactionRef& tx)
 {
     EvictConflicts(*tx, PSGTRemovalReason::CONFLICT_MEMPOOL);
+    // The tx may also be the funding an orphan PSGT was waiting on.
+    PromoteOrphans(*tx);
 }
 
 void PSGTPool::BlockConnected(const CBlock& block, int /*height*/)
 {
     for (const CTransaction& tx : block.vtx) {
         EvictConflicts(tx, PSGTRemovalReason::CONFLICT_BLOCK);
+        PromoteOrphans(tx);
     }
 }
 
@@ -607,6 +614,127 @@ void PSGTPool::EvictConflicts(const CTransaction& tx, PSGTRemovalReason reason)
                  entry.image.ToString(), PSGTRemovalReasonToString(reason),
                  tx.GetHash().ToString());
         Notify(entry, PSGTPoolChangeType::REMOVED, reason);
+    }
+}
+
+void PSGTPool::AddOrphan(std::vector<unsigned char> wire, const uint256& revision_hash,
+                         const std::vector<COutPoint>& prevouts, int64_t now)
+{
+    LOCK(cs_psgt_pool);
+
+    // Already pooled, recently removed, or already held: nothing to do.
+    if (m_by_revision.count(revision_hash) || m_recently_removed.count(revision_hash)
+        || m_orphans.count(revision_hash)) {
+        return;
+    }
+
+    // Bounded: drop the oldest held orphan when at the cap so a peer cannot grow
+    // the map without bound.
+    while (m_orphans.size() >= MAX_ORPHAN_PSGTS) {
+        auto oldest = m_orphans.begin();
+        for (auto it = m_orphans.begin(); it != m_orphans.end(); ++it) {
+            if (it->second.time_received < oldest->second.time_received) oldest = it;
+        }
+        EraseOrphanInternal(oldest->first);
+    }
+
+    m_orphans.emplace(revision_hash, OrphanPSGT{std::move(wire), now});
+    for (const COutPoint& prevout : prevouts) {
+        m_orphans_by_prevout.emplace(prevout, revision_hash);
+    }
+    LogPrint(BCLog::LogFlags::MEMPOOL, "psgtpool: holding orphan revision %s (%zu held)",
+             revision_hash.ToString(), m_orphans.size());
+}
+
+size_t PSGTPool::OrphanCount() const
+{
+    LOCK(cs_psgt_pool);
+    return m_orphans.size();
+}
+
+void PSGTPool::EraseOrphanInternal(const uint256& revision_hash)
+{
+    // Copy first: a caller may pass a reference INTO m_orphans (AddOrphan's
+    // oldest-eviction does), and erasing that node would dangle the argument
+    // before the prevout-index sweep below reads it again.
+    const uint256 rev = revision_hash;
+    m_orphans.erase(rev);
+    for (auto it = m_orphans_by_prevout.begin(); it != m_orphans_by_prevout.end();) {
+        it = (it->second == rev) ? m_orphans_by_prevout.erase(it) : std::next(it);
+    }
+}
+
+size_t PSGTPool::EraseExpiredOrphans(int64_t now)
+{
+    std::vector<uint256> stale;
+    for (const auto& [rev, orphan] : m_orphans) {
+        if (now - orphan.time_received > ORPHAN_EXPIRY_SECONDS) stale.push_back(rev);
+    }
+    for (const uint256& rev : stale) EraseOrphanInternal(rev);
+    return stale.size();
+}
+
+void PSGTPool::PromoteOrphans(const CTransaction& tx)
+{
+    AssertLockHeld(cs_main);
+
+    // Snapshot (revision, wire) of every orphan waiting on an output of tx under
+    // the pool lock, then re-validate with the pool lock RELEASED -- as in
+    // EvictConflicts. ValidatePSGTForPool needs cs_main only (held throughout by
+    // our caller, satisfying Add's funding-unspent invariant); Add re-takes
+    // cs_psgt_pool as a leaf.
+    std::vector<std::pair<uint256, std::vector<unsigned char>>> candidates;
+    {
+        LOCK(cs_psgt_pool);
+        if (m_orphans.empty()) return;
+
+        const uint256 txid = tx.GetHash();
+        std::set<uint256> seen;
+        for (size_t n = 0; n < tx.vout.size(); ++n) {
+            const auto range = m_orphans_by_prevout.equal_range(COutPoint(txid, n));
+            for (auto it = range.first; it != range.second; ++it) {
+                const uint256& rev = it->second;
+                if (!seen.insert(rev).second) continue;
+                const auto orphan = m_orphans.find(rev);
+                if (orphan != m_orphans.end()) candidates.emplace_back(rev, orphan->second.wire);
+            }
+        }
+    }
+    if (candidates.empty()) return;
+
+    const int64_t now = GetAdjustedTime();
+    for (auto& [rev, wire] : candidates) {
+        PSGTPoolEntry entry;
+        std::string error;
+        const PSGTPoolReject reject = ValidatePSGTForPool(*this, wire, now, entry, error);
+
+        // Still waiting on another funding input -- keep holding it.
+        if (reject == PSGTPoolReject::UTXO_MISSING) continue;
+
+        // Otherwise we stop holding it: either it now validates (promote) or it
+        // hard-rejects (e.g. this tx spent the funding output it needed).
+        {
+            LOCK(cs_psgt_pool);
+            EraseOrphanInternal(rev);
+        }
+
+        if (reject != PSGTPoolReject::NONE) {
+            LogPrint(BCLog::LogFlags::MEMPOOL, "psgtpool: orphan %s dropped on promotion: %s (%s)",
+                     rev.ToString(), PSGTPoolRejectToString(reject), error);
+            continue;
+        }
+
+        // Relay the freshly re-validated canonical revision (== rev by
+        // construction, but do not depend on the stash path for it).
+        const uint256 revision = entry.revision_hash;
+        std::string reject_reason;
+        const PSGTPoolAddResult result = Add(std::move(entry), reject_reason);
+        if (result == PSGTPoolAddResult::ACCEPTED_NEW
+            || result == PSGTPoolAddResult::ACCEPTED_REPLACEMENT) {
+            LogPrint(BCLog::LogFlags::MEMPOOL, "psgtpool: promoted orphan %s (funding arrived)",
+                     revision.ToString());
+            RelayPSGT(revision);
+        }
     }
 }
 

--- a/src/node/psgt_pool.h
+++ b/src/node/psgt_pool.h
@@ -203,6 +203,15 @@ public:
     //! Hard cap on the recently-removed set (safety net; TTL is the normal bound).
     static constexpr size_t MAX_RECENTLY_REMOVED = 1000;
 
+    //! Orphan holding pool for a PSGT whose funding transaction this node has
+    //! not seen yet (the unconfirmed-funding relay race: a peer relays the PSGT
+    //! before the funding tx reaches this node's mempool). Bounded (oldest
+    //! evicted at the cap) and TTL'd so a peer cannot grow it with fabricated
+    //! missing-funding PSGTs -- and an orphan is only held AFTER it passed every
+    //! admission check except the UTXO presence one (well-formed, signed, fee-ok).
+    static constexpr size_t MAX_ORPHAN_PSGTS = 100;
+    static constexpr int64_t ORPHAN_EXPIRY_SECONDS = 20 * 60;
+
     //! Notification hook, fired outside the pool lock for every mutation.
     //! For REMOVED changes the removal reason is provided. Wired to the
     //! uiInterface signal and -psgtnotify by the RPC/notification layer;
@@ -271,7 +280,23 @@ public:
         GetSerializedByRevision(const uint256& revision_hash) const;
 
     //! Evict entries older than EXPIRY_SECONDS. Returns the number evicted.
+    //! Also sweeps orphans older than ORPHAN_EXPIRY_SECONDS.
     size_t EraseExpired(int64_t now);
+
+    //! Hold a PSGT whose funding output(s) are unknown to this node (a
+    //! UTXO_MISSING reject at relay time) instead of dropping it, keyed by its
+    //! canonical revision hash and indexed by every input prevout. When a
+    //! funding transaction later arrives (TransactionAddedToMempool /
+    //! BlockConnected) the orphan is re-validated and, on success, pooled and
+    //! relayed. No-op if the revision is already pooled/recently-removed or
+    //! already held. wire is the received canonical bytes (re-validated on
+    //! promotion, so a stale orphan cannot be trusted blindly). Caller holds
+    //! cs_main (as ProcessPSGTMessage does); Add-style leaf on cs_psgt_pool.
+    void AddOrphan(std::vector<unsigned char> wire, const uint256& revision_hash,
+                   const std::vector<COutPoint>& prevouts, int64_t now);
+
+    //! Number of held orphans (diagnostics / tests).
+    size_t OrphanCount() const;
 
     size_t Size() const;
     void Clear();
@@ -280,10 +305,10 @@ public:
     //! pooled PSGT spending one of its inputs is dead (locally observed
     //! double spend -- or, commonly, the completed PSGT itself arriving as a
     //! transaction, which is how completion propagates network-wide).
-    void TransactionAddedToMempool(const CTransactionRef& tx) override;
+    void TransactionAddedToMempool(const CTransactionRef& tx) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     //! Eviction trigger 2 (authoritative): a connected block spent an input.
-    void BlockConnected(const CBlock& block, int height) override;
+    void BlockConnected(const CBlock& block, int height) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 private:
     mutable CCriticalSection cs_psgt_pool;
@@ -296,6 +321,17 @@ private:
     std::map<COutPoint, CScriptID> m_by_prevout GUARDED_BY(cs_psgt_pool);
     //! Removed revision hash -> removal time (TTL-pruned, hard-capped).
     std::map<uint256, int64_t> m_recently_removed GUARDED_BY(cs_psgt_pool);
+
+    //! A PSGT held pending its (unconfirmed) funding transaction.
+    struct OrphanPSGT {
+        std::vector<unsigned char> wire; //!< canonical bytes, re-validated on promotion
+        int64_t time_received;
+    };
+    //! Canonical revision hash -> held orphan.
+    std::map<uint256, OrphanPSGT> m_orphans GUARDED_BY(cs_psgt_pool);
+    //! Funding prevout -> revision hash(es) of orphans waiting on it. A multimap
+    //! because several orphans can reference the same missing output.
+    std::multimap<COutPoint, uint256> m_orphans_by_prevout GUARDED_BY(cs_psgt_pool);
 
     //! Erase an entry from every index and record its revision as recently
     //! removed. Returns the entry (for post-lock notification).
@@ -311,6 +347,20 @@ private:
 
     //! Shared body of the two eviction triggers.
     void EvictConflicts(const CTransaction& tx, PSGTRemovalReason reason);
+
+    //! Re-evaluate any orphan waiting on an output of tx (its funding just
+    //! became available). Re-runs ValidatePSGTForPool; on success pools + relays
+    //! the orphan, on a still-missing funding keeps it, on a hard reject drops
+    //! it. cs_main is held throughout (the two validation-interface triggers that
+    //! call it are annotated EXCLUSIVE_LOCKS_REQUIRED(cs_main), matching CWallet).
+    void PromoteOrphans(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    //! Drop orphans older than ORPHAN_EXPIRY_SECONDS. Returns the count removed.
+    size_t EraseExpiredOrphans(int64_t now) EXCLUSIVE_LOCKS_REQUIRED(cs_psgt_pool);
+
+    //! Remove one orphan from m_orphans and its m_orphans_by_prevout entries.
+    void EraseOrphanInternal(const uint256& revision_hash)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_psgt_pool);
 
     //! Fire m_notify_hook if set (call with the lock RELEASED).
     void Notify(const PSGTPoolEntry& entry, PSGTPoolChangeType change,

--- a/src/rpc/psgt.cpp
+++ b/src/rpc/psgt.cpp
@@ -1296,6 +1296,7 @@ static const RPCHelpMan getpsgtpoolinfo_help{
         {
             {RPCResult::Type::BOOL, "active", "Whether the pool is active (block v15 live and node in sync)."},
             {RPCResult::Type::NUM, "size", "Entries currently pooled."},
+            {RPCResult::Type::NUM, "orphan_count", "PSGTs held pending their (unconfirmed) funding transaction."},
             {RPCResult::Type::NUM, "maxsize", "Pool capacity (new images are rejected when full)."},
             {RPCResult::Type::NUM, "expiry", "Entry lifetime in seconds."},
             {RPCResult::Type::NUM, "psgtprotocolversion", "Minimum peer protocol version PSGT inventory is relayed to."},
@@ -1315,6 +1316,7 @@ UniValue getpsgtpoolinfo(const UniValue& params)
         obj.pushKV("active", IsV15Enabled(nBestHeight) && !OutOfSyncByAge());
     }
     obj.pushKV("size", (int64_t)g_psgt_pool.Size());
+    obj.pushKV("orphan_count", (int64_t)g_psgt_pool.OrphanCount());
     obj.pushKV("maxsize", (int64_t)PSGTPool::MAX_ENTRIES);
     obj.pushKV("expiry", PSGTPool::EXPIRY_SECONDS);
     obj.pushKV("psgtprotocolversion", PSGT_PROTO_VERSION);

--- a/src/test/psgt_pool_tests.cpp
+++ b/src/test/psgt_pool_tests.cpp
@@ -532,4 +532,75 @@ BOOST_AUTO_TEST_CASE(pool_local_remove)
     BOOST_CHECK(!pool.Remove(image, PSGTRemovalReason::LOCAL_REMOVE));
 }
 
+// ---------------------------------------------------------------------------
+// Orphan holding pool (unconfirmed-funding relay race)
+// ---------------------------------------------------------------------------
+
+//! A PSGT whose funding is UTXO_MISSING is held, not dropped, and is promoted
+//! into the pool (and would relay) once the funding transaction arrives.
+BOOST_AUTO_TEST_CASE(orphan_held_then_promoted_when_funding_arrives)
+{
+    mempool.clear();
+    FundedMultisig fixture;
+    const PartiallySignedTransaction psgt = fixture.Signed({fixture.k1});
+    const std::vector<unsigned char> wire = SerializePSGT(psgt);
+
+    // With the funding visible it would validate; capture its canonical revision.
+    PSGTPoolEntry probe;
+    std::string perr;
+    BOOST_REQUIRE(Validate(psgt, probe, perr) == PSGTPoolReject::NONE);
+    const uint256 revision = probe.revision_hash;
+
+    // Funding not visible to this node -> UTXO_MISSING (the relay-race case).
+    mempool.remove(fixture.funding);
+    PSGTPoolEntry entry;
+    std::string error;
+    BOOST_REQUIRE(Validate(psgt, entry, error) == PSGTPoolReject::UTXO_MISSING);
+
+    // Held as an orphan, not pooled.
+    PSGTPool pool;
+    const COutPoint prevout(fixture.funding.GetHash(), 0);
+    pool.AddOrphan(wire, revision, {prevout}, 1700003000);
+    BOOST_CHECK_EQUAL(pool.OrphanCount(), 1u);
+    BOOST_CHECK_EQUAL(pool.Size(), 0u);
+
+    // The funding transaction arrives -> the orphan is re-validated and pooled.
+    AddToMempool(fixture.funding);
+    {
+        LOCK(cs_main);
+        pool.TransactionAddedToMempool(MakeTransactionRef(fixture.funding));
+    }
+    BOOST_CHECK_EQUAL(pool.OrphanCount(), 0u);
+    BOOST_CHECK_EQUAL(pool.Size(), 1u);
+    BOOST_CHECK(pool.GetByRevision(revision).has_value());
+}
+
+//! The orphan map is bounded: past MAX_ORPHAN_PSGTS the oldest is evicted, so a
+//! peer cannot grow it without bound (DoS safety). AddOrphan does not validate,
+//! so opaque bytes with random keys suffice here.
+BOOST_AUTO_TEST_CASE(orphan_pool_is_bounded)
+{
+    PSGTPool pool;
+    const std::vector<unsigned char> opaque{'p', 's', 'g', 't'};
+    for (size_t i = 0; i < PSGTPool::MAX_ORPHAN_PSGTS + 5; ++i) {
+        pool.AddOrphan(opaque, InsecureRand256(),
+                       {COutPoint(InsecureRand256(), 0)}, 1700003000 + static_cast<int64_t>(i));
+    }
+    BOOST_CHECK_EQUAL(pool.OrphanCount(), PSGTPool::MAX_ORPHAN_PSGTS);
+}
+
+//! Orphans past ORPHAN_EXPIRY_SECONDS are swept by EraseExpired (the TTL bound).
+BOOST_AUTO_TEST_CASE(orphan_expires)
+{
+    PSGTPool pool;
+    const std::vector<unsigned char> opaque{'p', 's', 'g', 't'};
+    pool.AddOrphan(opaque, InsecureRand256(), {COutPoint(InsecureRand256(), 0)}, 1700003000);
+    BOOST_CHECK_EQUAL(pool.OrphanCount(), 1u);
+
+    pool.EraseExpired(1700003000 + PSGTPool::ORPHAN_EXPIRY_SECONDS);       // exactly at TTL: kept
+    BOOST_CHECK_EQUAL(pool.OrphanCount(), 1u);
+    pool.EraseExpired(1700003000 + PSGTPool::ORPHAN_EXPIRY_SECONDS + 1);   // past TTL: swept
+    BOOST_CHECK_EQUAL(pool.OrphanCount(), 0u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_psgt_orphan.py
+++ b/test/functional/p2p_psgt_orphan.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""PSGT orphan holding pool: the unconfirmed-funding relay race (#2910 Phase II).
+
+A node that receives a relayed `psgt` before it has seen the funding transaction
+used to reject it (UTXO_MISSING) and never reconsider, so it permanently missed
+a pool entry its peers held. It now HOLDS such a PSGT as an orphan and promotes
+it once the funding arrives.
+
+One node under test (node0, v15 at height 0), started with -persistmempool=0 so
+a restart drops its mempool. (A second node runs only as a pubkey source and is
+never connected.) node0 builds a genuinely partially signed 2-of-3 multisig PSGT
+(one own key, two keys from that second node) against an UNCONFIRMED funding
+transaction, then restarts -- which
+clears the funding from its mempool so it no longer knows the funding output.
+A scripted peer injects the PSGT and we assert:
+
+- it is held as an orphan (getpsgtpoolinfo orphan_count == 1, size == 0) and NOT
+  relayed (a watcher peer sees no inv);
+- resubmitting the funding transaction promotes it: re-validated, pooled and
+  relayed (size == 1, orphan_count == 0, the watcher receives inv(MSG_PSGT)).
+"""
+
+import time
+
+from base64 import b64decode
+
+from test_framework.messages import (
+    MSG_PSGT,
+    hash256,
+    msg_psgt,
+    uint256_from_str,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class InvCollector(P2PInterface):
+    """Records every MSG_PSGT inventory hash it is announced."""
+
+    def __init__(self):
+        super().__init__()
+        self.psgt_invs = []
+
+    def on_inv(self, message):
+        for inv in message.inv:
+            if inv.type == MSG_PSGT:
+                self.psgt_invs.append(inv.hash)
+
+
+class P2PPsgtOrphanTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+        # node0 is the node under test; -persistmempool=0 lets a restart drop the
+        # unconfirmed funding. node1 is only a pubkey source (never connected).
+        self.extra_args = [["-staking=0", "-blockv15height=0", "-persistmempool=0"],
+                           ["-staking=0", "-blockv15height=0"]]
+
+    def setup_network(self):
+        # Deliberately do NOT connect the nodes: node1 only supplies two multisig
+        # pubkeys node0 does not own (so walletprocesspsgt yields a PARTIAL sign).
+        self.add_nodes(self.num_nodes, self.extra_args)
+        self.start_nodes()
+
+    def build_unconfirmed_funding_and_psgt(self):
+        """On node0, create a 2-of-3 multisig (1 own key, 2 node1 keys), fund it
+        with an UNCONFIRMED raw spend of a mature UTXO, and build a partially
+        signed PSGT. Returns (wire_bytes, funding_hex)."""
+        node0, node1 = self.nodes[0], self.nodes[1]
+
+        pub_mine = node0.validateaddress(node0.getnewaddress())["pubkey"]
+        pub_other1 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        pub_other2 = node1.validateaddress(node1.getnewaddress())["pubkey"]
+        ms_address = node0.addmultisigaddress(2, [pub_mine, pub_other1, pub_other2])
+
+        utxo = node0.listunspent(11)[0]  # consensus-mature
+        ms_amount = round(float(utxo["amount"]) - 1.0, 8)  # ~1 GRC fee
+        raw = node0.createrawtransaction(
+            [{"txid": utxo["txid"], "vout": utxo["vout"]}], {ms_address: ms_amount})
+        signed = node0.signrawtransactionwithwallet(raw)
+        assert signed.get("complete"), signed
+        funding_hex = signed["hex"]
+        txid = node0.sendrawtransaction(funding_hex)  # unconfirmed, mempool only
+
+        funding = node0.getrawtransaction(txid, True)
+        vout = next(o["n"] for o in funding["vout"]
+                    if ms_address in o["scriptPubKey"].get("addresses", []))
+
+        dest = node0.getnewaddress()
+        psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
+                                {dest: round(ms_amount - 0.01, 8)})
+        psgt = node0.utxoupdatepsgt(psgt)
+        processed = node0.walletprocesspsgt(psgt)
+        assert not processed["complete"], "expected a PARTIALLY signed PSGT"
+        return b64decode(processed["psgt"]), funding_hex
+
+    def run_test(self):
+        node0 = self.nodes[0]
+
+        # Consensus-mature coins (>10 confirmations) and a current tip.
+        node0.generatetoaddress(12, node0.getnewaddress())
+
+        wire, funding_hex = self.build_unconfirmed_funding_and_psgt()
+        revision = uint256_from_str(hash256(wire))
+
+        # Restart: -persistmempool=0 drops the unconfirmed funding, so node0 no
+        # longer knows the funding output -- exactly the relay-race condition.
+        self.restart_node(0, self.extra_args[0])
+        assert_equal(node0.getrawmempool(), [])
+
+        watcher = node0.add_p2p_connection(InvCollector())
+        time.sleep(6)  # inbound rate limit: 1 per 5s per IP (all 127.0.0.1)
+        sender = node0.add_p2p_connection(P2PInterface())
+
+        # --- inject the PSGT while the funding is unknown: held, not pooled ---
+        sender.send_message(msg_psgt(wire))
+        sender.sync_with_ping()
+        time.sleep(1)  # allow any (wrong) relay to arrive
+
+        info = node0.getpsgtpoolinfo()
+        assert_equal(info["orphan_count"], 1)
+        assert_equal(info["size"], 0)
+        assert_equal(watcher.psgt_invs, [])
+        self.log.info("PSGT held as orphan (funding unknown); not pooled, not relayed")
+
+        # --- the funding transaction arrives -> promote, pool, relay ---
+        node0.sendrawtransaction(funding_hex)
+        watcher.wait_until(lambda: revision in watcher.psgt_invs)
+        info = node0.getpsgtpoolinfo()
+        assert_equal(info["size"], 1)
+        assert_equal(info["orphan_count"], 0)
+        self.log.info("funding arrived -> orphan re-validated, pooled, and relayed")
+
+
+if __name__ == "__main__":
+    P2PPsgtOrphanTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -148,6 +148,7 @@ BASE_SCRIPTS = [
     'p2p_version_handshake.py',
     'p2p_block_tx_relay.py',
     'p2p_psgt_relay.py',
+    'p2p_psgt_orphan.py',
     'p2p_ping.py',
     'rpc_help.py',
     'rpc_signmessage.py',


### PR DESCRIPTION
Fixes the **unconfirmed-funding relay race** found during the #3116–#3118 v15 mesh soak: a node that received a relayed `psgt` before the funding transaction reached its mempool rejected it (`UTXO_MISSING`) and never reconsidered, permanently missing a pool entry its peers held.

### Fix — orphan-PSGT holding pool (mirrors orphan-tx handling)
- **`psgt_pool.{h,cpp}`** — `AddOrphan` stashes a `UTXO_MISSING` PSGT (keyed by canonical revision hash, indexed by input prevouts) instead of dropping it. **Bounded** (`MAX_ORPHAN_PSGTS=100`, oldest evicted) and **TTL'd** (`ORPHAN_EXPIRY_SECONDS=20min`, swept by `EraseExpired`) → DoS-safe; a PSGT is only held after passing every admission check except UTXO presence. The pool's existing `TransactionAddedToMempool`/`BlockConnected` overrides now also **`PromoteOrphans`**: when a tx supplies a waited-on output, the orphan is re-validated → on success pooled + relayed, still-missing kept, hard-reject dropped.
- **`net_processing.cpp`** — the `UTXO_MISSING` branch stashes the orphan (keyed on all input prevouts).
- **`getpsgtpoolinfo`** — new `orphan_count` field.

### Testing
- Unit (`psgt_pool_tests`): `orphan_held_then_promoted_when_funding_arrives`, `orphan_pool_is_bounded`, `orphan_expires`.
- Functional (`p2p_psgt_orphan.py`): inject a PSGT before its funding → held as orphan (`orphan_count=1`, not relayed) → funding arrives → re-validated, pooled, relayed.
- Adversarially reviewed: lock ordering / re-entrancy (promotion runs under `cs_main` in the ATMP/connect callbacks; `RelayPSGT` is the established pattern; `cs_psgt_pool` is a leaf), the funding-unspent invariant, DoS bounds (no leak), and promotion correctness all confirmed sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)