### PR TITLE
wallet: bound contract-tx coin selection to keep it standard-sized (#3120)

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -311,6 +311,60 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     empty_wallet();
 }
 
+// Regression for issue #3120: on a fragmented wallet a contract's burn must not
+// drag in thousands of dust inputs (which would push the tx past
+// MAX_STANDARD_TX_SIZE and get it rejected with "tx size ... greater than
+// standard"). SelectContractCoins prefers the smallest UTXOs (dust
+// consolidation) but falls back to normal target-based selection when the
+// smallest-first set would blow the standard-tx input budget.
+BOOST_AUTO_TEST_CASE(contract_coin_selection_bounds_fragmented_wallet)
+{
+    CoinSet setCoinsRet;
+    int64_t nValueRet = 0;
+    const int64_t spendTime = GetTime();
+
+    empty_wallet();
+
+    // A heavily-fragmented wallet: 450 dust UTXOs (0.01 GRC each) plus two large
+    // consolidated coins. The dust alone (4.5 GRC) cannot fund a 6 GRC burn, so
+    // smallest-first must reach past every dust output into a large coin, i.e.
+    // > 450 inputs -- over the standard-tx input budget bound
+    // (MAX_CONTRACT_TX_SMALLEST_COIN_INPUTS, currently 400 in wallet.cpp). The
+    // dust count is chosen to exceed that bound; if the bound is ever retuned
+    // above ~450, raise the dust count here so the fallback still triggers.
+    for (int i = 0; i < 450; ++i) {
+        add_coin(CENT);            // 0.01 GRC dust
+    }
+    add_coin(100 * COIN);          // large consolidated coins
+    add_coin(100 * COIN);
+
+    const int64_t target = 6 * COIN;
+
+    // Witness the pathology: raw smallest-first sweeps every dust UTXO (plus a
+    // large coin to close the gap) -> a non-standard input count.
+    CoinSet smallestSet;
+    int64_t smallestValue = 0;
+    BOOST_REQUIRE(wallet.SelectSmallestCoins(target, spendTime, 1, 1, vCoins, smallestSet, smallestValue));
+    BOOST_CHECK_GT(smallestSet.size(), 450u);
+
+    // The fix: SelectContractCoins detects the oversized smallest-first set and
+    // falls back to target-based selection, funding the burn from a single large
+    // coin -- a standard-sized transaction.
+    BOOST_REQUIRE(wallet.SelectContractCoins(target, spendTime, vCoins, setCoinsRet, nValueRet));
+    BOOST_CHECK_EQUAL(setCoinsRet.size(), 1u);
+    BOOST_CHECK_EQUAL(nValueRet, 100 * COIN);
+
+    // A small burn the dust CAN cover within the budget still uses the
+    // smallest-first path -- dust consolidation is preserved for the common case.
+    CoinSet smallBurnSet;
+    int64_t smallBurnValue = 0;
+    BOOST_REQUIRE(wallet.SelectContractCoins(3 * CENT, spendTime, vCoins, smallBurnSet, smallBurnValue));
+    BOOST_CHECK_EQUAL(smallBurnSet.size(), 3u);   // three 0.01 GRC dust coins
+    BOOST_CHECK_EQUAL(smallBurnValue, 3 * CENT);
+
+    empty_wallet();
+}
+
 // ---------------------------------------------------------------------------
 // SyncLegacyFromState — derives hashBlock/nIndex from m_state
 // ---------------------------------------------------------------------------

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2755,6 +2755,21 @@ bool CWallet::SelectSmallestCoins(int64_t nTargetValue, unsigned int nSpendTime,
     return false;
 }
 
