### PR TITLE
rpc: parse RPC amounts exactly with ParseFixedPoint (#3148)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -5173,8 +5173,12 @@ UniValue createmrcrequest(const UniValue& params) {
         force = params[1].get_bool() && fTestNet;
     }
 
-    if (params.size() > 2 && !ParseMoney(params[2].get_str(), provided_fee)) {
-        throw runtime_error("Invalid fee.");
+    if (params.size() > 2) {
+        // AmountFromValue accepts the fee as either a JSON number or string and
+        // enforces the money range; it throws on anything invalid. A provided
+        // fee is therefore always strictly positive, so the provided_fee != 0
+        // "was a fee supplied" sentinel below still holds (the default is 0).
+        provided_fee = AmountFromValue(params[2]);
     }
 
     LOCK(cs_main);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -220,6 +220,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "beaconreport"           , 0 },
     { "createmrcrequest"       , 0 },
     { "createmrcrequest"       , 1 },
+    { "createmrcrequest"       , 2 },
     { "generate"               , 0 },
     { "generatetoaddress"      , 0 },
     { "getmrcinfo"             , 0 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -153,8 +153,8 @@ int64_t AmountFromValue(const UniValue& value)
     // amounts (a double carries ~15-16 significant digits, but MAX_MONEY in
     // satoshis is ~2e17) and rounds inputs with more than 8 decimal places
     // instead of rejecting them. ParseFixedPoint converts the string directly
-    // to an int64_t satoshi count with 8 implied decimals, so the value that
-    // reaches consensus is the value the user typed. It also accepts either a
+    // to an int64_t satoshi count with 8 implied decimals, so the amount the
+    // RPC acts on is exactly the value the user typed. It also accepts either a
     // JSON number or a JSON string (getValStr() yields the original token for
     // both), which fixes string-typed amounts being rejected outright.
     if (!value.isNum() && !value.isStr())

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -17,6 +17,7 @@
 #include "wallet/db.h"
 #include <rpc/util.h>
 #include <util.h>
+#include <util/strencodings.h>
 
 #include <boost/asio.hpp>
 #include <boost/asio/ip/v6_only.hpp>
@@ -147,11 +148,25 @@ bool HTTPAuthorized(map<string, string>& mapHeaders)
 
 int64_t AmountFromValue(const UniValue& value)
 {
-    double dAmount = value.get_real();
-    if (dAmount <= 0.0 || dAmount > MAX_MONEY)
+    // Parse the amount exactly from its decimal string representation rather
+    // than routing it through a double. get_real() loses precision for large
+    // amounts (a double carries ~15-16 significant digits, but MAX_MONEY in
+    // satoshis is ~2e17) and rounds inputs with more than 8 decimal places
+    // instead of rejecting them. ParseFixedPoint converts the string directly
+    // to an int64_t satoshi count with 8 implied decimals, so the value that
+    // reaches consensus is the value the user typed. It also accepts either a
+    // JSON number or a JSON string (getValStr() yields the original token for
+    // both), which fixes string-typed amounts being rejected outright.
+    if (!value.isNum() && !value.isStr())
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
+    int64_t nAmount;
+    if (!ParseFixedPoint(value.getValStr(), 8, &nAmount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    int64_t nAmount = roundint64(dAmount * COIN);
-    if (!MoneyRange(nAmount))
+    // Preserve Gridcoin's historical contract of strictly-positive amounts:
+    // zero and negative are rejected. MoneyRange already excludes negatives and
+    // the out-of-range high end; the explicit > 0 keeps zero rejected as the
+    // get_real()-based implementation did (Bitcoin Core's MoneyRange admits 0).
+    if (nAmount <= 0 || !MoneyRange(nAmount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
     return nAmount;
 }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VSTR, "")), UniValue);    // empty string
     BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VSTR, "1.2.3")), UniValue);   // not a fixed-point number
     BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VSTR, "1a")), UniValue);      // trailing junk
-    BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VBOOL, "1")), UniValue);      // neither number nor string
+    BOOST_CHECK_THROW(AmountFromValue(UniValue(true)), UniValue);                      // neither number nor string
 }
 
 // Regression guard: getaddednodeinfo dns=true must return an ARRAY of per-node

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -117,6 +117,28 @@ BOOST_AUTO_TEST_CASE(rpc_parse_monetary_values)
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("1.00000000")), 100000000LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.9999999")), 2099999999999990LL);
     BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("20999999.99999999")), 2099999999999999LL);
