### PR TITLE
gui: scaffold the interfaces:: abstraction layer (multiprocess Phase 1a)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(gridcoin_util STATIC
     gridcoin/voting/vote.cpp
     hash.cpp
     init.cpp
+    interfaces/handler.cpp
     key.cpp
     key_io.cpp
     keystore.cpp
@@ -187,6 +188,7 @@ add_library(gridcoin_util STATIC
     node/blockstorage.cpp
     node/chainman.cpp
     node/coherence.cpp
+    node/interfaces.cpp
     node/mempool_persist.cpp
     node/orphan_blocks.cpp
     node/psgt_pool.cpp
@@ -243,6 +245,7 @@ add_library(gridcoin_util STATIC
     validationinterface.cpp
     wallet/db.cpp
     wallet/diagnose.cpp
+    wallet/interfaces.cpp
     wallet/rpcdump.cpp
     wallet/rpcwallet.cpp
     wallet/wallet.cpp

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -1,0 +1,41 @@
+# interfaces
+
+Pure-virtual interfaces that define the boundary between the GUI and the node,
+introduced by the multiprocess program (design of record:
+`doc/multiprocess_design.md`; RFC discussion #2937).
+
+In the monolithic build the implementations are thin in-process wrappers over
+the existing globals and registries (`src/node/interfaces.cpp`,
+`src/wallet/interfaces.cpp`, later `src/gridcoin/interfaces.cpp`). In the
+Stage 2 multiprocess build the same headers are backed by generated IPC
+proxies instead — consumers do not change.
+
+Current set:
+
+- `handler.h` — `Handler`: RAII handle for a registered notification;
+  `MakeSignalHandler` adapts a `boost::signals2::connection`.
+- `node.h` — `Node`: chain/network state queries and node-side notification
+  registration for the GUI's client model.
+- `wallet.h` — `Wallet`: wallet queries and wallet notification registration.
+- `init.h` — `Init`: per-process bootstrap; hands out the other interfaces.
+
+The surface grows sub-phase by sub-phase (see `doc/multiprocess_design.md` §7);
+methods are added when a consumer migrates onto them, not speculatively.
+
+## Rules
+
+1. **Only value types cross the boundary.** No `CBlockIndex*`, `CWalletTx&`,
+   registry pointers, or references to global caches in any interface
+   signature. If a method wants to return a struct, the struct is a plain
+   value type.
+2. **Notification callbacks must never take `cs_main`** (nor call interface
+   methods that do). Gridcoin's core signals are emitted synchronously, often
+   while the emitter holds `cs_main` or another core lock; a callback that
+   re-enters core under those locks deadlocks the split build and silently
+   serializes the monolithic one. Callbacks enqueue and return.
+3. **`src/qt` may include only `src/interfaces/*.h`** (and Qt/GUI-local
+   headers) once its migration completes. `test/lint/lint-qt-includes.sh`
+   enforces this as a ratchet: the allowlist of existing offenders only
+   shrinks. Interface headers themselves may include core headers during
+   Phase 1; the Stage 2 schema generation is the final arbiter of
+   marshalability.

--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/handler.h"
+
+#include <boost/signals2/connection.hpp>
+
+#include <utility>
+
+namespace interfaces {
+namespace {
+
+class SignalHandler : public Handler
+{
+public:
+    explicit SignalHandler(boost::signals2::connection connection)
+        : m_connection(std::move(connection))
+    {
+    }
+
+    void disconnect() override { m_connection.disconnect(); }
+
+    boost::signals2::scoped_connection m_connection;
+};
+
+class CleanupHandler : public Handler
+{
+public:
+    explicit CleanupHandler(std::function<void()> cleanup)
+        : m_cleanup(std::move(cleanup))
+    {
+    }
+
+    ~CleanupHandler() override
+    {
+        if (m_cleanup) {
+            m_cleanup();
+        }
+    }
+
+    void disconnect() override
+    {
+        if (m_cleanup) {
+            m_cleanup();
+            m_cleanup = nullptr;
+        }
+    }
+
+    std::function<void()> m_cleanup;
+};
+
+} // namespace
+
+std::unique_ptr<Handler> MakeSignalHandler(boost::signals2::connection connection)
+{
+    return std::make_unique<SignalHandler>(std::move(connection));
+}
+
+std::unique_ptr<Handler> MakeCleanupHandler(std::function<void()> cleanup)
+{
+    return std::make_unique<CleanupHandler>(std::move(cleanup));
+}
+
+} // namespace interfaces

--- a/src/interfaces/handler.h
+++ b/src/interfaces/handler.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_HANDLER_H
+#define GRIDCOIN_INTERFACES_HANDLER_H
+
+#include <functional>
+#include <memory>
+
+namespace boost {
+namespace signals2 {
+class connection;
+} // namespace signals2
+} // namespace boost
+
+namespace interfaces {
+
+//! Generic interface for managing an event handler or callback function
+//! registered with another interface. Has a single disconnect method to cancel
+//! the registration and prevent any future notifications. Destroying the
+//! Handler also disconnects.
+class Handler
+{
+public:
+    virtual ~Handler() = default;
+
+    //! Disconnect the handler.
+    virtual void disconnect() = 0;
+};
+
+//! Return a Handler wrapping a boost::signals2 connection.
+std::unique_ptr<Handler> MakeSignalHandler(boost::signals2::connection connection);
+
+//! Return a Handler that runs a cleanup function on disconnect/destruction.
+std::unique_ptr<Handler> MakeCleanupHandler(std::function<void()> cleanup);
+
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_HANDLER_H

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_INIT_H
+#define GRIDCOIN_INTERFACES_INIT_H
+
+#include <memory>
+
+namespace interfaces {
+
+class Node;
+class Wallet;
+
+//! Per-process bootstrap interface: hands out the other interfaces. In the
+//! monolithic build MakeGridcoinInit() returns an implementation whose
+//! factories construct the in-process wrappers; in the Stage 2 multiprocess
+//! build the GUI process receives an Init proxy whose factories return IPC
+//! proxies instead (after the authentication and matching handshake described
+//! in doc/multiprocess_design.md).
+//!
+//! The default implementations return nullptr so each process type overrides
+//! only what it supports.
+class Init
+{
+public:
+    virtual ~Init() = default;
+
+    virtual std::unique_ptr<Node> makeNode() { return nullptr; }
+
+    //! Returns the interface for the node's single wallet. May return nullptr
+    //! before wallet startup completes.
+    virtual std::unique_ptr<Wallet> makeWallet() { return nullptr; }
+};
+
+//! Return the monolithic-build Init implementation.
+std::unique_ptr<Init> MakeGridcoinInit();
+
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_INIT_H

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_NODE_H
+#define GRIDCOIN_INTERFACES_NODE_H
+
+#include "interfaces/handler.h"
+// For ChangeType; scrapereventtypes is forward-declared there. TODO(Stage 2):
+// extract ChangeType into a standalone header (upstream: util/ui_change_type.h)
+// so interface headers stop pulling the signal hub transitively.
+#include "node/ui_interface.h"
+#include "uint256.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace interfaces {
+
+//! Top-level node interface for the GUI: chain and network state queries plus
+//! notification registration. In the monolithic build the implementation
+//! wraps the existing globals directly (see src/node/interfaces.cpp); in the
+//! Stage 2 multiprocess build the same interface is served over IPC.
+//!
+//! Rules (see src/interfaces/README.md):
+//! - only value types cross this boundary;
+//! - notification callbacks run on the emitting core thread, frequently while
+//!   the emitter holds core locks -- callbacks must enqueue and return, and
+//!   must never take cs_main or re-enter interface methods that do.
+//!
+//! The method set intentionally covers only what the migrated consumers need
+//! (Phase 1b starts with ClientModel); it grows with each migration.
+class Node
+{
+public:
+    virtual ~Node() = default;
+
+    //! Number of connected peers.
+    virtual int getNodeCount() = 0;
+
+    //! Total bytes received / sent across all peers since startup.
+    virtual uint64_t getTotalBytesRecv() = 0;
+    virtual uint64_t getTotalBytesSent() = 0;
+
+    //! Height of the best chain.
+    virtual int getNumBlocks() = 0;
+
+    //! Hash of the best chain tip.
+    virtual uint256 getBestBlockHash() = 0;
+
+    //! Timestamp of the best chain tip.
+    virtual int64_t getLastBlockTime() = 0;
+
+    //! Median best-chain height reported by connected peers, or the hardened
+    //! checkpoint height, whichever is greater.
+    virtual int getNumBlocksOfPeers() = 0;
+
+    //! Proof-of-stake difficulty of the chain tip.
+    virtual double getDifficulty() = 0;
+
+    //! Whether the node considers itself in initial block download.
+    virtual bool isInitialBlockDownload() = 0;
+
+    //! Whether the chain tip is stale relative to adjusted time.
+    virtual bool isOutOfSyncByAge() = 0;
+
+    //! Status-bar warning string (empty when there is nothing to show).
+    virtual std::string getWarnings() = 0;
+
+    //! Client version string.
+    virtual std::string getClientVersion() = 0;
+
+    //! Whether the node runs on testnet.
+    virtual bool isTestNet() = 0;
+
+    //! Register a handler for block-tip changes.
+    using NotifyBlocksChangedFn =
+        std::function<void(bool syncing, int height, int64_t best_time, uint32_t target_bits)>;
+    virtual std::unique_ptr<Handler> handleNotifyBlocksChanged(NotifyBlocksChangedFn fn) = 0;
+
+    //! Register a handler for peer-connection-count changes.
+    using NotifyNumConnectionsChangedFn = std::function<void(int num_connections)>;
+    virtual std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) = 0;
+
+    //! Register a handler for ban-list changes.
+    using BannedListChangedFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleBannedListChanged(BannedListChangedFn fn) = 0;
+
+    //! Register a handler for alert changes. The hash is a key; consumers
+    //! refetch the alert body through query methods.
+    using NotifyAlertChangedFn = std::function<void(const uint256& hash, ChangeType status)>;
+    virtual std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) = 0;
+
+    //! Register a handler for staking-status changes.
+    using MinerStatusChangedFn = std::function<void(bool staking, double coin_weight)>;
+    virtual std::unique_ptr<Handler> handleMinerStatusChanged(MinerStatusChangedFn fn) = 0;
+
+    //! Register a handler for PSGT pool changes. The revision hash is a key;
+    //! reason carries a PSGTRemovalReason as int on CT_DELETED, else -1.
+    using PSGTPoolChangedFn =
+        std::function<void(const uint256& revision_hash, ChangeType status, int reason)>;
+    virtual std::unique_ptr<Handler> handlePSGTPoolChanged(PSGTPoolChangedFn fn) = 0;
+
+    //! Register a handler for scraper events.
+    using NotifyScraperEventFn =
+        std::function<void(const scrapereventtypes& event_type, ChangeType status, const std::string& message)>;
+    virtual std::unique_ptr<Handler> handleNotifyScraperEvent(NotifyScraperEventFn fn) = 0;
+};
+
+//! Return an in-process Node interface implementation.
+std::unique_ptr<Node> MakeNode();
+
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_NODE_H

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -21,8 +21,12 @@ namespace interfaces {
 //! Wallet interface for the GUI: wallet queries plus notification
 //! registration. The same boundary rules as interfaces::Node apply (see
 //! src/interfaces/README.md); notification callbacks are bridged from
-//! CWallet's own signals, which fire on core threads under core locks --
-//! callbacks enqueue and return.
+//! CWallet's own signals, which fire on core threads and, depending on the
+//! signal, may or may not hold core locks at emission time (e.g.
+//! NotifyTransactionChanged fires with cs_wallet held while
+//! NotifyAddressBookChanged deliberately does not). Callbacks must not
+//! assume either way: enqueue and return, and never take core locks or
+//! re-enter interface methods that do.
 //!
 //! The method set covers only what the migrated consumers need (Phase 1c-i
 //! starts with WalletModel's balance/encryption surface); it grows with each

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_WALLET_H
+#define GRIDCOIN_INTERFACES_WALLET_H
+
+#include "interfaces/handler.h"
+#include "node/ui_interface.h" // For ChangeType.
+#include "uint256.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+class CWallet;
+
+namespace interfaces {
+
+//! Wallet interface for the GUI: wallet queries plus notification
+//! registration. The same boundary rules as interfaces::Node apply (see
+//! src/interfaces/README.md); notification callbacks are bridged from
+//! CWallet's own signals, which fire on core threads under core locks --
+//! callbacks enqueue and return.
+//!
+//! The method set covers only what the migrated consumers need (Phase 1c-i
+//! starts with WalletModel's balance/encryption surface); it grows with each
+//! migration. The wallet stays in-node in every build configuration, so this
+//! interface never carries key material.
+class Wallet
+{
+public:
+    virtual ~Wallet() = default;
+
+    //! Spendable balance.
+    virtual int64_t getBalance() = 0;
+
+    //! Balance currently staking (in coinstakes awaiting maturity).
+    virtual int64_t getStake() = 0;
+
+    //! Unconfirmed balance.
+    virtual int64_t getUnconfirmedBalance() = 0;
+
+    //! Immature (newly generated) balance.
+    virtual int64_t getImmatureBalance() = 0;
+
+    //! Whether the wallet is encrypted.
+    virtual bool isCrypted() = 0;
+
+    //! Whether the wallet is locked.
+    virtual bool isLocked() = 0;
+
+    //! Whether an unlocked wallet is restricted to staking only.
+    virtual bool isUnlockedForStakingOnly() = 0;
+
+    //! Register a handler for encryption/lock status changes.
+    using StatusChangedFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) = 0;
+
+    //! Register a handler for address-book changes.
+    using AddressBookChangedFn = std::function<void(const std::string& address,
+                                                    const std::string& label,
+                                                    bool is_mine,
+                                                    const std::string& purpose,
+                                                    ChangeType status)>;
+    virtual std::unique_ptr<Handler> handleAddressBookChanged(AddressBookChangedFn fn) = 0;
+
+    //! Register a handler for wallet-transaction changes.
+    using TransactionChangedFn = std::function<void(const uint256& tx_hash, ChangeType status)>;
+    virtual std::unique_ptr<Handler> handleTransactionChanged(TransactionChangedFn fn) = 0;
+};
+
+//! Return an in-process Wallet interface implementation wrapping the given
+//! wallet, which must outlive the returned object.
+std::unique_ptr<Wallet> MakeWallet(CWallet* wallet);
+
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_WALLET_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/node.h"
+
+#include "alert.h"
+#include "clientversion.h"
+#include "gridcoin/staking/difficulty.h"
+#include "init.h"
+#include "interfaces/handler.h"
+#include "interfaces/init.h"
+#include "interfaces/wallet.h"
+#include "main.h"
+#include "net.h"
+#include "node/ui_interface.h"
+#include "sync.h"
+#include "util.h"
+
+#include <memory>
+#include <utility>
+
+namespace interfaces {
+namespace {
+
+//! In-process Node implementation: thin wrappers over the existing globals.
+//! Methods that read cs_main-guarded chain state take the lock themselves, so
+//! callers never hold core locks (and per the boundary rules, must not).
+class NodeImpl : public Node
+{
+public:
+    int getNodeCount() override
+    {
+        return g_connman ? static_cast<int>(g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL)) : 0;
+    }
+
+    uint64_t getTotalBytesRecv() override { return CNode::GetTotalBytesRecv(); }
+
+    uint64_t getTotalBytesSent() override { return CNode::GetTotalBytesSent(); }
+
+    int getNumBlocks() override
+    {
+        LOCK(cs_main);
+        return nBestHeight;
+    }
+
+    uint256 getBestBlockHash() override
+    {
+        LOCK(cs_main);
+        return hashBestChain;
+    }
+
+    int64_t getLastBlockTime() override
+    {
+        LOCK(cs_main);
+        return pindexBest ? pindexBest->GetBlockTime() : 0;
+    }
+
+    int getNumBlocksOfPeers() override { return GetNumBlocksOfPeers(); }
+
+    double getDifficulty() override
+    {
+        LOCK(cs_main);
+        return GRC::GetCurrentDifficulty();
+    }
+
+    bool isInitialBlockDownload() override { return IsInitialBlockDownload(); }
+
+    bool isOutOfSyncByAge() override { return OutOfSyncByAge(); }
+
+    std::string getWarnings() override { return GetWarnings("statusbar"); }
+
+    std::string getClientVersion() override { return FormatFullVersion(); }
+
+    bool isTestNet() override { return fTestNet; }
+
+    std::unique_ptr<Handler> handleNotifyBlocksChanged(NotifyBlocksChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.NotifyBlocksChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.NotifyNumConnectionsChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleBannedListChanged(BannedListChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.BannedListChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.NotifyAlertChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleMinerStatusChanged(MinerStatusChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.MinerStatusChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handlePSGTPoolChanged(PSGTPoolChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.PSGTPoolChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleNotifyScraperEvent(NotifyScraperEventFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.NotifyScraperEvent_connect(std::move(fn)));
+    }
+};
+
+//! Monolithic-build bootstrap: the factories construct the in-process
+//! wrappers around this process's node and wallet.
+class InitImpl : public Init
+{
+public:
+    std::unique_ptr<Node> makeNode() override { return MakeNode(); }
+
+    std::unique_ptr<Wallet> makeWallet() override
+    {
+        return pwalletMain ? MakeWallet(pwalletMain) : nullptr;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<Node> MakeNode()
+{
+    return std::make_unique<NodeImpl>();
+}
+
+std::unique_ptr<Init> MakeGridcoinInit()
+{
+    return std::make_unique<InitImpl>();
+}
+
+} // namespace interfaces

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(test_gridcoin
     gridcoin/scraper_registry_tests.cpp
     gridcoin/sidestake_tests.cpp
     gridcoin/superblock_tests.cpp
+    interfaces_tests.cpp
     key_tests.cpp
     merkle_tests.cpp
     merkleblock_tests.cpp

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "chain.h"
+#include "clientversion.h"
+#include "interfaces/handler.h"
+#include "interfaces/init.h"
+#include "interfaces/node.h"
+#include "interfaces/wallet.h"
+#include "node/ui_interface.h"
+#include "sync.h"
+#include "util.h"
+#include "wallet/wallet.h"
+
+#include <boost/signals2/signal.hpp>
+#include <boost/test/unit_test.hpp>
+
+extern CWallet* pwalletMain;
+
+BOOST_AUTO_TEST_SUITE(interfaces_tests)
+
+BOOST_AUTO_TEST_CASE(signal_handler_disconnects)
+{
+    boost::signals2::signal<void()> sig;
+    int calls = 0;
+
+    std::unique_ptr<interfaces::Handler> handler =
+        interfaces::MakeSignalHandler(sig.connect([&] { ++calls; }));
+
+    sig();
+    BOOST_CHECK_EQUAL(calls, 1);
+
+    handler->disconnect();
+    sig();
+    BOOST_CHECK_EQUAL(calls, 1);
+}
+
+BOOST_AUTO_TEST_CASE(signal_handler_disconnects_on_destruction)
+{
+    boost::signals2::signal<void()> sig;
+    int calls = 0;
+
+    {
+        std::unique_ptr<interfaces::Handler> handler =
+            interfaces::MakeSignalHandler(sig.connect([&] { ++calls; }));
+        sig();
+    }
+
+    sig();
+    BOOST_CHECK_EQUAL(calls, 1);
+}
+
+BOOST_AUTO_TEST_CASE(cleanup_handler_runs_exactly_once)
+{
+    int cleanups = 0;
+
+    {
+        std::unique_ptr<interfaces::Handler> handler =
+            interfaces::MakeCleanupHandler([&] { ++cleanups; });
+        handler->disconnect();
+        BOOST_CHECK_EQUAL(cleanups, 1);
+        // Destruction after an explicit disconnect must not run it again.
+    }
+
+    BOOST_CHECK_EQUAL(cleanups, 1);
+}
+
+BOOST_AUTO_TEST_CASE(cleanup_handler_runs_on_destruction)
+{
+    int cleanups = 0;
+
+    {
+        std::unique_ptr<interfaces::Handler> handler =
+            interfaces::MakeCleanupHandler([&] { ++cleanups; });
+        // No explicit disconnect: destruction alone must run the cleanup.
+    }
+
+    BOOST_CHECK_EQUAL(cleanups, 1);
+}
+
+BOOST_AUTO_TEST_CASE(node_wraps_chain_globals)
+{
+    std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
+
+    BOOST_CHECK_EQUAL(node->getNumBlocks(), WITH_LOCK(cs_main, return nBestHeight));
+    BOOST_CHECK(node->getBestBlockHash() == WITH_LOCK(cs_main, return hashBestChain));
+    BOOST_CHECK_EQUAL(node->isTestNet(), fTestNet);
+    BOOST_CHECK_EQUAL(node->getClientVersion(), FormatFullVersion());
+    // No peers in the unit-test environment.
+    BOOST_CHECK_EQUAL(node->getNodeCount(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(node_handler_bridges_ui_signal)
+{
+    std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
+    int calls = 0;
+
+    std::unique_ptr<interfaces::Handler> handler =
+        node->handleBannedListChanged([&] { ++calls; });
+
+    uiInterface.BannedListChanged();
+    BOOST_CHECK_EQUAL(calls, 1);
+
+    handler->disconnect();
+    uiInterface.BannedListChanged();
+    BOOST_CHECK_EQUAL(calls, 1);
+}
+
+BOOST_AUTO_TEST_CASE(wallet_wraps_cwallet)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    std::unique_ptr<interfaces::Wallet> wallet = interfaces::MakeWallet(pwalletMain);
+
+    BOOST_CHECK_EQUAL(wallet->getBalance(), pwalletMain->GetBalance());
+    BOOST_CHECK_EQUAL(wallet->isCrypted(), pwalletMain->IsCrypted());
+    BOOST_CHECK_EQUAL(wallet->isLocked(), pwalletMain->IsLocked());
+
+    int calls = 0;
+    uint256 seen_hash;
+    std::unique_ptr<interfaces::Handler> handler = wallet->handleTransactionChanged(
+        [&](const uint256& tx_hash, ChangeType status) {
+            ++calls;
+            seen_hash = tx_hash;
+            BOOST_CHECK(status == CT_NEW);
+        });
+
+    const uint256 probe = uint256S("0xdeadbeef");
+    pwalletMain->NotifyTransactionChanged(pwalletMain, probe, CT_NEW);
+    BOOST_CHECK_EQUAL(calls, 1);
+    BOOST_CHECK(seen_hash == probe);
+
+    handler->disconnect();
+    pwalletMain->NotifyTransactionChanged(pwalletMain, probe, CT_NEW);
+    BOOST_CHECK_EQUAL(calls, 1);
+}
+
+BOOST_AUTO_TEST_CASE(init_hands_out_interfaces)
+{
+    std::unique_ptr<interfaces::Init> init = interfaces::MakeGridcoinInit();
+
+    BOOST_REQUIRE(init != nullptr);
+    BOOST_CHECK(init->makeNode() != nullptr);
+    // pwalletMain exists in the unit-test environment, so the monolithic
+    // Init must hand out a wallet interface for it.
+    BOOST_CHECK(init->makeWallet() != nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/wallet.h"
+
+#include "interfaces/handler.h"
+#include "key_io.h"
+#include "wallet/wallet.h"
+
+#include <memory>
+#include <utility>
+
+namespace interfaces {
+namespace {
+
+//! In-process Wallet implementation: thin wrappers over CWallet. Balance
+//! queries lock internally (CWallet takes LOCK2(cs_main, cs_wallet) itself),
+//! so callers never hold core locks. Signal bridges convert the wallet's own
+//! signal payloads to value types before they cross the boundary.
+class WalletImpl : public Wallet
+{
+public:
+    explicit WalletImpl(CWallet* wallet) : m_wallet(wallet) {}
+
+    int64_t getBalance() override { return m_wallet->GetBalance(); }
+
+    int64_t getStake() override { return m_wallet->GetStake(); }
+
+    int64_t getUnconfirmedBalance() override { return m_wallet->GetUnconfirmedBalance(); }
+
+    int64_t getImmatureBalance() override { return m_wallet->GetImmatureBalance(); }
+
+    bool isCrypted() override { return m_wallet->IsCrypted(); }
+
+    bool isLocked() override { return m_wallet->IsLocked(); }
+
+    bool isUnlockedForStakingOnly() override
+    {
+        return !m_wallet->IsLocked() && fWalletUnlockStakingOnly;
+    }
+
+    std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) override
+    {
+        return MakeSignalHandler(m_wallet->NotifyStatusChanged.connect(
+            [fn = std::move(fn)](CCryptoKeyStore*) { fn(); }));
+    }
+
+    std::unique_ptr<Handler> handleAddressBookChanged(AddressBookChangedFn fn) override
+    {
+        return MakeSignalHandler(m_wallet->NotifyAddressBookChanged.connect(
+            [fn = std::move(fn)](CWallet*,
+                                 const CTxDestination& address,
+                                 const std::string& label,
+                                 bool is_mine,
+                                 const std::string& purpose,
+                                 ChangeType status) {
+                fn(EncodeDestination(address), label, is_mine, purpose, status);
+            }));
+    }
+
+    std::unique_ptr<Handler> handleTransactionChanged(TransactionChangedFn fn) override
+    {
+        return MakeSignalHandler(m_wallet->NotifyTransactionChanged.connect(
+            [fn = std::move(fn)](CWallet*, const uint256& tx_hash, ChangeType status) {
+                fn(tx_hash, status);
+            }));
+    }
+
+private:
+    CWallet* m_wallet;
+};
+
+} // namespace
+
+std::unique_ptr<Wallet> MakeWallet(CWallet* wallet)
+{
+    return std::make_unique<WalletImpl>(wallet);
+}
+
+} // namespace interfaces

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+#
+# Ratchet for the interfaces:: migration (doc/multiprocess_design.md §7):
+# src/qt must not grow NEW direct includes of core headers -- new GUI code
+# goes through src/interfaces/*.h instead. The allowlist below records the
+# offenders that existed when the ratchet was introduced; entries may only
+# ever be REMOVED (the lint fails on stale entries so the list shrinks as
+# Phase 1 migrates each file). Flipping this from ratchet to empty-allowlist
+# hard-fail is the gate to Phase 2.
+#
+# Known non-goals: relative-path evasions (../main.h) are not chased; code
+# review owns those.
+
+export LC_ALL=C
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|netbase\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|chainparams\.h|chainparamsbase\.h|protocol\.h|psgt\.h|sync\.h|util\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
+
+# file:header pairs present when the ratchet was introduced. DO NOT ADD
+# ENTRIES -- migrate the file onto src/interfaces/*.h instead.
+ALLOWLIST="\
+src/qt/aboutdialog.cpp:util.h
+src/qt/addresstablemodel.cpp:util.h
+src/qt/addresstablemodel.cpp:wallet/wallet.h
+src/qt/addresstablemodel.h:wallet/ismine.h
+src/qt/bantablemodel.cpp:net.h
+src/qt/bantablemodel.cpp:sync.h
+src/qt/bantablemodel.cpp:util.h
+src/qt/bantablemodel.h:banman.h
+src/qt/bantablemodel.h:net.h
+src/qt/bitcoin.cpp:chainparamsbase.h
+src/qt/bitcoin.cpp:chainparams.h
+src/qt/bitcoin.cpp:gridcoin/gridcoin.h
+src/qt/bitcoin.cpp:gridcoin/upgrade.h
+src/qt/bitcoin.cpp:init.h
+src/qt/bitcoin.cpp:node/ui_interface.h
+src/qt/bitcoin.cpp:policy/fees.h
+src/qt/bitcoin.cpp:txdb.h
+src/qt/bitcoin.cpp:util.h
+src/qt/bitcoin.cpp:validation.h
+src/qt/bitcoingui.cpp:gridcoin/backup.h
+src/qt/bitcoingui.cpp:gridcoin/staking/difficulty.h
+src/qt/bitcoingui.cpp:gridcoin/superblock.h
+src/qt/bitcoingui.cpp:init.h
+src/qt/bitcoingui.cpp:main.h
+src/qt/bitcoingui.cpp:node/psgt_pool.h
+src/qt/bitcoingui.cpp:script/standard.h
+src/qt/bitcoingui.cpp:util.h
+src/qt/bitcoingui.cpp:wallet/wallet.h
+src/qt/clientmodel.cpp:alert.h
+src/qt/clientmodel.cpp:gridcoin/scraper/fwd.h
+src/qt/clientmodel.cpp:gridcoin/staking/difficulty.h
+src/qt/clientmodel.cpp:gridcoin/staking/status.h
+src/qt/clientmodel.cpp:gridcoin/superblock.h
+src/qt/clientmodel.cpp:main.h
+src/qt/clientmodel.cpp:node/ui_interface.h
+src/qt/clientmodel.cpp:util.h
+src/qt/coincontroldialog.cpp:policy/fees.h
+src/qt/coincontroldialog.cpp:policy/policy.h
+src/qt/coincontroldialog.cpp:validation.h
+src/qt/coincontroldialog.cpp:wallet/coincontrol.h
+src/qt/coincontroldialog.cpp:wallet/wallet.h
+src/qt/consolidateunspentdialog.cpp:util.h
+src/qt/consolidateunspentwizard.cpp:util.h
+src/qt/consolidateunspentwizardselectdestinationpage.cpp:util.h
+src/qt/consolidateunspentwizardselectinputspage.cpp:policy/fees.h
+src/qt/consolidateunspentwizardselectinputspage.cpp:policy/policy.h
+src/qt/consolidateunspentwizardselectinputspage.cpp:validation.h
+src/qt/consolidateunspentwizardselectinputspage.cpp:wallet/coincontrol.h
+src/qt/consolidateunspentwizardselectinputspage.cpp:wallet/wallet.h
+src/qt/consolidateunspentwizardsendpage.cpp:util.h
+src/qt/detailedtxmodel.cpp:util/system.h
+src/qt/diagnosticsdialog.h:sync.h
+src/qt/diagnosticsdialog.h:wallet/diagnose.h
+src/qt/guiutil.cpp:protocol.h
+src/qt/guiutil.cpp:util.h
+src/qt/intro.cpp:chainparams.h
+src/qt/intro.cpp:util.h
+src/qt/mrcmodel.cpp:gridcoin/contract/contract.h
+src/qt/mrcmodel.cpp:gridcoin/contract/message.h
+src/qt/mrcmodel.cpp:main.h
+src/qt/mrcmodel.cpp:node/ui_interface.h
+src/qt/mrcmodel.cpp:wallet/wallet.h
+src/qt/mrcmodel.h:gridcoin/mrc.h
+src/qt/multisigndialog.cpp:chainparams.h
+src/qt/multisigndialog.cpp:main.h
+src/qt/multisigndialog.cpp:net_processing.h
+src/qt/multisigndialog.cpp:node/psgt_pool.h
+src/qt/multisigndialog.cpp:psgt.h
+src/qt/multisigndialog.cpp:script/interpreter.h
+src/qt/multisigndialog.cpp:script/standard.h
+src/qt/multisigndialog.cpp:sync.h
+src/qt/multisigndialog.cpp:util.h
+src/qt/multisigndialog.cpp:wallet/wallet.h
+src/qt/multisigndialog.h:psgt.h
+src/qt/optionsdialog.cpp:miner.h
+src/qt/optionsdialog.cpp:netbase.h
+src/qt/optionsmodel.cpp:init.h
+src/qt/optionsmodel.cpp:miner.h
+src/qt/peertablemodel.cpp:net.h
+src/qt/peertablemodel.cpp:sync.h
+src/qt/peertablemodel.h:net.h
+src/qt/psgtpoolpage.cpp:chainparams.h
+src/qt/psgtpoolpage.cpp:main.h
+src/qt/psgtpoolpage.cpp:node/psgt_pool.h
+src/qt/psgtpoolpage.cpp:sync.h
+src/qt/psgtpooltablemodel.cpp:node/psgt_pool.h
+src/qt/psgtpooltablemodel.cpp:psgt.h
+src/qt/psgtpooltablemodel.cpp:script/standard.h
+src/qt/psgtpooltablemodel.cpp:util.h
+src/qt/psgtpooltablemodel.cpp:wallet/wallet.h
+src/qt/psgtpooltablemodel.h:node/psgt_pool.h
+src/qt/qtipcserver.cpp:node/ui_interface.h
+src/qt/qtipcserver.cpp:util.h
+src/qt/researcher/projecttablemodel.cpp:gridcoin/researcher.h
+src/qt/researcher/researchermodel.cpp:chainparams.h
+src/qt/researcher/researchermodel.cpp:gridcoin/beacon.h
+src/qt/researcher/researchermodel.cpp:gridcoin/boinc.h
+src/qt/researcher/researchermodel.cpp:gridcoin/magnitude.h
+src/qt/researcher/researchermodel.cpp:gridcoin/project.h
+src/qt/researcher/researchermodel.cpp:gridcoin/quorum.h
+src/qt/researcher/researchermodel.cpp:gridcoin/researcher.h
+src/qt/researcher/researchermodel.cpp:gridcoin/scraper/scraper.h
+src/qt/researcher/researchermodel.cpp:gridcoin/superblock.h
+src/qt/researcher/researchermodel.cpp:gridcoin/support/xml.h
+src/qt/researcher/researchermodel.cpp:main.h
+src/qt/researcher/researchermodel.cpp:node/ui_interface.h
+src/qt/researcher/researcherwizardpoolpage.cpp:key.h
+src/qt/rpcconsole.cpp:rpc/client.h
+src/qt/rpcconsole.cpp:rpc/protocol.h
+src/qt/rpcconsole.cpp:rpc/server.h
+src/qt/rpcconsole.h:net.h
+src/qt/sendcoinsdialog.cpp:wallet/coincontrol.h
+src/qt/sidestaketablemodel.cpp:gridcoin/support/enumbytes.h
+src/qt/sidestaketablemodel.cpp:node/ui_interface.h
+src/qt/sidestaketablemodel.h:gridcoin/sidestake.h
+src/qt/signverifymessagedialog.cpp:init.h
+src/qt/signverifymessagedialog.cpp:main.h
+src/qt/signverifymessagedialog.cpp:wallet/wallet.h
+src/qt/transactiondesc.cpp:gridcoin/tx_message.h
+src/qt/transactiondesc.cpp:main.h
+src/qt/transactiondesc.cpp:txdb.h
+src/qt/transactiondesc.cpp:util.h
+src/qt/transactiondesc.cpp:wallet/wallet.h
+src/qt/transactiondesc.h:wallet/ismine.h
+src/qt/transactionrecord.cpp:wallet/wallet.h
+src/qt/transactionrecord.h:wallet/generated_type.h
+src/qt/transactionrecord.h:wallet/ismine.h
+src/qt/transactiontablemodel.cpp:util.h
+src/qt/transactionview.cpp:util/system.h
+src/qt/updatedialog.h:gridcoin/upgrade.h
+src/qt/upgradeqt.cpp:gridcoin/upgrade.h
+src/qt/upgradeqt.cpp:util.h
+src/qt/voting/polltab.h:gridcoin/voting/filter.h
+src/qt/voting/polltablemodel.cpp:util.h
+src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
+src/qt/voting/poll_types.cpp:gridcoin/voting/poll.h
+src/qt/voting/pollwizarddetailspage.cpp:main.h
+src/qt/voting/votingmodel.cpp:chainparams.h
+src/qt/voting/votingmodel.cpp:gridcoin/contract/contract.h
+src/qt/voting/votingmodel.cpp:gridcoin/project.h
+src/qt/voting/votingmodel.cpp:gridcoin/voting/builders.h
+src/qt/voting/votingmodel.cpp:gridcoin/voting/payloads.h
+src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
+src/qt/voting/votingmodel.cpp:gridcoin/voting/registry.h
+src/qt/voting/votingmodel.cpp:gridcoin/voting/result.h
+src/qt/voting/votingmodel.cpp:main.h
+src/qt/voting/votingmodel.cpp:node/ui_interface.h
+src/qt/voting/votingmodel.cpp:sync.h
+src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
+src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
+src/qt/voting/votingmodel.h:gridcoin/voting/result.h
+src/qt/walletmodel.cpp:gridcoin/tx_message.h
+src/qt/walletmodel.cpp:main.h
+src/qt/walletmodel.cpp:node/ui_interface.h
+src/qt/walletmodel.cpp:util.h
+src/qt/walletmodel.cpp:wallet/coincontrol.h
+src/qt/walletmodel.cpp:wallet/wallet.h
+src/qt/walletmodel.h:wallet/ismine.h
+src/qt/wallettxstore.cpp:main.h
+src/qt/wallettxstore.cpp:wallet/wallet.h
+src/qt/wallettxstore.h:sync.h
+src/qt/winshutdownmonitor.cpp:init.h
+src/qt/winshutdownmonitor.cpp:util.h
+"
+
+EXIT_CODE=0
+
+# git wildmatch '*' crosses '/' in ls-files pathspecs, so these two patterns
+# also cover the researcher/, voting/ and test/ subdirectories.
+CURRENT=$(git ls-files 'src/qt/*.cpp' 'src/qt/*.h' | sort -u | while read -r f; do
+    grep -E "$FORBIDDEN_RE" "$f" 2>/dev/null \
+        | sed -E 's/^[[:space:]]*#[[:space:]]*include[[:space:]]*["<]([^">]+)[">].*/\1/' \
+        | while read -r h; do
+            echo "$f:$h"
+        done
+done | sort -u)
+
+NEW_VIOLATIONS=$(comm -13 <(echo "$ALLOWLIST" | grep -v '^$' | sort -u) <(echo "$CURRENT" | grep -v '^$'))
+STALE_ENTRIES=$(comm -23 <(echo "$ALLOWLIST" | grep -v '^$' | sort -u) <(echo "$CURRENT" | grep -v '^$'))
+
+if [ -n "$NEW_VIOLATIONS" ]; then
+    echo "New direct core include(s) in src/qt (file:header):"
+    echo "$NEW_VIOLATIONS"
+    echo
+    echo "GUI code must consume core state through src/interfaces/*.h (see"
+    echo "src/interfaces/README.md and doc/multiprocess_design.md). Do not add"
+    echo "these includes to the allowlist in $(basename "${BASH_SOURCE[0]}")."
+    EXIT_CODE=1
+fi
+
+if [ -n "$STALE_ENTRIES" ]; then
+    echo "Stale allowlist entr(y/ies) in $(basename "${BASH_SOURCE[0]}") -- the include is gone; remove the entry so the ratchet tightens:"
+    echo "$STALE_ENTRIES"
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Phase 1a of the multiprocess program (#3153; design of record `doc/multiprocess_design.md`, #3152): the `src/interfaces/` pure-virtual boundary, in-process implementations wrapping the existing globals, and the include-lint ratchet that enforces the migration direction from this point on.

**The abstraction:**
- `interfaces::Handler` + `MakeSignalHandler`/`MakeCleanupHandler` — RAII notification registration over boost::signals2; formalizes the retained-`scoped_connection` pattern the Qt models adopted in #3129/#3138.
- `interfaces::Node` — chain/network state queries (the impl takes `cs_main` itself; callers never hold core locks) plus Handler-returning registration for the seven `uiInterface` signals ClientModel consumes today.
- `interfaces::Wallet` — balance/encryption queries plus value-typed bridges for the `CWallet`/keystore signals (`CTxDestination` becomes an address string at the boundary; the `CWallet*`/`CCryptoKeyStore*` payloads never cross).
- `interfaces::Init` — per-process bootstrap; the monolithic `MakeGridcoinInit()` hands out the in-process wrappers.
- `src/interfaces/README.md` — the boundary rules: **value types only**, and **notification callbacks never take `cs_main`** (our core signals fire synchronously under core locks, so a callback that re-enters core deadlocks the split build).

The method set deliberately covers only what the first migrations need (1b ClientModel, 1c-i WalletModel) and grows per-migration — no speculative surface.

**The ratchet** (`test/lint/lint-qt-includes.sh`, auto-discovered by `lint-all.sh` and therefore CI): `src/qt` must not grow new direct includes of core headers. The 163 existing `file:header` pairs are allowlisted; the lint fails on both new violations *and* stale entries, so the allowlist only ever shrinks as each model migrates. An empty allowlist is the gate to Phase 2. Whitespace-tolerant matching, runs correctly from any cwd.

**Tests** (`src/test/interfaces_tests.cpp`): handler connect/disconnect/destruction semantics, Node-wraps-globals equivalence, both signal bridges end to end (uiInterface and CWallet sides), and Init handing out both interfaces.

## Verification

- Native Qt6 RelWithDebInfo build clean; unit, qt, and functional ctest suites all pass; `lint-all.sh` clean including the new ratchet.
- Adversarially reviewed pre-push (two independent passes): every signal-bridge typedef checked against the actual signal signatures; every impl lock placement verified against the wrapped functions' locking (no missing locks, no double-locks); handler lifetime semantics (signals2 stores the slot once; disconnect-after-signal-destruction is a no-op); the review is what expanded the ratchet's forbidden set (it had missed `chain.h` — the header that externs `cs_main`/`nBestHeight` — plus the PSGT/node headers and the `util.h` bypass of `util/system.h`) and caught a doc-drift on `getNumBlocksOfPeers`' checkpoint-floor behavior.

Refs #3153, #3152, discussion #2937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)