### PR TITLE
gui: view lifecycle + source-teardown hardening for the tx-table (Phase 1c-ii-c)

### DIFF
--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -19,6 +19,6 @@ std::unique_ptr<StakingStatus> Init::makeStakingStatus() { return nullptr; }
 
 std::unique_ptr<Wallet> Init::makeWallet() { return nullptr; }
 
-std::unique_ptr<WalletTxSource> Init::makeWalletTxSource(CWallet* /*wallet*/) { return nullptr; }
+std::shared_ptr<WalletTxSource> Init::makeWalletTxSource(CWallet* /*wallet*/) { return nullptr; }
 
 } // namespace interfaces

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -46,7 +46,7 @@ public:
     //! returned object owns the node-side machinery, so a headless process
     //! that never calls this pays nothing. Returns nullptr for a null wallet.
     //! \p wallet must outlive the returned object.
-    virtual std::unique_ptr<WalletTxSource> makeWalletTxSource(CWallet* wallet);
+    virtual std::shared_ptr<WalletTxSource> makeWalletTxSource(CWallet* wallet);
 };
 
 //! Return the monolithic-build Init implementation.

--- a/src/interfaces/wallet_tx_source.h
+++ b/src/interfaces/wallet_tx_source.h
@@ -44,6 +44,13 @@ public:
     virtual void registerView(int view_id, GRC::FilterSpec filter,
                               int sort_column, int sort_order) = 0;
 
+    //! Drop a registered view's cursor when its consumer tears down (Phase
+    //! 1c-ii-c). The GUI view models call this from their destructors so the
+    //! node-side per-view index no longer tracks store mutations for a view
+    //! that is gone. Idempotent. Must be called while the source is still
+    //! alive — see the teardown-ordering contract in bitcoin.cpp.
+    virtual void unregisterView(int view_id) = 0;
+
     //! Change a registered view's sort / filter / served-row cap. Each pushes
     //! the cursor's resulting events (Reset for sort/filter, Insert/Remove at
     //! the boundary for a limit change).
@@ -92,8 +99,16 @@ public:
 //! Return an in-process WalletTxSource over the given wallet, which must
 //! outlive the returned object. Constructing it starts the store worker and
 //! subscribes the producer handlers to the wallet's transaction signals;
-//! destroying it unsubscribes and joins.
-std::unique_ptr<WalletTxSource> MakeWalletTxSource(CWallet* wallet);
+//! releasing the last owning reference unsubscribes and joins.
+//!
+//! Returned by shared_ptr (not unique_ptr): the producer subscriptions hold a
+//! weak reference and lock it for each callback, so a core producer thread
+//! executing a callback when the owner releases keeps the source alive until
+//! that callback returns. This closes the cross-thread teardown race a bare
+//! signal disconnect leaves open. The single GUI owner still governs lifetime;
+//! the extra strong reference exists only for the duration of an in-flight
+//! callback.
+std::shared_ptr<WalletTxSource> MakeWalletTxSource(CWallet* wallet);
 
 } // namespace interfaces
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -189,7 +189,7 @@ public:
         return pwalletMain ? MakeWallet(pwalletMain) : nullptr;
     }
 
