### PR TITLE
gui: migrate WalletModel onto interfaces::Wallet (Phase 1c-i)

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -47,7 +47,8 @@ struct WalletOutput
     std::string address;
     int depth{0};
     int64_t time{0};
-    //! Coinstake (or coinbase) still maturing: shown disabled in the views.
+    //! Coinstake still maturing: shown disabled in the views. Deliberately
+    //! matches the old GUI-side check, which tested IsCoinStake() only.
     bool immature{false};
 };
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -7,16 +7,96 @@
 
 #include "interfaces/handler.h"
 #include "node/ui_interface.h" // For ChangeType.
+#include "primitives/transaction.h" // For COutPoint.
+#include "support/allocators/secure.h" // For SecureString.
 #include "uint256.h"
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
+class CCoinControl;
+class CKeyID;
+class CPubKey;
 class CWallet;
 
 namespace interfaces {
+
+//! Snapshot of the four GUI-displayed balances, filled atomically under one
+//! lock acquisition (see Wallet::tryGetBalances).
+struct WalletBalances
+{
+    int64_t balance{0};
+    int64_t stake{0};
+    int64_t unconfirmed_balance{0};
+    int64_t immature_balance{0};
+};
+
+//! Value snapshot of one unspent wallet output for the coin-control views.
+//! Carries no pointers into the wallet: everything the GUI renders —
+//! including the maturity flag, which needs cs_main — is computed node-side.
+struct WalletOutput
+{
+    COutPoint outpoint;
+    int64_t amount{0};
+    //! Encoded destination of the output's scriptPubKey; empty when a
+    //! destination cannot be extracted.
+    std::string address;
+    int depth{0};
+    int64_t time{0};
+    //! Coinstake (or coinbase) still maturing: shown disabled in the views.
+    bool immature{false};
+};
+
+//! One send-coins recipient (the Qt-free mirror of SendCoinsRecipient).
+struct WalletSendRecipient
+{
+    std::string address;
+    std::string label;
+    int64_t amount{0};
+    //! Optional user message, embedded as a GRC::TxMessage contract.
+    std::string message;
+    bool subtract_fee_from_amount{false};
+};
+
+//! Result statuses for Wallet::sendCoins. GUI-detectable conditions
+//! (duplicate recipient, user abort) are pre-checked by the GUI and never
+//! reach the interface; addresses and amounts are nevertheless re-validated
+//! node-side (InvalidAddress/InvalidAmount), because the node must not rely
+//! on the client for checks whose failure would fund an empty —
+//! anyone-can-spend — output script or sign-overflow the totals.
+enum class SendCoinsStatus
+{
+    OK,
+    InvalidAddress,
+    InvalidAmount,
+    AmountExceedsBalance,
+    AmountWithFeeExceedsBalance,
+    FeeExceedsSubtractedAmount,
+    TransactionCreationFailed,
+    TransactionCommitFailed,
+    //! The required fee exceeds both the configured transaction fee and the
+    //! caller's accepted_fee, and confirmation is needed before committing.
+    //! Nothing was committed; `fee` carries the amount to confirm. Re-invoke
+    //! with accepted_fee >= fee to proceed. This replaces the eliminated
+    //! ThreadSafeAskFee modal, which used to block inside
+    //! LOCK2(cs_main, cs_wallet) (doc/multiprocess_design.md section 4.5).
+    FeeConfirmationRequired,
+};
+
+//! Result of Wallet::sendCoins.
+struct SendCoinsResult
+{
+    SendCoinsStatus status{SendCoinsStatus::TransactionCreationFailed};
+    //! The fee at issue when status is AmountWithFeeExceedsBalance,
+    //! FeeExceedsSubtractedAmount, or FeeConfirmationRequired.
+    int64_t fee{0};
+    //! Committed transaction hash (hex) when status is OK.
+    std::string txid_hex;
+};
 
 //! Wallet interface for the GUI: wallet queries plus notification
 //! registration. The same boundary rules as interfaces::Node apply (see
@@ -49,6 +129,16 @@ public:
     //! Immature (newly generated) balance.
     virtual int64_t getImmatureBalance() = 0;
 
+    //! Fill all four balances in one shot, or return false without blocking
+    //! when the core is busy (cs_main/cs_wallet unavailable). The balance
+    //! scans are expensive on large wallets, so refresh-path callers must be
+    //! able to bow out instead of stalling the GUI thread; use the
+    //! unconditional single getters only where an initial value is required.
+    virtual bool tryGetBalances(WalletBalances& balances) = 0;
+
+    //! Number of transactions in the wallet.
+    virtual int getNumTransactions() = 0;
+
     //! Whether the wallet is encrypted.
     virtual bool isCrypted() = 0;
 
@@ -57,6 +147,56 @@ public:
 
     //! Whether an unlocked wallet is restricted to staking only.
     virtual bool isUnlockedForStakingOnly() = 0;
+
+    //! The persisted staking-only unlock preference, independent of the
+    //! current lock state (unlike isUnlockedForStakingOnly). Seeds the
+    //! unlock dialog's checkbox while the wallet is still locked.
+    virtual bool getUnlockStakingOnlyFlag() = 0;
+
+    //! Encrypt the wallet with the given passphrase.
+    virtual bool encryptWallet(const SecureString& passphrase) = 0;
+
+    //! Lock the wallet. Does not clear the staking-only preference.
+    virtual bool lockWallet() = 0;
+
+    //! Unlock the wallet; on success the staking-only preference is set to
+    //! staking_only (a full unlock clears a stale staking-only restriction).
+    virtual bool unlockWallet(const SecureString& passphrase, bool staking_only) = 0;
+
+    //! Change the wallet passphrase (locks the wallet first).
+    virtual bool changeWalletPassphrase(const SecureString& old_passphrase,
+                                        const SecureString& new_passphrase) = 0;
+
+    //! Look up the public key for a key id. Public keys only — the wallet
+    //! stays in-node in every build configuration, so this interface never
+    //! carries private key material.
+    virtual bool getPubKey(const CKeyID& address, CPubKey& pub_key_out) = 0;
+
+    //! Fetch a fresh public key from the key pool, labeling its address in
+    //! the address book when label is non-empty.
+    virtual bool getKeyFromPool(CPubKey& pub_key_out, const std::string& label) = 0;
+
+    //! Value snapshots of the given outpoints; unknown or conflicted
+    //! (negative-depth) outpoints are skipped.
+    virtual std::vector<WalletOutput> getOutputs(const std::vector<COutPoint>& outpoints) = 0;
+
+    //! Spendable outputs grouped by address, with change outputs grouped
+    //! under the address they derive from (walked node-side).
+    virtual std::map<std::string, std::vector<WalletOutput>> listCoins() = 0;
+
+    //! Create, fee-converge, and commit a transaction to the given
+    //! recipients. Stateless one-shot: when the required fee needs user
+    //! confirmation (it exceeds both the configured transaction fee and
+    //! accepted_fee), returns FeeConfirmationRequired without committing —
+    //! the reserved change key is released and no locks stay held while the
+    //! GUI prompts. The caller re-invokes with accepted_fee set to the
+    //! returned fee; the transaction is recreated from current wallet state,
+    //! and a fee that meanwhile grew past accepted_fee simply returns
+    //! FeeConfirmationRequired again, so no fee the user has not accepted is
+    //! ever committed. coin_control may be null.
+    virtual SendCoinsResult sendCoins(const std::vector<WalletSendRecipient>& recipients,
+                                      const CCoinControl* coin_control,
+                                      int64_t accepted_fee) = 0;
 
     //! Register a handler for encryption/lock status changes.
     using StatusChangedFn = std::function<void()>;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -15,10 +15,10 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
-class CCoinControl;
 class CKeyID;
 class CPubKey;
 class CWallet;
@@ -50,6 +50,18 @@ struct WalletOutput
     //! Coinstake still maturing: shown disabled in the views. Deliberately
     //! matches the old GUI-side check, which tested IsCoinStake() only.
     bool immature{false};
+};
+
+//! Value mirror of the coin-control options Wallet::sendCoins consumes —
+//! the wallet-side CCoinControl does not cross the boundary (value types
+//! only); the node reconstructs it from this.
+struct WalletCoinControl
+{
+    //! Encoded destination for change; empty lets the wallet pick.
+    std::string dest_change;
+    bool allow_watch_only{false};
+    //! Outpoints coin selection is pinned to.
+    std::vector<COutPoint> selected;
 };
 
 //! One send-coins recipient (the Qt-free mirror of SendCoinsRecipient).
@@ -194,9 +206,9 @@ public:
     //! returned fee; the transaction is recreated from current wallet state,
     //! and a fee that meanwhile grew past accepted_fee simply returns
     //! FeeConfirmationRequired again, so no fee the user has not accepted is
-    //! ever committed. coin_control may be null.
+    //! ever committed.
     virtual SendCoinsResult sendCoins(const std::vector<WalletSendRecipient>& recipients,
-                                      const CCoinControl* coin_control,
+                                      const std::optional<WalletCoinControl>& coin_control,
                                       int64_t accepted_fee) = 0;
 
     //! Register a handler for encryption/lock status changes.

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -28,7 +28,6 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::NewPollReceivedSig> NewPollReceived;
     boost::signals2::signal<CClientUIInterface::NewVoteReceivedSig> NewVoteReceived;
     boost::signals2::signal<CClientUIInterface::NotifyScraperEventSig> NotifyScraperEvent;
-    boost::signals2::signal<CClientUIInterface::ThreadSafeAskFeeSig> ThreadSafeAskFee;
     boost::signals2::signal<CClientUIInterface::ThreadSafeHandleURISig> ThreadSafeHandleURI;
     boost::signals2::signal<CClientUIInterface::QueueShutdownSig> QueueShutdown;
     boost::signals2::signal<CClientUIInterface::TranslateSig> Translate;
@@ -58,7 +57,6 @@ ADD_SIGNALS_IMPL_WRAPPER(PSGTPoolChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NewPollReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NewVoteReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyScraperEvent);
-ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeAskFee);
 ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeHandleURI);
 ADD_SIGNALS_IMPL_WRAPPER(QueueShutdown);
 ADD_SIGNALS_IMPL_WRAPPER(Translate);
@@ -68,7 +66,6 @@ ADD_SIGNALS_IMPL_WRAPPER(RwSettingsUpdated);
 
 void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
 void CClientUIInterface::UpdateMessageBox(const std::string& version, const int& update_type, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, update_type, message); }
