### PR TITLE
rpc: interrupt in-flight connections on RPC shutdown (#3123)

### DIFF
--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -171,6 +171,12 @@ public:
     virtual std::iostream& stream() = 0;
     virtual std::string peer_address_to_string() const = 0;
     virtual void close() = 0;
+    //! Wake a worker thread parked in a synchronous read on this connection by
+    //! shutting down the underlying socket. Safe to call from another thread
+    //! while the owning worker is blocked in ServiceConnection(); used by
+    //! StopRPCThreads() so join_all() cannot hang on an idle keep-alive client
+    //! (issue #3123).
+    virtual void interrupt() = 0;
 };
 
 template <typename Protocol>
@@ -200,6 +206,16 @@ public:
     virtual void close()
     {
         _stream.close();
+    }
+
+    virtual void interrupt()
+    {
+        // shutdown() (rather than close()) is the portable way to break a
+        // synchronous read that another thread is blocked in: it wakes the
+        // recv without racing on file-descriptor reuse. The owning worker
+        // still performs the actual close()/delete on its own thread.
+        boost::system::error_code ec;
+        sslStream.lowest_layer().shutdown(boost::asio::socket_base::shutdown_both, ec);
     }
 
     typename Protocol::endpoint peer;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -31,6 +31,8 @@
 #include <stdexcept>
 
 #include <memory>
+#include <mutex>
+#include <set>
 #include <vector>
 
 using namespace std;
@@ -50,6 +52,40 @@ static boost::thread_group* rpc_worker_group = nullptr;
 // the io_service, which prevents the shutdown hang on an open keep-alive socket
 // that authproxy.py works around on the client side.
 static std::vector<boost::shared_ptr<boost::asio::ip::tcp::acceptor>> rpc_acceptors;
+
+// Live connections currently being serviced (a worker parked in
+// ServiceConnection()). Closing the acceptors stops *new* connections, but an
+// already-established keep-alive client leaves its worker blocked in a
+// synchronous read; StopRPCThreads() must interrupt those sockets or
+// join_all() hangs forever (issue #3123). This registry is the leaf-most lock
+// in the process -- it guards only the set below and never calls back into any
+// subsystem while held, so it has no ordering relationship with cs_main et al.
+static std::mutex g_rpc_connections_mutex;
+static std::set<AcceptedConnection*> g_rpc_connections;
+// Set once StopRPCThreads() has begun tearing down. A connection that is
+// accepted after this point must not park in ServiceConnection(), or it would
+// re-introduce the very hang we are closing this window against.
+static bool g_rpc_connections_stopped = false;
+
+//! Register a just-accepted connection so StopRPCThreads() can interrupt it.
+//! Returns false if the server is already shutting down, in which case the
+//! caller must not service the connection (there is no worker-drain left to
+//! wake it).
+static bool RegisterRPCConnection(AcceptedConnection* conn)
+{
+    std::lock_guard<std::mutex> lock(g_rpc_connections_mutex);
+    if (g_rpc_connections_stopped) return false;
+    g_rpc_connections.insert(conn);
+    return true;
+}
+
+//! Remove a connection from the registry once its worker is done servicing it
+//! (before the connection is closed and deleted).
+static void UnregisterRPCConnection(AcceptedConnection* conn)
+{
+    std::lock_guard<std::mutex> lock(g_rpc_connections_mutex);
+    g_rpc_connections.erase(conn);
+}
 
 const UniValue emptyobj(UniValue::VOBJ);
 
@@ -666,8 +702,15 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol> 
             if (!fUseSSL)
                 conn->stream() << HTTPReply(HTTP_FORBIDDEN, "", false) << std::flush;
         }
-        else
+        // Register before servicing so a concurrent StopRPCThreads() can wake us
+        // out of the blocking read loop. If the server is already stopping,
+        // RegisterRPCConnection() returns false and we skip servicing entirely
+        // rather than park with no drain left to interrupt us (issue #3123).
+        else if (RegisterRPCConnection(conn))
+        {
             ServiceConnection(conn);
+            UnregisterRPCConnection(conn);
+        }
 
         conn->close();
     }
@@ -715,6 +758,19 @@ void StartRPCThreads()
     const bool fUseSSL = gArgs.GetBoolArg("-rpcssl");
 
     assert(rpc_io_service == nullptr);
