### PR TITLE
gui: remove vestigial core includes and dead code from src/qt (multiprocess PR-0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ qrc_*.cpp
 #qt creator
 *.pro.user
 *.pro.user.*
+.qmlls.ini
+.qtc_clangd/
 #mac specific
 .DS_Store
 background.tiff

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -15,7 +15,6 @@ CClientUIInterface uiInterface;
 
 struct UISignals {
     boost::signals2::signal<CClientUIInterface::ThreadSafeMessageBoxSig> ThreadSafeMessageBox;
-    boost::signals2::signal<CClientUIInterface::ThreadSafeAskQuestionSig> ThreadSafeAskQuestion;
     boost::signals2::signal<CClientUIInterface::InitMessageSig> InitMessage;
     boost::signals2::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
     boost::signals2::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
@@ -46,7 +45,6 @@ static UISignals g_ui_signals;
     }
 
 ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeMessageBox);
-ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeAskQuestion);
 ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
@@ -71,7 +69,6 @@ ADD_SIGNALS_IMPL_WRAPPER(RwSettingsUpdated);
 void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
 void CClientUIInterface::UpdateMessageBox(const std::string& version, const int& update_type, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, update_type, message); }
 bool CClientUIInterface::ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption) { return g_ui_signals.ThreadSafeAskFee(nFeeRequired, strCaption).value_or(false); }