-bool CClientUIInterface::ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption) { return g_ui_signals.ThreadSafeAskFee(nFeeRequired, strCaption).value_or(false); }
 void CClientUIInterface::ThreadSafeHandleURI(const std::string& strURI) { return g_ui_signals.ThreadSafeHandleURI(strURI); }
 void CClientUIInterface::InitMessage(const std::string &message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::QueueShutdown() { return g_ui_signals.QueueShutdown(); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -91,9 +91,6 @@ public:
     /** Update notification message box. */
     ADD_SIGNALS_DECL_WRAPPER(UpdateMessageBox, void, const std::string& version, const int& update_type, const std::string& message);
 
-    /** Ask the user whether they want to pay a fee or not. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeAskFee, bool, int64_t nFeeRequired, const std::string& strCaption);
-
     /** Handle a URL passed at the command line. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeHandleURI, void, const std::string& strURI);
 

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -16,11 +16,6 @@ static int noui_ThreadSafeMessageBox(const std::string& message, const std::stri
     return 4;
 }
 
-static bool noui_ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption)
-{
-    return true;
-}
-
 static int noui_UpdateMessageBox(const std::string& version, const int& upgrade_type, const std::string& message)
 {
     std::string caption = _("Gridcoin Update Available");
@@ -35,6 +30,5 @@ void noui_connect()
 {
     // Connect bitcoind signal handlers
     uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
-    uiInterface.ThreadSafeAskFee_connect(noui_ThreadSafeAskFee);
     uiInterface.UpdateMessageBox_connect(noui_UpdateMessageBox);
 }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -10,8 +10,6 @@
 #include <QPushButton>
 #include <QKeyEvent>
 
-extern bool fWalletUnlockStakingOnly;
-
 AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent)
                  : QDialog(parent)
                  , ui(new Ui::AskPassphraseDialog)
@@ -31,8 +29,6 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent)
     ui->oldPassphraseEdit->installEventFilter(this);
     ui->newPassphraseEdit->installEventFilter(this);
     ui->repeatNewPassphraseEdit->installEventFilter(this);
-
-    ui->stakingCheckBox->setChecked(fWalletUnlockStakingOnly);
 
     switch(mode)
     {
@@ -75,6 +71,15 @@ AskPassphraseDialog::~AskPassphraseDialog()
 void AskPassphraseDialog::setModel(WalletModel *model)
 {
     this->model = model;
+
+    // Seed the staking-only checkbox from the persisted unlock preference —
+    // done here rather than in the constructor, which runs before a model is
+    // attached (the preference lives behind the wallet interface now, not a
+    // core global). UnlockStaking mode forces the box checked in the
+    // constructor and stays forced.
+    if (model && mode != UnlockStaking) {
+        ui->stakingCheckBox->setChecked(model->wallet().getUnlockStakingOnlyFlag());
+    }
 }
 
 void AskPassphraseDialog::accept()
@@ -138,7 +143,10 @@ void AskPassphraseDialog::accept()
     } break;
     case UnlockStaking:
     case Unlock:
-        if(!model->setWalletLocked(false, oldpass)) {
+        // A successful unlock also persists the staking-only preference
+        // node-side (the checkbox state), which the old code applied to the
+        // fWalletUnlockStakingOnly global after the fact.
+        if(!model->setWalletLocked(false, oldpass, ui->stakingCheckBox->isChecked())) {
             // Check if the passphrase has a null character
             if (oldpass.find('\0') == std::string::npos) {
                     QMessageBox::critical(this, tr("Wallet unlock failed"),
@@ -155,7 +163,6 @@ void AskPassphraseDialog::accept()
         }
         else
         {
-            fWalletUnlockStakingOnly = ui->stakingCheckBox->isChecked();
             QDialog::accept(); // Success
         }
         break;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -21,6 +21,9 @@
 #include "interfaces/init.h"
 #include "interfaces/node.h"
 #include "interfaces/staking.h"
+#include "interfaces/wallet.h"
+
+#include <cassert>
 #include "init.h"
 #include "node/ui_interface.h"
 #include "qtipcserver.h"
@@ -133,34 +136,6 @@ static void ThreadSafeMessageBox(const std::string& message, const std::string& 
         tfm::format(std::cerr, "%s: %s\n", caption.c_str(), message.c_str());
     }
 }
-
-static bool ThreadSafeAskFee(int64_t nFeeRequired, const std::string& strCaption)
-{
-    if(!guiref)
-        return false;
-
-    int64_t nMinFee;
-
-    {
-        LOCK(cs_main);
-
-        CMutableTransaction txDummy;
-
-        // Min Fee
-        nMinFee = GetBaseFee(CTransaction(txDummy), GMF_SEND);
-    }
-
-    if (nFeeRequired < nMinFee || nFeeRequired <= nTransactionFee)
-        return true;
-    bool payFee = false;
-
-    QMetaObject::invokeMethod(guiref, "askFee", GUIUtil::blockingGUIThreadConnection(),
-                               Q_ARG(qint64, nFeeRequired),
-                               Q_ARG(bool*, &payFee));
-
-    return payFee;
-}
-
 
 static void ThreadSafeHandleURI(const std::string& strURI)
 {
@@ -619,8 +594,6 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
 
     // Subscribe to global signals from core
     uiInterface.ThreadSafeMessageBox_connect(ThreadSafeMessageBox);
-    uiInterface.ThreadSafeAskFee_connect(ThreadSafeAskFee);
-
     uiInterface.ThreadSafeHandleURI_connect(ThreadSafeHandleURI);
     uiInterface.InitMessage_connect(InitMessage);
     uiInterface.QueueShutdown_connect(QueueShutdown);
@@ -678,9 +651,13 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
                 std::unique_ptr<interfaces::Node> node = interface_init->makeNode();
                 std::unique_ptr<interfaces::StakingStatus> staking_status = interface_init->makeStakingStatus();
+                // Non-null here: wallet startup completed above, so
+                // pwalletMain is set for the monolithic build.
+                std::unique_ptr<interfaces::Wallet> wallet = interface_init->makeWallet();
+                assert(wallet);
 
                 ClientModel clientModel(*node, *staking_status, &optionsModel);
-                WalletModel walletModel(pwalletMain, &optionsModel);
+                WalletModel walletModel(*wallet, pwalletMain, &optionsModel);
                 ResearcherModel researcherModel;
                 MRCModel mrcModel(&walletModel, &clientModel, &researcherModel);
                 VotingModel votingModel(clientModel, optionsModel, walletModel);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -22,8 +22,6 @@
 #include "interfaces/node.h"
 #include "interfaces/staking.h"
 #include "interfaces/wallet.h"
-
-#include <cassert>
 #include "init.h"
 #include "node/ui_interface.h"
 #include "qtipcserver.h"
@@ -651,10 +649,18 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
                 std::unique_ptr<interfaces::Node> node = interface_init->makeNode();
                 std::unique_ptr<interfaces::StakingStatus> staking_status = interface_init->makeStakingStatus();
-                // Non-null here: wallet startup completed above, so
-                // pwalletMain is set for the monolithic build.
+                // Wallet startup completed above, so pwalletMain is set and
+                // the monolithic Init must hand out a wallet interface. If
+                // that invariant is ever broken, fail loudly instead of
+                // dereferencing null below (assert alone compiles out under
+                // NDEBUG).
                 std::unique_ptr<interfaces::Wallet> wallet = interface_init->makeWallet();
-                assert(wallet);
+                if (!wallet) {
+                    // Throw rather than return: the enclosing catch funnels
+                    // through handleRunawayException, and the normal
+                    // Shutdown()/thread-teardown path still runs.
+                    throw std::runtime_error("wallet interface unavailable after init");
+                }
 
                 ClientModel clientModel(*node, *staking_status, &optionsModel);
                 WalletModel walletModel(*wallet, pwalletMain, &optionsModel);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1310,19 +1310,6 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
 }
 
 
-void BitcoinGUI::askFee(qint64 nFeeRequired, bool *payFee)
-{
-    QString strMessage =
-        tr("This transaction is over the size limit.  You can still send it for a fee of %1, "
-          "which goes to the nodes that process your transaction and helps to support the network.  "
-          "Do you want to pay the fee?").arg(
-                BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, nFeeRequired));
-    QMessageBox::StandardButton retval = QMessageBox::question(
-          this, tr("Confirm transaction fee"), strMessage,
-          QMessageBox::Yes|QMessageBox::Cancel, QMessageBox::Yes);
-    *payFee = (retval == QMessageBox::Yes);
-}
-
 void BitcoinGUI::incomingTransaction(const QModelIndex & parent, int start, int end)
 {
     if(!walletModel || !clientModel)
@@ -1771,12 +1758,21 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setEnabled(true);
         break;
     case WalletModel::Unlocked:
-        if (fWalletUnlockStakingOnly) {
+    {
+        // The raw preference flag, exactly what the old code read from the
+        // fWalletUnlockStakingOnly global at render time. (Not the composite
+        // isUnlockedForStakingOnly: this slot runs queued, and a relock
+        // racing the queued delivery would flip the composite to false and
+        // paint "fully unlocked" where the old code kept the staking-only
+        // rendering until the lock's own status event arrived.)
+        const bool staking_only = walletModel && walletModel->wallet().getUnlockStakingOnlyFlag();
+
+        if (staking_only) {
             labelEncryptionIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_encryption_unlocked_" + sSheet));
         } else {
             labelEncryptionIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_encryption_none_" + sSheet));
         }
-        labelEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently %1 ").arg(fWalletUnlockStakingOnly ? tr("<b>unlocked for staking only</b>") : tr("<b>fully unlocked</b>")));
+        labelEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently %1 ").arg(staking_only ? tr("<b>unlocked for staking only</b>") : tr("<b>fully unlocked</b>")));
         encryptWalletAction->setChecked(true);
         changePassphraseAction->setEnabled(true);
         unlockWalletAction->setVisible(false);
@@ -1785,6 +1781,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
         lockWalletAction->setShortcut(QKeySequence(Qt::ALT | Qt::Key_7));
         encryptWalletAction->setEnabled(false);
         break;
+    }
     case WalletModel::Locked:
         labelEncryptionIcon->setPixmap(GRC::ScaleStatusIcon(this, ":/icons/status_encryption_locked_" + sSheet));
         labelEncryptionIcon->setToolTip(tr("Wallet is <b>encrypted</b> and currently <b>locked</b>"));

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -245,15 +245,6 @@ public slots:
 
     /** Notify the user of an error in the network or transaction handling code. */
     void error(const QString &title, const QString &message, bool modal);
-    /** Asks the user whether to pay the transaction fee or to cancel the transaction.
-       It is currently not possible to pass a return value to another thread through
-       BlockingQueuedConnection, so an indirected pointer is used.
-       https://bugreports.qt-project.org/browse/QTBUG-10440
-
-      @param[in] nFeeRequired       the required fee
-      @param[out] payFee            true to pay the fee, false to not pay the fee
-    */
-    void askFee(qint64 nFeeRequired, bool *payFee);
 
     void handleURI(QString strURI);
     void setOptionsStyleSheet(QString qssFileName);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -3,6 +3,7 @@
 
 #include "bitcoinunits.h"
 #include "addresstablemodel.h"
+#include "key_io.h"
 #include "optionsmodel.h"
 #include "wallet/wallet.h"
 #include "policy/policy.h"
@@ -48,8 +49,6 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl,
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
              copyTransactionHashAction = new QAction(tr("Copy transaction ID"), this);  // we need to enable/disable this
-             //lockAction = new QAction(tr("Lock unspent"), this);                        // we need to enable/disable this
-             //unlockAction = new QAction(tr("Unlock unspent"), this);                    // we need to enable/disable this
 
     // context menu
     contextMenu = new QMenu(this);
@@ -57,9 +56,6 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl,
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyAmountAction);
     contextMenu->addAction(copyTransactionHashAction);
-    //contextMenu->addSeparator();
-    //contextMenu->addAction(lockAction);
-    //contextMenu->addAction(unlockAction);
 
     // context menu signals
     connect(ui->treeWidget, &QWidget::customContextMenuRequested, this, &CoinControlDialog::showMenu);
@@ -67,8 +63,6 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl,
     connect(copyLabelAction, &QAction::triggered, this, &CoinControlDialog::copyLabel);
     connect(copyAmountAction, &QAction::triggered, this, &CoinControlDialog::copyAmount);
     connect(copyTransactionHashAction, &QAction::triggered, this, &CoinControlDialog::copyTransactionHash);
-    //connect(lockAction, &QAction::triggered, this, &CoinControlDialog::lockCoin);
-    //connect(unlockAction, &QAction::triggered, this, &CoinControlDialog::unlockCoin);
 
     // clipboard actions
     QAction *clipboardQuantityAction = new QAction(tr("Copy quantity"), this);
@@ -159,7 +153,6 @@ void CoinControlDialog::setModel(WalletModel *model)
     if(model && model->getOptionsModel() && model->getAddressTableModel())
     {
         updateView();
-        //updateLabelLocked();
         CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, m_fSubtractFeeFromAmount);
     }
 }
@@ -408,22 +401,10 @@ void CoinControlDialog::showMenu(const QPoint &point)
         if (item->text(COLUMN_TXHASH).length() == 64) // transaction hash is 64 characters (this means it is a child node, so it is not a parent node in tree mode)
         {
             copyTransactionHashAction->setEnabled(true);
-            //if (model->isLockedCoin(uint256(item->text(COLUMN_TXHASH).toStdString()), item->text(COLUMN_VOUT_INDEX).toUInt()))
-            //{
-            //    lockAction->setEnabled(false);
-            //    unlockAction->setEnabled(true);
-            //}
-            //else
-            //{
-            //    lockAction->setEnabled(true);
-            //    unlockAction->setEnabled(false);
-            //}
         }
         else // this means click on parent node in tree mode -> disable all
         {
             copyTransactionHashAction->setEnabled(false);
-            //lockAction->setEnabled(false);
-            //unlockAction->setEnabled(false);
         }
 
         // show context menu
@@ -460,29 +441,6 @@ void CoinControlDialog::copyTransactionHash()
 {
     QApplication::clipboard()->setText(contextMenuItem->text(COLUMN_TXHASH));
 }
-
-// context menu action: lock coin
-/*void CoinControlDialog::lockCoin()
-{
-    if (contextMenuItem->checkState(COLUMN_CHECKBOX) == Qt::Checked)
-        contextMenuItem->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
-
-    COutPoint outpt(uint256(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
-    model->lockCoin(outpt);
-    contextMenuItem->setDisabled(true);
-    contextMenuItem->setIcon(COLUMN_CHECKBOX, QIcon(":/icons/lock_closed"));
-    updateLabelLocked();
-}*/
-
-// context menu action: unlock coin
-/*void CoinControlDialog::unlockCoin()
-{
-    COutPoint outpt(uint256(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
-    model->unlockCoin(outpt);
-    contextMenuItem->setDisabled(false);
-    contextMenuItem->setIcon(COLUMN_CHECKBOX, QIcon());
-    updateLabelLocked();
-}*/
 
 // copy label "Quantity" to clipboard
 void CoinControlDialog::clipboardQuantity()
@@ -605,19 +563,6 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
     showHideConsolidationReadyToSend();
 }
 
-// shows count of locked unspent outputs
-/*void CoinControlDialog::updateLabelLocked()
-{
-    vector<COutPoint> vOutpts;
-    model->listLockedCoins(vOutpts);
-    if (vOutpts.size() > 0)
-    {
-       ui->labelLocked->setText(tr("(%1 locked)").arg(vOutpts.size()));
-       ui->labelLocked->setVisible(true);
-    }
-    else ui->labelLocked->setVisible(false);
-}*/
-
 void CoinControlDialog::updateLabels(WalletModel *model,
                                      CCoinControl *coinControl,
                                      QList<qint64>* payAmounts,
@@ -653,9 +598,8 @@ void CoinControlDialog::updateLabels(WalletModel *model,
     unsigned int nQuantity      = 0;
 
     vector<COutPoint> vCoinControl;
-    vector<COutput>   vOutputs;
     coinControl->ListSelected(vCoinControl);
-    model->getOutputs(vCoinControl, vOutputs);
+    const std::vector<interfaces::WalletOutput> vOutputs = model->getOutputs(vCoinControl);
 
     for (auto const& out : vOutputs)
     {
@@ -663,12 +607,12 @@ void CoinControlDialog::updateLabels(WalletModel *model,
         nQuantity++;
 
         // Amount
-        nAmount += out.tx->vout[out.i].nValue;
+        nAmount += out.amount;
 
         // Bytes
-        CTxDestination address;
-        if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
+        if (!out.address.empty())
         {
+            CTxDestination address = DecodeDestination(out.address);
             CPubKey pubkey;
             try {
                 if (model->getPubKey(std::get<CKeyID>(address), pubkey))
@@ -790,13 +734,12 @@ void CoinControlDialog::updateView()
     if (model && model->getOptionsModel())
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 
-    map<QString, vector<COutput> > mapCoins;
-    model->listCoins(mapCoins);
+    const std::map<std::string, std::vector<interfaces::WalletOutput>> mapCoins = model->listCoins();
 
     for (auto const& coins : mapCoins)
     {
         QTreeWidgetItem *itemWalletAddress = new QTreeWidgetItem();
-        QString sWalletAddress = coins.first;
+        QString sWalletAddress = QString::fromStdString(coins.first);
         QString sWalletLabel = "";
         if (model->getAddressTableModel())
             sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
@@ -822,7 +765,7 @@ void CoinControlDialog::updateView()
         int nChildren = 0;
         for (auto const& out : coins.second)
         {
-            nSum += out.tx->vout[out.i].nValue;
+            nSum += out.amount;
             nChildren++;
 
             QTreeWidgetItem *itemOutput;
@@ -832,16 +775,12 @@ void CoinControlDialog::updateView()
             itemOutput->setCheckState(COLUMN_CHECKBOX,Qt::Unchecked);
 
             // address
-            CTxDestination outputAddress;
-            QString sAddress = "";
-            if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, outputAddress))
+            QString sAddress = QString::fromStdString(out.address);
+            if (!sAddress.isEmpty())
             {
-                sAddress = EncodeDestination(outputAddress).c_str();
-
                 // if listMode or change => show bitcoin address. In tree mode, address is not shown again for direct wallet address outputs
                 if (!treeMode || (!(sAddress == sWalletAddress)))
                     itemOutput->setText(COLUMN_ADDRESS, sAddress);
-
             }
 
             // label
@@ -863,44 +802,31 @@ void CoinControlDialog::updateView()
             }
 
             // amount
-            itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.tx->vout[out.i].nValue));
-            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
+            itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.amount));
+            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.amount), 15, " ")); // padding so that sorting works correctly
 
             // date
-            itemOutput->setText(COLUMN_DATE, QDateTime::fromSecsSinceEpoch(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
+            itemOutput->setText(COLUMN_DATE, QDateTime::fromSecsSinceEpoch(out.time).toUTC().toString("yy-MM-dd hh:mm"));
 
-            // immature PoS reward
-            {
-                // LOCK on cs_main must be taken for depth and maturity.
-                LOCK(cs_main);
-
-                if (out.tx->IsCoinStake() && out.tx->GetBlocksToMaturity() > 0 && out.tx->GetDepthInMainChain() > 0) {
-                    itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
-                    itemOutput->setDisabled(true);
-                }
+            // immature PoS reward — flagged node-side (the maturity check
+            // needs cs_main, which no longer belongs on the GUI thread)
+            if (out.immature) {
+                itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
+                itemOutput->setDisabled(true);
             }
 
             // confirmations
-            itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.nDepth), 8, " "));
+            itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.depth), 8, " "));
 
             // transaction hash
-            uint256 txhash = out.tx->GetHash();
+            uint256 txhash = out.outpoint.hash;
             itemOutput->setText(COLUMN_TXHASH, txhash.GetHex().c_str());
 
             // vout index
-            itemOutput->setText(COLUMN_VOUT_INDEX, QString::number(out.i));
-
-            // disable locked coins
-            /*if (model->isLockedCoin(txhash, out.i))
-            {
-                COutPoint outpt(txhash, out.i);
-                coinControl->UnSelect(outpt); // just to be sure
-                itemOutput->setDisabled(true);
-                itemOutput->setIcon(COLUMN_CHECKBOX, QIcon(":/icons/lock_closed"));
-            }*/
+            itemOutput->setText(COLUMN_VOUT_INDEX, QString::number(out.outpoint.n));
 
             // set checkbox
-            if (coinControl->IsSelected(txhash, out.i))
+            if (coinControl->IsSelected(txhash, out.outpoint.n))
                 itemOutput->setCheckState(COLUMN_CHECKBOX,Qt::Checked);
         }
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -56,8 +56,6 @@ private:
     QMenu *contextMenu;
     QTreeWidgetItem *contextMenuItem;
     QAction *copyTransactionHashAction;
-    //QAction *lockAction;
-    //QAction *unlockAction;
 
     std::pair<QString, QString> m_consolidationAddress;
     Qt::CheckState m_ToState = Qt::Checked;
@@ -89,8 +87,6 @@ private slots:
     void copyLabel();
     void copyAddress();
     void copyTransactionHash();
-    //void lockCoin();
-    //void unlockCoin();
     void clipboardQuantity();
     void clipboardAmount();
     void clipboardFee();
@@ -109,7 +105,6 @@ private slots:
     void buttonFilterClicked();
     void buttonConsolidateClicked();
     void selectedConsolidationAddressSlot(std::pair<QString, QString> address);
-    //void updateLabelLocked();
 };
 
 #endif // BITCOIN_QT_COINCONTROLDIALOG_H

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -4,6 +4,7 @@
 
 #include "bitcoinunits.h"
 #include "addresstablemodel.h"
+#include "key_io.h"
 #include "optionsmodel.h"
 #include "wallet/wallet.h"
 #include "policy/policy.h"
@@ -376,9 +377,8 @@ void ConsolidateUnspentWizardSelectInputsPage::updateLabels()
     unsigned int nQuantity = 0;
 
     vector<COutPoint> vCoinControl;
