### PR TITLE
qt: sever retained core-signal connections in the remaining models (#3129 follow-up)

### DIFF
--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -220,12 +220,17 @@ bool MRCModel::isWalletLocked()
 
 void MRCModel::subscribeToCoreSignals()
 {
-    uiInterface.MRCChanged_connect(std::bind(MRCChanged, this));
+    // Retain the connection so it is severed in unsubscribeFromCoreSignals()
+    // (from ~MRCModel); the callback captures `this` and a signal firing after
+    // this object is gone would otherwise invoke a slot on freed memory.
+    m_handlers.emplace_back(uiInterface.MRCChanged_connect(std::bind(MRCChanged, this)));
 }
 
 void MRCModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from client (no-op currently)
+    // Disconnect signals from client: clearing the retained connections runs
+    // each scoped_connection's destructor, which disconnects it (issue #3129).
+    m_handlers.clear();
 }
 
 void MRCModel::refresh() EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/qt/mrcmodel.h
+++ b/src/qt/mrcmodel.h
@@ -6,6 +6,8 @@
 #define GRIDCOIN_QT_MRCMODEL_H
 
 #include <QObject>
+#include <vector>
+#include <boost/signals2/connection.hpp>
 #include "amount.h"
 #include "gridcoin/mrc.h"
 
@@ -85,6 +87,11 @@ public:
 private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+
+    //! Retained core-signal connections, cleared on teardown so a signal that
+    //! fires after this model is destroyed cannot invoke a slot bound to freed
+    //! memory. scoped_connection disconnects on destruction (issue #3129).
+    std::vector<boost::signals2::scoped_connection> m_handlers;
 
     WalletModel* m_wallet_model;
     ClientModel* m_client_model;

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -969,18 +969,23 @@ void ResearcherModel::onWizardClose()
 
 void ResearcherModel::subscribeToCoreSignals()
 {
-    // Connect signals to client
-    uiInterface.ResearcherChanged_connect(std::bind(ResearcherChanged, this));
-    uiInterface.AccrualChangedFromStakeOrMRC_connect(std::bind(AccrualChangedFromStakeOrMRC, this));
-    uiInterface.BeaconChanged_connect(std::bind(BeaconChanged, this));
-    uiInterface.NotifyBlocksChanged_connect(std::bind(NotifyBlocksChangedForResearcher, this,
+    // Connect signals to client, retaining each connection so it is severed in
+    // unsubscribeFromCoreSignals() (from ~ResearcherModel). Every callback below
+    // captures `this`; a signal firing after this object is gone would otherwise
+    // invoke a slot on freed memory.
+    m_handlers.emplace_back(uiInterface.ResearcherChanged_connect(std::bind(ResearcherChanged, this)));
+    m_handlers.emplace_back(uiInterface.AccrualChangedFromStakeOrMRC_connect(std::bind(AccrualChangedFromStakeOrMRC, this)));
+    m_handlers.emplace_back(uiInterface.BeaconChanged_connect(std::bind(BeaconChanged, this)));
+    m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(std::bind(NotifyBlocksChangedForResearcher, this,
                                                      std::placeholders::_1, std::placeholders::_2,
-                                                     std::placeholders::_3, std::placeholders::_4));
+                                                     std::placeholders::_3, std::placeholders::_4)));
 }
 
 void ResearcherModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from client
+    // Disconnect signals from client: clearing the retained connections runs
+    // each scoped_connection's destructor, which disconnects it (issue #3129).
+    m_handlers.clear();
 }
 
 void ResearcherModel::commitBeacon(const BeaconStatus beacon_status)

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <boost/signals2/connection.hpp>
 #include "amount.h"
 #include <QObject>
 #include <QString>
