### PR TITLE
gui: migrate SideStakeTableModel onto interfaces:: (Phase 1d-ii)

### DIFF
--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -4,25 +4,31 @@
 
 #include "interfaces/staking.h"
 #include "interfaces/mrc.h"
+#include "interfaces/sidestake.h"
 
 #include "amount.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/contract/message.h"
 #include "gridcoin/mrc.h"
+#include "gridcoin/sidestake.h"
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/staking/status.h"
 #include "interfaces/handler.h"
+#include "key_io.h"
 #include "main.h"
 #include "node/ui_interface.h"
 #include "sync.h"
 #include "txmempool.h"
+#include "util/strencodings.h"
 #include "validation.h"
 #include "wallet/wallet.h"
 
+#include <cmath>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace interfaces {
@@ -283,6 +289,260 @@ private:
     CWallet* m_wallet;
 };
 
+//! In-process SideStakeManager over the global sidestake registry (Phase 1d-ii).
+//! Presents the unified mandatory+local table as value rows and moves all local
+//! add/edit/delete validation (formerly in SideStakeTableModel) behind command
+//! methods, so no GUI code holds a GRC::SideStake or calls GetSideStakeRegistry()
+//! directly. Mutations return the post-mutation local sidestake revision (design
+//! §4.4) for read-your-writes.
+class SideStakeManagerImpl : public SideStakeManager
+{
+public:
+    SideStakeSnapshot entries() override
+    {
+        GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
+
+        SideStakeSnapshot snap;
+
+        // Read the revision BEFORE the entries so an interleaving local mutation
+        // only makes it conservatively low (an extra refetch), never stale.
+        snap.local_revision = registry.GetLocalSideStakeRevision();
+
+        for (const auto& entry :
+             registry.ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true)) {
+            SideStakeEntry row;
+            row.address = EncodeDestination(entry->GetDestination());
+            row.allocation_percent = entry->GetAllocation().ToPercent();
+            row.description = entry->GetDescription();
+            row.status = entry->StatusToString();
+            row.is_mandatory = entry->IsMandatory();
+            row.status_sort_key = StatusSortKey(*entry);
+
+            snap.entries.push_back(std::move(row));
+        }
+
+        return snap;
+    }
+
+    uint64_t localRevision() override
+    {
+        return GRC::GetSideStakeRegistry().GetLocalSideStakeRevision();
+    }
+
+    SideStakeEditResult addLocal(const std::string& address,
+                                 double allocation_percent,
+                                 const std::string& description) override
+    {
+        GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
+
+        const CTxDestination destination = DecodeDestination(address);
+        if (!IsValidDestination(destination)) {
+            return Result(SideStakeEditStatus::INVALID_ADDRESS);
+        }
+
+        // Duplicate local sidestake check against the registry (not a stale view).
+        if (!registry.Try(destination, GRC::SideStake::FilterFlag::LOCAL).empty()) {
+            return Result(SideStakeEditStatus::DUPLICATE_ADDRESS);
+        }
+
+        // Validate the percent before constructing GRC::Allocation, whose
+        // double -> int64_t conversion is undefined for NaN/Inf/out-of-range.
+        if (!ValidAllocationPercent(allocation_percent)) {
+            return Result(SideStakeEditStatus::INVALID_ALLOCATION);
+        }
+
+        const GRC::Allocation new_allocation(allocation_percent / 100.0);
+
+        // The new allocation plus all active entries must not exceed 100%.
+        if (TotalActiveAllocation(registry, nullptr) + new_allocation > 1) {
+            return Result(SideStakeEditStatus::INVALID_ALLOCATION);
+        }
+
+        const std::string sanitized = SanitizeString(description, SAFE_CHARS_CSV);
+        if (sanitized != description) {
+            return Result(SideStakeEditStatus::INVALID_DESCRIPTION);
+        }
+
+        registry.NonContractAdd(GRC::LocalSideStake(destination,
+                                                    new_allocation,
+                                                    sanitized,
+                                                    GRC::LocalSideStake::LocalSideStakeStatus::ACTIVE));
+
+        return Result(SideStakeEditStatus::OK, EncodeDestination(destination));
+    }
+
+    SideStakeEditResult setAllocation(const std::string& address,
+                                      double allocation_percent) override
+    {
+        GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
+
+        GRC::SideStake original;
+        if (!FindLocal(registry, address, original)) {
+            return Result(SideStakeEditStatus::INVALID_ADDRESS);
+        }
+
+        if (original.GetAllocation().ToPercent() == allocation_percent) {
+            return Result(SideStakeEditStatus::NO_CHANGES);
+        }
+
+        // Validate the percent before constructing GRC::Allocation (see addLocal).
+        if (!ValidAllocationPercent(allocation_percent)) {
+            return Result(SideStakeEditStatus::INVALID_ALLOCATION);
+        }
+
+        const CTxDestination destination = original.GetDestination();
+        const GRC::Allocation new_allocation(allocation_percent / 100.0);
+
+        // The new allocation plus the OTHER active entries must not exceed 100%.
+        if (TotalActiveAllocation(registry, &destination) + new_allocation > 1) {
+            return Result(SideStakeEditStatus::INVALID_ALLOCATION);
+        }
+
+        registry.NonContractAdd(
+            GRC::LocalSideStake(destination,
+                                new_allocation,
+                                original.GetDescription(),
+                                std::get<GRC::LocalSideStake::Status>(original.GetStatus()).Value()),
+            true);
+
+        return Result(SideStakeEditStatus::OK);
+    }
+
+    SideStakeEditResult setDescription(const std::string& address,
+                                       const std::string& description) override
+    {
+        GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
+
+        GRC::SideStake original;
+        if (!FindLocal(registry, address, original)) {
+            return Result(SideStakeEditStatus::INVALID_ADDRESS);
+        }
+
+        if (original.GetDescription() == description) {
+            return Result(SideStakeEditStatus::NO_CHANGES);
+        }
+
+        const std::string sanitized = SanitizeString(description, SAFE_CHARS_CSV);
+        if (sanitized != description) {
+            return Result(SideStakeEditStatus::INVALID_DESCRIPTION);
+        }
+
+        registry.NonContractAdd(
+            GRC::LocalSideStake(original.GetDestination(),
+                                original.GetAllocation(),
+                                sanitized,
+                                std::get<GRC::LocalSideStake::Status>(original.GetStatus()).Value()),
+            true);
+
+        return Result(SideStakeEditStatus::OK);
+    }
+
+    SideStakeEditResult deleteLocal(const std::string& address) override
+    {
+        GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
+
+        GRC::SideStake original;
+        // Only local entries are deletable; a mandatory address is not found as
+        // LOCAL, so this also enforces the GUI's "no deleting mandatory" rule.
+        if (!FindLocal(registry, address, original)) {
+            return Result(SideStakeEditStatus::INVALID_ADDRESS);
+        }
+
+        registry.NonContractDelete(original.GetDestination());
+
+        return Result(SideStakeEditStatus::OK);
+    }
+
+    std::unique_ptr<Handler> handleRwSettingsUpdated(RwSettingsUpdatedFn fn) override
+    {
+        // Forward the payload-free callback directly. Deliberately does NOT read
+        // the revision here: this slot may run before the registry's own
+        // RwSettingsUpdated reload slot (slot order is not guaranteed), so an
+        // emission-time revision could predate the reload. The consumer reads
+        // localRevision() itself when handling the notification — see
+        // interfaces/sidestake.h.
+        return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleMandatorySideStakeChanged(MandatorySideStakeChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.MandatorySideStakeChanged_connect(std::move(fn)));
+    }
+
+private:
+    //! Build a result stamped with the current local sidestake revision.
+    static SideStakeEditResult Result(SideStakeEditStatus status, std::string address = {})
+    {
+        SideStakeEditResult res;
+        res.status = status;
+        res.address = std::move(address);
+        res.local_revision = GRC::GetSideStakeRegistry().GetLocalSideStakeRevision();
+        return res;
+    }
+
+    //! A well-formed allocation percentage: finite and within [0, 100]. Checked
+    //! before constructing GRC::Allocation, whose double -> int64_t conversion is
+    //! undefined behavior for NaN/Inf/out-of-range values (QString::toDouble can
+    //! yield inf, e.g. from "1e400").
+    static bool ValidAllocationPercent(double percent)
+    {
+        return std::isfinite(percent) && percent >= 0.0 && percent <= 100.0;
+    }
+
+    //! The Status-column sort key: mandatory statuses keep their enum value,
+    //! local statuses are shifted above the mandatory range (reproducing the
+    //! former SideStakeLessThan ordering).
+    static int StatusSortKey(const GRC::SideStake& entry)
+    {
+        if (entry.IsMandatory()) {
+            return static_cast<int>(
+                std::get<GRC::MandatorySideStake::Status>(entry.GetStatus()).Value());
+        }
+
+        return static_cast<int>(std::get<GRC::LocalSideStake::Status>(entry.GetStatus()).Value())
+               + static_cast<int>(GRC::MandatorySideStake::MandatorySideStakeStatus::OUT_OF_BOUND);
+    }
+
+    //! Total allocation of the active entries, optionally excluding one
+    //! destination (used when re-validating an edit of that entry).
+    static GRC::Allocation TotalActiveAllocation(GRC::SideStakeRegistry& registry,
+                                                 const CTxDestination* exclude)
+    {
+        GRC::Allocation total;
+
+        for (const auto& entry :
+             registry.ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true)) {
+            if (exclude != nullptr && entry->GetDestination() == *exclude) {
+                continue;
+            }
+
+            total += entry->GetAllocation();
+        }
+
+        return total;
+    }
+
+    //! Look up an existing LOCAL sidestake by encoded address. Returns false if
+    //! the address is invalid or has no local entry.
+    static bool FindLocal(GRC::SideStakeRegistry& registry,
+                          const std::string& address,
+                          GRC::SideStake& out)
+    {
+        const CTxDestination destination = DecodeDestination(address);
+        if (!IsValidDestination(destination)) {
+            return false;
+        }
+
+        const auto existing = registry.Try(destination, GRC::SideStake::FilterFlag::LOCAL);
+        if (existing.empty()) {
+            return false;
+        }
+
+        out = *existing.front();
+        return true;
+    }
+};
+
 } // namespace
 
 std::unique_ptr<StakingStatus> MakeStakingStatus()