-    vector<COutput> vOutputs;
     coinControl->ListSelected(vCoinControl);
-    model->getOutputs(vCoinControl, vOutputs);
+    const std::vector<interfaces::WalletOutput> vOutputs = model->getOutputs(vCoinControl);
 
     for (const auto& out : vOutputs)
     {
@@ -386,12 +386,12 @@ void ConsolidateUnspentWizardSelectInputsPage::updateLabels()
         nQuantity++;
 
         // Amount
-        nAmount += out.tx->vout[out.i].nValue;
+        nAmount += out.amount;
 
         // Bytes
-        CTxDestination address;
-        if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
+        if (!out.address.empty())
         {
+            CTxDestination address = DecodeDestination(out.address);
             CPubKey pubkey;
             try {
                 if (model->getPubKey(std::get<CKeyID>(address), pubkey))
@@ -535,13 +535,12 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
     }
 
-    map<QString, vector<COutput>> mapCoins;
-    model->listCoins(mapCoins);
+    const std::map<std::string, std::vector<interfaces::WalletOutput>> mapCoins = model->listCoins();
 
     for (auto const& coins : mapCoins)
     {
         QTreeWidgetItem *itemWalletAddress = new QTreeWidgetItem();
-        QString sWalletAddress = coins.first;
+        QString sWalletAddress = QString::fromStdString(coins.first);
         QString sWalletLabel = "";
         if (model->getAddressTableModel())
             sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
@@ -568,7 +567,7 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
 
         for (auto const& out : coins.second)
         {
-            nSum += out.tx->vout[out.i].nValue;
+            nSum += out.amount;
             nChildren++;
 
             QTreeWidgetItem *itemOutput;
@@ -578,12 +577,9 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
             itemOutput->setCheckState(COLUMN_CHECKBOX,Qt::Unchecked);
 
             // address
-            CTxDestination outputAddress;
-            QString sAddress = "";
-            if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, outputAddress))
+            QString sAddress = QString::fromStdString(out.address);
+            if (!sAddress.isEmpty())
             {
-                sAddress = EncodeDestination(outputAddress).c_str();
-
                 // if listMode or change => show bitcoin address. In tree mode, address is not shown again for direct wallet address outputs
                 if (!treeMode || (!(sAddress == sWalletAddress)))
                     itemOutput->setText(COLUMN_ADDRESS, sAddress);
@@ -608,35 +604,31 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
             }
 
             // amount
-            itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.tx->vout[out.i].nValue));
-            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
+            itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.amount));
+            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.amount), 15, " ")); // padding so that sorting works correctly
 
             // date
-            itemOutput->setText(COLUMN_DATE, QDateTime::fromSecsSinceEpoch(out.tx->GetTxTime()).toUTC().toString("yy-MM-dd hh:mm"));
+            itemOutput->setText(COLUMN_DATE, QDateTime::fromSecsSinceEpoch(out.time).toUTC().toString("yy-MM-dd hh:mm"));
 
-            // immature PoS reward
-            {
-                // LOCK on cs_main must be taken for depth and maturity.
-                LOCK(cs_main);
-
-                if (out.tx->IsCoinStake() && out.tx->GetBlocksToMaturity() > 0 && out.tx->GetDepthInMainChain() > 0) {
-                    itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
-                    itemOutput->setDisabled(true);
-                }
+            // immature PoS reward — flagged node-side (the maturity check
+            // needs cs_main, which no longer belongs on the GUI thread)
+            if (out.immature) {
+                itemOutput->setBackground(COLUMN_CONFIRMATIONS, Qt::red);
+                itemOutput->setDisabled(true);
             }
 
             // confirmations
-            itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.nDepth), 8, " "));
+            itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.depth), 8, " "));
 
             // transaction hash
-            uint256 txhash = out.tx->GetHash();
+            uint256 txhash = out.outpoint.hash;
             itemOutput->setText(COLUMN_TXHASH, txhash.GetHex().c_str());
 
             // vout index
-            itemOutput->setText(COLUMN_VOUT_INDEX, QString::number(out.i));
+            itemOutput->setText(COLUMN_VOUT_INDEX, QString::number(out.outpoint.n));
 
             // set checkbox
-            if (coinControl->IsSelected(txhash, out.i))
+            if (coinControl->IsSelected(txhash, out.outpoint.n))
             {
                 itemOutput->setCheckState(COLUMN_CHECKBOX,Qt::Checked);
             }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -10,6 +10,7 @@
 #include "guiutil.h"
 #include "askpassphrasedialog.h"
 
+#include "key_io.h"
 #include "wallet/coincontrol.h"
 #include "coincontroldialog.h"
 #include "consolidateunspentdialog.h"
@@ -182,9 +183,21 @@ void SendCoinsDialog::on_sendButton_clicked()
     }
 
     WalletModel::SendCoinsReturn sendstatus;
-    const CCoinControl* coin_control =
-        (!model->getOptionsModel() || !model->getOptionsModel()->getCoinControlFeatures())
-            ? nullptr : coinControl;
+
+    // Snapshot the dialog's CCoinControl into the boundary value type when
+    // coin-control features are on; the wallet-side class itself does not
+    // cross the interface.
+    std::optional<interfaces::WalletCoinControl> coin_control;
+    if (model->getOptionsModel() && model->getOptionsModel()->getCoinControlFeatures())
+    {
+        interfaces::WalletCoinControl ctrl;
+        if (IsValidDestination(coinControl->destChange)) {
+            ctrl.dest_change = EncodeDestination(coinControl->destChange);
+        }
+        ctrl.allow_watch_only = coinControl->fAllowWatchOnly;
+        coinControl->ListSelected(ctrl.selected);
+        coin_control = std::move(ctrl);
+    }
 
     // Fee-confirmation loop. When the required fee exceeds both the
     // configured transaction fee and what the user has accepted so far,

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -16,6 +16,7 @@
 #include "consolidateunspentwizard.h"
 #include "qt/decoration.h"
 
+#include <QCoreApplication>
 #include <QMessageBox>
 #include <QLocale>
 #include <QTextDocument>
@@ -181,11 +182,63 @@ void SendCoinsDialog::on_sendButton_clicked()
     }
 
     WalletModel::SendCoinsReturn sendstatus;
+    const CCoinControl* coin_control =
+        (!model->getOptionsModel() || !model->getOptionsModel()->getCoinControlFeatures())
+            ? nullptr : coinControl;
 
-    if (!model->getOptionsModel() || !model->getOptionsModel()->getCoinControlFeatures())
-        sendstatus = model->sendCoins(recipients);
-    else
-        sendstatus = model->sendCoins(recipients, coinControl);
+    // Fee-confirmation loop. When the required fee exceeds both the
+    // configured transaction fee and what the user has accepted so far,
+    // sendCoins returns FeeConfirmationRequired WITHOUT committing; we ask
+    // here — with no core locks held, unlike the eliminated ThreadSafeAskFee
+    // modal, which used to block inside the wallet's LOCK2 scope — and
+    // re-invoke with the accepted fee. The transaction is recreated from
+    // current wallet state on each pass, so a fee that meanwhile grew past
+    // the accepted amount is asked about again, never silently committed.
+    // The accepted fee only ratchets up, so re-prompts need a strictly
+    // rising fee (e.g. randomized coin selection crossing a size tier);
+    // the attempt cap keeps a pathological oscillation finite.
+    qint64 acceptedFee = 0;
+    for (int nFeePromptAttempt = 0; ; ++nFeePromptAttempt)
+    {
+        sendstatus = model->sendCoins(recipients, coin_control, acceptedFee);
+
+        if (sendstatus.status != WalletModel::FeeConfirmationRequired)
+        {
+            break;
+        }
+
+        if (nFeePromptAttempt >= 10)
+        {
+            // Surface a visible error rather than Aborted: the user has been
+            // explicitly confirming fees, so a silent no-op would read as a
+            // sent transaction. Nothing was committed.
+            sendstatus = WalletModel::TransactionCreationFailed;
+            break;
+        }
+
+        // Deliberate context pin: these strings shipped for years from
+        // BitcoinGUI::askFee, so every locale's translation lives under the
+        // BitcoinGUI context in src/qt/locale/*.ts. Look them up there
+        // rather than orphaning the translations with this dialog's own
+        // tr() context.
+        QString strMessage =
+            QCoreApplication::translate("BitcoinGUI",
+               "This transaction is over the size limit.  You can still send it for a fee of %1, "
+               "which goes to the nodes that process your transaction and helps to support the network.  "
+               "Do you want to pay the fee?").arg(
+                    BitcoinUnits::formatWithUnit(BitcoinUnits::BTC, sendstatus.fee));
+        QMessageBox::StandardButton retval = QMessageBox::question(
+              this, QCoreApplication::translate("BitcoinGUI", "Confirm transaction fee"), strMessage,
+              QMessageBox::Yes|QMessageBox::Cancel, QMessageBox::Yes);
+
+        if (retval != QMessageBox::Yes)
+        {
+            sendstatus = WalletModel::Aborted;
+            break;
+        }
+
+        acceptedFee = sendstatus.fee;
+    }
 
     switch(sendstatus.status)
     {
@@ -231,6 +284,8 @@ void SendCoinsDialog::on_sendButton_clicked()
         QMessageBox::warning(this, tr("Send Coins"),
             tr("Error: The transaction was rejected. This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."),
             QMessageBox::Ok, QMessageBox::Ok);
+        break;
+    case WalletModel::FeeConfirmationRequired: // cannot reach here: consumed by the loop above
         break;
     case WalletModel::Aborted: // User aborted, nothing to do
         break;

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -9,6 +9,7 @@
 namespace Ui {
     class SendCoinsDialog;
 }
+class CCoinControl;
 class SendCoinsEntry;
 
 QT_BEGIN_NAMESPACE

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -7,18 +7,20 @@
 
 #include "node/ui_interface.h"
 #include "wallet/wallet.h"
-#include "wallet/coincontrol.h"
 #include "main.h"
 #include <key_io.h>
 #include "util.h"
-#include "gridcoin/tx_message.h"
 
 #include <QSet>
 #include <QTimer>
 
-WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* parent)
+#include <cassert>
+
+WalletModel::WalletModel(interfaces::Wallet& wallet, CWallet* core_wallet,
+                         OptionsModel* optionsModel, QObject* parent)
          : QObject(parent)
-         , wallet(wallet)
+         , m_wallet(wallet)
+         , m_core_wallet(core_wallet)
          , optionsModel(optionsModel)
          , addressTableModel(nullptr)
          , transactionTableModel(nullptr)
@@ -29,14 +31,14 @@ WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* p
          , cachedNumTransactions(0)
          , cachedEncryptionStatus(Unencrypted)
          , cachedNumBlocks(0)