@@ -164,6 +165,12 @@ private:
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+
+    //! Retained core-signal connections, cleared on teardown so a signal that
+    //! fires after this model is destroyed cannot invoke a slot bound to freed
+    //! memory. scoped_connection disconnects on destruction (issue #3129).
+    std::vector<boost::signals2::scoped_connection> m_handlers;
+
     void commitBeacon(const BeaconStatus beacon_status);
     void commitBeacon(
         const BeaconStatus beacon_status,

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -124,7 +124,7 @@ SideStakeTableModel::SideStakeTableModel(OptionsModel* parent)
 
 SideStakeTableModel::~SideStakeTableModel()
 {
-  // Intentionally left empty
+    unsubscribeFromCoreSignals();
 }
 
 int SideStakeTableModel::rowCount(const QModelIndex &parent) const
@@ -452,11 +452,16 @@ void SideStakeTableModel::updateSideStakeTableModel()
 
 void SideStakeTableModel::subscribeToCoreSignals()
 {
-    // Connect signals to client
-    uiInterface.RwSettingsUpdated_connect(boost::bind(RwSettingsUpdated, this));
+    // Retain the connection so it is severed in unsubscribeFromCoreSignals()
+    // (from ~SideStakeTableModel); the callback captures `this` and a signal
+    // firing after this object is gone would otherwise invoke a slot on freed
+    // memory.
+    m_handlers.emplace_back(uiInterface.RwSettingsUpdated_connect(boost::bind(RwSettingsUpdated, this)));
 }
 
 void SideStakeTableModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from client (currently no-op).
+    // Disconnect signals from client: clearing the retained connections runs
+    // each scoped_connection's destructor, which disconnects it (issue #3129).
+    m_handlers.clear();
 }

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -7,6 +7,8 @@
 
 #include <QAbstractTableModel>
 #include <memory>
+#include <vector>
+#include <boost/signals2/connection.hpp>
 #include "gridcoin/sidestake.h"
 
 class OptionsModel;
@@ -91,6 +93,11 @@ private:
     EditStatus m_edit_status;
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+
+    //! Retained core-signal connections, cleared on teardown so a signal that
+    //! fires after this model is destroyed cannot invoke a slot bound to freed
+    //! memory. scoped_connection disconnects on destruction (issue #3129).
+    std::vector<boost::signals2::scoped_connection> m_handlers;
 
 signals:
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -545,12 +545,18 @@ VotingResult VotingModel::sendVote(
 
 void VotingModel::subscribeToCoreSignals()
 {
-    uiInterface.NewPollReceived_connect(std::bind(NewPollReceived, this, std::placeholders::_1));
-    uiInterface.NewVoteReceived_connect(std::bind(NewVoteReceived, this, std::placeholders::_1));
+    // Retain each connection so it is severed in unsubscribeFromCoreSignals()
+    // (from ~VotingModel). Both callbacks capture `this`; a signal firing after
+    // this object is gone would otherwise invoke a slot on freed memory.
+    m_handlers.emplace_back(uiInterface.NewPollReceived_connect(std::bind(NewPollReceived, this, std::placeholders::_1)));
+    m_handlers.emplace_back(uiInterface.NewVoteReceived_connect(std::bind(NewVoteReceived, this, std::placeholders::_1)));
 }
 
 void VotingModel::unsubscribeFromCoreSignals()
 {
+    // Disconnect signals from client: clearing the retained connections runs
+    // each scoped_connection's destructor, which disconnects it (issue #3129).
+    m_handlers.clear();
 }
 
 void VotingModel::handleNewPoll(int64_t poll_time)

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include <QVariant>
 #include <QStringList>
+#include <boost/signals2/connection.hpp>
 
 namespace GRC {
 class PollRegistry;
@@ -192,6 +193,11 @@ private:
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+
+    //! Retained core-signal connections, cleared on teardown so a signal that
+    //! fires after this model is destroyed cannot invoke a slot bound to freed
+    //! memory. scoped_connection disconnects on destruction (issue #3129).
+    std::vector<boost::signals2::scoped_connection> m_handlers;
 
 private slots:
     void handleNewPoll(int64_t poll_time);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -894,33 +894,31 @@ static void NotifyBlocksChangedForWallet(WalletModel *walletmodel,
 
 void WalletModel::subscribeToCoreSignals()
 {
-    // Connect signals to wallet
-    wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this,
-                                                    boost::placeholders::_1));
-    wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this,
+    // Connect signals to wallet, retaining each connection so it is severed in
+    // unsubscribeFromCoreSignals() (from ~WalletModel). Every callback below
+    // captures `this`; a signal firing after this object is gone would
+    // otherwise invoke a slot on freed memory during shutdown.
+    m_handlers.emplace_back(wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this,
+                                                    boost::placeholders::_1)));
+    m_handlers.emplace_back(wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this,
                                                          boost::placeholders::_1, boost::placeholders::_2,
                                                          boost::placeholders::_3, boost::placeholders::_4,
-                                                         boost::placeholders::_5, boost::placeholders::_6));
-    wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this,
+                                                         boost::placeholders::_5, boost::placeholders::_6)));
+    m_handlers.emplace_back(wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this,
                                                          boost::placeholders::_1, boost::placeholders::_2,
-                                                         boost::placeholders::_3));
-    uiInterface.NotifyBlocksChanged_connect(boost::bind(NotifyBlocksChangedForWallet, this,
+                                                         boost::placeholders::_3)));
+    m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(boost::bind(NotifyBlocksChangedForWallet, this,
                                                        boost::placeholders::_1, boost::placeholders::_2,
-                                                       boost::placeholders::_3, boost::placeholders::_4));
+                                                       boost::placeholders::_3, boost::placeholders::_4)));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from wallet
-    wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this,
-                                                       boost::placeholders::_1));
-    wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this,
-                                                            boost::placeholders::_1, boost::placeholders::_2,
-                                                            boost::placeholders::_3, boost::placeholders::_4,
-                                                            boost::placeholders::_5, boost::placeholders::_6));
-    wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this,
-                                                            boost::placeholders::_1, boost::placeholders::_2,
-                                                            boost::placeholders::_3));
+    // Disconnect signals from wallet: clearing the retained connections runs
+    // each scoped_connection's destructor, which disconnects it. This also
+    // covers the uiInterface.NotifyBlocksChanged connection, which the previous
+    // hand-written disconnects missed and leaked (issue #3129 follow-up).
+    m_handlers.clear();
 }
 
 // WalletModel::UnlockContext implementation

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <map>
 