+
+    // Clear the shutdown latch so a same-process restart (stop then start) can
+    // service connections again; StopRPCThreads() sets it true (issue #3123).
+    // The set is already empty here (the prior StopRPCThreads()' join_all()
+    // guarantees every registered connection was unregistered), but clear it
+    // defensively so a future refactor that broke that invariant cannot leave a
+    // dangling pointer to be shutdown() on the next teardown.
+    {
+        std::lock_guard<std::mutex> lock(g_rpc_connections_mutex);
+        g_rpc_connections_stopped = false;
+        g_rpc_connections.clear();
+    }
+
     rpc_io_service = new ioContext();
     rpc_ssl_context = new ssl::context(ssl::context::sslv23);
 
@@ -824,9 +880,10 @@ void StopRPCThreads()
 
     // Close the listening acceptors before stopping the io_service. This makes
     // any pending async_accept complete with operation_aborted (RPCAcceptHandler
-    // then sees !is_open() and does not re-arm), so no newly-accepted connection
-    // can wedge the join_all() below. Without this, an open keep-alive socket can
-    // hang shutdown -- the exact failure authproxy.py works around client-side.
+    // then sees !is_open() and does not re-arm), so no further connection is
+    // accepted. This is necessary but not sufficient to unblock join_all() --
+    // connections already being serviced are handled by the interrupt loop
+    // below (issue #3123).
     for (auto& acc : rpc_acceptors) {
         if (acc && acc->is_open()) {
             boost::system::error_code ec;
@@ -834,6 +891,22 @@ void StopRPCThreads()
         }
     }
     rpc_acceptors.clear();
