### PR TITLE
gui: scrub Qt types from the wallet-transaction DTOs (Phase 1c-ii-a)

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -1,7 +1,6 @@
 #include "transactionrecord.h"
 #include "wallet/wallet.h"
 #include <key_io.h>
-#include <QObject>
 
 /* Return positive answer if transaction should be shown in list. */
 bool TransactionRecord::showTransaction(const CWalletTx &wtx, bool datetime_limit_flag, const int64_t &datetime_limit)
@@ -52,9 +51,9 @@ bool TransactionRecord::showTransaction(const CWalletTx &wtx, bool datetime_limi
 /*
  * Decompose CWallet transaction to model transaction records.
  */
-QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx)
+std::vector<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx)
 {
-    QList<TransactionRecord> parts;
+    std::vector<TransactionRecord> parts;
     int64_t nTime = wtx.GetTxTime();
     int64_t nCredit = wtx.GetCredit(true);
     int64_t nDebit = wtx.GetDebit();
@@ -95,7 +94,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 sub.type = TransactionRecord::Generated;
                 sub.credit = txout.nValue;
 
-                parts.append(sub);
+                parts.push_back(sub);
             }
         }
     }
@@ -135,8 +134,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
             sub.debit = -nDebit;
 
-            // Append the subtransaction to the parts QList (transaction record).
-            parts.append(sub);
+            // Append the subtransaction to the parts vector (transaction record).
+            parts.push_back(sub);
         }
 
         // We only want outputs > 1 because the zeroth output is always empty,
@@ -187,7 +186,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.debit = -nValue;
                 }
 
-                parts.append(sub);
+                parts.push_back(sub);
             }
         }
     }
@@ -221,7 +220,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
                 sub.credit = txout.nValue;
 
-                parts.append(sub);
+                parts.push_back(sub);
             }
         }
     }
@@ -250,7 +249,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             // Payment to self
             int64_t nChange = wtx.GetChange();
 
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
+            parts.push_back(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
                                            -(nDebit - nChange), nCredit - nChange, 0));
         }
         else if (fAllFromMe)
@@ -349,7 +348,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     }
                 }
 
-                parts.append(sub);
+                parts.push_back(sub);
             }
         }
         else
@@ -357,59 +356,11 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             //
             // Mixed debit transaction, can't break down payees
             //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0, 0));
+            parts.push_back(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0, 0));
         }
     }
 
     return parts;
-}
-
-QString TransactionRecord::TypeToString() const
-{
-    return TypeToString(type);
-}
-
-QString TransactionRecord::TypeToString(const Type& type, const bool& translated)
-{
-    if (translated) {
-        switch(type) {
-        case Other:                 return QObject::tr("Other");
-        case Generated:             return QObject::tr("Mined");
-        case SendToAddress:         return QObject::tr("Sent to Address");
-        case SendToOther:           return QObject::tr("Sent to Other");
-        case RecvWithAddress:       return QObject::tr("Received with Address");
-        case RecvFromOther:         return QObject::tr("Received from Other");
-        case SendToSelf:            return QObject::tr("Self");
-        case BeaconAdvertisement:   return QObject::tr("Beacon Advertisements");
-        case Poll:                  return QObject::tr("Polls");
-        case Vote:                  return QObject::tr("Votes");
-        case Message:               return QObject::tr("Messages");
-        case MRC:                   return QObject::tr("MRCs");
-        }
-
-        assert(false); // Suppress warning
-    } else {
-        switch(type) {
-        case Other:                 return "Other";
-        case Generated:             return "Mined";
-        case SendToAddress:         return "Sent to Address";
-        case SendToOther:           return "Sent to Other";
-        case RecvWithAddress:       return "Received with Address";
-        case RecvFromOther:         return "Received from Other";
-        case SendToSelf:            return "Self";
-        case BeaconAdvertisement:   return "Beacon Advertisements";
-        case Poll:                  return "Polls";
-        case Vote:                  return "Votes";
-        case Message:               return "Messages";
-        case MRC:                   return "MRCs";
-        }
-
-        assert(false); // Suppress warning
-    }
-
-    // This will never be reached. Put it in anyway to prevent control reaches end of non-void function warning
-    // from some compiler versions.
-    return QString{};
 }
 
 void TransactionRecord::updateStatus(const CWalletTx &wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -5,7 +5,10 @@
 #include "wallet/generated_type.h"
 #include "wallet/ismine.h"
 
-#include <QList>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 class CWallet;
 class CWalletTx;
@@ -124,19 +127,16 @@ public:
     /** Decompose CWallet transaction to model transaction records.
      */
     static bool showTransaction(const CWalletTx &wtx, bool datetime_limit_flag = false, const int64_t &datetime_limit = 0);
-    static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx);
-
-    QString TypeToString() const;
-    static QString TypeToString(const Type& type, const bool& translated = true);
+    static std::vector<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx);
 
     /** @name Immutable transaction attributes
       @{*/
     uint256 hash;
