### PR TITLE
test: use Decimal amounts across functional tests, not float

### DIFF
--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -51,7 +51,7 @@ class MempoolAcceptTest(GridcoinTestFramework):
         # most-recently-staked output (fewest confirmations) is a coinstake,
         # never the height-0 premine coinbase.
         u = min(node.listunspent(0), key=lambda x: x["confirmations"])
-        amt = float(u["amount"]) - 1  # ~1 GRC fee
+        amt = u["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
 
         # 1. a valid tx is accepted into the mempool
         first = self._signed_spend(node, u, node.getnewaddress(), amt)

--- a/test/functional/p2p_psgt_orphan.py
+++ b/test/functional/p2p_psgt_orphan.py
@@ -24,6 +24,7 @@ A scripted peer injects the PSGT and we assert:
 """
 
 import time
+from decimal import Decimal
 
 from base64 import b64decode
 
@@ -84,8 +85,8 @@ class P2PPsgtOrphanTest(GridcoinTestFramework):
         # hit an empty list once staking has consumed the mature premine outputs.
         utxo = None
         for cand in node0.listunspent(1):
-            ms_amount = round(float(cand["amount"]) - 1.0, 8)  # ~1 GRC fee
-            if ms_amount <= 0.01:  # need enough for the funding + the PSGT's 0.01 fee
+            ms_amount = cand["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
+            if ms_amount <= Decimal("0.01"):  # need enough for the funding + the PSGT's 0.01 fee
                 continue
             raw = node0.createrawtransaction(
                 [{"txid": cand["txid"], "vout": cand["vout"]}], {ms_address: ms_amount})
@@ -103,7 +104,7 @@ class P2PPsgtOrphanTest(GridcoinTestFramework):
 
         dest = node0.getnewaddress()
         psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
-                                {dest: round(ms_amount - 0.01, 8)})
+                                {dest: ms_amount - Decimal("0.01")})
         psgt = node0.utxoupdatepsgt(psgt)
         processed = node0.walletprocesspsgt(psgt)
         assert not processed["complete"], "expected a PARTIALLY signed PSGT"

--- a/test/functional/p2p_psgt_relay.py
+++ b/test/functional/p2p_psgt_relay.py
@@ -29,6 +29,7 @@ message and we assert, in order:
 """
 
 import time
+from decimal import Decimal
 
 from test_framework.messages import (
     CInv,
@@ -133,12 +134,12 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
             # still absorb the staker racing us for a chosen output.
             candidates = [u for u in node0.listunspent(1)
                           if (u["txid"], u["vout"]) not in tried
-                          and round(float(u["amount"]) - 1.0, 8) > 0.01]
+                          and u["amount"] - 1 > Decimal("0.01")]
             assert candidates, "no mature UTXO left to fund the multisig"
             utxo = candidates[0]
             tried.add((utxo["txid"], utxo["vout"]))
 
-            ms_amount = round(float(utxo["amount"]) - 1.0, 8)  # ~1 GRC fee
+            ms_amount = utxo["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
             raw = node0.createrawtransaction(
                 [{"txid": utxo["txid"], "vout": utxo["vout"]}], {ms_address: ms_amount})
             signed = node0.signrawtransactionwithwallet(raw)
@@ -158,7 +159,7 @@ class P2PPsgtRelayTest(GridcoinTestFramework):
         # 0.01 GRC fee: above the relay floor, below the absurd-fee ceiling.
         dest = node0.getnewaddress()
         psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
-                                {dest: round(ms_amount - 0.01, 8)})
+                                {dest: ms_amount - Decimal("0.01")})
         psgt = node0.utxoupdatepsgt(psgt)
         processed = node0.walletprocesspsgt(psgt)
         assert not processed["complete"], "expected a PARTIALLY signed PSGT"

--- a/test/functional/rpc_psgt.py
+++ b/test/functional/rpc_psgt.py
@@ -41,7 +41,7 @@ class RpcPsgtTest(GridcoinTestFramework):
         utxo = min(node.listunspent(0), key=lambda u: u["confirmations"])
         inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]}]
         dest = node.getnewaddress()
-        outputs = {dest: float(utxo["amount"]) - 1}
+        outputs = {dest: utxo["amount"] - 1}  # amounts are Decimal from authproxy
 
         # --- createpsgt + decodepsgt round-trip ---
         psgt = node.createpsgt(inputs, outputs)

--- a/test/functional/rpc_psgtpool.py
+++ b/test/functional/rpc_psgtpool.py
@@ -27,6 +27,7 @@ from test_framework.util import assert_equal
 
 import os
 import time
+from decimal import Decimal
 
 
 class RpcPsgtPoolTest(GridcoinTestFramework):
@@ -75,7 +76,7 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
         # still guards spendability (and both-nodes agreement) for whatever
         # listunspent(1) returns.
         for cand in node0.listunspent(1):
