### PR TITLE
test, mining: fix two regtest staking flakes (block-time vs wall-clock drift)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1695,7 +1695,8 @@ void StakeMiner(CWallet *pwallet)
 // to keep the mainnet/testnet staking path untouched.
 bool TryMineRegtestBlock(CWallet* pwallet,
                          CBlock& blocknew_out,
-                         std::string& err)
+                         std::string& err,
+                         int stake_time_slot_offset)
 {
     if (!Params().IsMockableChain()) {
         err = "TryMineRegtestBlock: only valid on regtest";
@@ -1720,7 +1721,16 @@ bool TryMineRegtestBlock(CWallet* pwallet,
 
     StakeBlock.nVersion = ComputeBlockVersion(pindexPrev->nHeight + 1);
 
-    StakeBlock.nTime = GetAdjustedTime();
+    // Advance the candidate stake time by one 16-second mask slot per retry
+    // attempt. CreateCoinStake masks this to STAKE_TIMESTAMP_MASK granularity
+    // and evaluates the kernel at that single timestamp — no time search — so a
+    // block mined at a masked slot where no coin's kernel hash falls under
+    // target fails, and (because generatetoaddress mines many blocks within one
+    // 16-second wall-clock window) a same-slot retry re-rolls nothing. Stepping
+    // to the next slot rerolls the kernel. Offset 0 (the first attempt) keeps
+    // the original behaviour.
+    StakeBlock.nTime = GetAdjustedTime()
+        + static_cast<int64_t>(stake_time_slot_offset) * (GRC::STAKE_TIMESTAMP_MASK + 1);
     StakeBlock.nNonce = 0;
     StakeBlock.nBits = GRC::GetNextTargetRequired(pindexPrev);
     StakeBlock.vtx.resize(2);

--- a/src/miner.h
+++ b/src/miner.h
@@ -70,9 +70,17 @@ bool CreateGridcoinReward(CMutableTransaction& mtxCoinbase, CMutableTransaction&
 // fills blocknew_out on success; returns false and sets err on failure. Used
 // by `generatetoaddress` / `generatesuperblock` RPCs to advance the chain
 // deterministically.
+//
+// stake_time_slot_offset advances the candidate stake timestamp by that many
+// 16-second STAKE_TIMESTAMP_MASK slots. The kernel is evaluated at a single
+// masked timestamp (no time search), so a given slot either yields a passing
+// kernel for the wallet's coins or does not; the caller passes the retry
+// attempt number here so each retry rolls a fresh slot instead of
+// re-evaluating the same dead one (see the retry loop in generatetoaddress).
 bool TryMineRegtestBlock(CWallet* pwallet,
                          CBlock& blocknew_out,
-                         std::string& err);
+                         std::string& err,
+                         int stake_time_slot_offset = 0);
 
 //! \brief The proof-of-stake miner loop. Runs until \ref fShutdown is set.
 void StakeMiner(CWallet* pwallet);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1097,14 +1097,19 @@ UniValue MineNBlocks(int nblocks, const std::string& dest_address /*advisory*/)
     for (int i = 0; i < nblocks; ++i) {
         CBlock block;
         std::string err;
-        // Retry transient CreateCoinStake failures (kernel hash too high, etc.)
-        // a few times before giving up. Under trivial powLimit + nStakeMinAge=0
-        // the kernel passes on first try, but UTXO selection can race with
-        // mempool / wallet flushes briefly.
+        // The coinstake kernel is evaluated at a single 16-second-masked
+        // timestamp (CreateCoinStake does no time search), so an "unlucky"
+        // masked slot — one where no wallet coin's kernel hash falls under
+        // target — yields "no stake found" even with a fully mature wallet.
+        // Because we mine many blocks within one 16-second wall-clock window,
+        // retrying at the same masked slot re-rolls nothing; pass the attempt
+        // number so each retry steps the candidate stake time to the next slot
+        // and rolls a fresh kernel. Five slots make an all-unlucky run
+        // vanishingly unlikely.
         bool ok = false;
         for (int attempt = 0; attempt < 5 && !ok; ++attempt) {
             err.clear();
-            ok = TryMineRegtestBlock(pwalletMain, block, err);
+            ok = TryMineRegtestBlock(pwalletMain, block, err, attempt);
             if (!ok) {
                 LogPrintf("generatetoaddress: attempt %d failed: %s", attempt, err);
             }

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -133,6 +133,14 @@ class TestNode():
         self.rpc_connected = False
         self.rpc = None
         self.url = None
+        # Last mock time this node was told to use (None => running on the real
+        # clock). Tracked so generatetoaddress can keep the node's adjusted time
+        # in step with the chain tip it produces; see generatetoaddress().
+        self._mocktime = None
+        # True once a test explicitly disables mock time (setmocktime(0)),
+        # distinguishing "test wants the real clock" from "never set" so the
+        # generatetoaddress auto-advance below leaves that choice alone.
+        self._mocktime_off = False
         self.log = logging.getLogger('TestFramework.node%d' % i)
         self.cleanup_on_exit = True # Whether to kill the node when this object goes away
         # Cache perf subprocesses here by their data output filename.
@@ -302,6 +310,53 @@ class TestNode():
     def generate(self, nblocks, maxtries=1000000):
         self.log.debug("TestNode.generate() dispatches `generate` call to `generatetoaddress`")
         return self.generatetoaddress(nblocks=nblocks, address=self.get_deterministic_priv_key().address, maxtries=maxtries)
+
+    def _rpc(self):
+        """The bare RPC/CLI dispatch target used by the methods below, which
+        shadow the RPC auto-dispatch in __getattr__ and so cannot call
+        themselves through it."""
+        return self.cli if self.use_cli else self.rpc
+
+    def setmocktime(self, timestamp):
+        """Shadow the RPC so we can track the node's mock clock (0 disables it).
+        See generatetoaddress() for why the clock is tracked."""
+        self._mocktime = None if timestamp == 0 else timestamp
+        self._mocktime_off = (timestamp == 0)
+        return self._rpc().setmocktime(timestamp)
+
+    def generatetoaddress(self, *args, **kwargs):
+        """Shadow the RPC to keep the node's adjusted time in step with the
+        chain tip it just produced.
+
+        Regtest proof-of-stake masks coinstake timestamps to 16-second slots and
+        requires each block's timestamp to advance past the previous one, so
+        mining several blocks within a single wall-clock 16-second window pushes
+        the block times AHEAD of real time. A freshly-mined coinstake output is
+        then future-dated, and a transaction spending it — which the wallet
+        stamps with the current adjusted time — is rejected by the coinstake
+        timestamp rule ("ConnectInputs: transaction timestamp earlier than input
+        transaction"). This surfaced as intermittent functional-test failures
+        (rpc_txoutproof, rpc_psgtpool, ...), most often under the slower
+        sanitizer CI job.
+
+        After mining, advance the node's mock clock to the tip so its adjusted
+        time never lags the chain. Guarded: the clock only ever moves FORWARD
+        (never behind a mocktime a test has deliberately set ahead of the tip),
+        it is a no-op when the tip is not ahead of the current clock, and it is
+        skipped entirely once a test has explicitly disabled mock time
+        (setmocktime(0)) — so tests that manage their own time are unaffected.
+
+        Limitation: mining through a raw wallet handle (get_wallet_rpc) calls
+        the RPC directly and bypasses this shadow, so the clock is not advanced.
+        No functional test mines that way; the direct node.generatetoaddress /
+        node.generate paths are the covered ones."""
+        hashes = self._rpc().generatetoaddress(*args, **kwargs)
+        if not self._mocktime_off:
+            tip_time = self._rpc().getblock(self._rpc().getbestblockhash())['time']
+            current = self._mocktime if self._mocktime is not None else int(time.time())
+            if tip_time > current:
+                self.setmocktime(tip_time)
+        return hashes
 
     def get_wallet_rpc(self, wallet_name):
         if self.use_cli:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -202,6 +202,14 @@ class TestNode():
         if extra_args is None:
             extra_args = self.extra_args
 
+        # The daemon resets its mock time on every (re)start, so drop the
+        # Python-side tracking (see setmocktime/generatetoaddress) — otherwise a
+        # stale _mocktime_off from a pre-restart setmocktime(0) would disable the
+        # clock auto-advance forever, and a stale _mocktime would be compared
+        # against the fresh process's real clock.
+        self._mocktime = None
+        self._mocktime_off = False
+
         # Add a new stdout and stderr file each time gridcoinresearchd is started
         if stderr is None:
             stderr = tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -314,8 +314,13 @@ class TestNode():
     def _rpc(self):
         """The bare RPC/CLI dispatch target used by the methods below, which
         shadow the RPC auto-dispatch in __getattr__ and so cannot call
-        themselves through it."""
-        return self.cli if self.use_cli else self.rpc
+        themselves through it. Mirrors __getattr__'s connection guard so a call
+        before wait_for_rpc_connection() raises the same clear assertion rather
+        than a NoneType error."""
+        if self.use_cli:
+            return self.cli
+        assert self.rpc_connected and self.rpc is not None, self._node_msg("Error: no RPC connection")
+        return self.rpc
 
     def setmocktime(self, timestamp):
         """Shadow the RPC so we can track the node's mock clock (0 disables it).
@@ -352,6 +357,8 @@ class TestNode():
         node.generate paths are the covered ones."""
         hashes = self._rpc().generatetoaddress(*args, **kwargs)
         if not self._mocktime_off:
+            # getblock (not getblockheader — Gridcoin has no such RPC) for the
+            # tip time; the extra payload is negligible against a mining call.
             tip_time = self._rpc().getblock(self._rpc().getbestblockhash())['time']
             current = self._mocktime if self._mocktime is not None else int(time.time())
             if tip_time > current:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -324,10 +324,13 @@ class TestNode():
 
     def setmocktime(self, timestamp):
         """Shadow the RPC so we can track the node's mock clock (0 disables it).
-        See generatetoaddress() for why the clock is tracked."""
+        See generatetoaddress() for why the clock is tracked. Local tracking is
+        updated only after the RPC succeeds, so a failed call cannot leave the
+        instance believing the daemon's clock changed when it did not."""
+        result = self._rpc().setmocktime(timestamp)
         self._mocktime = None if timestamp == 0 else timestamp
         self._mocktime_off = (timestamp == 0)
-        return self._rpc().setmocktime(timestamp)
+        return result
 
     def generatetoaddress(self, *args, **kwargs):
         """Shadow the RPC to keep the node's adjusted time in step with the
@@ -356,10 +359,11 @@ class TestNode():
         No functional test mines that way; the direct node.generatetoaddress /
         node.generate paths are the covered ones."""
         hashes = self._rpc().generatetoaddress(*args, **kwargs)
-        if not self._mocktime_off:
-            # getblock (not getblockheader — Gridcoin has no such RPC) for the
-            # tip time; the extra payload is negligible against a mining call.
-            tip_time = self._rpc().getblock(self._rpc().getbestblockhash())['time']
+        if not self._mocktime_off and hashes:
+            # The last returned hash is the block we just produced (the tip),
+            # so no getbestblockhash round-trip is needed. getblock (not
+            # getblockheader — Gridcoin has no such RPC) carries the time.
+            tip_time = self._rpc().getblock(hashes[-1])['time']
             current = self._mocktime if self._mocktime is not None else int(time.time())
             if tip_time > current:
                 self.setmocktime(tip_time)


### PR DESCRIPTION
Fixes two intermittent regtest functional-test failures — `CreateCoinStake: no stake found` and `ConnectInputs: transaction timestamp earlier than input transaction` — that surface most often in the **Sanitizers (Clang)** CI job (the slower instrumented binary widens the timing windows). Both trace to one thing: **regtest PoS block time decoupling from the wall clock.** Root-caused from `-debug=miner` logs, not guesswork.

## 1. `no stake found` — advance the stake time per retry (`src/miner.*`, `src/rpc/mining.cpp`)

`TryMineRegtestBlock` evaluates the coinstake kernel at a **single 16-second-masked timestamp** (`GRC::MaskStakeTime`, `STAKE_TIMESTAMP_MASK`) — there's no time search. An "unlucky" slot, where no wallet coin's kernel hash lands under target, yields `no stake found` **even with a fully mature wallet and ample stakeable balance** (the failing node logged `Balance considered for staking 1000140.00000000`). `generatetoaddress` retried 5×, but every retry re-used the *same* masked timestamp (`GetAdjustedTime()` returns the same masked second across sub-ms retries), so the retries re-rolled nothing and the call threw.

Fix: `TryMineRegtestBlock` gains a `stake_time_slot_offset` param; the retry loop passes the attempt number, advancing the candidate stake time one mask slot per attempt so each retry rolls a fresh kernel. Attempt 0 is unchanged (success path identical). +64s at attempt 4 is well inside the 128s future-drift tolerance (`validation.cpp`), so no retry block is rejected. The stale retry-loop comment (blamed a UTXO/mempool-flush race) is corrected.

## 2. `timestamp earlier than input` — keep the node's mock clock in step with the tip (`test_node.py`)

Mining several blocks within one wall-clock 16-second window makes their masked timestamps **march ahead of real time**, so the tip lands seconds-to-minutes in the future. A test that then spends a freshly-mined coinstake builds a spend tx the wallet stamps with the current adjusted time, so `txPrev.nTime > tx.nTime` and `ConnectInputs` rejects it (confirmed: a coinstake's block time was ~11s ahead of the wall clock at mine time).

Fix: `TestNode` shadows the `generatetoaddress` / `setmocktime` RPCs and, after mining, advances the node's mock clock to the tip when the tip is ahead — so its adjusted time never lags the chain it just built and a spend is never stamped before its coinstake input. **Guarded:** forward-only; a no-op when the tip isn't ahead; and skipped once a test explicitly disables mock time (`setmocktime(0)`), so tests managing their own clock are unaffected. (Mining through a raw wallet handle bypasses the shadow — no functional test does so, documented inline.)

## Validation

Contention reproduction — 32 concurrent `rpc_txoutproof` copies at `-j16`, repeated:
- **Before:** the timestamp flake hit ~15–20% of rounds; the no-stake flake within 24 rounds.
- **After:** **0 of either across 75 rounds (~2,400 runs).**

Full unit suite, `lint-all`, `interface_cli` (CLI mode — exercises the shadowed methods), `rpc_psgtpool`, and `wallet_basic` all pass. Adversarial review of the diff: C++ clean (future-drift, type-narrowing, all callers, reward/difficulty, locking all verified); Python surfaced two latent gaps (wallet-handle bypass; `setmocktime(0)` re-pin) — both addressed (the second closed with the explicit-disable guard, the first documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