+//! \brief Upper bound on the number of inputs the contract-tx "smallest coins
+//! first" selection may accumulate before falling back to normal target-based
+//! selection. Derived from MAX_STANDARD_TX_SIZE with headroom reserved for the
+//! contract payload(s), the burn/change outputs and per-tx overhead, using a
+//! conservative per-P2PKH-input serialized-size estimate. Keeps a large burn on
+//! a fragmented wallet from producing a non-standard (>MAX_STANDARD_TX_SIZE)
+//! transaction (issue #3120).
+static constexpr unsigned int CONTRACT_TX_INPUT_HEADROOM_BYTES = 20000;
+static constexpr unsigned int CONTRACT_TX_BYTES_PER_INPUT = 200;
+static_assert(MAX_STANDARD_TX_SIZE > CONTRACT_TX_INPUT_HEADROOM_BYTES,
+              "contract-tx input headroom must be smaller than the standard tx size, "
+              "otherwise the unsigned budget subtraction underflows into an enormous bound");
+static const size_t MAX_CONTRACT_TX_SMALLEST_COIN_INPUTS =
+    (MAX_STANDARD_TX_SIZE - CONTRACT_TX_INPUT_HEADROOM_BYTES) / CONTRACT_TX_BYTES_PER_INPUT;
+
 bool CWallet::SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl* coinControl, bool contract) const
 {
     vector<COutput> vCoins;
@@ -2772,12 +2787,57 @@ bool CWallet::SelectCoins(int64_t nTargetValue, unsigned int nSpendTime, set<pai
     }
 
     if (contract) {
-        LogPrint(BCLog::LogFlags::ESTIMATEFEE, "INFO %s: Contract is included so SelectSmallestCoins will be used.", __func__);
+        LogPrint(BCLog::LogFlags::ESTIMATEFEE, "INFO %s: Contract is included so SelectContractCoins will be used.", __func__);
 
-        return (SelectSmallestCoins(nTargetValue, nSpendTime, 1, 10, vCoins, setCoinsRet, nValueRet) ||
-                SelectSmallestCoins(nTargetValue, nSpendTime, 1, 1, vCoins, setCoinsRet, nValueRet)  ||
-                SelectSmallestCoins(nTargetValue, nSpendTime, 0, 1, vCoins, setCoinsRet, nValueRet));
+        // vCoins is not used again in this branch, so move it in to avoid copying
+        // a potentially large coin vector (the fragmented-wallet case #3120 targets).
+        return SelectContractCoins(nTargetValue, nSpendTime, std::move(vCoins), setCoinsRet, nValueRet);
     }
+
+    return (SelectCoinsMinConf(nTargetValue, nSpendTime, 1, 10, vCoins, setCoinsRet, nValueRet) ||
+            SelectCoinsMinConf(nTargetValue, nSpendTime, 1, 1, vCoins, setCoinsRet, nValueRet)  ||
+            SelectCoinsMinConf(nTargetValue, nSpendTime, 0, 1, vCoins, setCoinsRet, nValueRet));
+}
+
+bool CWallet::SelectContractCoins(int64_t nTargetValue, unsigned int nSpendTime, vector<COutput> vCoins,
+                                  set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const
+{
+    // Prefer consuming the smallest UTXOs for contract transactions (dust
+    // consolidation), but bound the input count. On a heavily-fragmented wallet
+    // -- normal for a long-running staker -- a contract carrying a non-trivial
+    // burn (e.g. registerpool's 100 GRC) would otherwise sweep thousands of tiny
+    // inputs and push the transaction past MAX_STANDARD_TX_SIZE, so
+    // CreateTransaction rejects it ("tx size ... greater than standard").
+    const bool funded =
+        SelectSmallestCoins(nTargetValue, nSpendTime, 1, 10, vCoins, setCoinsRet, nValueRet) ||
+        SelectSmallestCoins(nTargetValue, nSpendTime, 1, 1, vCoins, setCoinsRet, nValueRet)  ||
+        SelectSmallestCoins(nTargetValue, nSpendTime, 0, 1, vCoins, setCoinsRet, nValueRet);
+
+    // Smallest-first funds the target iff the eligible coins sum to at least it;
+    // if it cannot, neither can the target-based selection over the same coins
+    // and confirmation tiers, so report the shortfall directly rather than
+    // repeating the work.
+    if (!funded) {
+        return false;
+    }
+
+    // Funded within a standard-tx-safe input budget: keep the smallest-first set.
+    if (setCoinsRet.size() <= MAX_CONTRACT_TX_SMALLEST_COIN_INPUTS) {
+        return true;
+    }
+
+    // Funded, but the smallest-first set is too large for a standard transaction.
+    // Fall back to the normal target-based selection, which picks a near-minimal
+    // input set exactly as an ordinary send does (issue #3120).
+    LogPrint(BCLog::LogFlags::ESTIMATEFEE,
+             "INFO %s: smallest-coin selection needs %u inputs (over the standard-tx budget of %u); "
+             "falling back to target-based coin selection.",
+             __func__, static_cast<unsigned int>(setCoinsRet.size()),
+             static_cast<unsigned int>(MAX_CONTRACT_TX_SMALLEST_COIN_INPUTS));
+
+    // Discard the oversized smallest-coin selection before the fallback.
+    setCoinsRet.clear();
+    nValueRet = 0;
 
     return (SelectCoinsMinConf(nTargetValue, nSpendTime, 1, 10, vCoins, setCoinsRet, nValueRet) ||
             SelectCoinsMinConf(nTargetValue, nSpendTime, 1, 1, vCoins, setCoinsRet, nValueRet)  ||

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -239,6 +239,14 @@ public:
                             std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
     bool SelectSmallestCoins(int64_t nTargetValue, unsigned int nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins,
                              std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
+    //! \brief Coin selection for contract transactions: prefer the smallest UTXOs
+    //! (dust consolidation) but fall back to normal target-based selection when
+    //! the smallest-first set would exceed a standard-tx-safe input budget, so a
+    //! large burn on a fragmented wallet cannot produce a >MAX_STANDARD_TX_SIZE
+    //! transaction (issue #3120). Takes \p vCoins so it is unit-testable in
+    //! isolation, mirroring SelectCoinsMinConf / SelectSmallestCoins.
+    bool SelectContractCoins(int64_t nTargetValue, unsigned int nSpendTime, std::vector<COutput> vCoins,
+                             std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
 
     // keystore implementation
     // Generate a new key


### PR DESCRIPTION
## Summary

Fixes **#3120**. Contract transactions select their funding "smallest coins first" to consolidate dust. On a heavily-fragmented wallet — normal for a long-running staker — a contract carrying a non-trivial burn sweeps thousands of tiny inputs to reach the target and produces a transaction that exceeds `MAX_STANDARD_TX_SIZE` (100 KB), so `CreateTransaction` rejects it:

```
ERROR: CreateTransaction: tx size 1470302 greater than standard 100000
ERROR: SendContractTx: Error: Transaction creation failed.
```

`registerpool` (PR #2955, 100 GRC burn) is **impossible** to broadcast from such a wallet (~9,800 inputs → ~1.47 MB), while a plain `sendtoaddress` of the same amount succeeds from a handful of inputs — it is the contract-tx selection path specifically that is pathological.

## Fix

Extract the contract selection into `CWallet::SelectContractCoins`: it still prefers the smallest UTXOs, but when the smallest-first set would exceed a standard-tx-safe input budget it falls back to the normal target-based (knapsack) selection — the same path an ordinary send uses — which funds the burn from a near-minimal input set. The bound `MAX_CONTRACT_TX_SMALLEST_COIN_INPUTS` is derived from `MAX_STANDARD_TX_SIZE` with headroom reserved for the contract payload, outputs and overhead. Small burns the dust can cover within the budget still consolidate as before.

The helper takes its coin vector by value (mirroring `SelectCoinsMinConf` / `SelectSmallestCoins`) so it is unit-testable in isolation.

## Why this is safe

- **Behavior-equivalent for the common case**: when smallest-first yields ≤ budget inputs, the returned set is identical to before.
- **No large-payload contract can defeat the bound**: the contracts that reach this path exclude `MESSAGE` (arbitrary user data) and are all structured, sub-1 KB payloads (beacon, pool, protocol, project, sidestake, MRC). Poll/vote contracts pre-select their fee inputs via a `CCoinControl` and never enter this path. 400 real inputs ≈ 72 KB leaves ample room under 100 KB. The existing `nBytes >= MAX_STANDARD_TX_SIZE` check remains as a hard backstop.
- **No fundability regression**: whenever an over-budget smallest-first selection would have funded, the same-tier knapsack on the same coins also funds.

## Tests

Adds `wallet_tests/contract_coin_selection_bounds_fragmented_wallet`: a fragmented wallet (450 dust + two large coins) where smallest-first takes >450 inputs for a 6 GRC burn; asserts `SelectContractCoins` falls back to a single large input, and that a small burn still uses the dust path. Reverting the fallback makes the test fail. Full `test_gridcoin` suite green; daemon builds clean; lints pass.

A broader coin-selection-algorithm review is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)