-            amount = round(float(cand["amount"]) - 1.0, 8)  # ~1 GRC fee
+            amount = cand["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
             if amount <= 0:
                 continue  # too small to fund after fee (createrawtransaction rejects <= 0)
             raw = node0.createrawtransaction(
@@ -111,7 +112,7 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
         node0 = self.nodes[0]
         dest = node0.getnewaddress()
         psgt = node0.createpsgt([{"txid": txid, "vout": vout}],
-                                {dest: round(amount - fee, 8)})
+                                {dest: amount - fee})
         psgt = node0.utxoupdatepsgt(psgt)
         processed = node0.walletprocesspsgt(psgt)
         assert not processed["complete"], "expected a PARTIALLY signed PSGT"
@@ -145,7 +146,7 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
 
         # --- initiate: submitpsgt pools and relays ---
         txid, vout, amount = self.fund_multisig(ms_address)
-        submitted = node0.submitpsgt(self.initiator_psgt(txid, vout, amount, 0.01))
+        submitted = node0.submitpsgt(self.initiator_psgt(txid, vout, amount, Decimal("0.01")))
         assert_equal(submitted["sigs_valid"], 1)
         assert_equal(submitted["sigs_required"], 2)
         assert_equal(submitted["sigs_total"], 3)
@@ -181,10 +182,10 @@ class RpcPsgtPoolTest(GridcoinTestFramework):
 
         # --- initiator supersede: new destination replaces the pooled PSGT ---
         txid2, vout2, amount2 = self.fund_multisig(ms_address)
-        first = node0.submitpsgt(self.initiator_psgt(txid2, vout2, amount2, 0.01))
+        first = node0.submitpsgt(self.initiator_psgt(txid2, vout2, amount2, Decimal("0.01")))
         assert_equal(first["replaced"], False)
 
-        revised = node0.submitpsgt(self.initiator_psgt(txid2, vout2, amount2, 0.02))
+        revised = node0.submitpsgt(self.initiator_psgt(txid2, vout2, amount2, Decimal("0.02")))
         assert_equal(revised["replaced"], True)
         assert_equal(revised["image"], image)  # same arrangement, same slot
         assert revised["txid"] != first["txid"]

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -40,7 +40,7 @@ class RpcRawTransactionTest(GridcoinTestFramework):
         node.generatetoaddress(10, node.getnewaddress())
         utxo = min(node.listunspent(0), key=lambda u: u["confirmations"])
         dest = node.getnewaddress()
-        amount = float(utxo["amount"]) - 1  # ~1 GRC fee
+        amount = utxo["amount"] - 1  # ~1 GRC fee (amounts are Decimal from authproxy)
 
         # --- createrawtransaction ---
         raw = node.createrawtransaction(

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -89,7 +89,7 @@ class RpcTxoutProofTest(GridcoinTestFramework):
         cs = min(node.listunspent(0), key=lambda u: u["confirmations"])
         dest = node.getnewaddress()
         raw = node.createrawtransaction(
-            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: float(cs["amount"]) - 1})
+            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: cs["amount"] - 1})
         signed = node.signrawtransactionwithwallet(raw)
         assert signed.get("complete"), signed
         mempool_txid = node.sendrawtransaction(signed["hex"])

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -57,7 +57,7 @@ class WalletBasicTest(GridcoinTestFramework):
         cs = min(node.listunspent(0), key=lambda u: u["confirmations"])
         dest = node.getnewaddress()
         raw = node.createrawtransaction(
-            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: float(cs["amount"]) - 1})
+            [{"txid": cs["txid"], "vout": cs["vout"]}], {dest: cs["amount"] - 1})
         signed = node.signrawtransactionwithwallet(raw)
         assert signed.get("complete"), signed
         txid = node.sendrawtransaction(signed["hex"])


### PR DESCRIPTION
Follow-up to #3150 (the `AmountFromValue` → `ParseFixedPoint` change).

## Why

The Python harness parses RPC amounts as `Decimal` (authproxy, `parse_float=decimal.Decimal`) and serializes a `Decimal` back out as a JSON **string** (`EncodeDecimal` → `str(o)`). Before #3150 the server's `AmountFromValue` rejected string amounts, so the functional tests cast amounts to `float()` at the `createrawtransaction`/`createpsgt` boundary — reintroducing exactly the double-rounding #3148 was about. #3150 made the server accept string amounts and parse them exactly, so the `float()` round-trip is now pure loss.

This is the mechanical sweep flagged as a follow-up in #3150: convert the remaining `float(amount)` idioms across the functional suite to `Decimal`.

## What

- **5 simple files** (`rpc_rawtransaction`, `wallet_basic`, `rpc_txoutproof`, `rpc_psgt`, `mempool_accept`): `float(x["amount"]) - 1` → `x["amount"] - 1`. The amount is already a `Decimal`; it flows only into `createrawtransaction`/`createpsgt`, so no import is needed.
- **3 PSGT files** (`rpc_psgtpool`, `p2p_psgt_relay`, `p2p_psgt_orphan`): the whole chain, because `Decimal - float` raises `TypeError`. The fee literals `0.01`/`0.02` become `Decimal(...)`, the `<= 0.01` / `> 0.01` guards use `Decimal("0.01")`, and the now-unnecessary `round(..., 8)` is dropped (a `Decimal` minus an int or `Decimal` is already exact at 8 decimals). Added `from decimal import Decimal`.

`util.py`'s `check_json_precision()` is deliberately left on `float` — it exists to test `float` → satoshi precision.

## Verification

All eight affected tests pass locally (`rpc_rawtransaction`, `wallet_basic`, `rpc_txoutproof`, `rpc_psgt`, `mempool_accept`, `rpc_psgtpool`, `p2p_psgt_orphan`, `p2p_psgt_relay`). Lint clean. Independent adversarial review confirmed no Decimal/float mixing, no path producing >8 decimals (which the server now rejects), and no comparison-boundary flips (post-fee amounts are orders of magnitude above the 0.01 guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)