### PR TITLE
refactor: retire the net-half of setpwalletRegistered and delete the registry

### DIFF
--- a/doc/thread_safety_phase1_report.md
+++ b/doc/thread_safety_phase1_report.md
@@ -45,6 +45,11 @@ Applied to both the `DEBUG_LOCKORDER` and no-debug declarations. **Annotation-on
 
 ## Canonical lock order established in Phase 1
 
+> **Superseded (see the #3108 Update below).** The current canonical order is
+> `cs_main -> cs_wallet -> subsystem locks`; the `cs_setpwalletRegistered` hop
+> was retired with the wallet registry. The block immediately below records the
+> order as it stood in Phase 1, for historical reference.
+
 ```
 cs_main -> cs_setpwalletRegistered -> cs_wallet -> subsystem locks
 ```
@@ -67,7 +72,7 @@ The wallet-registry lock (`cs_setpwalletRegistered`) was not previously part of 
 | `nBestChainTrust` | `src/main.h:83` | `cs_main` |
 | `hashBestChain` | `src/main.h:84` | `cs_main` |
 | `pindexBest` | `src/main.h:85` | `cs_main` |
-| `setpwalletRegistered` | `src/main.h:89` | `cs_setpwalletRegistered` |
+| `setpwalletRegistered` _(removed, #3108)_ | `src/main.h:89` | `cs_setpwalletRegistered` |
 
 `net.h`'s `vNodes` / `cs_vNodes` / `mapRelay` / `cs_mapRelay` and the `wallet.cs_wallet` mutex were already declared and partially annotated upstream; Phase 1 left those declarations as-is and resolved only the warnings that surfaced from the new cs_main `GUARDED_BY` additions.
 

--- a/doc/thread_safety_phase1_report.md
+++ b/doc/thread_safety_phase1_report.md
@@ -51,6 +51,12 @@ cs_main -> cs_setpwalletRegistered -> cs_wallet -> subsystem locks
 
 The wallet-registry lock (`cs_setpwalletRegistered`) was not previously part of the canonical order documented in `CLAUDE.md`. Phase 1 inserted it between `cs_main` and `cs_wallet` because the wallet-registry wrappers (`SyncWithWallets` and friends) iterate `setpwalletRegistered` and then dispatch into per-wallet methods that take `cs_wallet`. Acquisition at the call site (rather than inside the wrapper) avoids the inversion an inside-lock would have created with `sendrawtransaction`'s `LOCK2(cs_main, cs_wallet)` → `SyncWithWallets` path against the `SendMessages` → `ResendWalletTransactions` path (which holds no cs_main).
 
+> **Update (2026-07, #3108):** the wallet registry and `cs_setpwalletRegistered` have been
+> retired entirely — wallet notifications flow through `CMainSignals`, and the remaining
+> net-processing request-count / own-tx-trickle paths call `pwalletMain` directly. The
+> canonical order is now simply `cs_main -> cs_wallet -> subsystem locks`. The
+> `cs_setpwalletRegistered` material below is retained as a historical record of Phase 1.
+
 ## Globals annotated in Phase 1
 
 | Variable | File:line | Lock |

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -309,7 +309,6 @@ void Shutdown(void* parg)
         UnregisterValidationInterface(&g_psgt_pool);
         UnregisterValidationInterface(&g_ui_notification_bridge);
         UnregisterValidationInterface(pwalletMain);
-        UnregisterWallet(pwalletMain);
         delete pwalletMain;
         // Null the global so any late/defensive `if (pwalletMain)` guard (e.g. the
         // scheduled wallet-rebroadcast job) is load-bearing rather than seeing a
@@ -1686,8 +1685,6 @@ bool AppInit2(ThreadHandlerPtr threads)
         }
     }
 
-    RegisterWallet(pwalletMain);
-
     // Init-time wallet rescan + GRC::Initialize reads pindexBest /
     // pindexGenesisBlock / mapBlockIndex; take cs_main for the whole block
     // (uncontended at init, required by Phase 1 thread-safety annotations).
@@ -1968,8 +1965,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     GetMainSignals().RegisterBackgroundSignalScheduler(*g_scheduler);
 
     // Subscribe the wallet to validation/mempool events now that the signal
-    // layer is wired (issue #3030, workstream B). The wallet also stays in
-    // setpwalletRegistered for the legacy notifications not yet migrated.
+    // layer is wired (issue #3030, workstream B).
     RegisterValidationInterface(pwalletMain);
 
     // Bridge chain-tip updates to the legacy ui_interface block notification so

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,9 +64,6 @@ using namespace boost;
 // Global state
 //
 
-CCriticalSection cs_setpwalletRegistered;
-set<CWallet*> setpwalletRegistered;
-
 CCriticalSection cs_main;
 CCriticalSection cs_tx_val_commit_to_disk;
 
@@ -147,29 +144,11 @@ arith_uint256 GetChainTrust(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(
     return g_chain_trust.GetTrust(pindex);
 }
 
-void RegisterWallet(CWallet* pwalletIn)
-{
-    {
-        LOCK(cs_setpwalletRegistered);
-        setpwalletRegistered.insert(pwalletIn);
-    }
-}
-
-void UnregisterWallet(CWallet* pwalletIn)
-{
-    {
-        LOCK(cs_setpwalletRegistered);
-        setpwalletRegistered.erase(pwalletIn);
-    }
-}
-
-// The setpwalletRegistered dispatch wrappers (EraseFromWallets, SetBestChain,
-// UpdatedTransaction, PrintWallets, ResendWalletTransactions) have been retired
-// under issue #3030: wallet notifications now flow through CMainSignals and the
-// wallet rebroadcast self-schedules on g_scheduler. cs_setpwalletRegistered now
-// guards only the registry set itself (RegisterWallet/UnregisterWallet above) and
-// the net-half Inventory/GetTransaction wrappers (tracked separately). The
-// canonical lock order remains cs_main -> cs_setpwalletRegistered -> cs_wallet.
+// The setpwalletRegistered wallet registry has been fully retired (issues #3030
+// and #3108): wallet notifications flow through CMainSignals, the wallet
+// rebroadcast self-schedules on g_scheduler, and the net-half request-count /
+// own-tx-trickle paths call pwalletMain directly. The canonical lock order is
+// now cs_main -> cs_wallet.
 
 
 double CoinToDouble(double surrogate)

--- a/src/main.h
+++ b/src/main.h
@@ -30,7 +30,6 @@
 #include <unordered_map>
 #include <set>
 
-class CWallet;
 class CBlock;
 class CBlockIndex;
 class CKeyItem;
@@ -77,8 +76,6 @@ extern unsigned int nStakeMaxAge;
 extern unsigned int nNodeLifespan;
 extern int nCoinbaseMaturity;
 extern const std::string strMessageMagic;
-extern CCriticalSection cs_setpwalletRegistered;
-extern std::set<CWallet*> setpwalletRegistered GUARDED_BY(cs_setpwalletRegistered);
 // Orphan block storage is managed by g_orphan_blocks in node/orphan_blocks.h
 
 // Settings
@@ -106,8 +103,6 @@ class CReserveKey;
 class CTxDB;
 class CTxIndex;
 
-void RegisterWallet(CWallet* pwalletIn);
-void UnregisterWallet(CWallet* pwalletIn);
 bool ProcessBlock(CNode* pfrom, CBlock* pblock, bool Generated_By_Me, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 // Block-file I/O helpers (CheckDiskSpace, OpenBlockFile, AppendBlockFile,
 // LoadExternalBlockFile) live in node/blockstorage.h, included above.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -194,24 +194,6 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRE
     return nEvicted;
 }
 
-// get the wallet transaction with the given hash (if it exists)
-bool static GetTransaction(const uint256& hashTx, CWalletTx& wtx)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        if (pwallet->GetTransaction(hashTx,wtx))
-            return true;
-    return false;
-}
-
-// notify wallets about an incoming inventory (for request counts)
-void static Inventory(const uint256& hash)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_setpwalletRegistered)
-{
-    for (auto const& pwallet : setpwalletRegistered)
-        pwallet->Inventory(hash);
-}
-
 bool static AlreadyHave(CTxDB& txdb, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     switch (inv.type)
@@ -745,10 +727,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 }
 
                 // Track requests for our stuff