+
+    // A JSON string amount parses identically to the numeric form. Before the
+    // ParseFixedPoint conversion, AmountFromValue called value.get_real() and
+    // threw on any string-typed amount; now it accepts either representation.
+    BOOST_CHECK_EQUAL(AmountFromValue(UniValue(UniValue::VSTR, "0.5")), 50000000LL);
+    BOOST_CHECK_EQUAL(AmountFromValue(UniValue(UniValue::VSTR, "1.00000000")), 100000000LL);
+
+    // Exact parsing at the top of the money range (a double would lose the low
+    // digits here): MAX_MONEY = 2000000000 * COIN.
+    BOOST_CHECK_EQUAL(AmountFromValue(ValueFromString("2000000000.00000000")), 200000000000000000LL);
+
+    // Rejections. JSONRPCError throws a UniValue.
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("0")), UniValue);            // zero (Gridcoin rejects <= 0)
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("0.00000000")), UniValue);   // zero, written out
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-1")), UniValue);           // negative
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("-0.00000001")), UniValue);  // negative sub-satoshi
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("0.000000001")), UniValue);  // more than 8 decimals (was silently rounded)
+    BOOST_CHECK_THROW(AmountFromValue(ValueFromString("2000000000.00000001")), UniValue); // just past MAX_MONEY
+    BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VSTR, "")), UniValue);    // empty string
+    BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VSTR, "1.2.3")), UniValue);   // not a fixed-point number
+    BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VSTR, "1a")), UniValue);      // trailing junk
+    BOOST_CHECK_THROW(AmountFromValue(UniValue(UniValue::VBOOL, "1")), UniValue);      // neither number nor string
 }
 
 // Regression guard: getaddednodeinfo dns=true must return an ARRAY of per-node

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -907,33 +907,20 @@ enum class CliConversion {
     FORBIDDEN, //!< must stay a string: a vRPCConvertParams entry would break it
 };
 
