### PR TITLE
qt: disconnect ClientModel core-signal handlers on destruction

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -359,26 +359,31 @@ static void PSGTPoolChanged(ClientModel *clientmodel, const uint256& revision_ha
 
 void ClientModel::subscribeToCoreSignals()
 {
-    // Connect signals to client
-    uiInterface.NotifyBlocksChanged_connect(boost::bind(NotifyBlocksChanged, this,
+    // Connect signals to client, retaining each connection so it is disconnected
+    // in unsubscribeFromCoreSignals() (from ~ClientModel). Every callback below
+    // captures `this`; a core signal firing after this object is gone would
+    // otherwise invoke a slot on freed memory during shutdown.
+    m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(boost::bind(NotifyBlocksChanged, this,
                                                       boost::placeholders::_1, boost::placeholders::_2,
-                                                      boost::placeholders::_3, boost::placeholders::_4));
-    uiInterface.BannedListChanged_connect(boost::bind(BannedListChanged, this));
-    uiInterface.NotifyNumConnectionsChanged_connect(boost::bind(NotifyNumConnectionsChanged, this,
-                                                              boost::placeholders::_1));
-    uiInterface.NotifyAlertChanged_connect(boost::bind(NotifyAlertChanged, this,
-                                                     boost::placeholders::_1, boost::placeholders::_2));
-    uiInterface.NotifyScraperEvent_connect(boost::bind(NotifyScraperEvent, this,
+                                                      boost::placeholders::_3, boost::placeholders::_4)));
+    m_handlers.emplace_back(uiInterface.BannedListChanged_connect(boost::bind(BannedListChanged, this)));
+    m_handlers.emplace_back(uiInterface.NotifyNumConnectionsChanged_connect(boost::bind(NotifyNumConnectionsChanged, this,
+                                                              boost::placeholders::_1)));
+    m_handlers.emplace_back(uiInterface.NotifyAlertChanged_connect(boost::bind(NotifyAlertChanged, this,
+                                                     boost::placeholders::_1, boost::placeholders::_2)));
+    m_handlers.emplace_back(uiInterface.NotifyScraperEvent_connect(boost::bind(NotifyScraperEvent, this,
                                                      boost::placeholders::_1, boost::placeholders::_2,
-                                                     boost::placeholders::_3));
-    uiInterface.MinerStatusChanged_connect(boost::bind(MinerStatusChanged, this,
-                                                     boost::placeholders::_1, boost::placeholders::_2));
-    uiInterface.PSGTPoolChanged_connect(boost::bind(PSGTPoolChanged, this,
+                                                     boost::placeholders::_3)));
+    m_handlers.emplace_back(uiInterface.MinerStatusChanged_connect(boost::bind(MinerStatusChanged, this,
+                                                     boost::placeholders::_1, boost::placeholders::_2)));
+    m_handlers.emplace_back(uiInterface.PSGTPoolChanged_connect(boost::bind(PSGTPoolChanged, this,
                                                     boost::placeholders::_1, boost::placeholders::_2,
-                                                    boost::placeholders::_3));
+                                                    boost::placeholders::_3)));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from client
+    // Disconnect signals from client: clearing the retained connections runs each
+    // scoped_connection's destructor, which disconnects it.
+    m_handlers.clear();
 }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -3,7 +3,10 @@
 
 #include <QObject>
 
+#include <boost/signals2/connection.hpp>
+
 #include <atomic>
+#include <vector>
 
 class OptionsModel;
 class AddressTableModel;
@@ -73,6 +76,13 @@ private:
     mutable std::atomic<double> m_cached_etts_days;
 
     QTimer *pollTimer;
+
+    //! uiInterface signal connections held so they are disconnected on
+    //! destruction. Each captures `this`; leaving them connected (the previous
+    //! empty unsubscribeFromCoreSignals) risked a core signal invoking a slot on
+    //! a destroyed ClientModel during shutdown. scoped_connection disconnects on
+    //! clear()/destruction.
+    std::vector<boost::signals2::scoped_connection> m_handlers;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -87,6 +87,7 @@ EXPECTED_BOOST_INCLUDES=(
     boost/range/adaptor/reversed.hpp
     boost/serialization/binary_object.hpp
     boost/shared_ptr.hpp
+    boost/signals2/connection.hpp
     boost/signals2/optional_last_value.hpp
     boost/signals2/signal.hpp
     boost/test/unit_test.hpp


### PR DESCRIPTION
Fixes the latent shutdown use-after-free flagged during the #3118 review (follow-up ③).

`ClientModel::subscribeToCoreSignals()` connects seven `uiInterface` signals with callbacks that capture `this`, but `unsubscribeFromCoreSignals()` was **empty** — the connections outlived the object, so a core signal firing during shutdown could invoke a slot on a destroyed `ClientModel`.

Each connection is now retained in a `std::vector<boost::signals2::scoped_connection>` and cleared in `unsubscribeFromCoreSignals()` (called first in `~ClientModel`, before any member is destroyed); `scoped_connection` disconnects on destruction, and boost::signals2's disconnect blocks until any in-flight slot returns.

Qt6 GUI + daemon build clean; adversarially reviewed (completeness, destruction ordering, disconnect thread-safety, scoped_connection semantics — all clean). A follow-up will audit sibling models (walletmodel/votingmodel/etc.) for the same empty-unsubscribe pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)