-         , m_txStore(wallet, m_event_queue)
+         , m_txStore(core_wallet, m_event_queue)
 {
-    addressTableModel = new AddressTableModel(wallet, this);
+    addressTableModel = new AddressTableModel(core_wallet, this);
     // TransactionTableModel's ctor performs the initial load via
     // m_txStore.reloadAndSnapshot(); m_txStore is already constructed (init
     // list) and no producer can run yet — subscribeToCoreSignals() is called
     // below, after the model exists.
-    transactionTableModel = new TransactionTableModel(wallet, this);
+    transactionTableModel = new TransactionTableModel(core_wallet, this);
 
     // Drain the producer→GUI event queue at a steady cadence. 500ms is
     // imperceptible for transaction-list updates while still giving the
@@ -67,32 +69,27 @@ WalletModel::~WalletModel()
 
 qint64 WalletModel::getBalance() const
 {
-    return wallet->GetBalance();
+    return m_wallet.getBalance();
 }
 
 qint64 WalletModel::getUnconfirmedBalance() const
 {
-    return wallet->GetUnconfirmedBalance();
+    return m_wallet.getUnconfirmedBalance();
 }
 
 qint64 WalletModel::getStake() const
 {
-    return wallet->GetStake();
+    return m_wallet.getStake();
 }
 
 qint64 WalletModel::getImmatureBalance() const
 {
-    return wallet->GetImmatureBalance();
+    return m_wallet.getImmatureBalance();
 }
 
 int WalletModel::getNumTransactions() const
 {
-    int numTransactions = 0;
-    {
-        LOCK(wallet->cs_wallet);
-        numTransactions = wallet->mapWallet.size();
-    }
-    return numTransactions;
+    return m_wallet.getNumTransactions();
 }
 
 void WalletModel::updateStatus()
@@ -105,60 +102,57 @@ void WalletModel::updateStatus()
 
 void WalletModel::checkBalanceChanged()
 {
-    // The Get*Balance() calls iterate the wallet's full mapWallet and become
+    // The balance scans iterate the wallet's full mapWallet and become
     // INCREDIBLY expensive on large wallets. Two layers of protection:
     //
-    //  1. TRY_LOCK on cs_main + cs_wallet: bow out cleanly if the core is
-    //     holding them (e.g. during a wallet rescan). This is the same
-    //     guard pollBalanceChanged used to apply.
+    //  1. A MODEL_UPDATE_DELAY (4s) stale-time gate: only actually recompute
+    //     at most once per gate interval. Bursts of rapid-fire wallet events
+    //     during a resync, rescan, or large consolidation collapse into a
+    //     single recompute. Checked first — it is free, while the interface
+    //     call below takes lock attempts even when it bows out.
     //
-    //  2. A MODEL_UPDATE_DELAY (4s) stale-time gate: even when the locks
-    //     are available, only actually recompute at most once per gate
-    //     interval. Bursts of rapid-fire wallet events during a resync,
-    //     rescan, or large consolidation collapse into a single recompute.
+    //  2. tryGetBalances: bows out cleanly (returns false) if the core is
+    //     holding cs_main/cs_wallet (e.g. during a wallet rescan). This is
+    //     the same TRY_LOCK guard pollBalanceChanged used to apply, now on
+    //     the node side of the interface boundary.
     //
-    // The last call in a burst that fails the stale-time test isn't lost:
-    // the next ChainTipChanged event (or the next drain pass with events
-    // in it) re-runs this function, which by then will pass the gate.
-    TRY_LOCK(cs_main, lockMain);
-    if (!lockMain) {
-        return;
-    }
-    TRY_LOCK(wallet->cs_wallet, lockWallet);
-    if (!lockWallet) {
+    // The gate timestamp advances only on an actual recompute — NOT when a
+    // busy core makes tryGetBalances bow out, and not only when a change is
+    // detected. The gate exists to rate-limit the expensive scans
+    // themselves; if the timestamp only advanced on a detected change, a
+    // long-stable balance would leave the gate permanently open and every
+    // drain tick (which can fire back-to-back when drainEventQueue re-arms
+    // to clear a backlog) would run a fresh full-wallet scan.
+    //
+    // A call that fails either layer isn't lost: the next ChainTipChanged
+    // event (or the next drain pass with events in it) re-runs this
+    // function, which by then will pass.
+    // Plain wall clock, not GetAdjustedTime(): this is a purely local rate
+    // limiter, and a network-time offset step must not wedge or bypass it.
+    int64_t current_time = GetTime();
+
+    if (current_time - last_balance_update_time <= MODEL_UPDATE_DELAY / 1000) {
         return;
     }
 
-    int64_t current_time = GetAdjustedTime();
+    interfaces::WalletBalances balances;
+    if (!m_wallet.tryGetBalances(balances)) {
+        return;
+    }
 
-    if (current_time - last_balance_update_time > MODEL_UPDATE_DELAY / 1000)
+    last_balance_update_time = current_time;
+
+    if (cachedBalance != balances.balance
+            || cachedStake != balances.stake
+            || cachedUnconfirmedBalance != balances.unconfirmed_balance
+            || cachedImmatureBalance != balances.immature_balance)
     {
-        // Stamp the gate as soon as we commit to a recompute — NOT only when
-        // a change is detected. The gate exists to rate-limit the expensive
-        // Get*Balance() scans themselves; if the timestamp only advanced on a
-        // detected change, a long-stable balance would leave the gate
-        // permanently open and every drain tick (which can fire back-to-back
-        // when drainEventQueue re-arms to clear a backlog) would run a fresh
-        // full-wallet scan.
-        last_balance_update_time = current_time;
+        cachedBalance = balances.balance;
+        cachedStake = balances.stake;
+        cachedUnconfirmedBalance = balances.unconfirmed_balance;
+        cachedImmatureBalance = balances.immature_balance;
 
-        qint64 newBalance = getBalance();
-        qint64 newStake = getStake();
-        qint64 newUnconfirmedBalance = getUnconfirmedBalance();
-        qint64 newImmatureBalance = getImmatureBalance();
-
-        if (cachedBalance != newBalance
-                || cachedStake != newStake
-                || cachedUnconfirmedBalance != newUnconfirmedBalance
-                || cachedImmatureBalance != newImmatureBalance)
-        {
-            cachedBalance = newBalance;
-            cachedStake = newStake;
-            cachedUnconfirmedBalance = newUnconfirmedBalance;
-            cachedImmatureBalance = newImmatureBalance;
-
-            emit balanceChanged(newBalance, newStake, newUnconfirmedBalance, newImmatureBalance);
-        }
+        emit balanceChanged(cachedBalance, cachedStake, cachedUnconfirmedBalance, cachedImmatureBalance);
     }
 }
 
@@ -295,18 +289,20 @@ bool WalletModel::validateAddress(const QString &address)
     return IsValidDestination(addressParsed);
 }
 
-WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipient> &recipients, const CCoinControl *coinControl)
+WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipient> &recipients,
+                                                    const CCoinControl *coinControl,
+                                                    qint64 acceptedFee)
 {
-    qint64 total = 0;
     QSet<QString> setAddress;
-    QString hex;
 
     if(recipients.empty())
     {
         return OK;
     }
 
-    // Pre-check input data for validity
+    // Pre-check input data for validity. These are purely GUI-detectable
+    // conditions (parseable address, positive amount, no duplicate
+    // recipients), so they are checked here and never reach the interface.
     for (const SendCoinsRecipient& rcp : recipients) {
         if(!validateAddress(rcp.address))
         {
@@ -318,7 +314,6 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         {
             return InvalidAmount;
         }
-        total += rcp.amount;
     }
 
     if(recipients.size() > setAddress.size())
@@ -326,312 +321,50 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         return DuplicateAddress;
     }
 
-    int64_t nBalance = 0;
-    std::vector<COutput> vCoins;
-    wallet->AvailableCoins(vCoins, true, coinControl,false);
+    std::vector<interfaces::WalletSendRecipient> vRecipients;
+    vRecipients.reserve(recipients.size());
 
-    for (auto const& out : vCoins)
-        nBalance += out.tx->vout[out.i].nValue;
-
-    bool fAnySubtractFeeFromAmount = false;
-    for (const SendCoinsRecipient& rcp : recipients)
-    {
-        if (rcp.fSubtractFeeFromAmount)
-        {
-            fAnySubtractFeeFromAmount = true;
-            break;
-        }
-    }
-
-    if(total > nBalance)
-    {
-        return AmountExceedsBalance;
-    }
-
-    if(!fAnySubtractFeeFromAmount && (total + nTransactionFee) > nBalance)
-    {
-        return SendCoinsReturn(AmountWithFeeExceedsBalance, nTransactionFee);
-    }
-
-    CWalletTx wtx;
-
-    if (fAnySubtractFeeFromAmount)
-    {
-        wtx.mapValue["subtractFeeFromAmount"] = "1";
-    }
-
-    if (!recipients[0].Message.isEmpty())
-    {
-        CMutableTransaction mtx;
-        mtx.vContracts.emplace_back(GRC::MakeContract<GRC::TxMessage>(
-            GRC::ContractAction::ADD,
-            recipients[0].Message.toStdString()));
-        static_cast<CTransaction&>(wtx) = CTransaction(std::move(mtx));
-    }
-
-    {
-        LOCK2(cs_main, wallet->cs_wallet);
-
-        // Sendmany
-        std::vector<std::pair<CScript, int64_t> > vecSend;
-        for (const SendCoinsRecipient& rcp : recipients) {
-            CScript scriptPubKey;
-            scriptPubKey.SetDestination(DecodeDestination(rcp.address.toStdString()));
-            vecSend.push_back(std::make_pair(scriptPubKey, rcp.amount));
-        }
-
-        CReserveKey keyChange(wallet);
-        int64_t nFeeRequired = 0;
-        bool fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
-
-        // If any recipient has "subtract fee from amount" enabled, rebuild
-        // the outputs with the fee deducted and create the transaction
-        // again. This runs even if the first pass failed (e.g. sending
-        // entire balance), since CWallet::CreateTransaction overwrites the
-        // caller's nFeeRet to nTransactionFee on entry (wallet.cpp:2964)
-        // and bumps from there — so even a failed pass leaves a reasonable
-        // starting estimate.
-        //
-        // The loop refines the subtracted fee against the fee the wallet
-        // actually charges. A single retry is not enough because the
-        // wallet's own internal fee-bumping — primarily byte-tier
-        // crossing where nPayFee = nTransactionFee * (1 + nBytes/1000)
-        // jumps when the signed tx crosses each 1 KB boundary
-        // (wallet.cpp:3191) — can return an nFeeRequired that exceeds
-        // what we subtracted. Committing at that point under-debits the
-        // recipient and silently absorbs the surplus into the sender's
-        // change (issue #2981). Sub-CENT change handling
-        // (wallet.cpp:3064-3078) is a second potential fee-bumper but
-        // is dormant under default fee parameters because its trigger
-        // `nFeeRet < GetBaseFee` is false when nFeeRet is seeded from
-        // the default nTransactionFee.
-        //
-        // We require strict equality (subtracted == returned) for
-        // convergence. The earlier `<=` form let the inverse case
-        // (returned < subtracted) commit silently, over-debiting the
-        // recipient and "saving" the difference back to the sender's
-        // change.
-        //
-        // In a uniform-UTXO wallet, the loop can enter a 2-cycle: when
-        // the higher fee is subtracted, the target shrinks and the wallet
-        // picks fewer inputs (size drops below 1 KB → tier-1 fee, e.g.
-        // 0.001); when the lower fee is subtracted, the target grows and
-        // the wallet picks more inputs (size crosses 1 KB → tier-2 fee,
-        // 0.002). The two states map to each other and strict equality
-        // never fires. Constructable: ten 400.000-GRC UTXOs, send 2400.001
-        // with subtract-fee — the loop alternates 0.001 / 0.002
-        // indefinitely.
-        //
-        // To force a deterministic, convergent commit in such a case,
-        // track the largest fee observed during the loop and the input
-        // set that produced it. If the loop exits without strict
-        // convergence — whether from oscillation or from a slower
-        // non-converging case hitting the 10-attempt cap — pin coin
-        // selection to that input set via CCoinControl and re-create
-        // the transaction with the larger fee subtracted. With inputs
-        // pinned, SelectCoins returns exactly those outpoints
-        // (wallet.cpp:2750-2758), the transaction size is fixed, the
-        // wallet's computed fee matches our subtraction, and the commit
-        // converges. The sender pays exactly the entered amount; the
-        // recipient receives (entered − higher fee).
-        if (fAnySubtractFeeFromAmount)
-        {
-            int nSubtractRecipients = 0;
-            for (const SendCoinsRecipient& rcp : recipients)
-            {
-                if (rcp.fSubtractFeeFromAmount) ++nSubtractRecipients;
-            }
-
-            // Rebuild vecSend with the given fee distributed across the
-            // subtract-fee recipients. Returns false if any opted-in
-            // recipient's amount would drop to zero or negative; the
-            // caller should respond with FeeExceedsSubtractedAmount.
-            auto BuildSubtractedVecSend = [&](int64_t nFee) -> bool {
-                vecSend.clear();
-                int64_t nFeeRemainder = nFee % nSubtractRecipients;
-                bool fFirst = true;
-                for (const SendCoinsRecipient& rcp : recipients)
-                {
-                    CScript scriptPubKey;
-                    scriptPubKey.SetDestination(DecodeDestination(rcp.address.toStdString()));
-                    int64_t nAmount = rcp.amount;
-
-                    if (rcp.fSubtractFeeFromAmount)
-                    {
-                        nAmount -= nFee / nSubtractRecipients;
-                        // First opted-in recipient absorbs the truncation remainder
-                        if (fFirst)
-                        {
-                            nAmount -= nFeeRemainder;
-                            fFirst = false;
-                        }
-                        if (nAmount <= 0)
-                            return false;
-                    }
-
-                    vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
-                }
-                return true;
-            };
-
-            // Track the largest fee returned and the input set that
-            // produced it. Seed from pass 1 only if it succeeded —
-            // seeding nMaxFeeSeen from a *failed* pass-1 call would
-            // leave a phantom high fee with no corresponding snapshot
-            // (the wallet sets nFeeRet = nTransactionFee on entry and
-            // can bump it before returning false), which would then
-            // block subsequent successful iterations with lower fees
-            // from populating vinsAtMaxFee via the `>` comparison.
-            // Inside the loop, snapshot on the first success regardless
-            // of fee value (vinsAtMaxFee.empty()) so we always have a
-            // valid input set to pin if the rescue is needed.
-            int64_t nMaxFeeSeen = 0;
-            std::vector<COutPoint> vinsAtMaxFee;
-            if (fCreated)
-            {
-                nMaxFeeSeen = nFeeRequired;
-                for (const CTxIn& in : wtx.vin)
-                    vinsAtMaxFee.push_back(in.prevout);
-            }
-            bool fConverged = false;
-
-            for (int nAttempt = 0; nAttempt < 10; ++nAttempt)
-            {
-                if (!BuildSubtractedVecSend(nFeeRequired))
-                    return SendCoinsReturn(FeeExceedsSubtractedAmount, nFeeRequired);
-
-                int64_t nFeePrev = nFeeRequired;
-                fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coinControl);
-
-                if (fCreated && nFeeRequired == nFeePrev)
-                {
-                    fConverged = true;
-                    break;
-                }
-
-                if (fCreated && (vinsAtMaxFee.empty() || nFeeRequired > nMaxFeeSeen))
-                {
-                    nMaxFeeSeen = nFeeRequired;
-                    vinsAtMaxFee.clear();
-                    for (const CTxIn& in : wtx.vin)
-                        vinsAtMaxFee.push_back(in.prevout);
-                }
-            }
-
-            // Rescue pass for oscillation or cap-without-convergence.
-            // Requires a non-empty snapshot — if every prior pass failed
-            // we have no input set to pin and we fall through to the
-            // TransactionCreationFailed return below.
-            //
-            // Pinning the inputs locks transaction size against
-            // SelectCoins-driven input-count flipping. Under default
-            // Gridcoin fee parameters and reasonable UTXO shapes the
-            // wallet returns the same fee on the rescue call that
-            // produced the snapshot — fee-tier transitions happen at
-            // the 1 KB byte boundary, and the only remaining structural
-            // variation (change-vout present/absent, ±34 bytes) plus
-            // per-signature DER length variation (1-2 bytes per input)
-            // are not enough to cross 1 KB at typical input counts:
-            // 6 pinned inputs span 936-970 bytes (tier 1×), 7 pinned
-            // span 1084-1118 bytes (tier 2×). So in practice the rescue
-            // converges in iter 0.
-            //
-            // The bounded loop is defensive against pathologies I can
-            // describe but cannot construct concretely: keypool
-            // exhaustion mid-rescue (CreateTransaction returns false on
-            // reservekey.GetReservedKey), an unusually low custom
-            // -paytxfee combined with an adversarial UTXO sum that
-            // re-activates the sub-CENT change handler at
-            // wallet.cpp:3064-3078 (which is dormant under defaults
-            // because the trigger nFeeRet < GetBaseFee is false once
-            // nFeeRet equals the default nTransactionFee), or a future
-            // change to wallet internals that introduces new
-            // fee-determining factors. The strict-equality convergence
-            // check matches the outer loop; on non-convergence we set
-            // fCreated = false so the caller returns
-            // TransactionCreationFailed rather than commit a tx whose
-            // subtract-fee accounting doesn't match the wallet's actual
-            // charge.
-            if (!fConverged && !vinsAtMaxFee.empty())
-            {
-                // Copy any caller-supplied options (destChange,
-                // fAllowWatchOnly) and add the pinned outpoints. CCoinControl
-                // uses default copy semantics; setSelected, destChange, and
-                // fAllowWatchOnly are all carried over.
-                CCoinControl pinControl;
-                if (coinControl) pinControl = *coinControl;
-                for (const COutPoint& op : vinsAtMaxFee)
-                    pinControl.Select(op);
-
-                int64_t nRescueFee = nMaxFeeSeen;
-                bool fRescueConverged = false;
-                for (int nRescueAttempt = 0; nRescueAttempt < 5; ++nRescueAttempt)
-                {
-                    if (!BuildSubtractedVecSend(nRescueFee))
-                        return SendCoinsReturn(FeeExceedsSubtractedAmount, nRescueFee);
-
-                    int64_t nRescuePrev = nRescueFee;
-                    nFeeRequired = 0;
-                    fCreated = wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, &pinControl);
-                    if (!fCreated)
-                        break;
-
-                    if (nFeeRequired == nRescuePrev)
-                    {
-                        fRescueConverged = true;
-                        break;
-                    }
-                    nRescueFee = nFeeRequired;
-                }
-
-                // Non-converging rescue: fall through to the
-                // TransactionCreationFailed return below rather than
-                // commit a tx whose subtract-fee accounting doesn't
-                // match the wallet's actual charge.
-                if (!fRescueConverged)
-                    fCreated = false;
-            }
-        }
-
-        if(!fCreated)
-        {
-            if(!fAnySubtractFeeFromAmount && (total + nFeeRequired) > nBalance)
-            {
-                return SendCoinsReturn(AmountWithFeeExceedsBalance, nFeeRequired);
-            }
-            return TransactionCreationFailed;
-        }
-
-        if(!uiInterface.ThreadSafeAskFee(nFeeRequired, tr("Sending...").toStdString()))
-        {
-            return Aborted;
-        }
-        if(!wallet->CommitTransaction(wtx, keyChange))
-        {
-            return TransactionCommitFailed;
-        }
-        hex = QString::fromStdString(wtx.GetHash().GetHex());
-    }
-
-    // Add addresses / update labels that we've sent to the address book
     for (const SendCoinsRecipient& rcp : recipients) {
-        std::string strAddress = rcp.address.toStdString();
-        CTxDestination dest = DecodeDestination(strAddress);
-        std::string strLabel = rcp.label.toStdString();
-        {
-            LOCK(wallet->cs_wallet);
-
-            auto mi = wallet->mapAddressBook.find(dest);
-
-            // Check if we have a new address or an updated label
-            if (mi == wallet->mapAddressBook.end() || mi->second.name != strLabel)
-            {
-                wallet->SetAddressBookName(dest, strLabel);
-            }
-        }
+        interfaces::WalletSendRecipient recipient;
+        recipient.address = rcp.address.toStdString();
+        recipient.label = rcp.label.toStdString();
+        recipient.amount = rcp.amount;
+        recipient.message = rcp.Message.toStdString();
+        recipient.subtract_fee_from_amount = rcp.fSubtractFeeFromAmount;
+        vRecipients.push_back(std::move(recipient));
     }
 
-    return SendCoinsReturn(OK, 0, hex);
+    // Creation, fee convergence, fee-threshold gating, and commit all run
+    // node-side; a FeeConfirmationRequired result comes back WITHOUT a
+    // commit so the caller can prompt the user with no core locks held and
+    // re-invoke with the accepted fee (the eliminated ThreadSafeAskFee used
+    // to block inside the node's LOCK2 scope right before the commit).
+    const interfaces::SendCoinsResult result =
+        m_wallet.sendCoins(vRecipients, coinControl, acceptedFee);
+
+    switch (result.status) {
+    case interfaces::SendCoinsStatus::OK:
+        return SendCoinsReturn(OK, 0, QString::fromStdString(result.txid_hex));
+    case interfaces::SendCoinsStatus::InvalidAddress:
+        return InvalidAddress;
+    case interfaces::SendCoinsStatus::InvalidAmount:
+        return InvalidAmount;
+    case interfaces::SendCoinsStatus::AmountExceedsBalance:
+        return AmountExceedsBalance;
+    case interfaces::SendCoinsStatus::AmountWithFeeExceedsBalance:
+        return SendCoinsReturn(AmountWithFeeExceedsBalance, result.fee);
+    case interfaces::SendCoinsStatus::FeeExceedsSubtractedAmount:
+        return SendCoinsReturn(FeeExceedsSubtractedAmount, result.fee);
+    case interfaces::SendCoinsStatus::TransactionCreationFailed:
+        return TransactionCreationFailed;
+    case interfaces::SendCoinsStatus::TransactionCommitFailed:
+        return TransactionCommitFailed;
+    case interfaces::SendCoinsStatus::FeeConfirmationRequired:
+        return SendCoinsReturn(FeeConfirmationRequired, result.fee);
+    }
+
+    // Unreachable: the switch above covers every SendCoinsStatus value.
+    assert(false);
 }
 
 OptionsModel *WalletModel::getOptionsModel()