-    qint64 time;
+    int64_t time;
     Type type;
     std::string address;
-    qint64 debit;
-    qint64 credit;
+    int64_t debit;
+    int64_t credit;
 
     // Side/Split Stake
     unsigned int vout;
@@ -172,5 +172,22 @@ public:
      */
     std::string label;
 };
+
+//! Marshalability pin (multiprocess design §4.1, windowed-model design): these
+//! records are the wallet-transaction-channel DTOs and must stay value types a
+//! node-side source can fill and ship across the interfaces:: boundary — no Qt
+//! types, no pointers into core state, freely copyable. The translated type
+//! rendering lives GUI-side (transactionview/transactiontablemodel), not here.
+static_assert(std::is_copy_constructible_v<TransactionRecord>
+                  && std::is_copy_assignable_v<TransactionRecord>
+                  && std::is_move_constructible_v<TransactionRecord>,
+              "TransactionRecord must remain a copyable value type");
+static_assert(std::is_copy_constructible_v<TransactionStatus>
+                  && std::is_copy_assignable_v<TransactionStatus>,
+              "TransactionStatus must remain a copyable value type");
+static_assert(std::is_same_v<decltype(TransactionRecord::time), int64_t>
+                  && std::is_same_v<decltype(TransactionRecord::debit), int64_t>
+                  && std::is_same_v<decltype(TransactionRecord::credit), int64_t>,
+              "TransactionRecord amounts/time are fixed-width value types");
 
 #endif // BITCOIN_QT_TRANSACTIONRECORD_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -726,13 +726,14 @@ QVariant TransactionTableModel::formatRole(TransactionRecord *rec, int columnInt
         case Status:
             return QString::fromStdString(rec->status.sortKey);
         case Date:
-            return rec->time;
+            // qint64: int64_t is `long` on LP64, which QVariant cannot take.
+            return qint64{rec->time};
         case Type:
             return formatTxType(rec);
         case ToAddress:
             return formatTxToAddress(rec, true);
         case Amount:
