### PR TITLE
net: guard AddressCurrentlyConnected with the established g_connman pattern (#3068)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -336,7 +336,18 @@ CNode* CConnman::FindNode(const CService& addr)
 
 void AddressCurrentlyConnected(const CService& addr)
 {
-    g_connman->GetAddrMan().Connected(addr);
+    // Defensive null check matching the `if (g_connman)` pattern every other
+    // external g_connman consumer uses (net.cpp:114 / 1251 / 2277 / 2285). This
+    // was the one free-function consumer still dereferencing g_connman
+    // unguarded. No null window is reachable today -- its only caller is
+    // ProcessMessage on the message-handler thread, which Shutdown() joins (via
+    // StopNode() -> CConnman::Stop()) before g_connman.reset() (init.cpp) -- so
+    // this is consistency hardening that keeps it from becoming a latent
+    // null-deref if the teardown order changes or a new caller appears (issue
+    // #3068, follow-up to #2558).
+    if (g_connman) {
+        g_connman->GetAddrMan().Connected(addr);
+    }
 }
 
 


### PR DESCRIPTION
## Summary

Resolves **#3068** (follow-up to #2558). `AddressCurrentlyConnected()` (`src/net.cpp`) was the one **free-function** `g_connman` consumer still dereferencing the global `unique_ptr` without the `if (g_connman)` guard that every other external consumer uses (`net.cpp:114 / 1251 / 2277 / 2285`). Adds that guard.

## Accuracy note (updated after review)

To be precise about severity: **no null window is reachable today.** `AddressCurrentlyConnected`'s only caller is `ProcessMessage` on the message-handler thread, which `Shutdown()` joins — via `StopNode()` → `CConnman::Stop()` — **before** `g_connman.reset()` (`init.cpp:215` / `297`; see the note at `init.cpp:291-292`: *"the net threads that drove the message processor were already joined by StopNode() above"*). So this is **consistency / defense-in-depth hardening**, not a live-bug fix — it keeps the last unguarded consumer from becoming a latent null-deref if the teardown ordering ever changes or a new caller appears. (The issue's "reachable after reset" framing predates tracing that join ordering.)

## Audit (per the issue's "audit for other unguarded free-function derefs")

| Site | Context | Null-risk? |
|------|---------|-----------|
| `AddressCurrentlyConnected` (339) | free function, called from `ProcessMessage` | guarded (consistency) |
| `ThreadDNSAddressSeed2` (1336) | runs on a `CConnman`-owned net thread | no — `g_connman` live |
| `DumpAddresses` (1362/1365) | called from a `CConnman`-owned thread and from `CConnman::Stop()` | no — `g_connman` live |
| `ThreadOpenConnections2` (1507/1525/1550) | `CConnman` member | no — `this` live |
| `ConnectNode` (363) | `CConnman` member (promoted in #2558) | no — `this` live |

## Testing

Daemon builds clean; whitespace lint passes. No unit test — a guard on a global with no presently-reachable null path isn't unit-exercisable; it matches the vetted `if (g_connman)` pattern already used throughout `net.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)