+#include <boost/signals2/connection.hpp>
+
 #include "qt/wallet_event_queue.h"
 #include "qt/wallettxstore.h"
 #include "support/allocators/secure.h" /* for SecureString */
@@ -216,6 +218,11 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
     void checkBalanceChanged();
+
+    //! Retained core-signal connections, cleared on teardown so a signal that
+    //! fires after this model is destroyed cannot invoke a slot bound to freed
+    //! memory. scoped_connection disconnects on destruction (issue #3129).
+    std::vector<boost::signals2::scoped_connection> m_handlers;
 
 
 public slots:


### PR DESCRIPTION
## Problem

PR #3129 fixed `ClientModel`, which left its `uiInterface` signal connections dangling at shutdown. Its sibling Qt models had the **same latent use-after-free**: each `subscribeToCoreSignals()` connects `uiInterface.*_connect(...)` (and, for `WalletModel`, `wallet->Notify*.connect(...)`) with callbacks that bind `this`, but `unsubscribeFromCoreSignals()` never severed them. If such a signal fires after the model is destroyed during shutdown, it invokes a slot on freed memory.

Audit of the five sibling models:

| Model | `this`-capturing connections | `unsubscribe` did | Verdict |
|---|---|---|---|
| `WalletModel` | 4 (3 `CWallet` + 1 `uiInterface.NotifyBlocksChanged`) | disconnected the 3 wallet ones, **leaked** the uiInterface one | partial leak |
| `MRCModel` | 1 | no-op | full leak |
| `ResearcherModel` | 4 | empty | full leak |
| `VotingModel` | 2 | empty | full leak |
| `SideStakeTableModel` | 1 | no-op (and `~SideStakeTableModel` didn't even call it) | full leak |

## Fix

Apply the #3129 pattern uniformly: retain every connection in a `std::vector<boost::signals2::scoped_connection> m_handlers` and `clear()` it in `unsubscribeFromCoreSignals()` (which each destructor calls — added the missing call to `~SideStakeTableModel`). `scoped_connection` also disconnects via RAII if the vector is destroyed without an explicit `clear()`.

For `WalletModel` this replaces the hand-written `.disconnect()` calls and closes the leaked `uiInterface.NotifyBlocksChanged` connection. As a side benefit it removes a fragile pattern: the old disconnects re-bound an *equal* functor, but `boost::bind` results are not reliably equality-comparable, so those `.disconnect()` calls were likely no-ops — the connections are now severed reliably.

## Verification

- Qt6 GUI build clean (all five model TUs compile, `gridcoinresearch` links); lint green.
- Adversarially reviewed for destruction/member-order safety, `CWallet`↔`WalletModel` lifetime (boost::signals2 makes disconnect-after-signal-destruction a safe no-op), unwrapped/leaked connections, `_connect` return types, and header-include correctness — no defects found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)