@@ -651,11 +384,11 @@ TransactionTableModel *WalletModel::getTransactionTableModel()
 
 WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const
 {
-    if(!wallet->IsCrypted())
+    if(!m_wallet.isCrypted())
     {
         return Unencrypted;
     }
-    else if(wallet->IsLocked())
+    else if(m_wallet.isLocked())
     {
         return Locked;
     }
@@ -667,53 +400,33 @@ WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const
 
 bool WalletModel::setWalletEncrypted(const SecureString& passphrase)
 {
-        return wallet->EncryptWallet(passphrase);
+    return m_wallet.encryptWallet(passphrase);
 }
 
-bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase)
+bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase, bool stakingOnly)
 {
     if(locked)
     {
-        // Lock
-        return wallet->Lock();
+        // Lock. Does not clear the staking-only unlock preference.
+        return m_wallet.lockWallet();
     }
     else
     {
-        // Unlock
-        return wallet->Unlock(passPhrase);
+        // Unlock; on success the staking-only preference is set node-side
+        // (a full unlock clears a stale staking-only restriction).
+        return m_wallet.unlockWallet(passPhrase, stakingOnly);
     }
 }
 
 bool WalletModel::changePassphrase(const SecureString &oldPass, const SecureString &newPass)
 {
-    bool retval;
-    {
-        LOCK(wallet->cs_wallet);
-        wallet->Lock(); // Make sure wallet is locked before attempting pass change
-        retval = wallet->ChangeWalletPassphrase(oldPass, newPass);
-    }
-    return retval;
+    // Locks the wallet first (node-side) before attempting the change.
+    return m_wallet.changeWalletPassphrase(oldPass, newPass);
 }
 
-// Handlers for core signals
-static void NotifyKeyStoreStatusChanged(WalletModel *walletmodel, CCryptoKeyStore *wallet)
-{
-    LogPrintf("NotifyKeyStoreStatusChanged");
-    QMetaObject::invokeMethod(walletmodel, "updateStatus", Qt::QueuedConnection);
-}
-
-static void NotifyAddressBookChanged(WalletModel *walletmodel, CWallet *wallet, const CTxDestination &address, const std::string &label, bool isMine, const std::string &purpose, ChangeType status)
-{
-    // `purpose` is accepted to match the 6-arg core signal but is not yet surfaced to the GUI;
-    // the updateAddressBook slot remains a 4-arg interface (address, label, isMine, status).
-    LogPrintf("NotifyAddressBookChanged %s %s isMine=%i purpose=%s status=%i", EncodeDestination(address), label, isMine, purpose, status);
-    QMetaObject::invokeMethod(walletmodel, "updateAddressBook", Qt::QueuedConnection,
-                              Q_ARG(QString, QString::fromStdString(EncodeDestination(address))),
-                              Q_ARG(QString, QString::fromStdString(label)),
-                              Q_ARG(bool, isMine),
-                              Q_ARG(int, status));
-}
-
+// Producer-side handlers for the tx-table core signals (the Phase 1c-ii
+// leg; the status and address-book notifications arrive through
+// interfaces::Wallet handlers registered in subscribeToCoreSignals).
 static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)
 {
@@ -892,17 +605,40 @@ static void NotifyBlocksChangedForWallet(WalletModel *walletmodel,
 
 void WalletModel::subscribeToCoreSignals()
 {
-    // Connect signals to wallet, retaining each connection so it is severed in
+    // Register notification handlers, retaining each so it is severed in
     // unsubscribeFromCoreSignals() (from ~WalletModel). Every callback below
     // captures `this`; a signal firing after this object is gone would
     // otherwise invoke a slot on freed memory during shutdown.
-    m_handlers.emplace_back(wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this,
-                                                    boost::placeholders::_1)));
-    m_handlers.emplace_back(wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this,
-                                                         boost::placeholders::_1, boost::placeholders::_2,
-                                                         boost::placeholders::_3, boost::placeholders::_4,
-                                                         boost::placeholders::_5, boost::placeholders::_6)));
-    m_handlers.emplace_back(wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this,
+    //
+    // Status and address-book changes come through the interfaces::Wallet
+    // boundary as value types (Phase 1c-i). The callbacks fire on core
+    // threads, possibly under core locks, so they enqueue to the Qt thread
+    // and return — same discipline the raw-signal handlers applied.
+    m_wallet_handlers.emplace_back(m_wallet.handleStatusChanged(
+        [this]() {
+            LogPrintf("NotifyKeyStoreStatusChanged");
+            QMetaObject::invokeMethod(this, "updateStatus", Qt::QueuedConnection);
+        }));
+    m_wallet_handlers.emplace_back(m_wallet.handleAddressBookChanged(
+        [this](const std::string& address, const std::string& label, bool is_mine,
+               const std::string& purpose, ChangeType status) {
+            // `purpose` is accepted to match the 6-arg core signal but is not
+            // yet surfaced to the GUI; the updateAddressBook slot remains a
+            // 4-arg interface (address, label, isMine, status).
+            LogPrintf("NotifyAddressBookChanged %s %s isMine=%i purpose=%s status=%i",
+                      address, label, is_mine, purpose, status);
+            QMetaObject::invokeMethod(this, "updateAddressBook", Qt::QueuedConnection,
+                                      Q_ARG(QString, QString::fromStdString(address)),
+                                      Q_ARG(QString, QString::fromStdString(label)),
+                                      Q_ARG(bool, is_mine),
+                                      Q_ARG(int, status));
+        }));
+
+    // The tx-table producer wiring stays on the raw core signals until the
+    // store/event-queue machinery migrates behind interfaces::WalletTxSource
+    // (Phase 1c-ii) — the producer runs under the emitting thread's locks by
+    // design (it decomposes transactions in place).
+    m_handlers.emplace_back(m_core_wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this,
                                                          boost::placeholders::_1, boost::placeholders::_2,
                                                          boost::placeholders::_3)));
     m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(boost::bind(NotifyBlocksChangedForWallet, this,
@@ -913,9 +649,11 @@ void WalletModel::subscribeToCoreSignals()
 void WalletModel::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from wallet: clearing the retained connections runs
-    // each scoped_connection's destructor, which disconnects it. This also
-    // covers the uiInterface.NotifyBlocksChanged connection, which the previous
-    // hand-written disconnects missed and leaked (issue #3129 follow-up).
+    // each scoped_connection's (and interfaces::Handler's) destructor, which
+    // disconnects it. This also covers the uiInterface.NotifyBlocksChanged
+    // connection, which the previous hand-written disconnects missed and
+    // leaked (issue #3129 follow-up).
+    m_wallet_handlers.clear();
     m_handlers.clear();
 }
 
@@ -924,7 +662,10 @@ WalletModel::UnlockContext WalletModel::requestUnlock()
 {
     bool was_locked = getEncryptionStatus() == Locked;
 
-    if ((!was_locked) && fWalletUnlockStakingOnly)
+    // A staking-only unlock is not enough here: relock and force a full
+    // unlock prompt. (isUnlockedForStakingOnly is the unlocked-AND-restricted
+    // composite, so it can only be true on the !was_locked path.)
+    if ((!was_locked) && m_wallet.isUnlockedForStakingOnly())
     {
        setWalletLocked(true);
        was_locked = getEncryptionStatus() == Locked;
@@ -938,7 +679,7 @@ WalletModel::UnlockContext WalletModel::requestUnlock()
     // If wallet is still locked, unlock was failed or cancelled, mark context as invalid
     bool valid = getEncryptionStatus() != Locked;
 
-    return UnlockContext(this, valid, was_locked && !fWalletUnlockStakingOnly);
+    return UnlockContext(this, valid, was_locked && !m_wallet.isUnlockedForStakingOnly());
 }
 
 WalletModel::UnlockContext::UnlockContext(WalletModel *wallet, bool valid, bool relock):
@@ -965,76 +706,24 @@ void WalletModel::UnlockContext::CopyFrom(const UnlockContext& rhs)
 
 bool WalletModel::getPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
 {
-    return wallet->GetPubKey(address, vchPubKeyOut);
+    return m_wallet.getPubKey(address, vchPubKeyOut);
 }
 
 bool WalletModel::getKeyFromPool(CPubKey& out_public_key, const std::string& label)
 {
-    if (!wallet->GetKeyFromPool(out_public_key, false)) {
-        return false;
-    }
-
-    if (!label.empty()) {
-        wallet->SetAddressBookName(out_public_key.GetID(), label);
-    }
-
-    return true;
+    return m_wallet.getKeyFromPool(out_public_key, label);
 }
 
-// returns a list of COutputs from COutPoints
-void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs)
+// returns value snapshots of the given outpoints (unknown or conflicted
+// outpoints are skipped)
+std::vector<interfaces::WalletOutput> WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints) const
 {
-    LOCK2(cs_main, wallet->cs_wallet);
-    for (auto const& outpoint : vOutpoints)
-    {
-        if (!wallet->mapWallet.count(outpoint.hash)) continue;
-        int nDepth = wallet->mapWallet[outpoint.hash].GetDepthInMainChain();
-        if (nDepth < 0) continue;
-        COutput out(&wallet->mapWallet[outpoint.hash], outpoint.n, nDepth);
-        vOutputs.push_back(out);
-    }
+    return m_wallet.getOutputs(vOutpoints);
 }
 
-// AvailableCoins + LockedCoins grouped by wallet address (put change in one group with wallet address)
-void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const
+// AvailableCoins grouped by wallet address (change is grouped under the
+// address it derives from, walked node-side)
+std::map<std::string, std::vector<interfaces::WalletOutput>> WalletModel::listCoins() const
 {
-    std::vector<COutput> vCoins;
-    wallet->AvailableCoins(vCoins, true, nullptr, false);
-
-    LOCK2(cs_main, wallet->cs_wallet); // ListLockedCoins, mapWallet
-
-    for (auto const& out : vCoins)
-    {
-        COutput cout = out;
-
-        while (wallet->IsChange(cout.tx->vout[cout.i]) && cout.tx->vin.size() > 0 && (wallet->IsMine(cout.tx->vin[0]) != ISMINE_NO))
-        {
-            if (!wallet->mapWallet.count(cout.tx->vin[0].prevout.hash)) break;
-            cout = COutput(&wallet->mapWallet[cout.tx->vin[0].prevout.hash], cout.tx->vin[0].prevout.n, 0);
-        }
-
-        CTxDestination address;
-        if(!ExtractDestination(cout.tx->vout[cout.i].scriptPubKey, address)) continue;
-        mapCoins[EncodeDestination(address).c_str()].push_back(out);
-    }
-}
-
-bool WalletModel::isLockedCoin(uint256 hash, unsigned int n) const
-{
-    return false;
-}
-
-void WalletModel::lockCoin(COutPoint& output)
-{
-    return;
-}
-
-void WalletModel::unlockCoin(COutPoint& output)
-{
-    return;
-}
-
-void WalletModel::listLockedCoins(std::vector<COutPoint>& vOutpts)
-{
-    return;
+    return m_wallet.listCoins();
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -363,8 +363,12 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipie
         return SendCoinsReturn(FeeConfirmationRequired, result.fee);
     }
 
-    // Unreachable: the switch above covers every SendCoinsStatus value.
+    // Unreachable: the switch above covers every SendCoinsStatus value (and
+    // deliberately has no default, so -Wswitch flags a new enumerator). The
+    // return keeps the function well-defined in NDEBUG builds, where the
+    // assert compiles out and falling off the end would be UB.
     assert(false);
+    return TransactionCreationFailed;
 }
 
 OptionsModel *WalletModel::getOptionsModel()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -290,7 +290,7 @@ bool WalletModel::validateAddress(const QString &address)
 }
 
 WalletModel::SendCoinsReturn WalletModel::sendCoins(const QList<SendCoinsRecipient> &recipients,
-                                                    const CCoinControl *coinControl,
+                                                    const std::optional<interfaces::WalletCoinControl>& coinControl,
                                                     qint64 acceptedFee)
 {
     QSet<QString> setAddress;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -20,7 +21,6 @@ class CWallet;
 class CKeyID;
 class CPubKey;
 class COutPoint;
-class CCoinControl;
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -123,7 +123,7 @@ public:
     // Send coins to a list of recipients. acceptedFee is the largest fee the
     // user has already confirmed (see StatusCode::FeeConfirmationRequired).
     SendCoinsReturn sendCoins(const QList<SendCoinsRecipient>& recipients,
-                              const CCoinControl* coinControl = nullptr,
+                              const std::optional<interfaces::WalletCoinControl>& coinControl = std::nullopt,
                               qint64 acceptedFee = 0);
 
     // Wallet encryption

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -2,15 +2,16 @@
 #define BITCOIN_QT_WALLETMODEL_H
 
 #include <QObject>
-#include <vector>
 #include <map>
+#include <string>
+#include <vector>
 
 #include <boost/signals2/connection.hpp>
 
+#include "interfaces/wallet.h"
 #include "qt/wallet_event_queue.h"
 #include "qt/wallettxstore.h"
 #include "support/allocators/secure.h" /* for SecureString */
-#include "wallet/ismine.h"
 
 class OptionsModel;
 class AddressTableModel;
@@ -18,9 +19,7 @@ class TransactionTableModel;
 class CWallet;
 class CKeyID;
 class CPubKey;
-class COutput;
 class COutPoint;
-class uint256;
 class CCoinControl;
 
 QT_BEGIN_NAMESPACE
@@ -43,7 +42,12 @@ class WalletModel : public QObject
     Q_OBJECT
 
 public:
-    explicit WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* parent = nullptr);
+    //! The query/command surface goes through the interfaces::Wallet
+    //! boundary (Phase 1c-i); the raw CWallet* leg feeds only the tx-table
+    //! store/event-queue machinery, which migrates behind
+    //! interfaces::WalletTxSource in Phase 1c-ii — do not add new uses.
+    explicit WalletModel(interfaces::Wallet& wallet, CWallet* core_wallet,
+                         OptionsModel* optionsModel, QObject* parent = nullptr);
     ~WalletModel();
 
     enum StatusCode // Returned by sendCoins
@@ -57,7 +61,13 @@ public:
         DuplicateAddress,
         TransactionCreationFailed, // Error returned when wallet is still locked
         TransactionCommitFailed,
-        Aborted
+        Aborted,
+        //! The required fee exceeds both the configured transaction fee and
+        //! the fee the caller has accepted so far; nothing was committed.
+        //! The caller prompts the user (with no core locks held — this
+        //! replaces the eliminated ThreadSafeAskFee modal) and re-invokes
+        //! sendCoins with acceptedFee set to the returned fee.
+        FeeConfirmationRequired
     };
 
     enum EncryptionStatus
@@ -66,6 +76,11 @@ public:
         Locked,       // wallet->IsCrypted() && wallet->IsLocked()
         Unlocked      // wallet->IsCrypted() && !wallet->IsLocked()
     };
+
+    //! The interface boundary for wallet queries and commands. Dialogs that
+    //! need surface not wrapped by this model (e.g. the staking-only unlock
+    //! preference) reach it here rather than through core globals.
+    interfaces::Wallet& wallet() const { return m_wallet; }
 
     OptionsModel *getOptionsModel();
     AddressTableModel *getAddressTableModel();
@@ -101,13 +116,18 @@ public:
         QString hex; // is filled with the transaction hash if status is "OK"
     };
 