+
+    // Closing the acceptors above only stops *new* connections. An established
+    // keep-alive client leaves its worker blocked in a synchronous read inside
+    // ServiceConnection(), which io_service->stop() cannot interrupt (that
+    // worker is not in the io_service run loop -- it is parked in recv). Shut
+    // those sockets down so the reads fail and the workers return; otherwise
+    // join_all() below hangs forever (issue #3123). Setting the stopped flag
+    // under the same lock closes the race with a connection accepted just now:
+    // its RegisterRPCConnection() will observe the flag and decline to park.
+    {
+        std::lock_guard<std::mutex> lock(g_rpc_connections_mutex);
+        g_rpc_connections_stopped = true;
+        for (AcceptedConnection* conn : g_rpc_connections) {
+            conn->interrupt();
+        }
+    }
 
     rpc_io_service->stop();
     if (rpc_worker_group != nullptr) {

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+"""Node shutdown must not hang on an in-service RPC connection (issue #3123).
+
+Gridcoin's RPC server uses a synchronous boost::asio model: an accepted
+connection is serviced on a worker thread that blocks in a synchronous read
+(ReadHTTPRequestLine -> read_some -> recv). An idle keep-alive client, or a
+client that has sent a partial request, leaves its worker parked in that recv.
+
+StopRPCThreads() closes the listening acceptors and calls io_service->stop()
+followed by worker_group->join_all(). io_service->stop() cannot wake a worker
+that is parked in recv (it is not in the io_service run loop), so before the
+fix join_all() blocked forever whenever such a connection was live -- the exact
+hang the framework works around client-side in TestNode.stop_node() by closing
+its own keep-alive socket.
+
+This test opens a raw connection that the framework does NOT close, parks a
+worker in the blocking read, issues `stop`, and asserts the daemon still exits
+within a bounded time. Against a pre-fix binary the daemon hangs and
+wait_until_stopped() times out; with the fix StopRPCThreads() shuts the socket
+down, the read fails, the worker returns and the daemon exits cleanly.
+"""
+
+import socket
+import time
+
+from test_framework.test_framework import GridcoinTestFramework
+from test_framework.util import rpc_port
+
+
+class FeatureShutdownTest(GridcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.chain = "regtest"
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        # Skip the default deterministic-coinbase wallet import: it calls
+        # createwallet with named args, which Gridcoin's RPC parser rejects
+        # ("Params must be an array"). This test needs no wallet or chain state.
+        self.add_nodes(self.num_nodes)
+        self.start_nodes()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Raw socket straight to the RPC port. No credentials are needed: the
+        # server blocks in ReadHTTPRequestLine / header parsing well before it
+        # checks authorization, which is exactly the state we want to reproduce.
+        host = node.rpchost or '127.0.0.1'
+        port = rpc_port(node.index)
+
+        raw = socket.create_connection((host, port), timeout=30)
+        try:
+            # Send a complete request line but no headers or terminating blank
+            # line. The worker gets past ReadHTTPRequestLine and then parks in
+            # the blocking header read, waiting for bytes that never arrive.
+            raw.sendall(b'GET / HTTP/1.1\r\n')
+
+            # Give the server a moment to accept the connection and hand it to a
+            # worker that then parks in recv. If we race ahead of that, the fix
+            # still handles it (RegisterRPCConnection observes the stopped latch
+            # and declines to park), but for a faithful reproduction against a
+            # pre-fix binary we want the worker demonstrably parked first.
+            time.sleep(2 * node.timeout_factor)
+
+            self.log.info("Parked a worker on a raw in-service RPC socket; issuing stop")
+            node.stop()
+
+            # Close the framework's own keep-alive RPC connection so the raw
+            # socket above is the *only* thing that can wedge shutdown -- this
+            # isolates the test to StopRPCThreads()'s ability to interrupt an
+            # in-service connection (issue #3123) rather than any idle client.
+            node.rpc._close_conn()
+
+            # The daemon must exit despite the parked worker. wait_until_stopped()
+            # asserts a clean (exit code 0) shutdown; a pre-fix binary hangs here.
+            node.wait_until_stopped(timeout=60)
+            self.log.info("Daemon shut down cleanly with an in-service RPC socket held open")
+        finally:
+            raw.close()
+
+
+if __name__ == "__main__":
+    FeatureShutdownTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -145,6 +145,9 @@ BASE_SCRIPTS = [
     #     bool/array/object args plus the dual-mode `logging <category>` form
     'feature_hello.py',
     'feature_regtest_staking.py',
+    # feature_shutdown.py: `stop` must not hang on an in-service RPC connection
+    # (issue #3123 -- StopRPCThreads must interrupt a worker parked in recv).
+    'feature_shutdown.py',
     'p2p_version_handshake.py',
     'p2p_block_tx_relay.py',
     'p2p_psgt_relay.py',


### PR DESCRIPTION
## Problem (issue #3123)

Gridcoin's RPC server uses an older *synchronous* boost::asio model: each accepted connection is serviced on a worker thread that blocks in a synchronous read (`ServiceConnection` → `ReadHTTPRequestLine` → `read_some` → `recv`). An idle keep-alive client — or one that has sent a partial request — leaves its worker parked in that `recv`.

`StopRPCThreads()` closes the listening acceptors, then calls `io_service->stop()` + `worker_group->join_all()`. Closing the acceptors stops *new* connections, but `io_service->stop()` cannot wake a worker parked in `recv` (it isn't in the io_service run loop). So `join_all()` blocked **forever** whenever such a connection was live at shutdown.

This is the residual half of the keep-alive shutdown hang: the functional-test framework already works around it *client-side* (`TestNode.stop_node()` closes its own keep-alive socket, mirroring `authproxy.py`), but a daemon whose client does not cooperate simply never exits.

## Fix

- Add `AcceptedConnection::interrupt()` — `sslStream.lowest_layer().shutdown(shutdown_both)`. `shutdown()` (not `close()`) is the portable way to break a `recv` another thread is parked in, without racing on file-descriptor reuse; the owning worker still performs the actual `close()`/`delete` on its own thread.
- Track in-service connections in a small registry (`g_rpc_connections`, guarded by a leaf-most mutex). `StopRPCThreads()` sets a stopped latch and calls `interrupt()` on every live socket **before** `join_all()`.
- The latch, set under the same lock as the interrupt loop, closes the accept-at-teardown race: a connection accepted at the instant of shutdown observes the latch in `RegisterRPCConnection()` and declines to service rather than parking with no drain left to wake it.
- The latch (and set) are cleared in `StartRPCThreads()` so a same-process restart works.

## Test

`feature_shutdown.py` parks a worker on a raw in-service RPC socket the framework does not close, issues `stop`, and asserts the daemon exits within a bounded time. **Verified to discriminate**: against a pre-fix binary the daemon hangs and `wait_until_stopped()` times out after 60s; with the fix it exits in ~1s.

## Review

Adversarially reviewed for use-after-free, lost-wakeup, lock inversion, and leak/double-free across the interrupt loop, the register/service/unregister ordering, the skip path, and the SSL read path — no defects found. Builds clean (daemon + GUI); functional + lint green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)