-            return rec->credit + rec->debit;
+            return qint64{rec->credit + rec->debit};
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     case Qt::ToolTipRole:
@@ -788,7 +789,7 @@ QVariant TransactionTableModel::formatRole(TransactionRecord *rec, int columnInt
     case LabelRole:
         return walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
     case AmountRole:
-        return rec->credit + rec->debit;
+        return qint64{rec->credit + rec->debit};
     case TxIDRole:
         return QString::fromStdString(rec->getTxID());
     case ConfirmedRole:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -39,6 +39,35 @@
 #include <QLabel>
 #include <QDateTimeEdit>
 
+namespace {
+//! Translated display name for a transaction type. Moved here from
+//! TransactionRecord (this combo is its only consumer) when the record was
+//! scrubbed of Qt for the multiprocess boundary — translated rendering stays
+//! GUI-side by design. QObject::tr keeps the strings' original translation
+//! context so shipped locale files keep working.
+QString TypeToString(TransactionRecord::Type type)
+{
+    switch (type) {
+    case TransactionRecord::Other:                 return QObject::tr("Other");
+    case TransactionRecord::Generated:             return QObject::tr("Mined");
+    case TransactionRecord::SendToAddress:         return QObject::tr("Sent to Address");
+    case TransactionRecord::SendToOther:           return QObject::tr("Sent to Other");
+    case TransactionRecord::RecvWithAddress:       return QObject::tr("Received with Address");
+    case TransactionRecord::RecvFromOther:         return QObject::tr("Received from Other");
+    case TransactionRecord::SendToSelf:            return QObject::tr("Self");
+    case TransactionRecord::BeaconAdvertisement:   return QObject::tr("Beacon Advertisements");
+    case TransactionRecord::Poll:                  return QObject::tr("Polls");
+    case TransactionRecord::Vote:                  return QObject::tr("Votes");
+    case TransactionRecord::Message:               return QObject::tr("Messages");
+    case TransactionRecord::MRC:                   return QObject::tr("MRCs");
+    }
+
+    // Unreachable: the switch covers every Type (and has no default so
+    // -Wswitch flags a new enumerator).
+    return QString{};
+}
+} // namespace
+
 TransactionView::TransactionView(QWidget *parent)
     : QFrame(parent)
     , model(nullptr)
@@ -95,7 +124,7 @@ TransactionView::TransactionView(QWidget *parent)
 
     // Add types from TransactionRecord Type enum.
     for (const auto& iter : TransactionRecord::TYPES) {
-        typeWidget->addItem(TransactionRecord::TypeToString(iter), GRC::TypeBit(iter));
+        typeWidget->addItem(TypeToString(iter), GRC::TypeBit(iter));
     }
 
     filterFrameLayout->addWidget(typeWidget);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -548,10 +548,9 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
             // and emits events off the core locks; the enqueue itself is O(1).
             // Status is computed here so the off-lock cursors can filter/sort by
             // it without re-touching the wallet.
-            const QList<TransactionRecord> decomposed =
+            std::vector<TransactionRecord> recs =
                 TransactionRecord::decomposeTransaction(wallet, wtx);
-            if (!decomposed.isEmpty()) {
-                std::vector<TransactionRecord> recs(decomposed.begin(), decomposed.end());
+            if (!recs.empty()) {
                 for (TransactionRecord& rec : recs) {
                     rec.updateStatus(wtx);
                     rec.populateDisplayLabel(*wallet);  // address-book label snapshot (PR4)

--- a/src/qt/wallettxstore.cpp
+++ b/src/qt/wallettxstore.cpp
@@ -420,7 +420,7 @@ std::vector<TransactionRecord> WalletTxStore::reloadAndSnapshot(bool limit_enabl
         if (!TransactionRecord::showTransaction(it->second)) {
             continue;
         }
-        const QList<TransactionRecord> decomposed =
+        const std::vector<TransactionRecord> decomposed =
             TransactionRecord::decomposeTransaction(m_wallet, it->second);
         for (const TransactionRecord& rec : decomposed) {
             if (limit_enabled && rec.time < limit_time) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -73,6 +73,11 @@ add_executable(test_gridcoin
     # two-channel split (structural deltas vs scroll-driven content fetch) and the
     # cache-base arithmetic (windowed-model PR5), tested GUI-OFF.
     qt_windowcache_tests.cpp
+    # Wallet-transaction DTOs (src/qt/transactionrecord.cpp), Qt-scrubbed for
+    # the multiprocess boundary (Phase 1c-ii) + smoke suite. Compiling the TU
+    # into the GUI-OFF binary pins the Qt-freedom the node-side source needs.
+    ${CMAKE_SOURCE_DIR}/src/qt/transactionrecord.cpp
+    qt_transactionrecord_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/qt_transactionrecord_tests.cpp
+++ b/src/test/qt_transactionrecord_tests.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+// GUI-OFF coverage for the wallet-transaction DTOs
+// (src/qt/transactionrecord.{h,cpp}), Qt-scrubbed in Phase 1c-ii of the
+// multiprocess program. Compiling this translation unit into the GUI-OFF
+// test binary is itself the load-bearing assertion: the records are the
+// wallet-transaction-channel value types a node-side source must be able to
+// fill, so they must build without Qt. The cases below cover the value-type
+// semantics the marshalability static_asserts promise and the decompose
+// entry point's degenerate path.
+
+#include <qt/transactionrecord.h>
+
+#include "sync.h"
+#include "uint256.h"
+#include "wallet/wallet.h"
+
+#include <boost/test/unit_test.hpp>
+
+extern CWallet* pwalletMain;
+
+BOOST_AUTO_TEST_SUITE(qt_transactionrecord_tests)
+
+BOOST_AUTO_TEST_CASE(record_is_a_copyable_value_type)
+{
+    TransactionRecord rec(uint256S("0xabcd"), 1234567,
+                          TransactionRecord::SendToAddress, "some-address",
+                          -5, 10, 2);
+    rec.idx = 3;
+    rec.label = "some-label";
+    rec.status.sortKey = "sort-key";
+    rec.status.depth = 7;
+
+    // Copy round-trip: the copy is independent of the original.
+    TransactionRecord copy = rec;
+    BOOST_CHECK_EQUAL(copy.getTxID(), rec.getTxID());
+    BOOST_CHECK_EQUAL(copy.time, rec.time);
+    BOOST_CHECK_EQUAL(copy.address, rec.address);
+    BOOST_CHECK_EQUAL(copy.label, rec.label);
+    BOOST_CHECK_EQUAL(copy.status.sortKey, rec.status.sortKey);
+
+    copy.address = "mutated";
+    copy.status.depth = 99;
+    BOOST_CHECK_EQUAL(rec.address, "some-address");
+    BOOST_CHECK_EQUAL(rec.status.depth, 7);
+}
+
+BOOST_AUTO_TEST_CASE(get_tx_id_is_the_hash_string)
+{
+    const uint256 hash = uint256S("0xdeadbeef");
+    TransactionRecord rec(hash, 0);
+    BOOST_CHECK_EQUAL(rec.getTxID(), hash.ToString());
+}
+
+BOOST_AUTO_TEST_CASE(decompose_empty_transaction_degenerate_path)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    // An empty wallet transaction (no inputs, no outputs, no contracts)
+    // exercises the degenerate decompose path: with zero inputs and outputs
+    // the "all from me / all to me" scans are vacuously true, so the
+    // transaction classifies as a single zero-amount payment-to-self record.
+    // The point of the pin is that the path must not crash and must produce
+    // exactly this classification. Locks held per the producer-side contract.
+    CWalletTx wtx(pwalletMain);
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    const std::vector<TransactionRecord> parts =
+        TransactionRecord::decomposeTransaction(pwalletMain, wtx);
+    BOOST_REQUIRE_EQUAL(parts.size(), 1U);
+    BOOST_CHECK(parts[0].type == TransactionRecord::SendToSelf);
+    BOOST_CHECK_EQUAL(parts[0].debit, 0);
+    BOOST_CHECK_EQUAL(parts[0].credit, 0);
+    BOOST_CHECK(parts[0].hash == wtx.GetHash());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/qt_txorder_tests.cpp
+++ b/src/test/qt_txorder_tests.cpp
@@ -8,8 +8,9 @@
 // guarantees — that the producer-side GRC::WalletTxStore relies on to compute
 // the position-stamped RowsInserted / RowsRemoved events. Testing it here keeps
 // the position/clustering logic covered in the ENABLE_GUI=OFF configuration CI
-// exercises (TransactionRecord itself is Qt-coupled, so the store proper is
-// covered by ASan-GUI + isolated-testnet validation instead).
+// exercises (the store proper stays Qt-coupled until Phase 1c-ii completes,
+// so it is covered by ASan-GUI + isolated-testnet validation instead;
+// TransactionRecord itself was Qt-scrubbed and now compiles GUI-OFF too).
 
 #include <qt/txorder.h>
 


### PR DESCRIPTION
Phase 1c-ii-a of the multiprocess program (#3153; stage a of the `WalletTxSource` decomposition in `doc/multiprocess_phasing.md` — PR #3159). Mechanical, self-contained: every later 1c-ii stage depends on it.

## What this does

Scrubs the wallet-transaction-channel DTOs (`TransactionRecord`/`TransactionStatus`) of their Qt residue so the node-side source can compile and fill them:

- **`qint64` → `int64_t`** members. On LP64 these are `long` vs `long long`, so the three QVariant return sites in `transactiontablemodel.cpp` gain explicit `qint64{}` wraps — QVariant has no `long` constructor, which conveniently makes the compiler flag any missed site as an ambiguous conversion. Every other consumer was audited (GUIUtil::dateTimeStr, BitcoinUnits::format, QDateTime::fromSecsSinceEpoch, the Qt-free txorder/txfilter/SortKey brace-inits): no overload-resolution target changes anywhere.
- **`decomposeTransaction` returns `std::vector`** instead of `QList`; the producer path in `walletmodel.cpp` drops its QList→vector conversion copy.
- **`TypeToString` leaves the record.** The translated rendering moves to its only consumer — the transactionview filter combo — as a file-local helper with byte-identical strings under the original `QObject::tr` translation context (shipped locales keep working). The untranslated branch had zero callers (sort keys derive numerically in `projectKeys`; CSV/table rendering uses `formatTxType`) and is deleted.
- **Marshalability `static_assert`s** pin the value-type property in the header — the windowed-model design promised this assert but it was never built.
- **`transactionrecord.cpp` now compiles into the GUI-OFF test binary** (same pattern as the Qt-free `txfilter`/`txorder`/`cursor` cores) — the load-bearing proof of Qt-freedom — with a new smoke suite covering copy semantics, `getTxID`, and the empty-transaction degenerate decompose path (vacuous all-from-me/all-to-me → one zero-amount SendToSelf record; pinned as current behavior).

## What this deliberately does not do

No interface header, no producer hoist, no ownership change — those are stages b–d per the phasing plan. The DTOs stay in `src/qt/` for now; relocation happens with the hoist.

## Testing

Full unit suite green (new `qt_transactionrecord_tests` ×3 included), lint-all green, qt-includes ratchet unchanged (147 — this PR removes Qt *from* files rather than core includes). Adversarial review of the diff: no behavior-parity regressions found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