-    // Send coins to a list of recipients
-    SendCoinsReturn sendCoins(const QList<SendCoinsRecipient>& recipients, const CCoinControl* coinControl = nullptr);
+    // Send coins to a list of recipients. acceptedFee is the largest fee the
+    // user has already confirmed (see StatusCode::FeeConfirmationRequired).
+    SendCoinsReturn sendCoins(const QList<SendCoinsRecipient>& recipients,
+                              const CCoinControl* coinControl = nullptr,
+                              qint64 acceptedFee = 0);
 
     // Wallet encryption
     bool setWalletEncrypted(const SecureString& passphrase);
-    // Passphrase only needed when unlocking
-    bool setWalletLocked(bool locked, const SecureString& passPhrase=SecureString());
+    // Passphrase only needed when unlocking; stakingOnly restricts the
+    // unlock to staking (persisted node-side as the unlock preference).
+    bool setWalletLocked(bool locked, const SecureString& passPhrase=SecureString(),
+                         bool stakingOnly = false);
     bool changePassphrase(const SecureString& oldPass, const SecureString& newPass);
 
     // RAI object for unlocking wallet, returned by requestUnlock()
@@ -137,12 +157,8 @@ public:
 
     bool getPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
     bool getKeyFromPool(CPubKey& out_public_key, const std::string& label);
-    void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
-    void listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const;
-    bool isLockedCoin(uint256 hash, unsigned int n) const;
-    void lockCoin(COutPoint& output);
-    void unlockCoin(COutPoint& output);
-    void listLockedCoins(std::vector<COutPoint>& vOutpts);
+    std::vector<interfaces::WalletOutput> getOutputs(const std::vector<COutPoint>& vOutpoints) const;
+    std::map<std::string, std::vector<interfaces::WalletOutput>> listCoins() const;
 
     //!
     //! \brief Producer→GUI event channel. Producers (core threads firing
@@ -166,7 +182,14 @@ public:
     void requestEventDrainSoon();
 
 private:
-    CWallet *wallet;
+    //! Interface boundary for the query/command surface (Phase 1c-i).
+    interfaces::Wallet& m_wallet;
+
+    //! Raw wallet pointer feeding ONLY the tx-table store/event-queue
+    //! producer leg (m_txStore, the NotifyTransactionChanged handler, and
+    //! the sub-models' constructors), which migrates behind
+    //! interfaces::WalletTxSource in Phase 1c-ii. Do not add new uses.
+    CWallet *m_core_wallet;
 
     // Wallet has an options model for wallet-specific options
     // (transaction fee, for example)
@@ -219,10 +242,16 @@ private:
     void unsubscribeFromCoreSignals();
     void checkBalanceChanged();
 
-    //! Retained core-signal connections, cleared on teardown so a signal that
-    //! fires after this model is destroyed cannot invoke a slot bound to freed
-    //! memory. scoped_connection disconnects on destruction (issue #3129).
+    //! Retained core-signal connections for the tx-table producer leg
+    //! (Phase 1c-ii), cleared on teardown so a signal that fires after this
+    //! model is destroyed cannot invoke a slot bound to freed memory.
+    //! scoped_connection disconnects on destruction (issue #3129).
     std::vector<boost::signals2::scoped_connection> m_handlers;
+
+    //! Retained interface notification handlers (status and address-book
+    //! changes), cleared on teardown. interfaces::Handler disconnects on
+    //! destruction.
+    std::vector<std::unique_ptr<interfaces::Handler>> m_wallet_handlers;
 
 
 public slots:

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -59,7 +59,11 @@ public:
         AmountWithFeeExceedsBalance,
         FeeExceedsSubtractedAmount,
         DuplicateAddress,
-        TransactionCreationFailed, // Error returned when wallet is still locked
+        //! Transaction could not be created and nothing was committed. Most
+        //! commonly the wallet is still locked; also covers subtract-fee
+        //! non-convergence node-side and the fee-confirmation attempt cap
+        //! in SendCoinsDialog.
+        TransactionCreationFailed,
         TransactionCommitFailed,
         Aborted,
         //! The required fee exceeds both the configured transaction fee and

--- a/src/rpc/htlc.cpp
+++ b/src/rpc/htlc.cpp
@@ -121,7 +121,7 @@ UniValue createhtlc(const UniValue& params)
 
         // Send the transaction
         CWalletTx wtx;
-        string strError = pwalletMain->SendMoney(scriptPubKey, nAmount, wtx, false);
+        string strError = pwalletMain->SendMoney(scriptPubKey, nAmount, wtx);
         if (!strError.empty())
             throw JSONRPCError(RPC_WALLET_ERROR, strError);
 

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(wallet_send_coins_boundary_guards)
 
     // An empty recipient list must fail cleanly rather than index
     // recipients[0] (the GUI pre-checks this; a direct caller must not UB).
-    interfaces::SendCoinsResult result = wallet->sendCoins({}, nullptr, 0);
+    interfaces::SendCoinsResult result = wallet->sendCoins({}, std::nullopt, 0);
     BOOST_CHECK(result.status == interfaces::SendCoinsStatus::TransactionCreationFailed);
 
     // An undecodable address must be rejected node-side — it would
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(wallet_send_coins_boundary_guards)
     interfaces::WalletSendRecipient bad_recipient;
     bad_recipient.address = "not-a-valid-address";
     bad_recipient.amount = 1;
-    result = wallet->sendCoins({bad_recipient}, nullptr, 0);
+    result = wallet->sendCoins({bad_recipient}, std::nullopt, 0);
     BOOST_CHECK(result.status == interfaces::SendCoinsStatus::InvalidAddress);
 
     // With a well-formed address, the empty test wallet has no spendable
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(wallet_send_coins_boundary_guards)
     interfaces::WalletSendRecipient recipient;
     recipient.address = EncodeDestination(CKeyID());
     recipient.amount = 1;
-    result = wallet->sendCoins({recipient}, nullptr, 0);
+    result = wallet->sendCoins({recipient}, std::nullopt, 0);
     BOOST_CHECK(result.status == interfaces::SendCoinsStatus::AmountExceedsBalance);
     BOOST_CHECK(result.txid_hex.empty());
 }

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -9,6 +9,7 @@
 #include "interfaces/node.h"
 #include "interfaces/staking.h"
 #include "interfaces/wallet.h"
+#include "key_io.h"
 #include "node/ui_interface.h"
 #include "sync.h"
 #include "util.h"
@@ -134,6 +135,129 @@ BOOST_AUTO_TEST_CASE(wallet_wraps_cwallet)
 
     handler->disconnect();
     pwalletMain->NotifyTransactionChanged(pwalletMain, probe, CT_NEW);
+    BOOST_CHECK_EQUAL(calls, 1);
+}
+
+BOOST_AUTO_TEST_CASE(wallet_query_surface_wraps_cwallet)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    std::unique_ptr<interfaces::Wallet> wallet = interfaces::MakeWallet(pwalletMain);
+
+    BOOST_CHECK_EQUAL(wallet->getNumTransactions(),
+                      static_cast<int>(WITH_LOCK(pwalletMain->cs_wallet,
+                                                 return pwalletMain->mapWallet.size())));
+
+    // No contention in the unit-test environment, so the try-variant must
+    // succeed and agree with the unconditional single getters.
+    interfaces::WalletBalances balances;
+    BOOST_REQUIRE(wallet->tryGetBalances(balances));
+    BOOST_CHECK_EQUAL(balances.balance, pwalletMain->GetBalance());
+    BOOST_CHECK_EQUAL(balances.stake, pwalletMain->GetStake());
+    BOOST_CHECK_EQUAL(balances.unconfirmed_balance, pwalletMain->GetUnconfirmedBalance());
+    BOOST_CHECK_EQUAL(balances.immature_balance, pwalletMain->GetImmatureBalance());
+
+    // Staking-only preference: the raw flag getter tracks the global; the
+    // composite requires the wallet to actually be unlocked.
+    const bool saved_flag = fWalletUnlockStakingOnly;
+    fWalletUnlockStakingOnly = true;
+    BOOST_CHECK(wallet->getUnlockStakingOnlyFlag());
+    BOOST_CHECK_EQUAL(wallet->isUnlockedForStakingOnly(), !pwalletMain->IsLocked());
+    fWalletUnlockStakingOnly = false;
+    BOOST_CHECK(!wallet->getUnlockStakingOnlyFlag());
+    BOOST_CHECK(!wallet->isUnlockedForStakingOnly());
+
+    // The test wallet is unencrypted: Unlock must fail, and a failed unlock
+    // must NOT overwrite the staking-only preference.
+    BOOST_CHECK(!wallet->unlockWallet(SecureString("passphrase"), true));
+    BOOST_CHECK(!wallet->getUnlockStakingOnlyFlag());
+    fWalletUnlockStakingOnly = saved_flag;
+
+    // Unknown outpoints are skipped; the coin queries return empty value
+    // containers rather than touching wallet internals.
+    const std::vector<COutPoint> unknown{COutPoint(uint256S("0xdeadbeef"), 0)};
+    BOOST_CHECK(wallet->getOutputs(unknown).empty());
+    BOOST_CHECK(wallet->getOutputs({}).empty());
+    BOOST_CHECK(wallet->listCoins().empty());
+}
+
+BOOST_AUTO_TEST_CASE(wallet_send_coins_boundary_guards)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    std::unique_ptr<interfaces::Wallet> wallet = interfaces::MakeWallet(pwalletMain);
+
+    // An empty recipient list must fail cleanly rather than index
+    // recipients[0] (the GUI pre-checks this; a direct caller must not UB).
+    interfaces::SendCoinsResult result = wallet->sendCoins({}, nullptr, 0);
+    BOOST_CHECK(result.status == interfaces::SendCoinsStatus::TransactionCreationFailed);
+
+    // An undecodable address must be rejected node-side — it would
+    // otherwise become an empty (anyone-can-spend) output script.
+    interfaces::WalletSendRecipient bad_recipient;
+    bad_recipient.address = "not-a-valid-address";
+    bad_recipient.amount = 1;
+    result = wallet->sendCoins({bad_recipient}, nullptr, 0);
+    BOOST_CHECK(result.status == interfaces::SendCoinsStatus::InvalidAddress);
+
+    // With a well-formed address, the empty test wallet has no spendable
+    // coins, so any positive send must fail the node-side balance pre-check
+    // without creating anything.
+    interfaces::WalletSendRecipient recipient;
+    recipient.address = EncodeDestination(CKeyID());
+    recipient.amount = 1;
+    result = wallet->sendCoins({recipient}, nullptr, 0);
+    BOOST_CHECK(result.status == interfaces::SendCoinsStatus::AmountExceedsBalance);
+    BOOST_CHECK(result.txid_hex.empty());
+}
+
+BOOST_AUTO_TEST_CASE(wallet_key_from_pool_labels_address_book)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    std::unique_ptr<interfaces::Wallet> wallet = interfaces::MakeWallet(pwalletMain);
+
+    CPubKey pub_key;
+    const std::string label = "interfaces-test-label";
+    BOOST_REQUIRE(wallet->getKeyFromPool(pub_key, label));
+    BOOST_CHECK(pub_key.IsValid());
+
+    LOCK(pwalletMain->cs_wallet);
+    auto it = pwalletMain->mapAddressBook.find(pub_key.GetID());
+    BOOST_REQUIRE(it != pwalletMain->mapAddressBook.end());
+    BOOST_CHECK_EQUAL(it->second.name, label);
+}
+
+BOOST_AUTO_TEST_CASE(wallet_address_book_handler_bridges_value_types)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    std::unique_ptr<interfaces::Wallet> wallet = interfaces::MakeWallet(pwalletMain);
+
+    int calls = 0;
+    std::string seen_address, seen_label, seen_purpose;
+    ChangeType seen_status = CT_DELETED;
+    std::unique_ptr<interfaces::Handler> handler = wallet->handleAddressBookChanged(
+        [&](const std::string& address, const std::string& label, bool is_mine,
+            const std::string& purpose, ChangeType status) {
+            ++calls;
+            seen_address = address;
+            seen_label = label;
+            seen_purpose = purpose;
+            seen_status = status;
+            BOOST_CHECK(is_mine);
+        });
+
+    const CTxDestination dest = CKeyID();
+    pwalletMain->NotifyAddressBookChanged(pwalletMain, dest, "label", true, "purpose", CT_NEW);
+    BOOST_CHECK_EQUAL(calls, 1);
+    BOOST_CHECK_EQUAL(seen_address, EncodeDestination(dest));
+    BOOST_CHECK_EQUAL(seen_label, "label");
+    BOOST_CHECK_EQUAL(seen_purpose, "purpose");
+    BOOST_CHECK(seen_status == CT_NEW);
+
+    handler->disconnect();
+    pwalletMain->NotifyAddressBookChanged(pwalletMain, dest, "label", true, "purpose", CT_NEW);
     BOOST_CHECK_EQUAL(calls, 1);
 }
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -4,15 +4,43 @@
 
 #include "interfaces/wallet.h"
 
+#include "gridcoin/tx_message.h"
 #include "interfaces/handler.h"
 #include "key_io.h"
+#include "main.h"
+#include "policy/fees.h"
+#include "wallet/coincontrol.h"
 #include "wallet/wallet.h"
 