-bool CClientUIInterface::ThreadSafeAskQuestion(std::string caption, std::string body) { return g_ui_signals.ThreadSafeAskQuestion(caption, body).value_or(false); }
 void CClientUIInterface::ThreadSafeHandleURI(const std::string& strURI) { return g_ui_signals.ThreadSafeHandleURI(strURI); }
 void CClientUIInterface::InitMessage(const std::string &message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::QueueShutdown() { return g_ui_signals.QueueShutdown(); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -94,9 +94,6 @@ public:
     /** Ask the user whether they want to pay a fee or not. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeAskFee, bool, int64_t nFeeRequired, const std::string& strCaption);
 
-	/** Ask the user a question */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeAskQuestion, bool, std::string caption, std::string body);
-
     /** Handle a URL passed at the command line. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeHandleURI, void, const std::string& strURI);
 

--- a/src/qt/.qmlls.ini
+++ b/src/qt/.qmlls.ini
@@ -1,0 +1,3 @@
+[General]
+buildDir=/home/jco/builds/Gridcoin-Research/build_qml/src/qt
+no-cmake-calls=false

--- a/src/qt/.qmlls.ini
+++ b/src/qt/.qmlls.ini
@@ -1,3 +1,0 @@
-[General]
-buildDir=/home/jco/builds/Gridcoin-Research/build_qml/src/qt
-no-cmake-calls=false

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -159,19 +159,6 @@ static bool ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption
 }
 
 
-static bool ThreadSafeAskQuestion(std::string strCaption, std::string Body)
-{
-    if(!guiref) return false;
-    bool result = false;
-    QMetaObject::invokeMethod(guiref, "askQuestion", GUIUtil::blockingGUIThreadConnection(),
-                               Q_ARG(std::string, strCaption), Q_ARG(std::string, Body),
-                               Q_ARG(bool*, &result));
-    return result;
-}
-
-
-
-
 static void ThreadSafeHandleURI(const std::string& strURI)
 {
     if(!guiref)
@@ -630,7 +617,6 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
     // Subscribe to global signals from core
     uiInterface.ThreadSafeMessageBox_connect(ThreadSafeMessageBox);
     uiInterface.ThreadSafeAskFee_connect(ThreadSafeAskFee);
-    uiInterface.ThreadSafeAskQuestion_connect(ThreadSafeAskQuestion);
 
     uiInterface.ThreadSafeHandleURI_connect(ThreadSafeHandleURI);
     uiInterface.InitMessage_connect(InitMessage);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -46,7 +46,6 @@
 #include "init.h"
 #include "main.h"
 #include "clicklabel.h"
-#include "univalue.h"
 #include "upgradeqt.h"
 #include "voting/votingmodel.h"
 #include "voting/polltablemodel.h"
@@ -91,9 +90,6 @@
 
 #include <boost/lexical_cast.hpp>
 
-#include "rpc/server.h"
-#include "rpc/client.h"
-#include "rpc/protocol.h"
 #include "gridcoin/backup.h"
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/superblock.h"
@@ -118,7 +114,6 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
         , rpcConsole(nullptr)
         , m_sync_overlay(nullptr)
         , m_in_sync(false)
-        , nWeight(0)
 {
     QSettings settings;
 
@@ -1317,16 +1312,6 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
 }
 
 
-void BitcoinGUI::askQuestion(std::string caption, std::string body, bool *result)
-{
-
-        QString qsCaption = tr(caption.c_str());
-        QString qsBody = tr(body.c_str());
-        QMessageBox::StandardButton retval = QMessageBox::question(this, qsCaption, qsBody, QMessageBox::Yes|QMessageBox::Cancel,   QMessageBox::Cancel);
-        *result = (retval == QMessageBox::Yes);
-
-}
-
 void BitcoinGUI::askFee(qint64 nFeeRequired, bool *payFee)
 {
     QString strMessage =
@@ -1898,22 +1883,6 @@ void BitcoinGUI::showNormalIfMinimized(bool fToggleHidden)
     }
     else if(fToggleHidden)
         hide();
-}
-
-void BitcoinGUI::updateWeight()
-{
-    if (!pwalletMain)
-        return;
-
-    TRY_LOCK(cs_main, lockMain);
-    if (!lockMain)
-        return;
-
-    TRY_LOCK(pwalletMain->cs_wallet, lockWallet);
-    if (!lockWallet)
-        return;
-
-    nWeight = GRC::GetStakeWeight(*pwalletMain);
 }
 
 QString BitcoinGUI::GetEstimatedStakingFrequency(unsigned int nEstimateTime)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -202,8 +202,6 @@ private:
 
     QMovie *syncIconMovie;
 
-    uint64_t nWeight;
-
 #ifdef Q_OS_MAC
     CAppNapInhibitor* m_app_nap_inhibitor = nullptr;
     MacDockShutdownHandler* m_dock_shutdown_handler = nullptr;
@@ -256,8 +254,6 @@ public slots:
       @param[out] payFee            true to pay the fee, false to not pay the fee
     */
     void askFee(qint64 nFeeRequired, bool *payFee);
-
-    void askQuestion(std::string caption, std::string body, bool *result);
 
     void handleURI(QString strURI);
     void setOptionsStyleSheet(QString qssFileName);
@@ -335,7 +331,6 @@ private slots:
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */
     void showNormalIfMinimized(bool fToggleHidden = false);
 
-    void updateWeight();
     void updateStakingIcon(bool staking, double net_weight, double coin_weight, double etts_days);
     void updateScraperIcon(int scraperEventtype, int status);
     void updateBeaconIcon();

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -15,7 +15,6 @@ class BanTableModel;
 class PeerTableModel;
 
 struct ConvergedScraperStats;
-class CWallet;
 
 QT_BEGIN_NAMESPACE
 class QDateTime;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -1,10 +1,10 @@
 #include "coincontroldialog.h"
 #include "ui_coincontroldialog.h"
 
-#include "init.h"
 #include "bitcoinunits.h"
 #include "addresstablemodel.h"
 #include "optionsmodel.h"
+#include "wallet/wallet.h"
 #include "policy/policy.h"
 #include "policy/fees.h"
 #include "validation.h"

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -2,10 +2,10 @@
 #include "consolidateunspentwizardselectinputspage.h"
 #include "ui_consolidateunspentwizardselectinputspage.h"
 
-#include "init.h"
 #include "bitcoinunits.h"
 #include "addresstablemodel.h"
 #include "optionsmodel.h"
+#include "wallet/wallet.h"
 #include "policy/policy.h"
 #include "policy/fees.h"
 #include "validation.h"

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -10,8 +10,6 @@
 #include <numeric>
 #include <type_traits>
 
-extern std::atomic<int64_t> g_nTimeBestReceived;
-
 DiagnosticsDialog::DiagnosticsDialog(QWidget *parent, ResearcherModel* researcher_model) :
     QDialog(parent),
     ui(new Ui::DiagnosticsDialog),

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -3,7 +3,8 @@
 #include "walletmodel.h"
 #include "bitcoinunits.h"
 #include "util.h"
-#include "init.h"
+#include "protocol.h"
+#include "clientversion.h"
 #include <codecvt>
 
 #include <QString>

--- a/src/qt/mrcrequestpage.cpp
+++ b/src/qt/mrcrequestpage.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "main.h"
 #include "qspinbox.h"
-#include "sync.h"
 #include "mrcrequestpage.h"
 #include "forms/ui_mrcrequestpage.h"
 #include "walletmodel.h"

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -7,7 +7,6 @@
 #include "monitoreddatamapper.h"
 #include "optionsmodel.h"
 #include "qt/decoration.h"
-#include "init.h"
 #include "miner.h"
 #include "sidestaketablemodel.h"
 #include "editsidestakedialog.h"

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -9,7 +9,6 @@
 #include "init.h"
 
 #include "miner.h"
-#include "wallet/walletdb.h"
 
 OptionsModel::OptionsModel(QObject *parent) :
     QAbstractListModel(parent)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -6,7 +6,6 @@
 
 #ifndef Q_MOC_RUN
 #include "qt/decoration.h"
-#include "main.h"
 #endif
 #include "researcher/researchermodel.h"
 #include "mrcmodel.h"
@@ -19,7 +18,6 @@
 #include "uint256.h"
 #include "guiutil.h"
 #include "guiconstants.h"
-#include "gridcoin/voting/fwd.h"
 
 #include <functional>
 

--- a/src/qt/receivecoinspage.h
+++ b/src/qt/receivecoinspage.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_QT_RECEIVECOINSPAGE_H
 #define BITCOIN_QT_RECEIVECOINSPAGE_H
 
-#include "walletmodel.h"
-
 #include <QWidget>
 
 namespace Ui {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -9,7 +9,6 @@
 #include "rpc/client.h"
 #include "rpc/protocol.h"
 #include "guiutil.h"
-#include "main.h"
 #endif
 
 #include <stdexcept>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -1,7 +1,6 @@
 #include "sendcoinsdialog.h"
 #include "ui_sendcoinsdialog.h"
 
-#include "init.h"
 #include "addresstablemodel.h"
 #include "addressbookpage.h"
 
@@ -12,7 +11,6 @@
 #include "askpassphrasedialog.h"
 
 #include "wallet/coincontrol.h"
-#include "policy/policy.h"
 #include "coincontroldialog.h"
 #include "consolidateunspentdialog.h"
 #include "consolidateunspentwizard.h"

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -1,17 +1,14 @@
 #include "transactiondesc.h"
-#include "clientmodel.h"
 #include "guiutil.h"
 #include "bitcoinunits.h"
 #include "main.h"
 #include "wallet/wallet.h"
 #include "txdb.h"
-#include "node/ui_interface.h"
 #ifdef GetMessage
 #undef GetMessage
 #endif
 #include "gridcoin/tx_message.h"
 #include <key_io.h>
-#include "bitcoingui.h"
 #include "util.h"
 
 #include <QInputDialog>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -6,9 +6,6 @@
 #include "optionsmodel.h"
 #include "addresstablemodel.h"
 #include "bitcoinunits.h"
-#include "main.h"
-#include "wallet/wallet.h"
-#include "node/ui_interface.h"
 #include "util.h"
 
 #include <QLocale>

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -27,9 +27,6 @@
 using namespace GRC;
 using LogFlags = BCLog::LogFlags;
 
-extern CCriticalSection cs_main;
-extern int nBestHeight;
-
 namespace {
 //!
 //! \brief Model callback bound to the \c NewPollReceived core signal.

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -16,8 +16,6 @@
 #include <QSet>
 #include <QTimer>
 
-void qtInsertConfirm(double dAmt, std::string sFrom, std::string sTo, std::string txid);
-
 WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* parent)
          : QObject(parent)
          , wallet(wallet)


### PR DESCRIPTION
## Summary

First checklist item of the multiprocess Phase 1 tracking issue (#3153; design of record `doc/multiprocess_design.md`, #3152): shrink the `src/qt` → core coupling baseline before the `interfaces::` scaffold and the include-lint ratchet land, so the ratchet's initial allowlist contains only real work, not noise.

Pure cleanup — 4 insertions, 84 deletions across 21 files, no behavior change:

- **`ThreadSafeAskQuestion` removed end-to-end** (UI signal, boost wrapper, Qt handler, `BitcoinGUI::askQuestion` slot). The signal had zero emit sites in the tree; headless it could only ever return `value_or(false)`.
- **`BitcoinGUI::updateWeight()` + the write-only `nWeight` member removed.** The slot had no callers (verified including string-based `SLOT()`/`invokeMethod` references and `forms/*.ui`) and took `TRY_LOCK(cs_main)`/`TRY_LOCK(cs_wallet)` to compute a value nothing read.
- **Phantom `qtInsertConfirm` forward declaration removed** (no definition or caller anywhere).
- **Hand-rolled `extern` re-declarations removed** where they bypassed the headers: `cs_main`/`nBestHeight` in `votingmodel.cpp` (both already come from `main.h`; the local `nBestHeight` extern also lacked `GUARDED_BY(cs_main)`, so this strictly improves thread-safety analysis) and `g_nTimeBestReceived` in `diagnosticsdialog.cpp` (unused in the file).
- **Vestigial core includes dropped from 14 GUI translation units** (`main.h`, `wallet/wallet.h`, `node/ui_interface.h`, `init.h`, `policy/policy.h`, `wallet/walletdb.h`, `rpc/{server,client,protocol}.h`, `univalue.h`), plus the unused `class CWallet;` forward declaration in `clientmodel.h` and the unused `walletmodel.h` include in `receivecoinspage.h`.
- Where a file used symbols only reachable *transitively* through a removed include, the dependency is now direct and minimal: `wallet/wallet.h` for the `COutput` users (`coincontroldialog.cpp`, `consolidateunspentwizardselectinputspage.cpp`) and `protocol.h` + `clientversion.h` for `guiutil.cpp` — a strict decoupling improvement over pulling them in via `init.h`.

## Verification

- Native Qt6 `RelWithDebInfo` build clean; `test_gridcoin` passes; the functional suite passes.
- Adversarial review pass over the diff before opening: tree-wide dangling-reference search for every removed symbol (including string-based Qt meta-object references and `.ui` files); every `#ifdef` region (`WIN32`, `Q_OS_MAC`, `Q_OS_WIN`, `QT_VERSION`, `USE_UPNP`, `Q_MOC_RUN`) in the touched files audited for symbols provided by removed headers; header-removal ripple checked against every includer of `clientmodel.h` and `receivecoinspage.h`. The review is what caught the three transitive-include breaks now fixed with direct includes.

Refs #3153, #3152, discussion #2937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)