-                {
-                    LOCK(cs_setpwalletRegistered);
-                    Inventory(inv.hash);
-                }
+                if (pwalletMain) pwalletMain->Inventory(inv.hash);
 
             }
         }
@@ -922,10 +901,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
 
             // Track requests for our stuff
-            {
-                LOCK(cs_setpwalletRegistered);
-                Inventory(inv.hash);
-            }
+            if (pwalletMain) pwalletMain->Inventory(inv.hash);
         }
     }
 
@@ -1540,10 +1516,8 @@ static bool SendMessages(CNode* pto, bool fSendTrickle)
                 if (!fTrickleWait)
                 {
                     CWalletTx wtx;
-                    LOCK(cs_setpwalletRegistered);
-                    if (GetTransaction(inv.hash, wtx))
-                        if (wtx.fFromMe)
-                            fTrickleWait = true;
+                    if (pwalletMain && pwalletMain->GetTransaction(inv.hash, wtx) && wtx.fFromMe)
+                        fTrickleWait = true;
                 }
 
                 if (fTrickleWait)

--- a/src/test/test_gridcoin.cpp
+++ b/src/test/test_gridcoin.cpp
@@ -64,7 +64,6 @@ struct TestingSetup {
         bool fFirstRun;
         pwalletMain = new CWallet("wallet.dat");
         pwalletMain->LoadWallet(fFirstRun);
-        RegisterWallet(pwalletMain);
         // Ban manager instance should not already be instantiated
         assert(!g_banman);
         // Create ban manager instance.


### PR DESCRIPTION
Closes #3108.

This is the final step of the `setpwalletRegistered` retirement begun under #3030: the two remaining registry users — the file-static `Inventory` and `GetTransaction` wrappers in `net_processing.cpp` — now call `pwalletMain` directly, and the registry itself is deleted.

This implements **option A** from #3108 (direct `pwalletMain` calls). It is the minimal, behavior-preserving variant; if a decoupled wallet-client interface (option B) or dropping the legacy features outright (option C) is preferred, I'm happy to pivot — see the trade-off discussion in the issue.

## What's removed

- `setpwalletRegistered` + `cs_setpwalletRegistered` (`main.{h,cpp}`)
- `RegisterWallet()` / `UnregisterWallet()` (`main.{h,cpp}`), their `init.cpp` startup/shutdown calls, and the test-fixture registration in `src/test/test_gridcoin.cpp`
- The two `net_processing.cpp` dispatch wrappers and the `LOCK(cs_setpwalletRegistered)` blocks at their three call sites
- The now-unused `class CWallet;` forward declaration in `main.h`

## Why this is behavior-neutral

**Single-wallet equivalence.** The registry only ever held `pwalletMain` (registered once in `AppInit2`), so each iterate-all-wallets loop is equivalent to a single guarded `pwalletMain` call — an empty set and a null pointer are the same case. The `if (pwalletMain)` guard follows the existing precedent in `node/chainman.cpp`, and `init.cpp` already nulls `pwalletMain` after deletion at shutdown.

**No lock-order change at any site.**

| Site | Lock context | After this PR |
|---|---|---|
| INV handler request-count (`ProcessMessage`) | `cs_main` | `pwalletMain->Inventory()` takes `cs_wallet` internally → `cs_main → cs_wallet`, canonical |
| GETDATA handler request-count (`ProcessMessage`) | `cs_main` | same |
| Own-tx trickle (`SendMessages`) | `pto->cs_inventory`, no `cs_main` | `pwalletMain->GetTransaction()` takes `cs_wallet` internally → `cs_inventory → cs_wallet`, an edge that **already existed** through the wrapper (the old wrapper called the same wallet method under the same locks) |

The only thing that disappears is the `cs_setpwalletRegistered` hop in the middle. The trickle-path call deliberately stays a plain synchronous call rather than becoming a `CValidationInterface` signal: that path holds no `cs_main`, and a synchronous signal there would create a novel `cs_inventory → signal → cs_wallet` sandwich (see #3108).

The canonical lock order simplifies to `cs_main → cs_wallet → subsystem locks`; `doc/thread_safety_phase1_report.md` gets a dated update note, with the Phase 1 material kept as a historical record.

Both live behaviors are preserved: the GUI's broadcast request-count (`mapRequestCount` → `CWalletTx::GetRequestCount()`) and the own-tx privacy trickle (`wtx.fFromMe` forcing the trickle-delay path).

Diff: 16(+) / 67(−) across 6 files. Full fork CI green: https://github.com/PrestackI/Gridcoin-Research/actions?query=branch%3Anet%2Fretire-setpwalletregistered