+#include <map>
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace interfaces {
 namespace {
+
+//! Build the value snapshot of one wallet output. The maturity flag needs
+//! cs_main (GetBlocksToMaturity walks the chain), which every caller holds.
+WalletOutput MakeWalletOutput(const CWalletTx& wtx, unsigned int n, int depth)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    WalletOutput output;
+    output.outpoint = COutPoint(wtx.GetHash(), n);
+    output.amount = wtx.vout[n].nValue;
+
+    CTxDestination address;
+    if (ExtractDestination(wtx.vout[n].scriptPubKey, address)) {
+        output.address = EncodeDestination(address);
+    }
+
+    output.depth = depth;
+    output.time = wtx.GetTxTime();
+    output.immature = wtx.IsCoinStake() && wtx.GetBlocksToMaturity() > 0 && depth > 0;
+
+    return output;
+}
 
 //! In-process Wallet implementation: thin wrappers over CWallet. Balance
 //! queries lock internally (CWallet takes LOCK2(cs_main, cs_wallet) itself),
@@ -31,6 +59,37 @@ public:
 
     int64_t getImmatureBalance() override { return m_wallet->GetImmatureBalance(); }
 
+    bool tryGetBalances(WalletBalances& balances) override
+    {
+        // The Get*Balance() calls iterate the wallet's full mapWallet and
+        // become very expensive on large wallets, so refresh-path callers
+        // must be able to bow out cleanly when the core is holding the locks
+        // (e.g. during a wallet rescan) instead of stalling the GUI thread.
+        // The locks are held across all four scans so the snapshot is
+        // coherent (the individual getters re-lock recursively).
+        TRY_LOCK(cs_main, lockMain);
+        if (!lockMain) {
+            return false;
+        }
+        TRY_LOCK(m_wallet->cs_wallet, lockWallet);
+        if (!lockWallet) {
+            return false;
+        }
+
+        balances.balance = m_wallet->GetBalance();
+        balances.stake = m_wallet->GetStake();
+        balances.unconfirmed_balance = m_wallet->GetUnconfirmedBalance();
+        balances.immature_balance = m_wallet->GetImmatureBalance();
+
+        return true;
+    }
+
+    int getNumTransactions() override
+    {
+        return WITH_LOCK(m_wallet->cs_wallet,
+                         return static_cast<int>(m_wallet->mapWallet.size()));
+    }
+
     bool isCrypted() override { return m_wallet->IsCrypted(); }
 
     bool isLocked() override { return m_wallet->IsLocked(); }
@@ -39,6 +98,128 @@ public:
     {
         return !m_wallet->IsLocked() && fWalletUnlockStakingOnly;
     }
+
+    bool getUnlockStakingOnlyFlag() override { return fWalletUnlockStakingOnly; }
+
+    bool encryptWallet(const SecureString& passphrase) override
+    {
+        return m_wallet->EncryptWallet(passphrase);
+    }
+
+    bool lockWallet() override { return m_wallet->Lock(); }
+
+    bool unlockWallet(const SecureString& passphrase, bool staking_only) override
+    {
+        if (!m_wallet->Unlock(passphrase)) {
+            return false;
+        }
+
+        fWalletUnlockStakingOnly = staking_only;
+
+        return true;
+    }
+
+    bool changeWalletPassphrase(const SecureString& old_passphrase,
+                                const SecureString& new_passphrase) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        m_wallet->Lock(); // Make sure wallet is locked before attempting pass change
+        return m_wallet->ChangeWalletPassphrase(old_passphrase, new_passphrase);
+    }
+
+    bool getPubKey(const CKeyID& address, CPubKey& pub_key_out) override
+    {
+        return m_wallet->GetPubKey(address, pub_key_out);
+    }
+
+    bool getKeyFromPool(CPubKey& pub_key_out, const std::string& label) override
+    {
+        if (!m_wallet->GetKeyFromPool(pub_key_out, false)) {
+            return false;
+        }
+
+        if (!label.empty()) {
+            m_wallet->SetAddressBookName(pub_key_out.GetID(), label);
+        }
+
+        return true;
+    }
+
+    std::vector<WalletOutput> getOutputs(const std::vector<COutPoint>& outpoints) override
+    {
+        std::vector<WalletOutput> outputs;
+
+        LOCK2(cs_main, m_wallet->cs_wallet);
+
+        for (const COutPoint& outpoint : outpoints) {
+            auto it = m_wallet->mapWallet.find(outpoint.hash);
+            if (it == m_wallet->mapWallet.end()) continue;
+            if (outpoint.n >= it->second.vout.size()) continue;
+            int depth = it->second.GetDepthInMainChain();
+            if (depth < 0) continue;
+            outputs.push_back(MakeWalletOutput(it->second, outpoint.n, depth));
+        }
+
+        return outputs;
+    }
+
+    std::map<std::string, std::vector<WalletOutput>> listCoins() override
+    {
+        // The locks are taken BEFORE the AvailableCoins scan (which re-locks
+        // recursively) and held across the loop below: COutput carries raw
+        // pointers into mapWallet, and an unlocked window between the scan
+        // and the dereferences would let a concurrent erasure (e.g. the
+        // mempool-conflict EraseFromWallet path) free the pointed-at
+        // transactions. The old GUI-side code scanned first and locked
+        // after; the migration closes that window.
+        std::map<std::string, std::vector<WalletOutput>> coins;
+
+        LOCK2(cs_main, m_wallet->cs_wallet); // mapWallet
+
+        std::vector<COutput> vCoins;
+        m_wallet->AvailableCoins(vCoins, true, nullptr, false);
+
+        for (const COutput& out : vCoins) {
+            // Group change under the address it derives from by walking back
+            // through own-wallet inputs (put change in one group with the
+            // wallet address).
+            COutput cout = out;
+
+            while (m_wallet->IsChange(cout.tx->vout[cout.i]) && cout.tx->vin.size() > 0
+                   && m_wallet->IsMine(cout.tx->vin[0]) != ISMINE_NO)
+            {
+                auto it = m_wallet->mapWallet.find(cout.tx->vin[0].prevout.hash);
+                if (it == m_wallet->mapWallet.end()) break;
+                cout = COutput(&it->second, cout.tx->vin[0].prevout.n, 0);
+            }
+
+            WalletOutput output = MakeWalletOutput(*out.tx, out.i, out.nDepth);
+
+            // Group key: the walked ancestor's address. When the change-walk
+            // stayed on the original output (the common case), reuse the
+            // snapshot's already-encoded address instead of extracting and
+            // base58-encoding the same destination a second time under the
+            // locks.
+            std::string group_key;
+            if (cout.tx == out.tx && cout.i == out.i) {
+                group_key = output.address;
+            } else {
+                CTxDestination address;
+                if (ExtractDestination(cout.tx->vout[cout.i].scriptPubKey, address)) {
+                    group_key = EncodeDestination(address);
+                }
+            }
+            if (group_key.empty()) continue;
+
+            coins[std::move(group_key)].push_back(std::move(output));
+        }
+
+        return coins;
+    }
+
+    SendCoinsResult sendCoins(const std::vector<WalletSendRecipient>& recipients,
+                              const CCoinControl* coin_control,
+                              int64_t accepted_fee) override;
 
     std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) override
     {
@@ -70,6 +251,377 @@ public:
 private:
     CWallet* m_wallet;
 };
+
+SendCoinsResult WalletImpl::sendCoins(const std::vector<WalletSendRecipient>& recipients,
+                                      const CCoinControl* coin_control,
+                                      int64_t accepted_fee)
+{
+    // Defensive guards at the trust boundary. The GUI pre-checks both
+    // conditions, but the node side must not rely on the client: an empty
+    // recipient list would index recipients[0] below, and an undecodable
+    // address becomes CNoDestination, which CScript::SetDestination renders
+    // as an EMPTY script — CreateTransaction would fund that
+    // anyone-can-spend output.
+    if (recipients.empty()) {
+        return {SendCoinsStatus::TransactionCreationFailed};
+    }
+
+    for (const WalletSendRecipient& rcp : recipients) {
+        if (!IsValidDestination(DecodeDestination(rcp.address))) {
+            return {SendCoinsStatus::InvalidAddress};
+        }
+    }
+
+    // Amounts likewise: a non-positive or out-of-range amount must not reach
+    // the balance arithmetic below. Checking MoneyRange on the running total
+    // after every add keeps the arithmetic itself defined: the total is at
+    // most MAX_MONEY before an add and each addend is at most MAX_MONEY, so
+    // no intermediate sum can approach INT64_MAX.
+    int64_t total = 0;
+    for (const WalletSendRecipient& rcp : recipients) {
+        if (rcp.amount <= 0 || !MoneyRange(rcp.amount)) {
+            return {SendCoinsStatus::InvalidAmount};
+        }
+        total += rcp.amount;
+        if (!MoneyRange(total)) {
+            return {SendCoinsStatus::InvalidAmount};
+        }
+    }
+
+    // Locked across scan AND dereference: COutput carries raw pointers into
+    // mapWallet, and the old GUI-side code's unlocked window between
+    // AvailableCoins returning and this loop reading out.tx let a concurrent
+    // wallet-transaction erasure free the pointed-at CWalletTx.
+    int64_t nBalance = 0;
+    {
+        LOCK2(cs_main, m_wallet->cs_wallet);
+
+        std::vector<COutput> vCoins;
+        m_wallet->AvailableCoins(vCoins, true, coin_control, false);
+
+        for (auto const& out : vCoins)
+            nBalance += out.tx->vout[out.i].nValue;
+    }
+
+    bool fAnySubtractFeeFromAmount = false;
+    for (const WalletSendRecipient& rcp : recipients)
+    {
+        if (rcp.subtract_fee_from_amount)
+        {
+            fAnySubtractFeeFromAmount = true;
+            break;
+        }
+    }
+
+    if (total > nBalance)
+    {
+        return {SendCoinsStatus::AmountExceedsBalance};
+    }
+
+    if (!fAnySubtractFeeFromAmount && (total + nTransactionFee) > nBalance)
+    {
+        return {SendCoinsStatus::AmountWithFeeExceedsBalance, nTransactionFee};
+    }
+
+    CWalletTx wtx;
+
+    if (fAnySubtractFeeFromAmount)
+    {
+        wtx.mapValue["subtractFeeFromAmount"] = "1";
+    }
+
+    if (!recipients[0].message.empty())
+    {
+        CMutableTransaction mtx;
+        mtx.vContracts.emplace_back(GRC::MakeContract<GRC::TxMessage>(
+            GRC::ContractAction::ADD,
+            recipients[0].message));
+        static_cast<CTransaction&>(wtx) = CTransaction(std::move(mtx));
+    }
+
+    {
+        LOCK2(cs_main, m_wallet->cs_wallet);
+
+        // Sendmany
+        std::vector<std::pair<CScript, int64_t>> vecSend;
+        for (const WalletSendRecipient& rcp : recipients) {
+            CScript scriptPubKey;
+            scriptPubKey.SetDestination(DecodeDestination(rcp.address));
+            vecSend.push_back(std::make_pair(scriptPubKey, rcp.amount));
+        }
+
+        CReserveKey keyChange(m_wallet);
+        int64_t nFeeRequired = 0;
+        bool fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coin_control);
+
+        // If any recipient has "subtract fee from amount" enabled, rebuild
+        // the outputs with the fee deducted and create the transaction
+        // again. This runs even if the first pass failed (e.g. sending
+        // entire balance), since CWallet::CreateTransaction overwrites the
+        // caller's nFeeRet to nTransactionFee on entry (wallet.cpp:2964)
+        // and bumps from there — so even a failed pass leaves a reasonable
+        // starting estimate.
+        //
+        // The loop refines the subtracted fee against the fee the wallet
+        // actually charges. A single retry is not enough because the
+        // wallet's own internal fee-bumping — primarily byte-tier
+        // crossing where nPayFee = nTransactionFee * (1 + nBytes/1000)
+        // jumps when the signed tx crosses each 1 KB boundary
+        // (wallet.cpp:3191) — can return an nFeeRequired that exceeds
+        // what we subtracted. Committing at that point under-debits the
+        // recipient and silently absorbs the surplus into the sender's
+        // change (issue #2981). Sub-CENT change handling
+        // (wallet.cpp:3064-3078) is a second potential fee-bumper but
+        // is dormant under default fee parameters because its trigger
+        // `nFeeRet < GetBaseFee` is false when nFeeRet is seeded from
+        // the default nTransactionFee.
+        //
+        // We require strict equality (subtracted == returned) for
+        // convergence. The earlier `<=` form let the inverse case
+        // (returned < subtracted) commit silently, over-debiting the
+        // recipient and "saving" the difference back to the sender's
+        // change.
+        //
+        // In a uniform-UTXO wallet, the loop can enter a 2-cycle: when
+        // the higher fee is subtracted, the target shrinks and the wallet
+        // picks fewer inputs (size drops below 1 KB → tier-1 fee, e.g.
+        // 0.001); when the lower fee is subtracted, the target grows and
+        // the wallet picks more inputs (size crosses 1 KB → tier-2 fee,
+        // 0.002). The two states map to each other and strict equality
+        // never fires. Constructable: ten 400.000-GRC UTXOs, send 2400.001
+        // with subtract-fee — the loop alternates 0.001 / 0.002
+        // indefinitely.
+        //
+        // To force a deterministic, convergent commit in such a case,
+        // track the largest fee observed during the loop and the input
+        // set that produced it. If the loop exits without strict
+        // convergence — whether from oscillation or from a slower
+        // non-converging case hitting the 10-attempt cap — pin coin
+        // selection to that input set via CCoinControl and re-create
+        // the transaction with the larger fee subtracted. With inputs
+        // pinned, SelectCoins returns exactly those outpoints
+        // (wallet.cpp:2750-2758), the transaction size is fixed, the
+        // wallet's computed fee matches our subtraction, and the commit
+        // converges. The sender pays exactly the entered amount; the
+        // recipient receives (entered − higher fee).
+        if (fAnySubtractFeeFromAmount)
+        {
+            int nSubtractRecipients = 0;
+            for (const WalletSendRecipient& rcp : recipients)
+            {
+                if (rcp.subtract_fee_from_amount) ++nSubtractRecipients;
+            }
+
+            // Rebuild vecSend with the given fee distributed across the
+            // subtract-fee recipients. Returns false if any opted-in
+            // recipient's amount would drop to zero or negative; the
+            // caller should respond with FeeExceedsSubtractedAmount.
+            auto BuildSubtractedVecSend = [&](int64_t nFee) -> bool {
+                vecSend.clear();
+                int64_t nFeeRemainder = nFee % nSubtractRecipients;
+                bool fFirst = true;
+                for (const WalletSendRecipient& rcp : recipients)
+                {
+                    CScript scriptPubKey;
+                    scriptPubKey.SetDestination(DecodeDestination(rcp.address));
+                    int64_t nAmount = rcp.amount;
+
+                    if (rcp.subtract_fee_from_amount)
+                    {
+                        nAmount -= nFee / nSubtractRecipients;
+                        // First opted-in recipient absorbs the truncation remainder
+                        if (fFirst)
+                        {
+                            nAmount -= nFeeRemainder;
+                            fFirst = false;
+                        }
+                        if (nAmount <= 0)
+                            return false;
+                    }
+
+                    vecSend.push_back(std::make_pair(scriptPubKey, nAmount));
+                }
+                return true;
+            };
+
+            // Track the largest fee returned and the input set that
+            // produced it. Seed from pass 1 only if it succeeded —
+            // seeding nMaxFeeSeen from a *failed* pass-1 call would
+            // leave a phantom high fee with no corresponding snapshot
+            // (the wallet sets nFeeRet = nTransactionFee on entry and
+            // can bump it before returning false), which would then
+            // block subsequent successful iterations with lower fees
+            // from populating vinsAtMaxFee via the `>` comparison.
+            // Inside the loop, snapshot on the first success regardless
+            // of fee value (vinsAtMaxFee.empty()) so we always have a
+            // valid input set to pin if the rescue is needed.
+            int64_t nMaxFeeSeen = 0;
+            std::vector<COutPoint> vinsAtMaxFee;
+            if (fCreated)
+            {
+                nMaxFeeSeen = nFeeRequired;
+                for (const CTxIn& in : wtx.vin)
+                    vinsAtMaxFee.push_back(in.prevout);
+            }
+            bool fConverged = false;
+
+            for (int nAttempt = 0; nAttempt < 10; ++nAttempt)
+            {
+                if (!BuildSubtractedVecSend(nFeeRequired))
+                    return {SendCoinsStatus::FeeExceedsSubtractedAmount, nFeeRequired};
+
+                int64_t nFeePrev = nFeeRequired;
+                fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coin_control);
+
+                if (fCreated && nFeeRequired == nFeePrev)
+                {
+                    fConverged = true;
+                    break;
+                }
+
+                if (fCreated && (vinsAtMaxFee.empty() || nFeeRequired > nMaxFeeSeen))
+                {
+                    nMaxFeeSeen = nFeeRequired;
+                    vinsAtMaxFee.clear();
+                    for (const CTxIn& in : wtx.vin)
+                        vinsAtMaxFee.push_back(in.prevout);
+                }
+            }
+
+            // Rescue pass for oscillation or cap-without-convergence.
+            // Requires a non-empty snapshot — if every prior pass failed
+            // we have no input set to pin and we fall through to the
+            // TransactionCreationFailed return below.
+            //
+            // Pinning the inputs locks transaction size against
+            // SelectCoins-driven input-count flipping. Under default
+            // Gridcoin fee parameters and reasonable UTXO shapes the
+            // wallet returns the same fee on the rescue call that
+            // produced the snapshot — fee-tier transitions happen at
+            // the 1 KB byte boundary, and the only remaining structural
+            // variation (change-vout present/absent, ±34 bytes) plus
+            // per-signature DER length variation (1-2 bytes per input)
+            // are not enough to cross 1 KB at typical input counts:
+            // 6 pinned inputs span 936-970 bytes (tier 1×), 7 pinned
+            // span 1084-1118 bytes (tier 2×). So in practice the rescue
+            // converges in iter 0.
+            //
+            // The bounded loop is defensive against pathologies I can
+            // describe but cannot construct concretely: keypool
+            // exhaustion mid-rescue (CreateTransaction returns false on
+            // reservekey.GetReservedKey), an unusually low custom
+            // -paytxfee combined with an adversarial UTXO sum that
+            // re-activates the sub-CENT change handler at
+            // wallet.cpp:3064-3078 (which is dormant under defaults
+            // because the trigger nFeeRet < GetBaseFee is false once
+            // nFeeRet equals the default nTransactionFee), or a future
+            // change to wallet internals that introduces new
+            // fee-determining factors. The strict-equality convergence
+            // check matches the outer loop; on non-convergence we set
+            // fCreated = false so the caller returns
+            // TransactionCreationFailed rather than commit a tx whose
+            // subtract-fee accounting doesn't match the wallet's actual
+            // charge.
+            if (!fConverged && !vinsAtMaxFee.empty())
+            {
+                // Copy any caller-supplied options (destChange,
+                // fAllowWatchOnly) and add the pinned outpoints. CCoinControl
+                // uses default copy semantics; setSelected, destChange, and
+                // fAllowWatchOnly are all carried over.
+                CCoinControl pinControl;
+                if (coin_control) pinControl = *coin_control;
+                for (const COutPoint& op : vinsAtMaxFee)
+                    pinControl.Select(op);
+
+                int64_t nRescueFee = nMaxFeeSeen;
+                bool fRescueConverged = false;
+                for (int nRescueAttempt = 0; nRescueAttempt < 5; ++nRescueAttempt)
+                {
+                    if (!BuildSubtractedVecSend(nRescueFee))
+                        return {SendCoinsStatus::FeeExceedsSubtractedAmount, nRescueFee};
+
+                    int64_t nRescuePrev = nRescueFee;
+                    nFeeRequired = 0;
+                    fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, &pinControl);
+                    if (!fCreated)
+                        break;
+
+                    if (nFeeRequired == nRescuePrev)
+                    {
+                        fRescueConverged = true;
+                        break;
+                    }
+                    nRescueFee = nFeeRequired;
+                }
+
+                // Non-converging rescue: fall through to the
+                // TransactionCreationFailed return below rather than
+                // commit a tx whose subtract-fee accounting doesn't
+                // match the wallet's actual charge.
+                if (!fRescueConverged)
+                    fCreated = false;
+            }
+        }
+
+        if (!fCreated)
+        {
+            if (!fAnySubtractFeeFromAmount && (total + nFeeRequired) > nBalance)
+            {
+                return {SendCoinsStatus::AmountWithFeeExceedsBalance, nFeeRequired};
+            }
+            return {SendCoinsStatus::TransactionCreationFailed};
+        }
+
+        // Fee-confirmation gate, replacing the ThreadSafeAskFee modal that
+        // used to block right here — inside LOCK2, across arbitrary user
+        // think-time (doc/multiprocess_design.md section 4.5). Same
+        // thresholds the old GUI handler applied: auto-accept a fee below
+        // the base fee or within the configured transaction fee. A larger
+        // fee needs the user's explicit acceptance: unless the caller
+        // already accepted at least this much, return without committing —
+        // this scope's locks release and keyChange's destructor returns the
+        // reserved key to the pool. The caller re-invokes with the accepted
+        // fee, the transaction is recreated from current wallet state, and
+        // any fee that meanwhile grew past the accepted amount lands back
+        // here, so no unaccepted fee is ever committed.
+        // Threshold on the actual transaction rather than the dummy the old
+        // GUI handler used (it had no wtx in scope; GetBaseFee is
+        // version-sensitive, and today wtx carries the same default version
+        // as a fresh CMutableTransaction, so this is behavior-identical).
+        int64_t nMinFee = GetBaseFee(wtx, GMF_SEND);
+        if (nFeeRequired >= nMinFee && nFeeRequired > nTransactionFee && nFeeRequired > accepted_fee)
+        {
+            return {SendCoinsStatus::FeeConfirmationRequired, nFeeRequired};
+        }
+
+        if (!m_wallet->CommitTransaction(wtx, keyChange))
+        {
+            return {SendCoinsStatus::TransactionCommitFailed};
+        }
+    }
+
+    // Add addresses / update labels that we've sent to the address book
+    for (const WalletSendRecipient& rcp : recipients) {
+        CTxDestination dest = DecodeDestination(rcp.address);
+        {
+            LOCK(m_wallet->cs_wallet);
+
+            auto mi = m_wallet->mapAddressBook.find(dest);
+
+            // Check if we have a new address or an updated label
+            if (mi == m_wallet->mapAddressBook.end() || mi->second.name != rcp.label)
+            {
+                m_wallet->SetAddressBookName(dest, rcp.label);
+            }
+        }
+    }
+
+    SendCoinsResult result;
+    result.status = SendCoinsStatus::OK;
+    result.txid_hex = wtx.GetHash().GetHex();
+
+    return result;
+}
 
 } // namespace
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -218,7 +218,7 @@ public:
     }
 
     SendCoinsResult sendCoins(const std::vector<WalletSendRecipient>& recipients,
-                              const CCoinControl* coin_control,
+                              const std::optional<WalletCoinControl>& coin_control,
                               int64_t accepted_fee) override;
 
     std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) override