-    std::unique_ptr<WalletTxSource> makeWalletTxSource(CWallet* wallet) override
+    std::shared_ptr<WalletTxSource> makeWalletTxSource(CWallet* wallet) override
     {
         return wallet ? MakeWalletTxSource(wallet) : nullptr;
     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -666,7 +666,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 // producer subscriptions). Owned here so it outlives the
                 // WalletModel that drives it and is torn down — worker joined,
                 // producers severed — before Shutdown() destroys the wallet.
-                std::unique_ptr<interfaces::WalletTxSource> wallet_tx_source =
+                std::shared_ptr<interfaces::WalletTxSource> wallet_tx_source =
                     interface_init->makeWalletTxSource(pwalletMain);
                 if (!wallet_tx_source) {
                     throw std::runtime_error("wallet tx source unavailable after init");
@@ -683,6 +683,25 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 window.setWalletModel(&walletModel);
                 window.setMRCModel(&mrcModel);
                 window.setVotingModel(&votingModel);
+
+                // Exception-safe teardown of the tx-table view models (Phase
+                // 1c-ii-c). `window` is declared in an OUTER scope than
+                // walletModel / wallet_tx_source, so on an exception thrown below
+                // (window.show / ipcInit / app.exec) the stack unwind frees the
+                // model and source FIRST, then destroys `window` — and
+                // ~OverviewTxModel / ~DetailedTxModel would call
+                // txSource().unregisterView() against an already-freed source
+                // (UAF). This guard is declared AFTER the model and source, so
+                // its destructor runs BEFORE theirs on every exit path (normal or
+                // exception): it detaches the wallet from the window — destroying
+                // the view models while the source is still alive — so their
+                // unregisterView() always reaches a live source. The explicit
+                // setWalletModel(nullptr) on the normal path below makes this a
+                // no-op there; on the throw path it is the only teardown.
+                struct WalletModelDetachGuard {
+                    BitcoinGUI& window;
+                    ~WalletModelDetachGuard() { window.setWalletModel(nullptr); }
+                } wallet_model_detach_guard{window};
 
                 // If -min option passed, start window minimized.
                 if(gArgs.GetBoolArg("-min"))
@@ -710,18 +729,15 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
 
                 window.hide();
                 window.setClientModel(nullptr);
+                // Normal-path detach of the tx-table view models, in order with
+                // the other models. Destroys OverviewTxModel / DetailedTxModel
+                // (via BitcoinGUI -> {transactionView->setModel,
+                // overviewPage->setWalletModel}(nullptr)) while walletModel and
+                // wallet_tx_source below are still alive, so their
+                // unregisterView() reaches a live source. wallet_model_detach_guard
+                // above enforces the same on the exception path; this explicit
+                // call then becomes an idempotent no-op for the guard.
                 window.setWalletModel(nullptr);
-                // Lifetime note (Phase 1c-ii): the per-view tx-table sub-models
-                // (OverviewTxModel, DetailedTxModel) are destroyed with `window`
-                // at block exit below — AFTER walletModel and wallet_tx_source
-                // are gone. This is safe only because those sub-models have no
-                // destructor that reaches back through walletModel->txSource()
-                // (and no Qt event loop runs after app.exec() returns, so no
-                // slot fires on them). Phase 1c-ii-c adds unregisterView on view
-                // teardown; when it does, setWalletModel(nullptr) must first
-                // detach the sub-models (BitcoinGUI currently skips that on a
-                // null model), or the unregisterView call will dereference the
-                // already-destroyed source here.
                 window.setResearcherModel(nullptr);
                 // Clear the voting model BEFORE the enclosing block exits and
                 // destroys the stack-allocated VotingModel: this propagates to

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -894,6 +894,19 @@ void BitcoinGUI::setWalletModel(WalletModel *walletModel)
         // Ask for passphrase if needed
         connect(walletModel, &WalletModel::requireUnlock, this, &BitcoinGUI::unlockWallet);
     }
+    else
+    {
+        // Teardown (Phase 1c-ii-c): drive the tx-table view holders to detach
+        // their per-view models (OverviewTxModel / DetailedTxModel) NOW, while
+        // the previous WalletModel and its node-side WalletTxSource are still
+        // alive. bitcoin.cpp calls setWalletModel(nullptr) before destroying the
+        // model and the source; without this propagation those view models would
+        // instead be destroyed later with this window — after the source is gone
+        // — and their destructors' unregisterView() would dereference freed
+        // state. Only the two tx-table holders own such views.
+        transactionView->setModel(nullptr);
+        overviewPage->setWalletModel(nullptr);
+    }
 }
 
 void BitcoinGUI::setResearcherModel(ResearcherModel *researcherModel)

--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -77,6 +77,16 @@ DetailedTxModel::DetailedTxModel(WalletModel* walletModel, QObject* parent)
             this, &DetailedTxModel::applyEventBatch);
 }
 