@@ -293,6 +553,11 @@ std::unique_ptr<StakingStatus> MakeStakingStatus()
 std::unique_ptr<MRC> MakeMRC(CWallet* wallet)
 {
     return std::make_unique<MRCImpl>(wallet);
+}
+
+std::unique_ptr<SideStakeManager> MakeSideStakeManager()
+{
+    return std::make_unique<SideStakeManagerImpl>();
 }
 
 } // namespace interfaces

--- a/src/gridcoin/sidestake.cpp
+++ b/src/gridcoin/sidestake.cpp
@@ -750,6 +750,11 @@ void SideStakeRegistry::AddDelete(const ContractContext& ctx)
     // Finally, insert the new SideStake entry (payload) smart pointer into the m_sidestake_entries map.
     m_mandatory_sidestake_entries[payload.m_entry.m_destination] = m_sidestake_db.find(ctx.m_tx.GetHash())->second;
 
+    // A mandatory (contract) sidestake entry changed; nudge the GUI table with a
+    // payload-free refetch trigger. The only subscriber marshals to the GUI
+    // thread, so emitting under cs_lock is safe (see ui_interface.h).
+    uiInterface.MandatorySideStakeChanged();
+
     return;
 }
 
@@ -770,6 +775,8 @@ void SideStakeRegistry::NonContractAdd(const LocalSideStake& sidestake, const bo
     // Using this form of insert because we want the latest record with the same key to override any previous one.
     m_local_sidestake_entries[sidestake.m_destination] = std::make_shared<LocalSideStake>(sidestake);
 
+    ++m_local_sidestake_revision;
+
     if (save_to_file) {
         SaveLocalSideStakesToConfig();
     }
@@ -783,6 +790,8 @@ void SideStakeRegistry::NonContractDelete(const CTxDestination& destination, con
 
     if (sidestake_entry_pair_iter != m_local_sidestake_entries.end()) {
         m_local_sidestake_entries.erase(sidestake_entry_pair_iter);
+
+        ++m_local_sidestake_revision;
     }
 
     if (save_to_file) {
@@ -825,6 +834,11 @@ void SideStakeRegistry::Revert(const ContractContext& ctx) EXCLUSIVE_LOCKS_REQUI
             // If the record to revert is not found in the m_sidestake_entries map, no point in continuing.
             return;
         }
+
+        // A mandatory sidestake entry was reverted (reorg); nudge the GUI table.
+        // The queued refetch runs after this Revert completes, so it observes the
+        // final state (including any resurrected prior entry below).
+        uiInterface.MandatorySideStakeChanged();
 
                // Also erase the record from the db.
         if (!m_sidestake_db.erase(ctx.m_tx.GetHash())) {
@@ -939,6 +953,8 @@ void SideStakeRegistry::ResetInMemoryOnly()
     m_local_sidestake_entries.clear();
     m_mandatory_sidestake_entries.clear();
     m_sidestake_db.clear_in_memory_only();
+
+    ++m_local_sidestake_revision;
 }
 
 uint64_t SideStakeRegistry::PassivateDB()
@@ -946,6 +962,17 @@ uint64_t SideStakeRegistry::PassivateDB()
     LOCK(cs_lock);
 
     return m_sidestake_db.passivate_db();
+}
+
+uint64_t SideStakeRegistry::GetLocalSideStakeRevision() const
+{
+    // Lock-free read of the monotonic revision. Each LOCAL mutation bumps it
+    // while holding cs_lock, so a reader here observes a value that is at least
+    // as new as any mutation ordered before this load (design §4.4). Callers that
+    // need a revision consistent with a snapshot read the revision BEFORE the
+    // snapshot, so an interleaving mutation only makes the revision
+    // conservatively low (an extra refetch), never stale.
+    return m_local_sidestake_revision.load();
 }
 
 void SideStakeRegistry::LoadLocalSideStakesFromConfig()
@@ -1116,6 +1143,12 @@ void SideStakeRegistry::LoadLocalSideStakesFromConfig()
     if (gArgs.GetBoolArg("-enablesidestaking") && !sum_allocation)
         LogPrintf("WARN: %s: enablesidestaking was set in config but nothing has been allocated for"
                   " distribution!", __func__);
+
+    // A config-driven reload mutated the local map. Per-entry NonContractAdd
+    // already bumps the revision, but a removal that only reseats a map entry to
+    // INACTIVE (above) does not, so bump once here to guarantee any reload
+    // advances the revision (over-counting coalesces on the consumer side).
+    ++m_local_sidestake_revision;
 }
 
 bool SideStakeRegistry::SaveLocalSideStakesToConfig()

--- a/src/gridcoin/sidestake.h
+++ b/src/gridcoin/sidestake.h
@@ -840,6 +840,25 @@ public:
     void LoadLocalSideStakesFromConfig();
 
     //!
+    //! \brief Monotonic in-memory revision of the LOCAL (voluntary, rwsettings-
+    //! persisted) sidestake state, advanced at every local mutation commit
+    //! (design §4.4 versioned refetch). Lets a consumer (e.g. the GUI sidestake
+    //! model via interfaces::SideStakeManager) keep a high-water mark, drop stale
+    //! RwSettingsUpdated notifications, and read-its-writes.
+    //!
+    //! Scope is deliberately local-only: the mandatory (contract) side already has
+    //! block-height ordering and does not drive the GUI's RwSettingsUpdated
+    //! refresh, so contract Add/Delete/Revert do not touch this counter. It is
+    //! memory-only (reset to 0 on restart, per §4.4 point 4), never serialized,
+    //! not consensus state. It is distinct from both SideStakePayload::m_version
+    //! (a payload serialization format version) and the SideStakeDB format version
+    //! passed to m_sidestake_db on construction — hence "revision", not "version".
+    //!
+    //! \return The current local sidestake revision.
+    //!
+    uint64_t GetLocalSideStakeRevision() const;
+
+    //!
     //! \brief Specializes the template RegistryDB for the SideStake class. Note that std::set<MandatorySideStake>
     //! is not actually used.
     //!