@@ -253,9 +253,24 @@ private:
 };
 
 SendCoinsResult WalletImpl::sendCoins(const std::vector<WalletSendRecipient>& recipients,
-                                      const CCoinControl* coin_control,
+                                      const std::optional<WalletCoinControl>& coin_control,
                                       int64_t accepted_fee)
 {
+    // Reconstruct the wallet-side CCoinControl from the boundary value type
+    // (the raw class does not cross the interface).
+    CCoinControl ctrl;
+    const CCoinControl* coin_control_ptr = nullptr;
+    if (coin_control) {
+        if (!coin_control->dest_change.empty()) {
+            ctrl.destChange = DecodeDestination(coin_control->dest_change);
+        }
+        ctrl.fAllowWatchOnly = coin_control->allow_watch_only;
+        for (const COutPoint& outpoint : coin_control->selected) {
+            ctrl.Select(outpoint);
+        }
+        coin_control_ptr = &ctrl;
+    }
+
     // Defensive guards at the trust boundary. The GUI pre-checks both
     // conditions, but the node side must not rely on the client: an empty
     // recipient list would index recipients[0] below, and an undecodable
@@ -297,7 +312,7 @@ SendCoinsResult WalletImpl::sendCoins(const std::vector<WalletSendRecipient>& re
         LOCK2(cs_main, m_wallet->cs_wallet);
 
         std::vector<COutput> vCoins;
-        m_wallet->AvailableCoins(vCoins, true, coin_control, false);
+        m_wallet->AvailableCoins(vCoins, true, coin_control_ptr, false);
 
         for (auto const& out : vCoins)
             nBalance += out.tx->vout[out.i].nValue;
@@ -352,7 +367,7 @@ SendCoinsResult WalletImpl::sendCoins(const std::vector<WalletSendRecipient>& re
 
         CReserveKey keyChange(m_wallet);
         int64_t nFeeRequired = 0;
-        bool fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coin_control);
+        bool fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coin_control_ptr);
 
         // If any recipient has "subtract fee from amount" enabled, rebuild
         // the outputs with the fee deducted and create the transaction
@@ -471,7 +486,7 @@ SendCoinsResult WalletImpl::sendCoins(const std::vector<WalletSendRecipient>& re
                     return {SendCoinsStatus::FeeExceedsSubtractedAmount, nFeeRequired};
 
                 int64_t nFeePrev = nFeeRequired;
-                fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coin_control);
+                fCreated = m_wallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, coin_control_ptr);
 
                 if (fCreated && nFeeRequired == nFeePrev)
                 {
@@ -529,7 +544,7 @@ SendCoinsResult WalletImpl::sendCoins(const std::vector<WalletSendRecipient>& re
                 // uses default copy semantics; setSelected, destChange, and
                 // fAllowWatchOnly are all carried over.
                 CCoinControl pinControl;
-                if (coin_control) pinControl = *coin_control;
+                if (coin_control_ptr) pinControl = *coin_control_ptr;
                 for (const COutPoint& op : vinsAtMaxFee)
                     pinControl.Select(op);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -442,7 +442,7 @@ bool CWallet::AddCScript(const CScript& redeemScript)
 // optional setting to unlock wallet for staking only
 // serves to disable the trivial sendmoney when OS account compromised
 // provides no real security
-bool fWalletUnlockStakingOnly = false;
+std::atomic<bool> fWalletUnlockStakingOnly{false};
 
 bool CWallet::LoadCScript(const CScript& redeemScript)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3402,7 +3402,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 
 
 
-string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew)
 {
     CReserveKey reservekey(this);
     int64_t nFeeRequired;
@@ -3432,16 +3432,13 @@ string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNe
         return strError;
     }
 
-    if (fAskFee && !uiInterface.ThreadSafeAskFee(nFeeRequired, _("Sending...")))
-        return "ABORTED";
-
     if (!CommitTransaction(wtxNew, reservekey))
         return _("Error: The transaction was rejected.  This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
 
     return "";
 }
 
-string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nValue, CWalletTx& wtxNew)
 {
     // Check amount
     if (nValue <= 0)        return _("Invalid amount");
@@ -3453,7 +3450,7 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nV
     CScript scriptPubKey;
     scriptPubKey.SetDestination(address);
 
-    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee);
+    return SendMoney(scriptPubKey, nValue, wtxNew);
 }
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_WALLET_WALLET_H
 #define BITCOIN_WALLET_WALLET_H
 
+#include <atomic>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -30,7 +31,10 @@
 #include <wallet/walletutil.h>
 #include "wallet/ismine.h"
 
-extern bool fWalletUnlockStakingOnly;
+//! Staking-only unlock preference. Atomic: written by the GUI unlock path
+//! (interfaces::Wallet::unlockWallet) and RPC walletpassphrase, read by RPC
+//! send paths and the GUI status rendering, on different threads.
+extern std::atomic<bool> fWalletUnlockStakingOnly;
 extern bool fConfChange;
 class CAccountingEntry;
 class CWalletTx;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -400,8 +400,8 @@ public:
                            const CCoinControl* coinControl = nullptr, bool change_back_to_input_address = false);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
-    std::string SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);
-    std::string SendMoneyToDestination(const CTxDestination &address, int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);
+    std::string SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew);
+    std::string SendMoneyToDestination(const CTxDestination &address, int64_t nValue, CWalletTx& wtxNew);
 
     bool NewKeyPool();
     bool TopUpKeyPool(unsigned int nSize = 0);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -14,7 +14,6 @@
 using namespace std;
 
 static uint64_t nAccountingEntryNumber = 0;
-extern bool fWalletUnlockStakingOnly;
 
 //
 // CWalletDB

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -165,13 +165,10 @@ src/qt/voting/votingmodel.cpp:sync.h
 src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
 src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
 src/qt/voting/votingmodel.h:gridcoin/voting/result.h
-src/qt/walletmodel.cpp:gridcoin/tx_message.h
 src/qt/walletmodel.cpp:main.h
 src/qt/walletmodel.cpp:node/ui_interface.h
 src/qt/walletmodel.cpp:util.h
-src/qt/walletmodel.cpp:wallet/coincontrol.h
 src/qt/walletmodel.cpp:wallet/wallet.h
-src/qt/walletmodel.h:wallet/ismine.h
 src/qt/wallettxstore.cpp:main.h
 src/qt/wallettxstore.cpp:wallet/wallet.h
 src/qt/wallettxstore.h:sync.h


### PR DESCRIPTION
Phase 1c-i of the multiprocess program (#3153, design doc `doc/multiprocess_design.md`, RFC #2937). Follows #3156 (1a scaffold) and #3157 (1b ClientModel).

## What this does

Migrates WalletModel's **query/command surface** off direct `CWallet*`/global reaches and onto `interfaces::Wallet`, growing the interface consumer-driven (per the 1a grow-per-migration rule) and implementing it node-side in `src/wallet/interfaces.cpp`:

- **Balances**: `tryGetBalances()` — atomic four-balance snapshot with TRY_LOCK bow-out. The GUI-side stale-time gate is now checked *before* the lock attempt, so a gated call costs nothing.
- **Queries**: `getNumTransactions`, `getPubKey`, `getKeyFromPool`.
- **Encryption commands**: `encryptWallet` / `lockWallet` / `unlockWallet` / `changeWalletPassphrase`. The staking-only unlock preference is folded into `unlockWallet(passphrase, staking_only)` — the `fWalletUnlockStakingOnly` global write leaves `AskPassphraseDialog`; the checkbox seed and status icon read `getUnlockStakingOnlyFlag()`.
- **Coin control**: `getOutputs` / `listCoins` return `WalletOutput` **value snapshots** — no `CWalletTx*` crosses the boundary. The immature-coinstake flag is computed node-side, removing a raw `LOCK(cs_main)` from both coin-control views.
- **sendCoins**: the entire creation / subtract-fee convergence (#2981) / commit machinery moves node-side **verbatim** (whitespace-normalized diff against the old body is empty apart from the intended substitutions) behind a value-typed recipient/result contract.

## ThreadSafeAskFee eliminated (design §4.5)

The modal fired *inside* `LOCK2(cs_main, cs_wallet)`, blocking core locks on user think-time. Instead of porting it, `sendCoins` returns `FeeConfirmationRequired{fee}` **without committing** (locks released, reserved change key returned to the pool). `SendCoinsDialog` confirms with no core locks held and re-invokes with the accepted fee. The accepted fee only ratchets up and the loop is attempt-capped, so no fee the user hasn't accepted is ever committed. The thresholds (auto-accept below base fee or within the configured `nTransactionFee`) are byte-identical to the old GUI handler's. Removed end-to-end: the `ui_interface` signal, the `noui`/`bitcoin.cpp` handlers, `BitcoinGUI::askFee`, and `CWallet::SendMoney`'s dead `fAskFee` parameter (default false; the one explicit caller passed false).

The confirmation strings are looked up under the **BitcoinGUI translation context** deliberately — they shipped for years from `BitcoinGUI::askFee`, and every locale's translation lives under that context in `src/qt/locale/*.ts`.

**Semantics note**: the old flow committed the exact transaction whose fee was confirmed under one lock scope. The new flow recreates the transaction after confirmation (stateless boundary, per the design). The binding quantity — the fee — can only be committed if ≤ the user-accepted amount; a fee that grew in between re-prompts.

## Trust-boundary hardening

The node side no longer relies on the GUI's pre-checks (adversarial review findings):
- **Addresses re-validated node-side** — an undecodable address became `CNoDestination`, which `CScript::SetDestination` renders as an **empty (anyone-can-spend) script** that `CreateTransaction` would fund.
- **Amounts validated through `MoneyRange`** (including the running total, so the sum can't sign-overflow).
- **Empty recipient lists rejected** (would have indexed `recipients[0]`).
- The `AvailableCoins` scan → `COutput::tx` dereference window is now **closed under `LOCK2`** in both `sendCoins` and `listCoins` — the old GUI code dereferenced raw mapWallet pointers with *no lock held* (latent use-after-free against the mempool-conflict `EraseFromWallet` path).

## Deliberate deltas from strict parity

- `checkBalanceChanged` uses `GetTime()` instead of `GetAdjustedTime()` for its purely local rate limiter (network-time offset steps must not wedge/bypass the gate).
- The fee gate thresholds on the **actual** `wtx` instead of a dummy transaction (`GetBaseFee` is version-sensitive; identical value today, correct if versions diverge).
- Dead coin-lock stubs (`isLockedCoin`/`lockCoin`/`unlockCoin`/`listLockedCoins` — no live callers, all referenced only from commented-out code) are removed along with every commented reference.
- The fee-prompt attempt cap surfaces `TransactionCreationFailed` (visible error) rather than a silent no-op.

## Kept for 1c-ii (untouched by design)

The tx-table store/event-queue leg — `m_txStore`, `m_event_queue`, the producer `NotifyTransactionChanged`/`NotifyBlocksChangedForWallet` handlers, and the sub-model constructors — keeps its raw `CWallet*` (now `m_core_wallet`, documented as do-not-add-uses). It migrates behind `interfaces::WalletTxSource` in Phase 1c-ii.

## Ratchet

`lint-qt-includes.sh`: **150 → 147** (`walletmodel.cpp` drops `gridcoin/tx_message.h` + `wallet/coincontrol.h`; `walletmodel.h` drops `wallet/ismine.h`).

## Follow-up candidates (out of scope here)

- `WalletOutput` could carry the key id / estimated input bytes so the coin-control views drop their per-output `DecodeDestination` + `getPubKey` round-trip (N calls per label refresh → N IPC round-trips under Phase 2).
- Lock-state could consolidate into one snapshot struct (crypted/locked/staking-only) mirroring `WalletBalances`, collapsing 2–3 IPC round-trips per status render.
- `unlockWallet` may want a duration parameter before the Phase 2 schema freeze (design §4.3 time-bounded unlock).
- ~~`fWalletUnlockStakingOnly` remains a bare global bool~~ — addressed during review (commit 123d1926f): the flag is now `std::atomic<bool>`.
- The send machinery could arguably live as a `CWallet` method with a thin interface forwarder rather than in the interface impl — happy to move it if preferred.

## Testing

- Full unit suite green; `interfaces_tests` grown 10 → 16 cases (query surface, staking-flag semantics incl. failed-unlock non-clobber, send boundary guards: empty list / invalid address / insufficient balance, key-pool labeling, address-book handler value bridging — order-independent assertions per the 1b lesson).
- Qt test binary green; `lint-all.sh` green.
- Functional suite: one `rpc_psgtpool.py` flake in the batch run (known kernel-collision class, post-#3149 field data) — passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