+DetailedTxModel::~DetailedTxModel()
+{
+    // Symmetric with the ctor's registerView: drop the VIEW_DETAILED cursor so
+    // the node-side store stops maintaining a per-view index for a consumer that
+    // is gone (Phase 1c-ii-c). m_walletModel — and the WalletTxSource it hands
+    // out — outlives this model by the teardown-ordering contract (bitcoin.cpp).
+    if (m_walletModel)
+        m_walletModel->txSource().unregisterView(GRC::VIEW_DETAILED);
+}
+
 int DetailedTxModel::rowCount(const QModelIndex& parent) const
 {
     return parent.isValid() ? 0 : m_cache.total();

--- a/src/qt/detailedtxmodel.h
+++ b/src/qt/detailedtxmodel.h
@@ -56,6 +56,12 @@ class DetailedTxModel : public QAbstractTableModel
 public:
     explicit DetailedTxModel(WalletModel* walletModel, QObject* parent = nullptr);
 
+    //! Unregisters the VIEW_DETAILED cursor node-side (Phase 1c-ii-c). Must run
+    //! while the WalletModel/WalletTxSource is still alive — TransactionView
+    //! deletes this model on setModel(nullptr), which BitcoinGUI drives before
+    //! the source is torn down (teardown-ordering contract in bitcoin.cpp).
+    ~DetailedTxModel() override;
+
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role) const override;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -463,6 +463,17 @@ void OverviewPage::setWalletModel(WalletModel *model)
         // Connect the privacy mode setting to the options dialog.
         connect(walletModel->getOptionsModel(), &OptionsModel::MaskValuesChanged, this, &OverviewPage::setPrivacy);
     }
+    else if (!model)
+    {
+        // Detach on teardown (Phase 1c-ii-c): destroy the OverviewTxModel now, so
+        // its destructor unregisters the VIEW_OVERVIEW cursor while the previous
+        // WalletModel and its WalletTxSource are still alive. BitcoinGUI drives
+        // this on shutdown before the source is torn down; deferring to the
+        // page's own destruction (after the source is gone) would dereference a
+        // freed source.
+        ui->listTransactions->setModel(nullptr);
+        m_overviewTxModel.reset();
+    }
 
     // update the display unit, to not use the default ("BTC")
     updateDisplayUnit();

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -43,6 +43,16 @@ OverviewTxModel::OverviewTxModel(WalletModel* walletModel, int initialLimit, QOb
             this, &OverviewTxModel::applyEventBatch);
 }
 
+OverviewTxModel::~OverviewTxModel()
+{
+    // Symmetric with the ctor's registerView: drop the VIEW_OVERVIEW cursor so
+    // the node-side store stops maintaining a per-view index for a consumer that
+    // is gone (Phase 1c-ii-c). m_walletModel — and the WalletTxSource it hands
+    // out — outlives this model by the teardown-ordering contract (bitcoin.cpp).
+    if (m_walletModel)
+        m_walletModel->txSource().unregisterView(GRC::VIEW_OVERVIEW);
+}
+
 int OverviewTxModel::rowCount(const QModelIndex& parent) const
 {
     return parent.isValid() ? 0 : static_cast<int>(m_rows.size());

--- a/src/qt/overviewtxmodel.h
+++ b/src/qt/overviewtxmodel.h
@@ -40,6 +40,12 @@ class OverviewTxModel : public QAbstractListModel
 public:
     explicit OverviewTxModel(WalletModel* walletModel, int initialLimit, QObject* parent = nullptr);
 
+    //! Unregisters the VIEW_OVERVIEW cursor node-side (Phase 1c-ii-c). Must run
+    //! while the WalletModel/WalletTxSource is still alive — OverviewPage resets
+    //! this model on setWalletModel(nullptr), which BitcoinGUI drives before the
+    //! source is torn down (teardown-ordering contract in bitcoin.cpp).
+    ~OverviewTxModel() override;
+
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role) const override;
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -252,6 +252,17 @@ void TransactionView::setModel(WalletModel *model)
             this, &TransactionView::updateIcons);
         updateIcons(model->getOptionsModel()->getCurrentStyle());
     }