@@ -901,6 +920,13 @@ private:
     //! flag, no other state is published through it. It is deliberately NOT
     //! GUARDED_BY(cs_lock) — it is accessed outside the registry lock by design.
     std::atomic<bool> m_local_entry_already_saved_to_config{false};
+
+    //! \brief Monotonic in-memory revision of the local sidestake state (design
+    //! §4.4). Incremented at each LOCAL mutation commit while cs_lock is held (so
+    //! the bump is ordered with the map change); read lock-free via
+    //! GetLocalSideStakeRevision(). See the accessor's note — observability-only,
+    //! local-scope, never consensus state.
+    std::atomic<uint64_t> m_local_sidestake_revision{0};
 }; // sidestakeRegistry
 
 //!

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -6,6 +6,7 @@
 
 #include "interfaces/mrc.h"
 #include "interfaces/node.h"
+#include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
 #include "interfaces/wallet.h"
 #include "interfaces/wallet_tx_source.h"
@@ -19,6 +20,8 @@ std::unique_ptr<Node> Init::makeNode() { return nullptr; }
 std::unique_ptr<StakingStatus> Init::makeStakingStatus() { return nullptr; }
 
 std::unique_ptr<MRC> Init::makeMRC(CWallet* /*wallet*/) { return nullptr; }
+
+std::unique_ptr<SideStakeManager> Init::makeSideStakeManager() { return nullptr; }
 
 std::unique_ptr<Wallet> Init::makeWallet() { return nullptr; }
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -13,6 +13,7 @@ namespace interfaces {
 
 class MRC;
 class Node;
+class SideStakeManager;
 class StakingStatus;
 class Wallet;
 class WalletTxSource;
@@ -42,6 +43,11 @@ public:
     //! wallet. Returns nullptr for a null wallet; \p wallet must outlive the
     //! returned object.
     virtual std::unique_ptr<MRC> makeMRC(CWallet* wallet);
+
+    //! Returns the sidestake registry interface (the unified mandatory + local
+    //! sidestake table and local add/edit/delete commands). Over the global
+    //! registry, so no wallet argument.
+    virtual std::unique_ptr<SideStakeManager> makeSideStakeManager();
 
     //! Returns the interface for the node's single wallet. May return nullptr
     //! before wallet startup completes.

--- a/src/interfaces/sidestake.h
+++ b/src/interfaces/sidestake.h
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_SIDESTAKE_H
+#define GRIDCOIN_INTERFACES_SIDESTAKE_H
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace interfaces {
+
+class Handler;
+
+//! One row of the sidestake table as pointer-free value data (Phase 1d-ii).
+//! Replaces SideStakeTableModel's former handoff of a raw GRC::SideStake*
+//! through QModelIndex::internalPointer; every field the table renders or sorts
+//! on is precomputed on the node side.
+struct SideStakeEntry
+{
+    //! Encoded destination address (EncodeDestination(GetDestination())).
+    std::string address;
+
+    //! Allocation as a percentage in [0, 100] (GetAllocation().ToPercent()).
+    double allocation_percent = 0.0;
+
+    //! Free-text description (already CSV-sanitized in the registry).
+    std::string description;
+
+    //! Human-readable status (StatusToString()).
+    std::string status;
+
+    //! Mandatory (contract) sidestake — the GUI blocks editing/deletion of these.
+    bool is_mandatory = false;
+
+    //! Sort key for the Status column: mandatory statuses keep their enum value,
+    //! local statuses are shifted above the mandatory range, reproducing the
+    //! former SideStakeLessThan ordering without exposing the status enums.
+    int status_sort_key = 0;
+};
+
+//! A snapshot of the active sidestake table together with the local sidestake
+//! revision it was read at (design §4.4 versioned refetch). The revision is read
+//! just before the entries, so an interleaving local mutation only makes it
+//! conservatively low (the GUI over-refetches at worst, never goes stale).
+struct SideStakeSnapshot
+{
+    std::vector<SideStakeEntry> entries;
+    uint64_t local_revision = 0;
+};
+
+//! Outcome of an add/edit/delete command, mirroring the former
+//! SideStakeTableModel::EditStatus.
+enum class SideStakeEditStatus
+{
+    OK,                  //!< Applied.
+    NO_CHANGES,          //!< The value matched the existing entry; nothing done.
+    INVALID_ADDRESS,     //!< Address does not decode to a valid destination.
+    DUPLICATE_ADDRESS,   //!< A local sidestake for this address already exists.
+    INVALID_ALLOCATION,  //!< Allocation negative or would push the total past 100%.
+    INVALID_DESCRIPTION, //!< Description contains characters outside SAFE_CHARS_CSV.
+};
+
+//! Result of a mutating command. \p local_revision is the post-mutation local
+//! sidestake revision (design §4.4 read-your-writes): the GUI advances its
+//! high-water mark to it and refetches immediately rather than waiting for a
+//! notification it may legitimately drop. \p address is the encoded address on a
+//! successful add.
+struct SideStakeEditResult
+{
+    SideStakeEditStatus status = SideStakeEditStatus::OK;
+    std::string address;
+    uint64_t local_revision = 0;
+};
+
+//! Called when the read-write settings change (uiInterface.RwSettingsUpdated).
+//! Payload-free: the consumer must read the current revision via localRevision()
+//! when handling this, NOT capture one at notification time. RwSettingsUpdated is
+//! a shared signal and the node's own local-sidestake reload runs as a separate
+//! slot whose order relative to this subscription is not guaranteed, so an
+//! emission-time revision can predate the reload. Reading localRevision() on the
+//! consumer's thread (after the whole synchronous emission, reload included, has
+//! completed) yields the post-reload value and keeps the §4.4 high-water logic
+//! correct regardless of slot order.
+using RwSettingsUpdatedFn = std::function<void()>;
+
+//! Called when a mandatory (contract) sidestake entry changes
+//! (uiInterface.MandatorySideStakeChanged) — payload-free; the GUI refetches the
+//! unified table. Mandatory changes are rare and already block-height ordered, so
+//! no coalescing revision is carried (unlike the local side).
+using MandatorySideStakeChangedFn = std::function<void()>;
+
+//! The local sidestake registry boundary (Phase 1d-ii). Hands the GUI value-type
+//! rows and command-style mutations, so no GUI code holds a GRC::SideStake or
+//! calls GetSideStakeRegistry() directly. Every query and command runs under the
+//! registry's internal lock on the node side, and all input validation
+//! (address, allocation total, description sanitization, duplicates) lives here
+//! rather than in the table model.
+class SideStakeManager
+{
+public:
+    virtual ~SideStakeManager() = default;
+
+    //! The active sidestake entries (mandatory first, then local) as value rows,
+    //! with the local sidestake revision they were read at. This is the single
+    //! unified list the GUI table renders; is_mandatory distinguishes the two
+    //! kinds for edit/delete gating.
+    virtual SideStakeSnapshot entries() = 0;
+
+    //! The current local sidestake revision (design §4.4) — read on a
+    //! notification to compare against the GUI's high-water mark.
+    virtual uint64_t localRevision() = 0;
+
+    //! Add a local sidestake. \p allocation_percent is in percent [0, 100].
+    virtual SideStakeEditResult addLocal(const std::string& address,
+                                         double allocation_percent,
+                                         const std::string& description) = 0;
+
+    //! Change an existing local sidestake's allocation (percent [0, 100]).
+    virtual SideStakeEditResult setAllocation(const std::string& address,
+                                              double allocation_percent) = 0;
+
+    //! Change an existing local sidestake's description.
+    virtual SideStakeEditResult setDescription(const std::string& address,
+                                               const std::string& description) = 0;
+
+    //! Delete a local sidestake by address. Mandatory entries are refused.
+    virtual SideStakeEditResult deleteLocal(const std::string& address) = 0;
+
+    //! Subscribe to the versioned RwSettingsUpdated notification for local
+    //! sidestake changes (design §4.4).
+    virtual std::unique_ptr<Handler> handleRwSettingsUpdated(RwSettingsUpdatedFn fn) = 0;
+
+    //! Subscribe to mandatory (contract) sidestake changes — a payload-free
+    //! refetch trigger. Together with handleRwSettingsUpdated this keeps the
+    //! single unified table fresh for both kinds of entry, without polling.
+    virtual std::unique_ptr<Handler> handleMandatorySideStakeChanged(MandatorySideStakeChangedFn fn) = 0;
+};
+
+//! Return an in-process SideStakeManager over the global sidestake registry.
+std::unique_ptr<SideStakeManager> MakeSideStakeManager();
+
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_SIDESTAKE_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -14,6 +14,7 @@
 #include "interfaces/handler.h"
 #include "interfaces/init.h"
 #include "interfaces/mrc.h"
+#include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
 #include "interfaces/wallet.h"
 #include "interfaces/wallet_tx_source.h"
@@ -188,6 +189,11 @@ public:
     std::unique_ptr<MRC> makeMRC(CWallet* wallet) override
     {
         return wallet ? MakeMRC(wallet) : nullptr;
+    }
+
+    std::unique_ptr<SideStakeManager> makeSideStakeManager() override
+    {
+        return MakeSideStakeManager();
     }
 
     std::unique_ptr<Wallet> makeWallet() override

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -34,6 +34,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::NotifyBlocksChangedSig> NotifyBlocksChanged;
     boost::signals2::signal<CClientUIInterface::UpdateMessageBoxSig> UpdateMessageBox;
     boost::signals2::signal<CClientUIInterface::RwSettingsUpdatedSig> RwSettingsUpdated;
+    boost::signals2::signal<CClientUIInterface::MandatorySideStakeChangedSig> MandatorySideStakeChanged;
 };
 static UISignals g_ui_signals;
 
@@ -63,6 +64,7 @@ ADD_SIGNALS_IMPL_WRAPPER(Translate);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlocksChanged);
 ADD_SIGNALS_IMPL_WRAPPER(UpdateMessageBox);
 ADD_SIGNALS_IMPL_WRAPPER(RwSettingsUpdated);
