### PR TITLE
refactor: move GetWarnings into the alert module (#3125 C6)

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -289,3 +289,42 @@ bool CAlert::ProcessAlert(bool fThread)
     LogPrint(BCLog::LogFlags::VERBOSE, "accepted alert %d, AppliesToMe()=%d", nID, AppliesToMe());
     return true;
 }
+
+// Aggregate the highest-priority warning for the status bar / RPC "errors"
+// field: misc warnings (out of disk space, wrong clock) plus any applicable
+// alerts. Moved from main.cpp next to the alert storage it reads (issue #3125,
+// workstream C6).
+string GetWarnings(string strFor)
+{
+    int nPriority = 0;
+    string strStatusBar;
+
+    // Misc warnings like out of disk space and clock is wrong
+    if (strMiscWarning != "")
+    {
+        nPriority = 1000;
+        strStatusBar = strMiscWarning;
+    }
+
+    // Alerts
+    {
+        LOCK(cs_mapAlerts);
+        for (auto const& item : mapAlerts)
+        {
+            const CAlert& alert = item.second;
+            if (alert.AppliesToMe() && alert.nPriority > nPriority)
+            {
+                nPriority = alert.nPriority;
+                strStatusBar = alert.strStatusBar;
+            }
+        }
+    }
+
+    if (strFor == "statusbar")
+    {
+        return strStatusBar;
+    }
+
+    assert(!"GetWarnings() : invalid parameter");
+    return "error";
+}

--- a/src/alert.h
+++ b/src/alert.h
@@ -106,4 +106,8 @@ public:
     static CAlert getAlertByHash(const uint256 &hash);
 };
 
+//! Aggregate the highest-priority warning for the status bar / RPC "errors"
+//! field (issue #3125, workstream C6). strFor must be "statusbar".
+std::string GetWarnings(std::string strFor);
+
 #endif // BITCOIN_ALERT_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1099,49 +1099,6 @@ void PrintBlockTree() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 //////////////////////////////////////////////////////////////////////////////
 //
-// CAlert
-//
-
-extern CCriticalSection cs_mapAlerts;
-extern map<uint256, CAlert> mapAlerts GUARDED_BY(cs_mapAlerts);
-
-string GetWarnings(string strFor)
-{
-    int nPriority = 0;
-    string strStatusBar;
-
-    // Misc warnings like out of disk space and clock is wrong
-    if (strMiscWarning != "")
-    {
-        nPriority = 1000;
-        strStatusBar = strMiscWarning;
-    }
-
-    // Alerts
-    {
-        LOCK(cs_mapAlerts);
-        for (auto const& item : mapAlerts)
-        {
-            const CAlert& alert = item.second;
-            if (alert.AppliesToMe() && alert.nPriority > nPriority)
-            {
-                nPriority = alert.nPriority;
-                strStatusBar = alert.strStatusBar;
-            }
-        }
-    }
-
-    if (strFor == "statusbar")
-    {
-        return strStatusBar;
-    }
-
-    assert(!"GetWarnings() : invalid parameter");
-    return "error";
-}
-
-//////////////////////////////////////////////////////////////////////////////
-//
 // Messages
 //
 

--- a/src/main.h
+++ b/src/main.h
@@ -165,7 +165,7 @@ GRC::ClaimOption GetClaimByIndex(const CBlockIndex* const pblockindex) EXCLUSIVE
 
 int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
-std::string GetWarnings(std::string strFor);
+// GetWarnings lives in alert.h (issue #3125, workstream C6).
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock);
 bool OutOfSyncByAge();
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -4,6 +4,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "alert.h"
 #include "chainparams.h"
 #include "blockchain.h"
 #include "gridcoin/pool.h"

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "alert.h"
 #include "init.h"
 #include <key_io.h>
 #include "main.h"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <key_io.h>
+#include "alert.h"
 #include "version.h"
 #include "txdb.h"
 #include "rpc/server.h"


### PR DESCRIPTION
Workstream **C6** of #3125 (successor to #3030).

Moves `GetWarnings` from `main.cpp` into `alert.{h,cpp}`, next to the `cs_mapAlerts`/`mapAlerts` storage it reads. **Pure code move, no behavior change.**

- `main.cpp` loses the function plus its ad-hoc `extern` declarations of `cs_mapAlerts`/`mapAlerts` (`alert.cpp` defines them, so the externs are no longer needed anywhere).
- The declaration moves from `main.h` to `alert.h`. The callers that relied on `main.h` for it (`rpc/mining.cpp`, `rpc/blockchain.cpp`, `wallet/rpcwallet.cpp`) now include `alert.h` directly — `qt/clientmodel.cpp` and `rpc/net.cpp` already did.

Stacked on #3132 (C1) (all the workstream-C extractions carve from `main.{h,cpp}`, so they are sequenced as one stack to avoid rebase conflicts; each commit is independently reviewable).

CI: this branch's compile/functional gates ran green before its remaining fork runs were cancelled to free the runner queue; the full 5-workflow fork CI is green on the stack tip (`validation/move-mempool-accept`), whose tree contains this commit: https://github.com/PrestackI/Gridcoin-Research/actions?query=branch%3Avalidation%2Fmove-mempool-accept