+    else if (!model && m_detailedModel) {
+        // Detach on teardown (Phase 1c-ii-c): destroy the DetailedTxModel now, so
+        // its destructor unregisters the VIEW_DETAILED cursor while the previous
+        // WalletModel and its WalletTxSource are still alive. BitcoinGUI drives
+        // this on shutdown before the source is torn down; deferring to this
+        // TransactionView's own destruction (after the source is gone) would
+        // dereference a freed source.
+        transactionView->setModel(nullptr);
+        delete m_detailedModel;
+        m_detailedModel = nullptr;
+    }
 }
 
 // The cursor's date bounds are seconds since epoch (FilterSpec defaults

--- a/src/test/qt_wallettxstore_tests.cpp
+++ b/src/test/qt_wallettxstore_tests.cpp
@@ -60,6 +60,38 @@ void waitForQueue(WalletEventQueue& q, std::size_t expected)
     }
 }
 
+//! True if the event's payload carries the given viewId. All payload variants
+//! except ChainTipChangedPayload are per-view and stamp a viewId (C++17: no
+//! `requires`, so match the concrete types explicitly).
+bool eventHasViewId(const GRC::WalletEvent& ev, int viewId)
+{
+    if (const auto* p = std::get_if<GRC::RowsInsertedPayload>(&ev.payload))   return p->viewId == viewId;
+    if (const auto* p = std::get_if<GRC::RowsRemovedPayload>(&ev.payload))    return p->viewId == viewId;
+    if (const auto* p = std::get_if<GRC::RowsResetPayload>(&ev.payload))      return p->viewId == viewId;
+    if (const auto* p = std::get_if<GRC::RowCountChangedPayload>(&ev.payload))return p->viewId == viewId;
+    if (const auto* p = std::get_if<GRC::RowsChangedPayload>(&ev.payload))    return p->viewId == viewId;
+    return false;
+}
+
+//! Does any event in the batch belong to the given view?
+bool batchHasViewId(const std::vector<GRC::WalletEvent>& batch, int viewId)
+{
+    for (const auto& ev : batch) {
+        if (eventHasViewId(ev, viewId)) return true;
+    }
+    return false;
+}
+
+//! A fully-permissive view filter: show_orphans (and the default show_inactive)
+//! accept every row regardless of status, so a synthetic makeRec record is
+//! guaranteed to pass the cursor and produce a per-view event.
+GRC::FilterSpec permissiveSpec()
+{
+    GRC::FilterSpec spec;
+    spec.show_orphans = true;
+    return spec;
+}
+
 } // anonymous namespace
 
 BOOST_AUTO_TEST_SUITE(qt_wallettxstore_tests)
@@ -202,6 +234,63 @@ BOOST_AUTO_TEST_CASE(getRowDetailWrongIdxReturnsEmpty)
     BOOST_CHECK(q.size() >= 1);
 
     BOOST_CHECK(!store.getRowDetail(h, 5).found);