+ADD_SIGNALS_IMPL_WRAPPER(MandatorySideStakeChanged);
 
 void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
 void CClientUIInterface::UpdateMessageBox(const std::string& version, const int& update_type, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, update_type, message); }
@@ -84,6 +86,7 @@ void CClientUIInterface::NewVoteReceived(const uint256& poll_txid) { return g_ui
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }
 void CClientUIInterface::NotifyScraperEvent(const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message) { return g_ui_signals.NotifyScraperEvent(ScraperEventtype, status, message); }
 void CClientUIInterface::RwSettingsUpdated() { return g_ui_signals.RwSettingsUpdated(); }
+void CClientUIInterface::MandatorySideStakeChanged() { return g_ui_signals.MandatorySideStakeChanged(); }
 
 bool InitError(const std::string &str)
 {

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -143,6 +143,12 @@ public:
     /** Read-write settings file updated **/
     ADD_SIGNALS_DECL_WRAPPER(RwSettingsUpdated, void);
 
+    /** A mandatory (contract) sidestake entry was added, deleted, or reverted.
+     *  Payload-free refetch trigger for the GUI sidestake table (the mandatory
+     *  side already has block-height ordering). @note emitted with the sidestake
+     *  registry lock held; the only subscriber marshals to the GUI thread. */
+    ADD_SIGNALS_DECL_WRAPPER(MandatorySideStakeChanged, void);
+
     /**
      * New, updated or cancelled alert.
      * @note called with lock cs_mapAlerts held.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -21,6 +21,7 @@
 #include "interfaces/init.h"
 #include "interfaces/mrc.h"
 #include "interfaces/node.h"
+#include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
 #include "interfaces/wallet.h"
 #include "interfaces/wallet_tx_source.h"
@@ -352,9 +353,17 @@ int main(int argc, char *argv[])
     app.installNativeEventFilter(new WinShutdownMonitor());
 #endif
 
+    // The sidestake registry interface backs the OptionsModel's sidestake table
+    // model (Phase 1d-ii). Created here, before optionsModel, so it outlives it
+    // (reverse destruction order). It wraps the global registry, so it needs no
+    // node/wallet; Phase 2 will hand this out from the single process Init
+    // instead of a locally-minted one.
+    std::unique_ptr<interfaces::Init> gui_init = interfaces::MakeGridcoinInit();
+    std::unique_ptr<interfaces::SideStakeManager> sidestake_manager = gui_init->makeSideStakeManager();
+
     // Load the optionsModel. This has to be loaded before the translations, because the language selection is
     // a setting that can be stored in options.
-    OptionsModel optionsModel;
+    OptionsModel optionsModel(*sidestake_manager);
 
     // Get desired locale (e.g. "de_DE") from command line or use system locale
     QString lang_territory = QString::fromStdString(gArgs.GetArg("-lang", QLocale::system().name().toStdString()));

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -10,8 +10,9 @@
 
 #include "miner.h"
 
-OptionsModel::OptionsModel(QObject *parent) :
-    QAbstractListModel(parent)
+OptionsModel::OptionsModel(interfaces::SideStakeManager& sidestake_manager, QObject *parent) :
+    QAbstractListModel(parent),
+    m_sidestake_manager(sidestake_manager)
 {
     Init();
 }
@@ -85,7 +86,7 @@ void OptionsModel::Init()
         }
     }
 
-    m_sidestake_model = new SideStakeTableModel(this);
+    m_sidestake_model = new SideStakeTableModel(m_sidestake_manager, this);
 }
 
 int OptionsModel::rowCount(const QModelIndex & parent) const

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -5,6 +5,10 @@
 #include <QAbstractListModel>
 #include <QDate>
 
+namespace interfaces {
+class SideStakeManager;
+} // namespace interfaces
+
 /** Interface from Qt to configuration data structure for Bitcoin client.
    To Qt, the options are presented as a list with the different options
    laid out vertically.
@@ -16,7 +20,9 @@ class OptionsModel : public QAbstractListModel
     Q_OBJECT
 
 public:
-    explicit OptionsModel(QObject* parent = nullptr);
+    //! \p sidestake_manager backs the sidestake table model constructed here; it
+    //! is owned by the process and must outlive this OptionsModel.
+    explicit OptionsModel(interfaces::SideStakeManager& sidestake_manager, QObject* parent = nullptr);
 
     enum OptionID {
         StartAtStartup,          // bool
@@ -105,6 +111,11 @@ private:
     QString language;
     QString walletStylesheet;
     QString dataDir;
+
+    //! The sidestake registry interface backing m_sidestake_model. Owned by the
+    //! process (created before this OptionsModel) and outlives it; held by
+    //! reference so Init() can construct the table model with it.
+    interfaces::SideStakeManager& m_sidestake_manager;
 
     SideStakeTableModel* m_sidestake_model;
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -18,6 +18,7 @@
 #include "uint256.h"
 #include "guiutil.h"
 #include "guiconstants.h"
+#include "logging.h"
 
 #include <functional>
 

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -1,108 +1,112 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2026 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include <qt/sidestaketablemodel.h>
 #include <qt/optionsmodel.h>
-#include <node/ui_interface.h>
-#include <gridcoin/support/enumbytes.h>
 
-#include <QList>
-#include <QTimer>
-#include <QDebug>
+#include <interfaces/handler.h>
+#include <interfaces/sidestake.h>
+
+#include <QMetaObject>
+
+#include <algorithm>
+#include <cassert>
+#include <utility>
 
 namespace {
 
-static void RwSettingsUpdated(SideStakeTableModel* sidestake_model)
+//! Sorts the unified table's value rows. Address sorts by the encoded address
+//! string (what the column displays); Status by the precomputed sort key
+//! (mandatory statuses first, local statuses shifted above them).
+class SideStakeLessThan
 {
-    qDebug() << QString("%1").arg(__func__);
-    QMetaObject::invokeMethod(sidestake_model, "updateSideStakeTableModel", Qt::QueuedConnection);
+public:
+    SideStakeLessThan(int column, Qt::SortOrder order)
+        : m_column(column)
+        , m_order(order)
+    {}
+
+    bool operator()(const interfaces::SideStakeEntry& left,
+                    const interfaces::SideStakeEntry& right) const
+    {
+        const interfaces::SideStakeEntry* pLeft = &left;
+        const interfaces::SideStakeEntry* pRight = &right;
+
+        if (m_order == Qt::DescendingOrder) {
+            std::swap(pLeft, pRight);
+        }
+
+        switch (static_cast<SideStakeTableModel::ColumnIndex>(m_column)) {
+        case SideStakeTableModel::Address:
+            return pLeft->address < pRight->address;
+        case SideStakeTableModel::Allocation:
+            return pLeft->allocation_percent < pRight->allocation_percent;
+        case SideStakeTableModel::Description:
+            return pLeft->description < pRight->description;
+        case SideStakeTableModel::Status:
+            return pLeft->status_sort_key < pRight->status_sort_key;
+        } // no default case, so the compiler can warn about missing cases
+
+        assert(false);
+        return false;
+    }
+
+private:
+    int m_column;
+    Qt::SortOrder m_order;
+};
+
+//! Map the interface edit status onto the model's public EditStatus enum
+//! (OptionsDialog inspects the latter).
+SideStakeTableModel::EditStatus MapEditStatus(interfaces::SideStakeEditStatus status)
+{
+    switch (status) {
+    case interfaces::SideStakeEditStatus::OK:                  return SideStakeTableModel::OK;
+    case interfaces::SideStakeEditStatus::NO_CHANGES:          return SideStakeTableModel::NO_CHANGES;
+    case interfaces::SideStakeEditStatus::INVALID_ADDRESS:     return SideStakeTableModel::INVALID_ADDRESS;
+    case interfaces::SideStakeEditStatus::DUPLICATE_ADDRESS:   return SideStakeTableModel::DUPLICATE_ADDRESS;
+    case interfaces::SideStakeEditStatus::INVALID_ALLOCATION:  return SideStakeTableModel::INVALID_ALLOCATION;
+    case interfaces::SideStakeEditStatus::INVALID_DESCRIPTION: return SideStakeTableModel::INVALID_DESCRIPTION;
+    }
+
+    assert(false);
+    return SideStakeTableModel::OK;
 }
 
 } // anonymous namespace
 
-SideStakeLessThan::SideStakeLessThan(int column, Qt::SortOrder order)
-    : m_column(column)
-      , m_order(order)
-{}
-
-bool SideStakeLessThan::operator()(const GRC::SideStake& left, const GRC::SideStake& right) const
-{
-    const GRC::SideStake* pLeft = &left;
-    const GRC::SideStake* pRight = &right;
-
-    if (m_order == Qt::DescendingOrder) {
-        std::swap(pLeft, pRight);
-    }
-
-    // For the purposes of sorting mandatory and local sidestakes in the GUI table, we will shift the local status enum to int
-    // values that are above the mandatory enum values by OUT_OF_BOUND on the mandatory status enum.
-    int left_status, right_status;
-
-    if (pLeft->IsMandatory()) {
-        left_status = static_cast<int>(std::get<GRC::MandatorySideStake::Status>(pLeft->GetStatus()).Value());
-    } else {
-        // For purposes of comparison, the enum value for local sidestake is shifted by the max entry of the mandatory
-        // status enum.
-        left_status = static_cast<int>(std::get<GRC::LocalSideStake::Status>(pLeft->GetStatus()).Value())
-                      + static_cast<int>(GRC::MandatorySideStake::MandatorySideStakeStatus::OUT_OF_BOUND);
-    }
-
-    if (pRight->IsMandatory()) {
-        right_status = static_cast<int>(std::get<GRC::MandatorySideStake::Status>(pRight->GetStatus()).Value());
-    } else {
-        // For purposes of comparison, the enum value for local sidestake is shifted by the max entry of the mandatory
-        // status enum.
-        right_status = static_cast<int>(std::get<GRC::LocalSideStake::Status>(pRight->GetStatus()).Value())
-                      + static_cast<int>(GRC::MandatorySideStake::MandatorySideStakeStatus::OUT_OF_BOUND);
-    }
-
-    switch (static_cast<SideStakeTableModel::ColumnIndex>(m_column)) {
-    case SideStakeTableModel::Address:
-        return pLeft->GetDestination() < pRight->GetDestination();
-    case SideStakeTableModel::Allocation:
-        return pLeft->GetAllocation() < pRight->GetAllocation();
-    case SideStakeTableModel::Description:
-        return pLeft->GetDescription().compare(pRight->GetDescription()) < 0;
-    case SideStakeTableModel::Status:
-        return left_status < right_status;
-    } // no default case, so the compiler can warn about missing cases
-    assert(false);
-}
-
+//! Holds the cached value-row snapshot and the current sort, sourced entirely
+//! from interfaces::SideStakeManager (no core types).
 class SideStakeTablePriv
 {
 public:
-    QList<GRC::SideStake> m_cached_sidestakes;
+    std::vector<interfaces::SideStakeEntry> m_cached_sidestakes;
     int m_sort_column{-1};
-    Qt::SortOrder m_sort_order;
+    Qt::SortOrder m_sort_order{Qt::AscendingOrder};
 
-    void refreshSideStakes()
+    void setEntries(std::vector<interfaces::SideStakeEntry> entries)
     {
-        m_cached_sidestakes.clear();
+        m_cached_sidestakes = std::move(entries);
+        applySort();
+    }
 
-        std::vector<GRC::SideStake_ptr> core_sidestakes
-            = GRC::GetSideStakeRegistry().ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true);
-
-        m_cached_sidestakes.reserve(core_sidestakes.size());
-
-        for (const auto& entry : core_sidestakes) {
-            m_cached_sidestakes.append(*entry);
-        }
-
+    void applySort()
+    {
         if (m_sort_column >= 0) {
-            std::stable_sort(m_cached_sidestakes.begin(), m_cached_sidestakes.end(), SideStakeLessThan(m_sort_column, m_sort_order));
+            std::stable_sort(m_cached_sidestakes.begin(), m_cached_sidestakes.end(),
+                             SideStakeLessThan(m_sort_column, m_sort_order));
         }
     }
 
-    int size()
+    int size() const
     {
-        return m_cached_sidestakes.size();
+        return static_cast<int>(m_cached_sidestakes.size());
     }
 
-    GRC::SideStake* index(int idx)
+    const interfaces::SideStakeEntry* at(int idx) const
     {
-        if (idx >= 0 && idx < m_cached_sidestakes.size()) {
+        if (idx >= 0 && idx < size()) {
             return &m_cached_sidestakes[idx];
         }
 
@@ -110,16 +114,27 @@ public:
     }
 };
 
-SideStakeTableModel::SideStakeTableModel(OptionsModel* parent)
+SideStakeTableModel::SideStakeTableModel(interfaces::SideStakeManager& sidestake_manager, OptionsModel* parent)
     : QAbstractTableModel(parent)
+    , m_edit_status(OK)
+    , m_sidestake_manager(sidestake_manager)
+    , m_local_revision_high_water(0)
 {
     m_columns << tr("Address") << tr("Allocation") << tr("Description") << tr("Status");
     m_priv.reset(new SideStakeTablePriv());
 
     subscribeToCoreSignals();
 
-    // load initial data
-    refresh();
+    // Deliberately do NOT refresh() here. This model is constructed early in
+    // main() (via OptionsModel), before SelectParams(gArgs.GetChainName()) and
+    // before the sidestake registry is loaded during node init. Because entries()
+    // returns value rows with the address already encoded (EncodeDestination uses
+    // the active chain params), an initial refresh under the provisional MAIN
+    // params could cache mainnet-prefixed strings on testnet/regtest. The model
+    // is empty until its first refresh, which happens when OptionsDialog binds it
+    // (OptionsDialog::setModel -> refresh()) — well after final chain selection
+    // and registry load. The registry is empty at construction anyway, so nothing
+    // is lost by deferring.
 }
 
 SideStakeTableModel::~SideStakeTableModel()
@@ -145,34 +160,39 @@ int SideStakeTableModel::columnCount(const QModelIndex &parent) const
 
 QVariant SideStakeTableModel::data(const QModelIndex &index, int role) const
 {
-    if(!index.isValid())
+    if (!index.isValid()) {
         return QVariant();
+    }
 
-    GRC::SideStake* rec = static_cast<GRC::SideStake*>(index.internalPointer());
+    const interfaces::SideStakeEntry* rec = m_priv->at(index.row());
+
+    if (!rec) {
+        return QVariant();
+    }
 
     const auto column = static_cast<ColumnIndex>(index.column());
     if (role == Qt::DisplayRole) {
         switch (column) {
         case Address:
-            return QString::fromStdString(EncodeDestination(rec->GetDestination()));
+            return QString::fromStdString(rec->address);
         case Allocation:
-            return QString().setNum(rec->GetAllocation().ToPercent(), 'f', 2) + QString("\%");
+            return QString().setNum(rec->allocation_percent, 'f', 2) + QString("\%");
         case Description:
-            return QString::fromStdString(rec->GetDescription());
+            return QString::fromStdString(rec->description);
         case Status:
-            return QString::fromStdString(rec->StatusToString());
+            return QString::fromStdString(rec->status);
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     } else if (role == Qt::EditRole) {
         switch (column) {
         case Address:
-            return QString::fromStdString(EncodeDestination(rec->GetDestination()));
+            return QString::fromStdString(rec->address);
         case Allocation:
-            return QString().setNum(rec->GetAllocation().ToPercent(), 'f', 2);
+            return QString().setNum(rec->allocation_percent, 'f', 2);
         case Description:
-            return QString::fromStdString(rec->GetDescription());
+            return QString::fromStdString(rec->description);
         case Status:
-            return QString::fromStdString(rec->StatusToString());
+            return QString::fromStdString(rec->status);
         } // no default case, so the compiler can warn about missing cases
     } else if (role == Qt::TextAlignmentRole) {
         switch (column) {
@@ -198,13 +218,18 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
         return false;
     }
 
-    GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
-
-    GRC::SideStake* rec = static_cast<GRC::SideStake*>(index.internalPointer());
-
     if (role != Qt::EditRole) {
         return false;
     }
+
+    const interfaces::SideStakeEntry* rec = m_priv->at(index.row());
+
+    if (!rec) {
+        return false;
+    }
+
+    // Copy the address before any mutation, which invalidates rec via refetch.
+    const std::string address = rec->address;
 
     m_edit_status = OK;
 
@@ -217,75 +242,39 @@ bool SideStakeTableModel::setData(const QModelIndex &index, const QVariant &valu
     }
     case Allocation:
     {
-        GRC::Allocation prior_total_allocation;
-
-        // Save the original local sidestake (also in the core).
-        GRC::SideStake orig_sidestake = *rec;
-
-        if (orig_sidestake.GetAllocation().ToPercent() == value.toDouble()) {
-            m_edit_status = NO_CHANGES;
-            return false;
-        }
-
-        for (const auto& entry : registry.ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true)) {
-            CTxDestination destination = entry->GetDestination();
-            GRC::Allocation allocation = entry->GetAllocation();
-
-            if (destination == orig_sidestake.GetDestination()) {
-                continue;
-            }
-
-            prior_total_allocation += allocation;
-        }
-
         bool parse_ok = false;
-        double read_allocation = value.toDouble(&parse_ok) / 100.0;
+        const double allocation_percent = value.toDouble(&parse_ok);
 
-        GRC::Allocation modified_allocation(read_allocation);
-
-        if (!parse_ok || modified_allocation < 0 || prior_total_allocation + modified_allocation > 1) {
+        if (!parse_ok) {
             m_edit_status = INVALID_ALLOCATION;
-
-            LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: m_edit_status = %i",
-                     __func__,
-                     (int) m_edit_status);
-
             return false;
         }
 
-        // Overwrite the existing sidestake entry with the modified allocation
-        registry.NonContractAdd(GRC::LocalSideStake(orig_sidestake.GetDestination(),
-                                                    modified_allocation,
-                                                    orig_sidestake.GetDescription(),
-                                                    std::get<GRC::LocalSideStake::Status>(orig_sidestake.GetStatus()).Value()),
-                                true);
+        const interfaces::SideStakeEditResult result =
+            m_sidestake_manager.setAllocation(address, allocation_percent);
+
+        m_edit_status = MapEditStatus(result.status);
+
+        if (result.status != interfaces::SideStakeEditStatus::OK) {
+            return false;
+        }
+
+        m_local_revision_high_water = std::max(m_local_revision_high_water, result.local_revision);
 
         break;
     }
     case Description:
     {
-        std::string orig_value = value.toString().toStdString();
-        std::string san_value = SanitizeString(orig_value, SAFE_CHARS_CSV);
+        const interfaces::SideStakeEditResult result =
+            m_sidestake_manager.setDescription(address, value.toString().toStdString());
 
-        if (rec->GetDescription() == orig_value) {
-            m_edit_status = NO_CHANGES;
+        m_edit_status = MapEditStatus(result.status);
+
+        if (result.status != interfaces::SideStakeEditStatus::OK) {
             return false;
         }
 
-        if (san_value != orig_value) {
-            m_edit_status = INVALID_DESCRIPTION;
-            return false;
-        }
-
-        // Save the original local sidestake (also in the core).
-        GRC::SideStake orig_sidestake = *rec;
-
-        // Overwrite the existing sidestake entry with the modified description
-        registry.NonContractAdd(GRC::LocalSideStake(orig_sidestake.GetDestination(),
-                                                    orig_sidestake.GetAllocation(),
-                                                    san_value,
-                                                    std::get<GRC::LocalSideStake::Status>(orig_sidestake.GetStatus()).Value()),
-                                true);
+        m_local_revision_high_water = std::max(m_local_revision_high_water, result.local_revision);
 
         break;
     }
@@ -317,11 +306,15 @@ Qt::ItemFlags SideStakeTableModel::flags(const QModelIndex &index) const
         return Qt::NoItemFlags;
     }
 
-    GRC::SideStake* rec = static_cast<GRC::SideStake*>(index.internalPointer());
+    const interfaces::SideStakeEntry* rec = m_priv->at(index.row());
+
+    if (!rec) {
+        return Qt::NoItemFlags;
+    }
 
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
 
-    if (!rec->IsMandatory() && (index.column() == Allocation || index.column() == Description)) {
+    if (!rec->is_mandatory && (index.column() == Allocation || index.column() == Description)) {
         retval |= Qt::ItemIsEditable;
     }
 
@@ -331,90 +324,64 @@ Qt::ItemFlags SideStakeTableModel::flags(const QModelIndex &index) const
 QModelIndex SideStakeTableModel::index(int row, int column, const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    GRC::SideStake* data = m_priv->index(row);
 
-    if (data)
-        return createIndex(row, column, data);
+    if (m_priv->at(row)) {
+        return createIndex(row, column);
+    }
+
     return QModelIndex();
 }
 
 QString SideStakeTableModel::addRow(const QString &address, const QString &allocation, const QString description)
 {
-    GRC::SideStakeRegistry& registry = GRC::GetSideStakeRegistry();
-
-    CTxDestination sidestake_address = DecodeDestination(address.toStdString());
-
     m_edit_status = OK;
 
-    if (!IsValidDestination(sidestake_address)) {
-        m_edit_status = INVALID_ADDRESS;
-        return QString();
-    }
-
-    // Check for duplicate local sidestakes. Here we use the actual core sidestake registry rather than the
-    // UI model.
-    std::vector<GRC::SideStake_ptr> core_local_sidestake = registry.Try(sidestake_address, GRC::SideStake::FilterFlag::LOCAL);
-
-    if (!core_local_sidestake.empty()) {
-        m_edit_status = DUPLICATE_ADDRESS;
-        return QString();
-    }
-
-    GRC::Allocation prior_total_allocation;
-
-    // Get total allocation of all active/mandatory sidestake entries
-    for (const auto& entry : registry.ActiveSideStakeEntries(GRC::SideStake::FilterFlag::ALL, true)) {
-        prior_total_allocation += entry->GetAllocation();
-    }
-
-    // The new allocation must be parseable as a double, must be greater than or equal to 0, and
-    // must result in a total allocation of less than or equal to 100%.
+    // Parse the allocation (percent) GUI-side; the node validates address,
+    // duplicate, allocation total and description.
     bool parse_ok = false;
-    double read_allocation = allocation.toDouble(&parse_ok) / 100.0;
+    const double allocation_percent = allocation.toDouble(&parse_ok);
 
-    GRC::Allocation sidestake_allocation(read_allocation);
-
-    if (!parse_ok || sidestake_allocation < 0 || prior_total_allocation + sidestake_allocation > 1) {
+    if (!parse_ok) {
         m_edit_status = INVALID_ALLOCATION;
-
-        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: m_edit_status = %i",
-                 __func__,
-                 (int) m_edit_status);
-
         return QString();
     }
 
-    std::string sidestake_description = description.toStdString();
-    std::string sanitized_description = SanitizeString(sidestake_description, SAFE_CHARS_CSV);
+    const interfaces::SideStakeEditResult result =
+        m_sidestake_manager.addLocal(address.toStdString(), allocation_percent, description.toStdString());
 
-    if (sanitized_description != sidestake_description) {
-        m_edit_status = INVALID_DESCRIPTION;
+    m_edit_status = MapEditStatus(result.status);
+
+    if (result.status != interfaces::SideStakeEditStatus::OK) {
         return QString();
     }
 
-    registry.NonContractAdd(GRC::LocalSideStake(sidestake_address,
-                                                sidestake_allocation,
-                                                sanitized_description,
-                                                GRC::LocalSideStake::LocalSideStakeStatus::ACTIVE));
+    m_local_revision_high_water = std::max(m_local_revision_high_water, result.local_revision);
 
     updateSideStakeTableModel();
 
-    return QString::fromStdString(EncodeDestination(sidestake_address));
+    return QString::fromStdString(result.address);
 }
 
 bool SideStakeTableModel::removeRows(int row, int count, const QModelIndex &parent)
 {
     Q_UNUSED(parent);
-    GRC::SideStake* rec = m_priv->index(row);
 
-    if (count != 1 || !rec || rec->IsMandatory())
+    const interfaces::SideStakeEntry* rec = m_priv->at(row);
+
+    if (count != 1 || !rec || rec->is_mandatory)
     {
         // Can only remove one row at a time, and cannot remove rows not in model.
         // Also refuse to remove mandatory sidestakes.
         return false;
     }
 
-    GRC::GetSideStakeRegistry().NonContractDelete(rec->GetDestination());
+    const interfaces::SideStakeEditResult result = m_sidestake_manager.deleteLocal(rec->address);
+
+    if (result.status != interfaces::SideStakeEditStatus::OK) {
+        return false;
+    }
+
+    m_local_revision_high_water = std::max(m_local_revision_high_water, result.local_revision);
 
     updateSideStakeTableModel();
 
@@ -429,7 +396,12 @@ SideStakeTableModel::EditStatus SideStakeTableModel::getEditStatus() const
 void SideStakeTableModel::refresh()
 {
     Q_EMIT layoutAboutToBeChanged();
-    m_priv->refreshSideStakes();
+
+    interfaces::SideStakeSnapshot snapshot = m_sidestake_manager.entries();
+
+    m_local_revision_high_water = std::max(m_local_revision_high_water, snapshot.local_revision);
+
+    m_priv->setEntries(std::move(snapshot.entries));
 
     m_edit_status = OK;
 
@@ -438,9 +410,14 @@ void SideStakeTableModel::refresh()
 
 void SideStakeTableModel::sort(int column, Qt::SortOrder order)
 {
+    // Re-sort the cached rows without refetching from the node.
+    Q_EMIT layoutAboutToBeChanged();
+
     m_priv->m_sort_column = column;
     m_priv->m_sort_order = order;
-    refresh();
+    m_priv->applySort();
+
+    Q_EMIT layoutChanged();
 }
 
 void SideStakeTableModel::updateSideStakeTableModel()
@@ -450,18 +427,49 @@ void SideStakeTableModel::updateSideStakeTableModel()
     emit updateSideStakeTableModelSig();
 }
 
+void SideStakeTableModel::localSideStakeUpdated()
+{
+    // Read the revision fresh here (not at notification time): this slot runs on
+    // the GUI thread after the whole synchronous RwSettingsUpdated emission,
+    // including the node's own reload slot, has completed — so it reflects the
+    // reload regardless of slot order. Drop stale/coalesced notifications,
+    // including the one echoing our own just-applied write (design §4.4);
+    // refresh() then advances the high-water mark to the refetched revision.
+    if (m_sidestake_manager.localRevision() <= m_local_revision_high_water) {
+        return;
+    }
+
+    updateSideStakeTableModel();
+}
+
+void SideStakeTableModel::mandatorySideStakeChanged()
+{
+    // Mandatory (contract) changes are rare and carry no revision; always refetch
+    // the unified table.
+    updateSideStakeTableModel();
+}
+
 void SideStakeTableModel::subscribeToCoreSignals()
 {
-    // Retain the connection so it is severed in unsubscribeFromCoreSignals()
-    // (from ~SideStakeTableModel); the callback captures `this` and a signal
+    // Retain the handlers so they are severed in unsubscribeFromCoreSignals()
+    // (from ~SideStakeTableModel); each callback captures `this` and a signal
     // firing after this object is gone would otherwise invoke a slot on freed
-    // memory.
-    m_handlers.emplace_back(uiInterface.RwSettingsUpdated_connect(boost::bind(RwSettingsUpdated, this)));
+    // memory. The callbacks only marshal to the GUI thread (issue #3129).
+    m_rw_settings_handler = m_sidestake_manager.handleRwSettingsUpdated(
+        [this]() {
+            QMetaObject::invokeMethod(this, "localSideStakeUpdated", Qt::QueuedConnection);
+        });
+
+    m_mandatory_handler = m_sidestake_manager.handleMandatorySideStakeChanged(
+        [this]() {
+            QMetaObject::invokeMethod(this, "mandatorySideStakeChanged", Qt::QueuedConnection);
+        });
 }
 
 void SideStakeTableModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from client: clearing the retained connections runs
-    // each scoped_connection's destructor, which disconnects it (issue #3129).
-    m_handlers.clear();
+    // Disconnect from the node: resetting each handler runs its destructor, which
+    // disconnects the subscription (issue #3129).
+    m_rw_settings_handler.reset();
+    m_mandatory_handler.reset();
 }

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 The Gridcoin developers
+// Copyright (c) 2014-2026 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
@@ -6,40 +6,31 @@
 #define BITCOIN_QT_SIDESTAKETABLEMODEL_H
 
 #include <QAbstractTableModel>
+#include <QStringList>
+#include <cstdint>
 #include <memory>
-#include <vector>
-#include <boost/signals2/connection.hpp>
-#include "gridcoin/sidestake.h"
 
 class OptionsModel;
 class SideStakeTablePriv;
 
-QT_BEGIN_NAMESPACE
-class QTimer;
-QT_END_NAMESPACE
-
-class SideStakeLessThan
-{
-public:
-    SideStakeLessThan(int column, Qt::SortOrder order);
-
-    bool operator()(const GRC::SideStake& left, const GRC::SideStake& right) const;
-
-private:
-    int m_column;
-    Qt::SortOrder m_order;
-};
+namespace interfaces {
+class Handler;
+class SideStakeManager;
+} // namespace interfaces
 
 //!
-//! \brief The SideStakeTableModel class represents the core sidestake registry as a model which can be consumed
-//! and updated by the GUI.
+//! \brief The SideStakeTableModel class represents the sidestake registry as a
+//! single unified table (mandatory + local entries) for the GUI, sourced through
+//! interfaces::SideStakeManager. No core types cross into the GUI: rows are
+//! value-type interfaces::SideStakeEntry and add/edit/delete are command calls.
 //!
 class SideStakeTableModel : public QAbstractTableModel
 {
     Q_OBJECT
 
 public:
-    explicit SideStakeTableModel(OptionsModel* parent = nullptr);
+    explicit SideStakeTableModel(interfaces::SideStakeManager& sidestake_manager,
+                                 OptionsModel* parent = nullptr);
     ~SideStakeTableModel();
 
     enum ColumnIndex {
@@ -91,13 +82,25 @@ private:
     QStringList m_columns;
     std::unique_ptr<SideStakeTablePriv> m_priv;
     EditStatus m_edit_status;
+
+    //! The node-side sidestake registry boundary (Phase 1d-ii). Owned by the
+    //! process and outlives this model.
+    interfaces::SideStakeManager& m_sidestake_manager;
+
+    //! High-water mark of the local sidestake revision seen across mutation
+    //! returns and accepted notifications (design §4.4). RwSettingsUpdated
+    //! notifications with revision <= this are dropped (they coalesce and prevent
+    //! a redundant refetch after our own write).
+    uint64_t m_local_revision_high_water;
+
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
-    //! Retained core-signal connections, cleared on teardown so a signal that
-    //! fires after this model is destroyed cannot invoke a slot bound to freed
-    //! memory. scoped_connection disconnects on destruction (issue #3129).
-    std::vector<boost::signals2::scoped_connection> m_handlers;
+    //! Retained node subscriptions, released on teardown so a signal that fires
+    //! after this model is destroyed cannot invoke a slot on freed memory (issue
+    //! #3129). The Handlers disconnect on destruction.
+    std::unique_ptr<interfaces::Handler> m_rw_settings_handler;
+    std::unique_ptr<interfaces::Handler> m_mandatory_handler;
 
 signals:
 
@@ -105,6 +108,15 @@ signals:
 
 public slots:
     void updateSideStakeTableModel();
+
+    //! RwSettingsUpdated notification (local sidestake change). Reads the current
+    //! local revision fresh (on this GUI thread, after the node's reload slot has
+    //! run) and refetches only when it advances past the high-water mark.
+    void localSideStakeUpdated();
+
+    //! MandatorySideStakeChanged notification (contract sidestake change).
+    //! Payload-free: always refetches the unified table.
+    void mandatorySideStakeChanged();
 };
 
 #endif // BITCOIN_QT_SIDESTAKETABLEMODEL_H

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -120,9 +120,6 @@ src/qt/rpcconsole.cpp:rpc/protocol.h
 src/qt/rpcconsole.cpp:rpc/server.h
 src/qt/rpcconsole.h:net.h
 src/qt/sendcoinsdialog.cpp:wallet/coincontrol.h
-src/qt/sidestaketablemodel.cpp:gridcoin/support/enumbytes.h
-src/qt/sidestaketablemodel.cpp:node/ui_interface.h
-src/qt/sidestaketablemodel.h:gridcoin/sidestake.h
 src/qt/signverifymessagedialog.cpp:init.h
 src/qt/signverifymessagedialog.cpp:main.h
 src/qt/signverifymessagedialog.cpp:wallet/wallet.h


### PR DESCRIPTION
## Phase 1d-ii — `interfaces::SideStakeManager`

Part of the GUI/node interface migration (RFC #2937, tracking #3153). Follows 1d-i (`interfaces::MRC`, #3164).

### The coupling removed

`SideStakeTableModel` handed out raw `GRC::SideStake*` through `QModelIndex::internalPointer`, mutated the registry directly (`GetSideStakeRegistry().NonContractAdd/Delete`), and ran all add/edit/delete validation in the GUI.

### The boundary

New **`interfaces::SideStakeManager`** (`src/interfaces/sidestake.h`):

- **`entries()`** — the unified mandatory + local sidestake table as pointer-free value rows (`SideStakeEntry`: encoded address, allocation %, description, status string, `is_mandatory`, a precomputed status sort-key). The GUI still renders **one** table and just gates edit/delete on `!is_mandatory`.
- **Command mutations** — `addLocal` / `setAllocation` / `setDescription` / `deleteLocal`, with **all validation node-side** (address decode, duplicate, allocation total, description sanitization), returning the post-mutation revision.
- **Two subscriptions** — `handleRwSettingsUpdated` (local changes, versioned) and `handleMandatorySideStakeChanged` (contract changes).

The in-process impl lives in `src/gridcoin/interfaces.cpp` (alongside `MakeStakingStatus`/`MakeMRC`); `Init` grows `makeSideStakeManager()`.

### Versioned refetch (design §4.4)

The registry gains an **in-memory, local-scope** monotonic `m_local_sidestake_revision`, bumped only at the *local* mutation commit points (`NonContractAdd`/`NonContractDelete`, config reload, `ResetInMemoryOnly`). It is deliberately **not** bumped for the mandatory (contract) side — that already has block-height ordering and does not drive the `RwSettingsUpdated` refresh — and it is named "revision" to avoid colliding with the `SideStakeDB` format version. The GUI keeps a high-water mark and drops `RwSettingsUpdated` notifications with `revision <=` it (coalescing, and no redundant refetch after its own write).

### Mandatory changes now refresh the open table

A new payload-free `uiInterface.MandatorySideStakeChanged` signal is emitted from `SideStakeRegistry::Add`/`AddDelete`/`Revert` and exposed via the interface. So a mandatory sidestake arriving while the Settings dialog is open now updates the table, instead of only on next open. A push callback is cheaper than pulling on every dialog open given how rare mandatory contracts are, and it removes the stale-while-open case. (The mandatory side carries no revision — always refetch.)

### GUI + wiring

`SideStakeTableModel` is rewritten onto row-indexed value rows and the two subscriptions. `OptionsModel` takes the manager (created in `main()` **before** it, so it outlives it — reverse destruction order) and threads it through `Init()`. `OptionsDialog` is untouched (public API preserved).

### Notes for reviewers

- **Address column sort** now orders by the encoded address string (what the column displays) rather than the binary `CTxDestination` order the old comparator used — a small, intentional behavior change (sort matches what's shown).
- The `m_local_sidestake_revision` counter is **not** consensus state: not serialized, not in any hash, not validated — purely an observability sequence for the refetch pattern.

### Ratchet

The three sidestake `lint-qt-includes.sh` allowlist entries are removed. `overviewpage.cpp` gains a direct `logging.h` include it had been getting transitively through the now-removed `gridcoin/sidestake.h`.

### Testing

- Native Qt6 GUI `RelWithDebInfo` build + full `ctest` suite green.
- `lint-qt-includes.sh` and `lint-all.sh` green.
- Self-review walked the §4.4 high-water logic (no double-refetch after a local write), the mandatory-signal emit-under-lock safety (queued subscriber only), and the `main()` construction/destruction order.
- Isolated-testnet mesh soak (RelWithDebInfo on instance 8, ASan on instance 9) is planned together with the 1d-i MRC build before this stack is depended on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