-//! AMOUNT args whose command body parses a *string* (ParseMoney(get_str()))
-//! instead of calling AmountFromValue (rpc/server.cpp). ParseMoney rejects a
-//! JSON number, and a vRPCConvertParams entry turns the CLI token into a
-//! number, so a conversion entry would break these -- they must stay strings.
-//! (AmountFromValue itself accepts either a number or a string, so it imposes
-//! no such constraint.) createmrcrequest's fee is the only string-parsed one.
-bool IsStringParsedAmountArg(const std::string& method, const size_t idx)
-{
-    return method == "createmrcrequest" && idx == 2;
-}
-
-CliConversion ArgTypeCliConversion(const std::string& method, const size_t idx, const RPCArg::Type type)
+CliConversion ArgTypeCliConversion(const RPCArg::Type type)
 {
     switch (type) {
     case RPCArg::Type::STR:
     case RPCArg::Type::STR_HEX:
         return CliConversion::FORBIDDEN;
     case RPCArg::Type::AMOUNT:
-        // Documented as "can be either NUM or STR" (rpc/util.h). AmountFromValue
-        // accepts both, so a convert entry is not strictly mandatory for those
-        // args -- but every one of them has one, routing the amount to the
-        // server as a JSON number, and this cross-check pins that wiring so an
-        // entry is not dropped by accident. The exception is a ParseMoney
-        // (get_str()) arg, which rejects a JSON number outright and so must NOT
-        // have a convert entry.
-        return IsStringParsedAmountArg(method, idx) ? CliConversion::FORBIDDEN
-                                                    : CliConversion::REQUIRED;
+        // Documented as "can be either NUM or STR" (rpc/util.h). Every AMOUNT
+        // arg is parsed by AmountFromValue (rpc/server.cpp), which accepts a
+        // JSON number or a string; each carries a vRPCConvertParams entry that
+        // routes the CLI token to the server as a number, and this cross-check
+        // pins that wiring so an entry is not dropped by accident. No AMOUNT arg
+        // is parsed as a bare string (ParseMoney) any longer.
+        return CliConversion::REQUIRED;
     case RPCArg::Type::OBJ:
     case RPCArg::Type::ARR:
     case RPCArg::Type::NUM:
@@ -1027,7 +1014,7 @@ BOOST_AUTO_TEST_CASE(every_helpman_arg_type_matches_client_conversion_table)
                 continue;
             }
 
-            switch (ArgTypeCliConversion(name, i, args[i].m_type)) {
+            switch (ArgTypeCliConversion(args[i].m_type)) {
             case CliConversion::REQUIRED:
                 BOOST_CHECK_MESSAGE(!converted[i].isStr(),
                     strprintf("%s arg %u (%s): declared as a non-string JSON type but "

--- a/src/test/rpchelpman_tests.cpp
+++ b/src/test/rpchelpman_tests.cpp
@@ -908,8 +908,11 @@ enum class CliConversion {
 };
 
 //! AMOUNT args whose command body parses a *string* (ParseMoney(get_str()))
-//! instead of calling the number-only AmountFromValue (rpc/server.cpp), so a
-//! conversion entry would break them. createmrcrequest's fee is the only one.
+//! instead of calling AmountFromValue (rpc/server.cpp). ParseMoney rejects a
+//! JSON number, and a vRPCConvertParams entry turns the CLI token into a
+//! number, so a conversion entry would break these -- they must stay strings.
+//! (AmountFromValue itself accepts either a number or a string, so it imposes
+//! no such constraint.) createmrcrequest's fee is the only string-parsed one.
 bool IsStringParsedAmountArg(const std::string& method, const size_t idx)
 {
     return method == "createmrcrequest" && idx == 2;
@@ -922,10 +925,13 @@ CliConversion ArgTypeCliConversion(const std::string& method, const size_t idx, 
     case RPCArg::Type::STR_HEX:
         return CliConversion::FORBIDDEN;
     case RPCArg::Type::AMOUNT:
-        // Documented as "can be either NUM or STR" (rpc/util.h), but which of
-        // the two a command accepts is fixed by its body (AmountFromValue
-        // wants VNUM, ParseMoney wants VSTR), so resolve the expectation per
-        // (method, index) instead of exempting the type from the cross-check.
+        // Documented as "can be either NUM or STR" (rpc/util.h). AmountFromValue
+        // accepts both, so a convert entry is not strictly mandatory for those
+        // args -- but every one of them has one, routing the amount to the
+        // server as a JSON number, and this cross-check pins that wiring so an
+        // entry is not dropped by accident. The exception is a ParseMoney
+        // (get_str()) arg, which rejects a JSON number outright and so must NOT
+        // have a convert entry.
         return IsStringParsedAmountArg(method, idx) ? CliConversion::FORBIDDEN
                                                     : CliConversion::REQUIRED;
     case RPCArg::Type::OBJ:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -749,20 +749,18 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         # Pick a mature source UTXO unspent in every consensus view.
         src = None
         for cand in funder.listunspent(11):
-            # Amount math stays in Decimal (authproxy parses amounts as Decimal)
-            # so it is exact at 1e-8 (satoshi) granularity. Only cast to float at
-            # the createrawtransaction boundary: Gridcoin's AmountFromValue takes
-            # a JSON number via get_real() (it does not accept the string a
-            # Decimal serializes to) and rounds double*COIN to the satoshi, which
-            # recovers the exact value for these ranges. Drop the float() once
-            # AmountFromValue accepts exact string amounts (issue #3148).
+            # Amount math stays in Decimal end to end (authproxy parses amounts
+            # as Decimal), exact at 1e-8 (satoshi) granularity, and is handed
+            # straight to createrawtransaction: a Decimal serializes to a JSON
+            # string, which AmountFromValue now parses exactly to the satoshi
+            # (issue #3148). No float() round-trip, so no double-rounding.
             amount = cand["amount"] - Decimal("1.0")  # ~1 GRC fee
             if amount <= 0:
                 continue
             probe = funder.signrawtransactionwithwallet(
                 funder.createrawtransaction(
                     [{"txid": cand["txid"], "vout": cand["vout"]}],
-                    {funder.getnewaddress(): float(amount)}))
+                    {funder.getnewaddress(): amount}))
             if not probe.get("complete"):
                 continue
             if not funder.testmempoolaccept([probe["hex"]])[0]["allowed"]:
@@ -779,7 +777,7 @@ class GridcoinTestFramework(metaclass=GridcoinTestMetaClass):
         per_out = ((src["amount"] - Decimal("1.0")) / count).quantize(
             Decimal("0.00000001"), rounding=ROUND_DOWN)  # ~1 GRC total fee
         assert per_out > 0, "source UTXO too small to fan out into `count` outputs"
-        outputs = {funder.getnewaddress(): float(per_out) for _ in range(count)}
+        outputs = {funder.getnewaddress(): per_out for _ in range(count)}
         signed = funder.signrawtransactionwithwallet(
             funder.createrawtransaction(
                 [{"txid": src["txid"], "vout": src["vout"]}], outputs))


### PR DESCRIPTION
Fixes #3148.

## Problem

`AmountFromValue` (`src/rpc/server.cpp`) parsed every RPC amount through a `double`:

```cpp
double dAmount = value.get_real();
...
int64_t nAmount = roundint64(dAmount * COIN);
```

That has three problems:
- **Precision loss** near `MAX_MONEY`: a `double` carries ~15–16 significant digits, but `MAX_MONEY` is `2e17` satoshis — so the value that reaches the RPC is not always the value the user typed.
- **Silent rounding** of over-precise input: `0.000000009` was rounded to `1` satoshi instead of being rejected.
- **String amounts rejected** outright: `get_real()` throws on a JSON string, even though the AMOUNT arg type is documented as accepting *either* a number or a string.

## Fix

Parse the amount directly from its decimal-string representation with `ParseFixedPoint` (already in `src/util/strencodings`), the same approach Bitcoin Core uses:

```cpp
if (!value.isNum() && !value.isStr())
    throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
int64_t nAmount;
if (!ParseFixedPoint(value.getValStr(), 8, &nAmount))
    throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
if (nAmount <= 0 || !MoneyRange(nAmount))
    throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
```

Gridcoin's historical **`<= 0` rejection is preserved** — Bitcoin Core's `MoneyRange` admits `0`, but the old `get_real()` path rejected it, so the explicit `> 0` check keeps zero rejected.

## Behavior deltas and blast radius

Audited all 23 C++ callers, both unit-test files, and the full functional suite:

| Delta | Impact |
|-------|--------|
| String amounts now **accepted** (was rejected) | Additive — no test asserted string-rejection |
| **> 8 decimals now rejected** (was silently rounded) | No test/caller passes such amounts — user-facing behavior is now *stricter and correct* |
| Large amounts now **exact** (was double-rounded) | exact ≥ accurate |
| Zero still **rejected** | Contract preserved |

`AmountFromValue` is declared in `rpc/server.h` and used only on RPC/wallet-RPC input paths — it does **not** appear in `main.cpp`/`miner.cpp` block/transaction validation, so there is **no consensus impact**.

## Tests / docs

- Expanded `rpc_parse_monetary_values` (`src/test/rpc_tests.cpp`) with string-form, >8-decimal, out-of-range, and malformed-input cases to lock in the new semantics.
- Updated the `rpchelpman_tests` CLI-conversion cross-check **comments**: their premise that `AmountFromValue` is "number-only" no longer holds (it accepts both now). The test logic is unchanged — the `vRPCConvertParams` wiring it pins is unchanged, and the `ParseMoney(get_str())` case (`createmrcrequest`, which rejects a JSON number) is what still forbids a convert entry.

Full unit suite, `rpc_psgtpool.py` functional (exercises the amount RPC path end-to-end), and lint all pass. Adversarial self-review found no defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-on (commit 2): migrate `createmrcrequest` fee to `AmountFromValue`

`createmrcrequest` parsed its optional fee with `ParseMoney(params[2].get_str())` — which required the fee as a JSON **string**, and was the *only* reason `AmountFromValue`'s old number-only nature needed a special case in the rpchelpman CLI-conversion cross-check. Now that `AmountFromValue` accepts both a number and a string (commit 1), the fee moves to it:\n\n```cpp\nif (params.size() > 2) {\n    provided_fee = AmountFromValue(params[2]);\n}\n```\n\n- Unifies the two Gridcoin amount parsers on this arg.\n- Bonus: applies the `MoneyRange` + strictly-positive checks `ParseMoney` lacked. A `0` fee (which the `provided_fee != 0` sentinel already treated as "unset", so it was silently ignored) and an out-of-range fee are now rejected up front. A supplied fee is always `> 0`, so the sentinel still holds. `ParseMoney` already rejected `> 8` decimals, so that is unchanged.\n- Registers the `{ "createmrcrequest", 2 }` client convert entry so the CLI routes the fee to the server as a JSON number like every other AMOUNT arg, and **removes** the now-obsolete `IsStringParsedAmountArg` exception — no AMOUNT arg is parsed as a bare string anymore.\n\nVerified on regtest: a string fee (`"0.01"`) and a numeric fee (`0.01`) parse identically (both reach `CreateMRC` and fail there on the MRC-specific reward check); `> 8` decimals and negative fees are rejected with `Invalid amount`. Independent adversarial review of this commit found no defects.

## Follow-on (commit 3): drop the `float()` workaround in `grow_utxo_universe`

The original motivation for this PR: the Python functional harness parses RPC amounts as `Decimal` (exact at 1e-8) but serializes a `Decimal` back out as a JSON **string**, which the old `AmountFromValue` rejected — so amounts had to be cast to `float()` at the `createrawtransaction` boundary, reintroducing the exact double-rounding this PR removes. The `grow_utxo_universe` helper carried a comment flagging the cast to drop once #3148 landed.

With the server now accepting string amounts, the helper hands its `Decimal` amounts straight through — no `float()` round-trip. This closes that comment and gives the string-amount path real end-to-end coverage (`rpc_psgtpool` / `p2p_psgt_orphan` / `p2p_psgt_relay` all exercise it; verified locally).

The remaining incidental `float(amount)` idioms across ~8 functional test files (`rpc_rawtransaction`, `wallet_basic`, `rpc_psgt`, `mempool_accept`, …) are a separate mechanical sweep, left for a stacked follow-up PR.