+}
+
+BOOST_AUTO_TEST_CASE(unregisterViewStopsCursorEvents)
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    // Register a permissive VIEW_OVERVIEW cursor. registerView pushes a Reset
+    // SYNCHRONOUSLY on this thread; drain it so it cannot satisfy a later
+    // waitForQueue or bleed into a batch we assert on (a Reset also carries
+    // viewId==VIEW_OVERVIEW, which would make the insert assertion below vacuous).
+    store.registerView(GRC::VIEW_OVERVIEW, permissiveSpec(), GRC::TXCOL_DATE, GRC::TXSORT_DESC);
+    q.drain();
+
+    // An insert while the view is registered drives the cursor. The worker
+    // produces exactly two events — the native VIEW_FULL RowsInserted and the
+    // VIEW_OVERVIEW cursor delta — under one cs_store hold. Wait for BOTH so the
+    // insert is fully applied (the cursor drive complete) before we assert or
+    // unregister; then the VIEW_OVERVIEW event genuinely proves the record passed
+    // the filter and the cursor is live.
+    store.enqueueInsert(std::vector<TransactionRecord>{makeRec(hashOf(1), 1000, 0)});
+    waitForQueue(q, 2);
+    auto batch1 = q.drain();
+    BOOST_CHECK(batchHasViewId(batch1, GRC::VIEW_FULL));
+    BOOST_CHECK(batchHasViewId(batch1, GRC::VIEW_OVERVIEW));
+
+    // Drop the view. The first insert is fully drained above, so nothing from it
+    // can bleed into the next batch. A subsequent identical insert must still
+    // drive the native VIEW_FULL stream but emit NOTHING for the now-unregistered
+    // VIEW_OVERVIEW.
+    store.unregisterView(GRC::VIEW_OVERVIEW);
+    store.enqueueInsert(std::vector<TransactionRecord>{makeRec(hashOf(2), 1001, 0)});
+    waitForQueue(q, 1);
+    auto batch2 = q.drain();
+    BOOST_CHECK(batchHasViewId(batch2, GRC::VIEW_FULL));
+    BOOST_CHECK(!batchHasViewId(batch2, GRC::VIEW_OVERVIEW));
+}
+
+BOOST_AUTO_TEST_CASE(unregisterViewIsIdempotent)
+{
+    WalletEventQueue q;
+    WalletTxStore store(nullptr, q);
+    store.start();
+
+    // Unregistering a never-registered view is a harmless no-op.
+    store.unregisterView(GRC::VIEW_OVERVIEW);
+
+    // Register, then unregister twice — the second call is a no-op, not a crash.
+    store.registerView(GRC::VIEW_DETAILED, permissiveSpec(), GRC::TXCOL_DATE, GRC::TXSORT_DESC);
+    store.unregisterView(GRC::VIEW_DETAILED);
+    store.unregisterView(GRC::VIEW_DETAILED);
+
+    // Re-registering after an unregister works: it pushes a fresh Reset for the view.
+    q.drain();
+    store.registerView(GRC::VIEW_DETAILED, permissiveSpec(), GRC::TXCOL_DATE, GRC::TXSORT_DESC);
+    BOOST_CHECK(batchHasViewId(q.drain(), GRC::VIEW_DETAILED));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet_tx_source.cpp
+++ b/src/wallet/wallet_tx_source.cpp
@@ -24,7 +24,19 @@ namespace {
 //! CWallet's transaction signals. Constructing an instance is the "attach"
 //! (worker started, producers wired); destroying it is the "detach" (producers
 //! severed, worker joined) — so nothing runs when no GUI holds a source.
-class WalletTxSourceImpl : public WalletTxSource
+//!
+//! Held by shared_ptr: the producer subscriptions capture a weak_ptr to this
+//! source and lock() it for the duration of each callback. A core producer
+//! thread (e.g. the stake miner firing NotifyBlocksChanged) that is inside a
+//! callback when the last owning shared_ptr is released therefore holds a
+//! strong reference across the call, which defers this object's destruction
+//! until the callback returns — closing the cross-thread teardown UAF that a
+//! bare boost::signals2 disconnect does not (disconnect does not block an
+//! in-flight slot running on another thread). enable_shared_from_this supplies
+//! the weak_ptr; the factory constructs via make_shared and calls subscribe()
+//! afterward, since weak_from_this() is only valid once the shared_ptr owns it.
+class WalletTxSourceImpl : public WalletTxSource,
+                           public std::enable_shared_from_this<WalletTxSourceImpl>
 {
 public:
     explicit WalletTxSourceImpl(CWallet* wallet)
@@ -33,9 +45,15 @@ public:
     {
         // Launch the store-worker before producers can fire, so it is ready to
         // drain the intake queue off the core locks (windowed-model PR2.5).
+        // subscribe() is NOT called here: it needs weak_from_this(), which is
+        // only valid after make_shared has taken ownership — see MakeWalletTxSource.
         m_store.start();
-        subscribe();
     }
+
+    //! Wire the producer subscriptions. Called by MakeWalletTxSource immediately
+    //! after make_shared (weak_from_this() is valid only then). Not part of the
+    //! interface — invoked through the concrete shared_ptr.
+    void subscribe();
 
     ~WalletTxSourceImpl() override
     {
@@ -51,6 +69,8 @@ public:
     {
         m_store.registerView(view_id, std::move(filter), sort_column, sort_order);
     }
+
+    void unregisterView(int view_id) override { m_store.unregisterView(view_id); }
 
     void setViewSort(int view_id, int sort_column, int sort_order) override
     {
@@ -97,21 +117,26 @@ public:
     }
 
 private:
-    void subscribe();
-
     //! Producer: a wallet transaction became visible / changed / was deleted.
     //! Runs on the emitting core thread under the locks it already holds;
     //! decomposes and status-stamps in place, then enqueues to the store worker
     //! (O(1)). Body hoisted unchanged from the former WalletModel free function.
+    //! Dispatched through a weak_ptr-locking lambda (see subscribe()), so the
+    //! Clang analyzer cannot see the emitter's held cs_main/cs_wallet across the
+    //! signals2 boundary; NO_THREAD_SAFETY_ANALYSIS suppresses the false
+    //! positive, and the AssertLockHeld() calls inside enforce the contract at
+    //! runtime (DEBUG_LOCKORDER) exactly as before.
     void onTransactionChanged(CWallet* wallet, const uint256& hash, ChangeType status)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet);
+        NO_THREAD_SAFETY_ANALYSIS;
 
     //! Producer: the chain tip advanced (connect/disconnect/reorg). Pushes a
     //! ChainTipChanged marker and runs the bounded per-tip status refresh inline
     //! under cs_main. Body hoisted unchanged from the former WalletModel free
-    //! function.
+    //! function. NO_THREAD_SAFETY_ANALYSIS for the same signals2-dispatch reason
+    //! as onTransactionChanged; the inline applyChainTipRefresh still requires
+    //! cs_main, held by the SetBestChain emitter.
     void onBlocksChanged(bool syncing, int height, int64_t best_time, uint32_t target_bits)
-        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        NO_THREAD_SAFETY_ANALYSIS;
 
     CWallet* const m_wallet;
 
@@ -129,29 +154,46 @@ private:
 void WalletTxSourceImpl::subscribe()
 {
     // The producer runs under the emitting thread's locks by design (it
-    // decomposes transactions in place). The handlers are bound to this source
-    // (not the WalletModel), so the source outlives the GUI models that drive
-    // it. ~WalletTxSourceImpl clears m_handlers first, disconnecting the
-    // subscriptions so no NEW emission is dispatched to a freed handler. This
-    // does NOT block an emission already in flight on another core thread when
-    // disconnect runs (boost::signals2's default mutex releases before the slot
-    // body executes, and the binds carry no shared_ptr slot tracking); that
-    // narrow window is bounded only by shutdown ordering — the same pre-existing
-    // property the former WalletModel::unsubscribeFromCoreSignals() relied on.
-    // Closing it fully (shared_ptr-tracked slots, or teardown gated on producer
-    // quiescence) belongs to the attach/detach lifecycle work (Phase 1c-ii-c).
+    // decomposes transactions in place). Each handler is a lambda that captures
+    // a weak_ptr to this source and lock()s it before touching any member. This
+    // closes the cross-thread teardown UAF (Phase 1c-ii-c): weak_ptr::lock() is
+    // atomic w.r.t. the owning shared_ptr's refcount, so
+    //   - if the source is already being destroyed, lock() returns empty and the
+    //     callback is a no-op (no access to freed state); and
+    //   - if a callback is IN FLIGHT on a core thread when the last owning
+    //     shared_ptr (bitcoin.cpp) is released, the locked shared_ptr held here
+    //     keeps the refcount >= 1, deferring ~WalletTxSourceImpl until the
+    //     callback returns.
+    // This is stronger than a bare boost::signals2 disconnect, which does not
+    // block a slot already executing on another thread. m_handlers.clear() in
+    // the destructor still severs the subscriptions so no NEW emission is
+    // dispatched; the weak_ptr guard covers the in-flight overlap.
+    std::weak_ptr<WalletTxSourceImpl> weak_self = weak_from_this();
+
     m_handlers.emplace_back(m_wallet->NotifyTransactionChanged.connect(
-        boost::bind(&WalletTxSourceImpl::onTransactionChanged, this,
-                    boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3)));
+        [weak_self](CWallet* wallet, const uint256& hash, ChangeType status) {
+            if (auto self = weak_self.lock()) {
+                self->onTransactionChanged(wallet, hash, status);
+            }
+        }));
     m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(
-        boost::bind(&WalletTxSourceImpl::onBlocksChanged, this,
-                    boost::placeholders::_1, boost::placeholders::_2,
-                    boost::placeholders::_3, boost::placeholders::_4)));
+        [weak_self](bool syncing, int height, int64_t best_time, uint32_t target_bits) {
+            if (auto self = weak_self.lock()) {
+                self->onBlocksChanged(syncing, height, best_time, target_bits);
+            }
+        }));
 }
 
 void WalletTxSourceImpl::onTransactionChanged(CWallet* wallet, const uint256& hash, ChangeType status)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)
+    NO_THREAD_SAFETY_ANALYSIS
 {
+    // Invoked via the weak_ptr-locking lambda in subscribe(), on the emitting
+    // core thread, under the cs_main + cs_wallet the emitter already holds (all
+    // CT_NEW/CT_UPDATED callsites: AddToWallet / CommitTransaction /
+    // WalletUpdateSpent). The analyzer cannot see those locks across the signals2
+    // dispatch, hence NO_THREAD_SAFETY_ANALYSIS; the AssertLockHeld() calls below
+    // enforce the contract at runtime under DEBUG_LOCKORDER, exactly as the prior
+    // EXCLUSIVE_LOCKS_REQUIRED annotation did for the analyzer.
     LogPrint(BCLog::LogFlags::VERBOSE, "NotifyTransactionChanged %s status=%i", hash.GetHex(), status);
 
     // CT_NEW and CT_UPDATED are handled identically: look up the wtx, apply the
@@ -251,7 +293,7 @@ void WalletTxSourceImpl::onTransactionChanged(CWallet* wallet, const uint256& ha
 
 void WalletTxSourceImpl::onBlocksChanged(bool /*syncing*/, int height, int64_t best_time,
                                          uint32_t /*target_bits*/)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    NO_THREAD_SAFETY_ANALYSIS
 {
     // Fired under cs_main after every chain-tip advance, via the synchronous
     // validation-interface bridge (SetBestChain -> UpdatedBlockTip ->
@@ -269,9 +311,14 @@ void WalletTxSourceImpl::onBlocksChanged(bool /*syncing*/, int height, int64_t b
 
 } // namespace
 
-std::unique_ptr<WalletTxSource> MakeWalletTxSource(CWallet* wallet)
+std::shared_ptr<WalletTxSource> MakeWalletTxSource(CWallet* wallet)
 {
-    return std::make_unique<WalletTxSourceImpl>(wallet);
+    // Two-phase: construct under shared ownership FIRST, then subscribe(). The
+    // producer handlers capture weak_from_this(), which is only valid once the
+    // shared_ptr owns the object — so subscribe() cannot run from the ctor.
+    auto source = std::make_shared<WalletTxSourceImpl>(wallet);
+    source->subscribe();
+    return source;
 }
 
 } // namespace interfaces

--- a/src/wallet/wallettxstore.cpp
+++ b/src/wallet/wallettxstore.cpp
@@ -729,6 +729,17 @@ void WalletTxStore::registerView(int viewId, FilterSpec filter, int sort_column,
     emitCursorDeltas(viewId, epoch, deltas);
 }
 
+void WalletTxStore::unregisterView(int viewId)
+{
+    // Drop the view's cursor. Called when a consumer view tears down (Phase
+    // 1c-ii-c) so its per-view index no longer tracks store mutations. No event
+    // is emitted: the consumer is going away and will not drain again.
+    // Idempotent — erasing an absent viewId is a no-op, so a double teardown or
+    // a never-registered view is harmless.
+    LOCK(cs_store);
+    m_cursors.erase(viewId);
+}
+
 void WalletTxStore::setViewSort(int viewId, int sort_column, int sort_order)
 {
     LOCK(cs_store);

--- a/src/wallet/wallettxstore.h
+++ b/src/wallet/wallettxstore.h
@@ -147,6 +147,10 @@ public:
     //!
     void registerView(int viewId, FilterSpec filter, int sort_column, int sort_order);
 
+    //! Qt thread: drop a registered view's cursor on consumer teardown (Phase
+    //! 1c-ii-c). Idempotent; emits no event (the consumer is going away).
+    void unregisterView(int viewId);
+
     //! Qt thread: change a registered view's sort / filter / served-row cap.
     //! Each pushes the cursor's resulting events (Reset for sort/filter,
     //! Insert/Remove at the boundary for a limit change).


### PR DESCRIPTION
## Phase 1c-ii-c — view lifecycle + source-teardown hardening

Completes the windowed transaction-table lifecycle behind `interfaces::WalletTxSource` (RFC #2937, `doc/multiprocess_phasing.md` §3): per-view teardown, exception-safe GUI teardown ordering, and closing the cross-thread source-teardown race the 1c-ii-b code comment flagged for this phase.

### View lifecycle (`unregisterView`)
- `WalletTxStore::unregisterView(viewId)` erases the view's cursor under `cs_store` (idempotent; no event — the consumer is going away). Re-added to `interfaces::WalletTxSource` + the impl.
- `~OverviewTxModel` / `~DetailedTxModel` unregister `VIEW_OVERVIEW` / `VIEW_DETAILED`, symmetric with their ctor `registerView`. Views no longer leak-by-design.

### Teardown ordering (the load-bearing part)
- `BitcoinGUI::setWalletModel(nullptr)` now propagates to `transactionView->setModel(nullptr)` + `overviewPage->setWalletModel(nullptr)`, destroying the view models **while `walletModel` and the source are still alive** so their `unregisterView()` reaches a live source.
- `bitcoin.cpp` adds a scope guard (`WalletModelDetachGuard`) declared **after** the model and source, so its destructor runs **before** theirs on every exit path — including an exception between view-model creation and the normal teardown call (which would otherwise unwind the inner block, freeing model + source, before destroying the outer-scope `window`, turning the new destructors into a UAF). This exception-path UAF was caught in adversarial review and fixed here.

### Source-teardown UAF hardening (shared_ptr + weak-guard)
- `MakeWalletTxSource` / `Init::makeWalletTxSource` now return `shared_ptr`, and the impl derives `enable_shared_from_this` (two-phase `make_shared` → `subscribe()`). Each producer handler is a lambda capturing `weak_from_this()` that `lock()`s before touching any member: a core producer thread (e.g. the stake miner in `NotifyBlocksChanged`) inside a callback when the GUI releases the last owner holds a strong ref that **defers destruction until the callback returns**; a callback that starts after teardown gets an empty lock and no-ops. This closes the window a bare `boost::signals2` disconnect leaves open (disconnect does not block an in-flight slot on another thread). `NotifyBlocksChanged_connect` takes `std::function`, so boost `track_foreign` could not compose — the `weak_ptr` guard is uniform across both signals. The two producers move to `NO_THREAD_SAFETY_ANALYSIS` (the analyzer cannot see the emitter's locks across the lambda dispatch; the existing `AssertLockHeld` calls remain the runtime enforcement).

Deliberately deferred to Phase 2: lazy refcounted source construction (the monolith has a single eager client).

### Testing
- Builds clean (Qt6, RelWithDebInfo). Unit + qt suites green; `qt_wallettxstore_tests` gains `unregisterViewStopsCursorEvents` + `unregisterViewIsIdempotent` (GUI-OFF Boost).
- Two-reviewer adversarial pass; both real findings fixed (the exception-path UAF above; a vacuous/flaky test assertion).
- **ASan-GUI mesh soak** (isolated testnet, instance 9): ~11 h + interactive GUI session, staking active — **zero ASan/UBSan**. A graceful shutdown was verified **ASan-clean** end-to-end (view-model unregister → shared_ptr source destruction → all worker threads exit → `[Inferior exited normally]`), which is exactly the teardown-ordering + UAF-fix path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
