### PR TITLE
gui: migrate Researcher/Beacon/Scraper onto interfaces:: (Phase 1d-iv)

### DIFF
--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -10,6 +10,7 @@
 
 #include "amount.h"
 #include "chainparams.h"
+#include "fs.h"
 #include "gridcoin/beacon.h"
 #include "gridcoin/boinc.h"
 #include "gridcoin/contract/contract.h"
@@ -1291,7 +1292,10 @@ private:
 
         DeriveBeacon(*researcher, snap);
         snap.action_needed = ComputeActionNeeded(snap);
-        snap.boinc_data_dir = GRC::GetBoincDataDir().string();
+        // UTF-8 so the GUI's QString::fromStdString() is correct cross-platform
+        // (path.string() is the system code page on Windows); mirrors the former
+        // GUIUtil::boostPathToQString handling via the in-tree helper.
+        snap.boinc_data_dir = fsbridge::Utf8PathString(GRC::GetBoincDataDir());
 
         return snap;
     }

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -43,10 +43,12 @@
 #include "validation.h"
 #include "wallet/wallet.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <functional>
 #include <limits>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -1139,6 +1141,8 @@ public:
         // pwalletMain is the node's single wallet (== m_wallet); referencing it
         // directly matches SendBeaconContractV3/GenerateBeaconKey's
         // EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet) annotation.
+        // Enforce the single-wallet invariant this relies on.
+        assert(pwalletMain && pwalletMain == m_wallet);
         LOCK2(cs_main, pwalletMain->cs_wallet);
 
         GRC::AdvertiseBeaconResult result = GRC::GenerateBeaconKey(*cpid);
@@ -1186,6 +1190,10 @@ public:
             return {BeaconStatus::ERROR_INVALID_PROOF_XML};
         }
 
+        // pwalletMain (== the node's single wallet m_wallet) is used to satisfy
+        // SendBeaconContractV3's EXCLUSIVE_LOCKS_REQUIRED(pwalletMain->cs_wallet)
+        // annotation; enforce that single-wallet invariant.
+        assert(pwalletMain && pwalletMain == m_wallet);
         LOCK2(cs_main, pwalletMain->cs_wallet);
 
         if (!pwalletMain->HaveKey(beacon_pubkey.GetID())) {

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -4,17 +4,27 @@
 
 #include "interfaces/staking.h"
 #include "interfaces/mrc.h"
+#include "interfaces/researcher.h"
 #include "interfaces/sidestake.h"
 #include "interfaces/voting.h"
 
 #include "amount.h"
 #include "chainparams.h"
+#include "gridcoin/beacon.h"
+#include "gridcoin/boinc.h"
 #include "gridcoin/contract/contract.h"
 #include "gridcoin/contract/message.h"
+#include "gridcoin/magnitude.h"
 #include "gridcoin/mrc.h"
+#include "gridcoin/project.h"
+#include "gridcoin/quorum.h"
+#include "gridcoin/researcher.h"
+#include "gridcoin/scraper/scraper.h"
 #include "gridcoin/sidestake.h"
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/staking/status.h"
+#include "gridcoin/superblock.h"
+#include "gridcoin/support/xml.h"
 #include "gridcoin/voting/builders.h"
 #include "gridcoin/voting/filter.h"
 #include "gridcoin/voting/fwd.h"
@@ -29,16 +39,23 @@
 #include "sync.h"
 #include "txmempool.h"
 #include "util/strencodings.h"
+#include "util/string.h"
 #include "validation.h"
 #include "wallet/wallet.h"
 
+#include <cassert>
 #include <cmath>
 #include <functional>
 #include <limits>
 #include <memory>
+#include <set>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
+
+extern CWallet* pwalletMain;
+extern ConvergedScraperStats ConvergedScraperStatsCache;
 
 namespace interfaces {
 namespace {
@@ -807,6 +824,591 @@ private:
     }
 };
 
+//! Maps a core BeaconError to the interface BeaconStatus. Ported verbatim from
+//! the former GUI ResearcherModel::MapAdvertiseBeaconError so the classification
+//! is byte-for-byte identical, now computed node-side.
+BeaconStatus MapBeaconError(const GRC::BeaconError error)
+{
+    switch (error) {
+        case GRC::BeaconError::NONE:               return BeaconStatus::ACTIVE;
+        case GRC::BeaconError::INSUFFICIENT_FUNDS: return BeaconStatus::ERROR_INSUFFICIENT_FUNDS;
+        case GRC::BeaconError::MISSING_KEY:        return BeaconStatus::ERROR_MISSING_KEY;
+        case GRC::BeaconError::NO_CPID:            return BeaconStatus::NO_CPID;
+        case GRC::BeaconError::NOT_NEEDED:         return BeaconStatus::ERROR_NOT_NEEDED;
+        case GRC::BeaconError::PENDING:            return BeaconStatus::PENDING;
+        case GRC::BeaconError::TX_FAILED:          return BeaconStatus::ERROR_TX_FAILED;
+        case GRC::BeaconError::V14_NOT_ENABLED:    return BeaconStatus::ERROR_TX_FAILED;
+        case GRC::BeaconError::WALLET_LOCKED:      return BeaconStatus::ERROR_WALLET_LOCKED;
+        case GRC::BeaconError::ALEADY_IN_MEMPOOL:  return BeaconStatus::ALREADY_IN_MEMPOOL;
+    }
+
+    assert(false); // unreachable: every BeaconError enumerator is handled above
+    return BeaconStatus::UNKNOWN;
+}
+
+//! Beacon-renewal warning window (mirrors the former GUI ResearcherModel constant
+//! BEACON_RENEWAL_WARNING_THRESHOLD): a beacon expiring within 15 days reads as
+//! RENEWAL_NEEDED.
+constexpr int64_t BEACON_RENEWAL_WARNING_THRESHOLD = 15 * 24 * 60 * 60;
+
+//! Classify a whitelist entry's status into a ResearcherProjectRow::WhitelistStatus,
+//! matching the former buildProjectTable's if/else chain. \p is_label_status is
+//! set true for the greylisted/excluded cases where the status itself is the row's
+//! error label (so the caller clears any baseline error, letting the GUI derive the
+//! label from the status).
+ResearcherProjectRow::WhitelistStatus ClassifyWhitelist(const GRC::ProjectEntry& wl,
+                                                        const std::vector<std::string>& excluded,
+                                                        bool& is_label_status)
+{
+    using WS = ResearcherProjectRow::WhitelistStatus;
+
+    is_label_status = true;
+
+    if (wl.m_status == GRC::ProjectEntryStatus::MAN_GREYLISTED) {
+        return WS::MANUALLY_GREYLISTED;
+    }
+    if (wl.m_status == GRC::ProjectEntryStatus::AUTO_GREYLISTED) {
+        return WS::AUTOMATICALLY_GREYLISTED;
+    }
+    if (std::find(excluded.begin(), excluded.end(), wl.m_name) != excluded.end()) {
+        return WS::EXCLUDED;
+    }
+
+    is_label_status = false;
+
+    if (wl.m_status == GRC::ProjectEntryStatus::UNKNOWN) {
+        return WS::NOT_WHITELISTED;
+    }
+
+    // Remaining REG_ACTIVE / AUTO_GREYLIST_OVERRIDE == the ACTIVE whitelist filter.
+    return WS::WHITELISTED;
+}
+
+//! Copy a whitelist entry's magnitude/RAC into the row from the ExplainMagnitude
+//! results (matches the inner lookup loops in the former buildProjectTable).
+void ApplyExplainMagnitude(ResearcherProjectRow& row,
+                           const std::string& project_name,
+                           const std::vector<GRC::ExplainMagnitudeProject>& explain_mag)
+{
+    for (const auto& explain_mag_project : explain_mag) {
+        if (explain_mag_project.m_name == project_name) {
+            row.magnitude = explain_mag_project.m_magnitude;
+            row.rac = explain_mag_project.m_rac;
+            return;
+        }
+    }
+}
+
+//! In-process ResearcherContext (Phase 1d-iv). Owns the node's single wallet
+//! pointer for the beacon-key/advertise/V3 paths; every read runs node-side so the
+//! Qt ResearcherModel holds no GRC::Researcher / GRC::Beacon and touches no beacon
+//! registry, quorum, whitelist, or scraper-cache global directly.
+class ResearcherContextImpl : public ResearcherContext
+{
+public:
+    explicit ResearcherContextImpl(CWallet* wallet) : m_wallet(wallet) {}
+
+    ResearcherSnapshot snapshot() override
+    {
+        LOCK(cs_main);
+        return BuildSnapshotLocked();
+    }
+
+    std::optional<ResearcherSnapshot> trySnapshot() override
+    {
+        TRY_LOCK(cs_main, locked);
+        if (!locked) {
+            return std::nullopt;
+        }
+        return BuildSnapshotLocked();
+    }
+
+    bool outOfSync() override
+    {
+        // Lock-free, matching the former ResearcherModel::refresh()'s unguarded
+        // OutOfSyncByAge() call.
+        return OutOfSyncByAge();
+    }
+
+    bool hasV3CapableProjects() override
+    {
+        return !GetProjectsWithOwnershipProofSupport().empty();
+    }
+
+    std::vector<ResearcherProjectRow> projects(bool extended) override
+    {
+        // Fuses the same three loosely-related record types the former
+        // ResearcherModel::buildProjectTable did: local BOINC projects, the
+        // Gridcoin whitelist, and scraper magnitude statistics.
+        const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
+
+        // One whitelist snapshot, reused for both TryWhitelist() and the
+        // whitelist-only pass below (the former GUI took two snapshots; one is
+        // more internally consistent and cheaper).
+        const GRC::WhitelistSnapshot whitelist =
+            GRC::GetWhitelist().Snapshot(GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED);
+
+        std::vector<std::string> excluded_projects;
+        {
+            LOCK(cs_ConvergedScraperStatsCache);
+            excluded_projects = ConvergedScraperStatsCache.Convergence.vExcludedProjects;
+        }
+
+        const std::vector<std::string> external_adapter_projects = GetProjectsExternalAdapterRequired();
+
+        std::vector<GRC::ExplainMagnitudeProject> explain_mag;
+        if (extended) {
+            if (const GRC::CpidOption cpid = researcher->Id().TryCpid()) {
+                explain_mag = GRC::Quorum::ExplainMagnitude(*cpid);
+            }
+        }
+
+        std::map<std::string, ResearcherProjectRow> rows;
+
+        // Pass 1: local BOINC projects, linked to the whitelist where possible.
+        for (const auto& project_pair : researcher->Projects()) {
+            const GRC::MiningProject& project = project_pair.second;
+
+            ResearcherProjectRow row;
+
+            if (!project.m_cpid.IsZero()) {
+                row.cpid = project.m_cpid.ToString();
+            }
+
+            const bool eligible = project.Eligible();
+            if (!eligible) {
+                row.error_kind = ResearcherProjectRow::ErrorKind::CORE_MESSAGE;
+                row.error_message = project.ErrorMessage();
+            }
+
+            if (const GRC::ProjectEntry* whitelist_project = project.TryWhitelist(whitelist)) {
+                bool is_label_status = false;
+                row.whitelisted = ClassifyWhitelist(*whitelist_project, excluded_projects, is_label_status);
+
+                // Greylisted/excluded: the status IS the label, so drop the
+                // baseline core error and let the GUI render the status label.
+                if (is_label_status) {
+                    row.error_kind = ResearcherProjectRow::ErrorKind::NONE;
+                    row.error_message.clear();
+                }
+
+                // Display name in original case; the GUI lowercases it with
+                // QString::toLower() (Unicode-aware, as the former code did).
+                row.name = whitelist_project->DisplayName();
+                ApplyExplainMagnitude(row, whitelist_project->m_name, explain_mag);
+                row.gdpr_controls = whitelist_project->HasGDPRControls();
+
+                rows.emplace(whitelist_project->m_name, std::move(row));
+            } else {
+                row.whitelisted = ResearcherProjectRow::WhitelistStatus::NOT_WHITELISTED;
+                row.name = project.m_name;
+                row.rac = project.m_rac;
+
+                if (eligible) {
+                    row.error_kind = ResearcherProjectRow::ErrorKind::NOT_WHITELISTED;
+                    row.error_message.clear();
+                }
+
+                rows.emplace(project.m_name, std::move(row));
+            }
+        }
+
+        // Pass 2: whitelisted projects not detected from the local BOINC client.
+        for (const auto& project : whitelist) {
+            if (rows.find(project.m_name) != rows.end()) {
+                continue;
+            }
+
+            ResearcherProjectRow row;
+            row.gdpr_controls = project.HasGDPRControls();
+            row.name = project.DisplayName();
+            row.magnitude = 0.0;
+
+            const bool requires_external_adapter =
+                project.RequiresExtAdapter().has_value() && project.RequiresExtAdapter().value();
+            const bool legacy_external_adapter = std::find(external_adapter_projects.begin(),
+                                                           external_adapter_projects.end(),
+                                                           project.m_name) != external_adapter_projects.end();
+
+            if (requires_external_adapter || legacy_external_adapter) {
+                row.error_kind = ResearcherProjectRow::ErrorKind::USES_EXTERNAL_ADAPTER;
+            } else {
+                row.error_kind = ResearcherProjectRow::ErrorKind::NOT_ATTACHED;
+            }
+
+            bool is_label_status = false;
+            row.whitelisted = ClassifyWhitelist(project, excluded_projects, is_label_status);
+            if (is_label_status) {
+                row.error_kind = ResearcherProjectRow::ErrorKind::NONE;
+            }
+
+            ApplyExplainMagnitude(row, project.m_name, explain_mag);
+
+            rows.emplace(project.m_name, std::move(row));
+        }
+
+        std::vector<ResearcherProjectRow> rows_out;
+        rows_out.reserve(rows.size());
+        for (auto& row_pair : rows) {
+            rows_out.emplace_back(std::move(row_pair.second));
+        }
+
+        return rows_out;
+    }
+
+    std::vector<WhitelistProject> whitelistProjects() override
+    {
+        // Matches the former VotingModel::getActiveProjectNames/getActiveProjectUrls
+        // exactly: the ACTIVE-filter snapshot, Sorted(), raw m_name/m_url (not the
+        // Display* variants the researcher table uses). A single call now backs both
+        // of the wizard's parallel name/url lists, so their indices still align.
+        std::vector<WhitelistProject> result;
+
+        for (const auto& project : GRC::GetWhitelist().Snapshot().Sorted()) {
+            result.push_back({project.m_name, project.m_url});
+        }
+
+        return result;
+    }
+
+    int maxProjectNameLength() override { return static_cast<int>(GRC::Project::MAX_NAME_SIZE); }
+
+    int maxProjectUrlLength() override { return static_cast<int>(GRC::Project::MAX_URL_SIZE); }
+
+    std::vector<WhitelistProject> v3CapableProjects() override
+    {
+        // Ports ResearcherModel::buildV3ProjectList: the whitelist entries whose
+        // (trailing-slash-normalized) base URL is in the ownership-proof set.
+        const std::set<std::string> v3_urls = GetProjectsWithOwnershipProofSupport();
+
+        std::vector<WhitelistProject> result;
+        if (v3_urls.empty()) {
+            return result;
+        }
+
+        for (const auto& project : GRC::GetWhitelist().Snapshot(
+                 GRC::ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED)) {
+            std::string base_url = project.BaseUrl();
+            if (!base_url.empty() && base_url.back() != '/') {
+                base_url += '/';
+            }
+
+            if (v3_urls.count(base_url) > 0) {
+                result.push_back({project.DisplayName(), project.DisplayUrl()});
+            }
+        }
+
+        return result;
+    }
+
+    bool switchMode(ResearcherMode mode, const std::string& email) override
+    {
+        const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
+
+        switch (mode) {
+            case ResearcherMode::SOLO:
+                return researcher->ChangeMode(GRC::ResearcherMode::SOLO, email);
+            case ResearcherMode::POOL:
+                return researcher->ChangeMode(GRC::ResearcherMode::POOL, std::string());
+            case ResearcherMode::NONCRUNCHER:
+                return researcher->ChangeMode(GRC::ResearcherMode::NONCRUNCHER, std::string());
+        }
+
+        return false;
+    }
+
+    BeaconAdvertiseResult advertiseBeacon() override
+    {
+        const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
+        const GRC::AdvertiseBeaconResult result = researcher->AdvertiseBeacon();
+
+        return {MapBeaconError(result.Error())};
+    }
+
+    std::string generateBeaconKeyForV3() override
+    {
+        const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
+        const GRC::CpidOption cpid = researcher->Id().TryCpid();
+
+        // The wizard flow requires a CPID before the beacon page, so this is not
+        // reachable in practice; defensive only.
+        if (!cpid) {
+            return std::string();
+        }
+
+        // pwalletMain is the node's single wallet (== m_wallet); referencing it
+        // directly matches SendBeaconContractV3/GenerateBeaconKey's
+        // EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwalletMain->cs_wallet) annotation.
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+
+        GRC::AdvertiseBeaconResult result = GRC::GenerateBeaconKey(*cpid);
+
+        if (auto public_key = result.TryPublicKey()) {
+            return HexStr(*public_key);
+        }
+
+        return std::string();
+    }
+
+    BeaconAdvertiseResult advertiseBeaconV3(const std::string& ownership_proof_xml) override
+    {
+        const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
+        const GRC::CpidOption cpid = researcher->Id().TryCpid();
+
+        if (!cpid) {
+            return {BeaconStatus::NO_CPID};
+        }
+
+        const std::string master_url = TrimString(ExtractXML(ownership_proof_xml, "<master_url>", "</master_url>"));
+        const std::string msg = TrimString(ExtractXML(ownership_proof_xml, "<msg>", "</msg>"));
+        const std::string sig_b64 = TrimString(ExtractXML(ownership_proof_xml, "<signature>", "</signature>"));
+
+        if (master_url.empty() || msg.empty() || sig_b64.empty()) {
+            return {BeaconStatus::ERROR_INVALID_PROOF_XML};
+        }
+
+        // Parse the msg field: "{account_id} {beacon_public_key_hex}".
+        const size_t space_pos = msg.find(' ');
+        if (space_pos == std::string::npos || space_pos + 1 >= msg.size()) {
+            return {BeaconStatus::ERROR_INVALID_PROOF_XML};
+        }
+
+        uint32_t account_id = 0;
+        if (!ParseUInt32(msg.substr(0, space_pos), &account_id) || account_id == 0) {
+            return {BeaconStatus::ERROR_INVALID_PROOF_XML};
+        }
+
+        const std::string public_key_hex = msg.substr(space_pos + 1);
+        const std::vector<uint8_t> pubkey_bytes = ParseHex(public_key_hex);
+        CPubKey beacon_pubkey(pubkey_bytes);
+
+        if (!beacon_pubkey.IsValid()) {
+            return {BeaconStatus::ERROR_INVALID_PROOF_XML};
+        }
+
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+
+        if (!pwalletMain->HaveKey(beacon_pubkey.GetID())) {
+            return {BeaconStatus::ERROR_MISSING_KEY};
+        }
+
+        bool b64_invalid = false;
+        const std::vector<uint8_t> rsa_sig_bytes = DecodeBase64(sig_b64.c_str(), &b64_invalid);
+
+        if (b64_invalid || rsa_sig_bytes.empty()) {
+            return {BeaconStatus::ERROR_INVALID_PROOF_XML};
+        }
+
+        GRC::Beacon beacon(beacon_pubkey);
+        GRC::OwnershipProof proof;
+        proof.m_master_url = master_url;
+        proof.m_account_id = account_id;
+        proof.m_rsa_signature = rsa_sig_bytes;
+
+        GRC::AdvertiseBeaconResult result = GRC::SendBeaconContractV3(*cpid, beacon, std::move(proof));
+
+        return {MapBeaconError(result.Error())};
+    }
+
+    void reload() override
+    {
+        LOCK(cs_main);
+        GRC::Researcher::Reload();
+    }
+
+    std::unique_ptr<Handler> handleResearcherChanged(ResearcherChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.ResearcherChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleBeaconChanged(BeaconChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.BeaconChanged_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleAccrualChanged(AccrualChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.AccrualChangedFromStakeOrMRC_connect(std::move(fn)));
+    }
+
+    std::unique_ptr<Handler> handleBlocksChanged(BlocksChangedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.NotifyBlocksChanged_connect(std::move(fn)));
+    }
+
+private:
+    CWallet* m_wallet;
+
+    //! Build the full snapshot with cs_main held. Shared by snapshot() (blocking)
+    //! and trySnapshot() (TRY_LOCK). The whole snapshot is built under one cs_main
+    //! hold so it reflects a single consistent tip (identity/magnitude reads off
+    //! the immutable Researcher::Get() pointer do not strictly need cs_main, but
+    //! holding it is harmless and keeps the beacon/version reads consistent).
+    ResearcherSnapshot BuildSnapshotLocked() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        ResearcherSnapshot snap;
+
+        const GRC::ResearcherPtr researcher = GRC::Researcher::Get();
+
+        const GRC::MiningId id = researcher->Id();
+        snap.has_cpid = id.Which() == GRC::MiningId::Kind::CPID;
+        snap.has_eligible_projects = snap.has_cpid;
+        snap.cpid = id.ToString();
+        snap.has_split_cpid = researcher->hasSplitCpid();
+        snap.has_rac = researcher->HasRAC();
+        snap.has_pool_projects = researcher->Projects().ContainsPool();
+        snap.detected_pool_mode = !snap.has_eligible_projects && snap.has_pool_projects;
+        snap.email = GRC::Researcher::Email();
+        snap.configured_for_noncruncher_mode = GRC::Researcher::ConfiguredForNoncruncherMode();
+
+        const GRC::Magnitude magnitude = researcher->Magnitude();
+        snap.magnitude = magnitude.Floating();
+        snap.magnitude_text = magnitude.ToString();
+        snap.has_magnitude = magnitude != 0;
+        snap.accrual = researcher->Accrual();
+        snap.accrual_near_limit = researcher->AccrualNearLimit();
+
+        snap.out_of_sync = OutOfSyncByAge();
+        snap.is_v14_enabled = IsV14Enabled(nBestHeight);
+
+        // msMiningErrors is shared with the getstakinginfo RPC; read it under its
+        // own lock. cs_msMiningErrors is a leaf everywhere it is taken
+        // (StoreResearcher, getstakinginfo, and here all acquire it alone and
+        // release without acquiring cs_main under it), so nesting it beneath
+        // cs_main here introduces no lock-order inversion.
+        {
+            LOCK(cs_msMiningErrors);
+            snap.mining_status = msMiningErrors;
+        }
+
+        DeriveBeacon(*researcher, snap);
+        snap.action_needed = ComputeActionNeeded(snap);
+        snap.boinc_data_dir = GRC::GetBoincDataDir().string();
+
+        return snap;
+    }
+
+    //! Ports ResearcherModel::updateBeacon(): derive the beacon status and flatten
+    //! the committed active/pending beacons into the snapshot's value fields.
+    void DeriveBeacon(const GRC::Researcher& researcher, ResearcherSnapshot& snap)
+    {
+        const GRC::CpidOption cpid = researcher.Id().TryCpid();
+
+        if (!cpid) {
+            snap.beacon_status = BeaconStatus::NO_CPID;
+            return;
+        }
+
+        if (snap.out_of_sync) {
+            snap.beacon_status = BeaconStatus::UNKNOWN;
+            return;
+        }
+
+        bool beacon_key_present = false;
+        std::unique_ptr<GRC::Beacon> beacon;
+        std::unique_ptr<GRC::Beacon> pending_beacon;
+
+        if (auto beacon_option = researcher.TryBeacon()) {
+            beacon = std::make_unique<GRC::Beacon>(std::move(*beacon_option));
+            beacon_key_present = beacon->WalletHasPrivateKey(m_wallet);
+        }
+
+        if (auto beacon_option = researcher.TryPendingBeacon()) {
+            pending_beacon = std::make_unique<GRC::Beacon>(std::move(*beacon_option));
+            beacon_key_present = pending_beacon->WalletHasPrivateKey(m_wallet);
+        }
+
+        BeaconStatus beacon_status;
+
+        if (beacon_key_present) {
+            beacon_status = MapBeaconError(researcher.BeaconError());
+        } else if (!beacon && !pending_beacon) {
+            beacon_status = BeaconStatus::NO_BEACON;
+        } else {
+            beacon_status = BeaconStatus::ERROR_MISSING_KEY;
+        }
+
+        const int64_t now = GetAdjustedTime();
+
+        if (beacon_status != BeaconStatus::ACTIVE) {
+            // Keep the mapped/derived status.
+        } else if (pending_beacon) {
+            beacon_status = BeaconStatus::PENDING;
+        } else if (beacon) {
+            if (beacon->Expired(now + BEACON_RENEWAL_WARNING_THRESHOLD)) {
+                beacon_status = BeaconStatus::RENEWAL_NEEDED;
+            } else if (beacon->Renewable(now)) {
+                beacon_status = BeaconStatus::RENEWAL_POSSIBLE;
+            } else if (researcher.Magnitude() == 0) {
+                beacon_status = BeaconStatus::NO_MAGNITUDE;
+            } else {
+                beacon_status = BeaconStatus::ACTIVE;
+            }
+        }
+
+        snap.beacon_status = beacon_status;
+
+        FillBeaconFields(beacon.get(), pending_beacon.get(), now, snap);
+    }
+
+    //! Flatten the committed active/pending beacons into the snapshot's value
+    //! fields — the booleans the former ResearcherModel getters returned plus the
+    //! epochs (Unix seconds) the GUI formats locally.
+    static void FillBeaconFields(const GRC::Beacon* beacon,
+                                 const GRC::Beacon* pending,
+                                 int64_t now,
+                                 ResearcherSnapshot& snap)
+    {
+        snap.beacon_present = beacon != nullptr;
+        snap.pending_beacon_present = pending != nullptr;
+        snap.has_active_beacon = beacon && !beacon->Expired(now);
+        snap.beacon_expired = beacon && beacon->Expired(now);
+        snap.has_renewable_beacon = beacon && beacon->Renewable(now);
+
+        bool has_pending = false;
+        if (pending) {
+            GRC::PendingBeacon pending_beacon(*pending);
+            has_pending = !pending_beacon.PendingExpired(now);
+        }
+        snap.has_pending_beacon = has_pending;
+
+        if (!has_pending) {
+            snap.needs_beacon_auth = false;
+        } else if (!snap.has_active_beacon) {
+            snap.needs_beacon_auth = true;
+        } else {
+            snap.needs_beacon_auth = beacon->m_public_key != pending->m_public_key;
+        }
+
+        if (beacon) {
+            snap.beacon_timestamp = beacon->m_timestamp;
+            snap.beacon_age = beacon->Age(now);
+            snap.time_to_beacon_expiration = GRC::Beacon::MAX_AGE - beacon->Age(now);
+            snap.beacon_address = EncodeDestination(beacon->GetAddress());
+        }
+
+        if (pending) {
+            snap.time_to_pending_beacon_expiration = GRC::PendingBeacon::RETENTION_AGE - pending->Age(now);
+            snap.beacon_verification_code = pending->GetVerificationCode();
+        }
+    }
+
+    //! Ports ResearcherModel::actionNeeded() over the already-filled snapshot.
+    static bool ComputeActionNeeded(const ResearcherSnapshot& snap)
+    {
+        if (snap.out_of_sync) {
+            return false;
+        }
+        if (snap.configured_for_noncruncher_mode) {
+            return false;
+        }
+        if (snap.has_eligible_projects) {
+            return snap.has_split_cpid || (!snap.has_active_beacon && !snap.has_pending_beacon);
+        }
+        return !snap.has_pool_projects;
+    }
+};
+
 } // namespace
 
 std::unique_ptr<StakingStatus> MakeStakingStatus()
@@ -827,6 +1429,11 @@ std::unique_ptr<SideStakeManager> MakeSideStakeManager()
 std::unique_ptr<VotingManager> MakeVotingManager()
 {
     return std::make_unique<VotingManagerImpl>();
+}
+
+std::unique_ptr<ResearcherContext> MakeResearcherContext(CWallet* wallet)
+{
+    return std::make_unique<ResearcherContextImpl>(wallet);
 }
 
 } // namespace interfaces

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -1292,10 +1292,12 @@ private:
 
         DeriveBeacon(*researcher, snap);
         snap.action_needed = ComputeActionNeeded(snap);
-        // UTF-8 so the GUI's QString::fromStdString() is correct cross-platform
-        // (path.string() is the system code page on Windows); mirrors the former
-        // GUIUtil::boostPathToQString handling via the in-tree helper.
-        snap.boinc_data_dir = fsbridge::Utf8PathString(GRC::GetBoincDataDir());
+        // UTF-8 for user-facing display: fsbridge::LongPathString is the in-tree
+        // helper documented "for error messages, log output, and any user-facing
+        // display" (it restores the long Unicode form on Windows before UTF-8
+        // encoding), so the GUI's QString::fromStdString() renders non-ASCII paths
+        // correctly cross-platform. Matches the datadir display in bitcoin.cpp.
+        snap.boinc_data_dir = fsbridge::LongPathString(GRC::GetBoincDataDir());
 
         return snap;
     }

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -6,6 +6,7 @@
 
 #include "interfaces/mrc.h"
 #include "interfaces/node.h"
+#include "interfaces/researcher.h"
 #include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
 #include "interfaces/voting.h"
@@ -25,6 +26,8 @@ std::unique_ptr<MRC> Init::makeMRC(CWallet* /*wallet*/) { return nullptr; }
 std::unique_ptr<SideStakeManager> Init::makeSideStakeManager() { return nullptr; }
 
 std::unique_ptr<VotingManager> Init::makeVotingManager() { return nullptr; }
+
+std::unique_ptr<ResearcherContext> Init::makeResearcherContext(CWallet* /*wallet*/) { return nullptr; }
 
 std::unique_ptr<Wallet> Init::makeWallet() { return nullptr; }
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -13,6 +13,7 @@ namespace interfaces {
 
 class MRC;
 class Node;
+class ResearcherContext;
 class SideStakeManager;
 class StakingStatus;
 class VotingManager;
@@ -54,6 +55,12 @@ public:
     //! poll/vote submission commands) over the global poll registry and the
     //! node's single wallet.
     virtual std::unique_ptr<VotingManager> makeVotingManager();
+
+    //! Returns the researcher/beacon interface (identity/magnitude/accrual/beacon
+    //! snapshot, the fused project table, and beacon/mode commands) over the
+    //! global researcher registries and the node's single wallet. Returns nullptr
+    //! for a null wallet; \p wallet must outlive the returned object.
+    virtual std::unique_ptr<ResearcherContext> makeResearcherContext(CWallet* wallet);
 
     //! Returns the interface for the node's single wallet. May return nullptr
     //! before wallet startup completes.

--- a/src/interfaces/researcher.h
+++ b/src/interfaces/researcher.h
@@ -62,7 +62,7 @@ enum class ResearcherMode
 struct ResearcherSnapshot
 {
     // Identity
-    std::string cpid;             //!< External CPID hex ("" if none).
+    std::string cpid;             //!< MiningId::ToString(): CPID hex, "NONCRUNCHER", or "" (invalid). has_cpid distinguishes an actual CPID.
     bool has_cpid = false;
     bool has_split_cpid = false;
     bool has_rac = false;

--- a/src/interfaces/researcher.h
+++ b/src/interfaces/researcher.h
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_RESEARCHER_H
+#define GRIDCOIN_INTERFACES_RESEARCHER_H
+
+#include "amount.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+class CWallet;
+
+namespace interfaces {
+
+class Handler;
+
+//! The researcher's current beacon status (Phase 1d-iv). Moved here from the Qt
+//! layer so the node side can classify it and the GUI just maps it to text/icon;
+//! researchermodel.h aliases its `BeaconStatus` to this so existing GUI code is
+//! unchanged.
+enum class BeaconStatus
+{
+    ACTIVE,
+    ERROR_INSUFFICIENT_FUNDS,
+    ERROR_MISSING_KEY,
+    ERROR_NOT_NEEDED,
+    ERROR_TX_FAILED,
+    ERROR_INVALID_PROOF_XML,
+    ERROR_WALLET_LOCKED,
+    NO_BEACON,
+    NO_CPID,
+    NO_MAGNITUDE,
+    PENDING,
+    RENEWAL_NEEDED,
+    RENEWAL_POSSIBLE,
+    ALREADY_IN_MEMPOOL,
+    UNKNOWN,
+};
+
+//! The researcher's configured participation mode.
+enum class ResearcherMode
+{
+    SOLO,
+    POOL,
+    NONCRUNCHER,
+};
+
+//! A pointer-free snapshot of the researcher/beacon context (Phase 1d-iv),
+//! replacing ResearcherModel's direct reads of Researcher::Get(), the beacon
+//! registry, magnitude/accrual, and the version gate. Raw values only — the GUI
+//! keeps all the format*() presentation (cpid masking, magnitude/accrual/age
+//! strings), so no core type crosses the boundary. Beacon times are Unix seconds
+//! so the GUI's periodic timer can recompute countdowns locally without a
+//! refetch.
+struct ResearcherSnapshot
+{
+    // Identity
+    std::string cpid;             //!< External CPID hex ("" if none).
+    bool has_cpid = false;
+    bool has_split_cpid = false;
+    bool has_rac = false;
+    std::string email;
+
+    // Magnitude / accrual
+    double magnitude = 0.0;
+    std::string magnitude_text;   //!< Magnitude::ToString() ("%g"); GUI shows verbatim.
+    bool has_magnitude = false;
+    CAmount accrual = 0;
+    std::optional<CAmount> accrual_near_limit; //!< Set when accrual is near the cap.
+
+    // Mode / sync
+    bool configured_for_noncruncher_mode = false;
+    bool detected_pool_mode = false;
+    bool out_of_sync = false;
+    std::string mining_status;   //!< msMiningErrors verbatim; GUI shows it below sync.
+
+    // Eligibility helpers (drive UI gating / the MRC seam)
+    bool has_eligible_projects = false;
+    bool has_pool_projects = false;
+    bool action_needed = false;
+
+    // Beacon status
+    BeaconStatus beacon_status = BeaconStatus::UNKNOWN;
+    bool beacon_present = false;         //!< A beacon record exists (may be expired); gates the age/address/expiry formatters.
+    bool pending_beacon_present = false; //!< A pending beacon record exists (may be pending-expired); gates the pending formatters.
+    bool has_active_beacon = false;
+    bool has_pending_beacon = false;
+    bool has_renewable_beacon = false;
+    bool beacon_expired = false;
+    bool needs_beacon_auth = false;
+    std::string beacon_address;
+    std::string beacon_verification_code;
+    std::string beacon_error;            //!< Human-readable beacon error, if any.
+    std::string cached_beacon_pubkey_hex; //!< V3 generated-but-not-advertised key.
+
+    // Beacon times (Unix seconds; the GUI formats age/countdowns locally)
+    int64_t beacon_timestamp = 0;
+    int64_t beacon_age = 0;
+    int64_t time_to_beacon_expiration = 0;
+    int64_t time_to_pending_beacon_expiration = 0;
+
+    // Misc
+    std::string boinc_data_dir;
+    bool is_v14_enabled = false;
+};
+
+//! One BOINC project row for the researcher table (Phase 1d-iv), as value data.
+//! Fuses the Gridcoin whitelist, locally-detected projects, and scraper magnitude
+//! for the CPID — computed node-side in one atomic pass (this is where the last
+//! raw scraper read, `ConvergedScraperStatsCache`, moves off the GUI). The GUI
+//! maps this to its Qt ProjectRow.
+struct ResearcherProjectRow
+{
+    //! Whitelist state, mirroring the GUI's former ProjectRow::WhiteListStatus.
+    enum class WhitelistStatus
+    {
+        NOT_WHITELISTED,
+        EXCLUDED,
+        MANUALLY_GREYLISTED,
+        AUTOMATICALLY_GREYLISTED,
+        WHITELISTED,
+    };
+
+    //! Non-status-derivable error label for the row. The greylisted/excluded
+    //! labels are NOT here — the GUI derives those from `whitelisted` so there is
+    //! one source of truth; this covers only the cases the status can't express.
+    //! The GUI maps each to a tr() string (CORE_MESSAGE uses `error_message`).
+    enum class ErrorKind
+    {
+        NONE,
+        CORE_MESSAGE,          //!< A core Project::ErrorMessage() (ineligible project).
+        NOT_WHITELISTED,       //!< Local project absent from the whitelist.
+        NOT_ATTACHED,          //!< Whitelisted project not attached locally.
+        USES_EXTERNAL_ADAPTER, //!< Whitelisted project needs an external adapter.
+    };
+
+    WhitelistStatus whitelisted = WhitelistStatus::NOT_WHITELISTED;
+    ErrorKind error_kind = ErrorKind::NONE;
+    std::optional<bool> gdpr_controls;
+    std::string name;
+    std::string cpid;
+    double magnitude = 0.0;
+    double rac = 0.0;
+    std::string error_message; //!< Core Project::ErrorMessage() when error_kind == CORE_MESSAGE.
+};
+
+//! Outcome of a beacon-advertise command: the resulting BeaconStatus the GUI maps
+//! to translated text (mirrors the former return of ResearcherModel::advertise*).
+struct BeaconAdvertiseResult
+{
+    BeaconStatus status = BeaconStatus::UNKNOWN;
+};
+
+//! One whitelisted project (name + url) — value rows for the poll-wizard project
+//! pickers. Decision A (1d-iv): VotingModel's getActiveProjectNames/getActive
+//! ProjectUrls migrate onto this too, closing the last 1d-iii ratchet entry.
+struct WhitelistProject
+{
+    std::string name;
+    std::string url;
+};
+
+//! Called when the researcher context changes (uiInterface.ResearcherChanged).
+//! Payload-free (decision B): the consumer refetches snapshot() on its own thread,
+//! which drops the former cross-thread marshal of a GRC::ResearcherPtr.
+using ResearcherChangedFn = std::function<void()>;
+
+//! Called when accrual changes from a stake or MRC
+//! (uiInterface.AccrualChangedFromStakeOrMRC).
+using AccrualChangedFn = std::function<void()>;
+
+//! Called when the beacon changes (uiInterface.BeaconChanged).
+using BeaconChangedFn = std::function<void()>;
+
+//! Called when the block tip changes (uiInterface.NotifyBlocksChanged) — the
+//! researcher panel refreshes sync-dependent state. Payload mirrors the core
+//! signal (new best height/time and whether a header-only update).
+using BlocksChangedFn = std::function<void(bool, int, int64_t, uint32_t)>;
+
+//! The researcher/beacon/scraper boundary (Phase 1d-iv). Hands the GUI a value
+//! snapshot, the fused project table, and command-style beacon/mode operations,
+//! so ResearcherModel holds no GRC::Researcher / GRC::Beacon and calls no beacon
+//! registry, quorum, whitelist, or scraper-cache global directly. Over the node's
+//! single wallet (needed for the beacon-key / advertise / V3 paths).
+class ResearcherContext
+{
+public:
+    virtual ~ResearcherContext() = default;
+
+    //! The current researcher/beacon snapshot (one node-side read under cs_main).
+    //! Blocks on cs_main; use for the initial fetch and researcher-changed resets.
+    virtual ResearcherSnapshot snapshot() = 0;
+
+    //! Like snapshot() but with TRY_LOCK(cs_main): returns nullopt if cs_main is
+    //! contended rather than blocking. Preserves the former ResearcherModel::
+    //! refresh() behaviour of bowing out cleanly during heavy chain catch-up so
+    //! the per-block refresh never stalls the GUI thread.
+    virtual std::optional<ResearcherSnapshot> trySnapshot() = 0;
+
+    //! Cheap, lock-free out-of-sync-by-age check (wraps OutOfSyncByAge()). The
+    //! former refresh() updated this flag even when it could not take cs_main, so
+    //! the GUI can show "Waiting for sync..." during catch-up without blocking.
+    virtual bool outOfSync() = 0;
+
+    //! Whether any BOINC project supports beacon ownership-proof (V3) advertisement
+    //! (wraps GetProjectsWithOwnershipProofSupport()). Gates the wizard's V3 UI.
+    virtual bool hasV3CapableProjects() = 0;
+
+    //! The researcher project table (whitelist + local projects + scraper
+    //! magnitude/exclusions, fused node-side). \p extended controls whether
+    //! greylist/GDPR detail is included, matching the former buildProjectTable.
+    virtual std::vector<ResearcherProjectRow> projects(bool extended) = 0;
+
+    //! The whitelisted projects (name + url) for the poll-wizard pickers.
+    virtual std::vector<WhitelistProject> whitelistProjects() = 0;
+
+    //! Maximum on-chain project name / URL lengths (GRC::Project::MAX_NAME_SIZE /
+    //! MAX_URL_SIZE). The poll wizard's project-entry fields cap their Qt input at
+    //! these, so the limit crosses the boundary rather than gridcoin/project.h.
+    virtual int maxProjectNameLength() = 0;
+    virtual int maxProjectUrlLength() = 0;
+
+    //! V3-ownership-proof-capable projects (name + url) for the wizard.
+    virtual std::vector<WhitelistProject> v3CapableProjects() = 0;
+
+    //! Switch participation mode. SOLO takes the researcher email; POOL /
+    //! NONCRUNCHER ignore it. Returns whether the change was applied.
+    virtual bool switchMode(ResearcherMode mode, const std::string& email) = 0;
+
+    //! Advertise a (V2) beacon; returns the resulting status.
+    virtual BeaconAdvertiseResult advertiseBeacon() = 0;
+
+    //! Generate (and cache) a V3 beacon key, returning its public-key hex ("" on
+    //! failure). Runs the cs_main + cs_wallet key generation node-side.
+    virtual std::string generateBeaconKeyForV3() = 0;
+
+    //! Advertise a V3 beacon with the supplied ownership-proof XML.
+    virtual BeaconAdvertiseResult advertiseBeaconV3(const std::string& ownership_proof_xml) = 0;
+
+    //! Reload the researcher context from configuration.
+    virtual void reload() = 0;
+
+    //! Subscribe to the researcher/beacon/accrual/tip notifications.
+    virtual std::unique_ptr<Handler> handleResearcherChanged(ResearcherChangedFn fn) = 0;
+    virtual std::unique_ptr<Handler> handleBeaconChanged(BeaconChangedFn fn) = 0;
+    virtual std::unique_ptr<Handler> handleAccrualChanged(AccrualChangedFn fn) = 0;
+    virtual std::unique_ptr<Handler> handleBlocksChanged(BlocksChangedFn fn) = 0;
+};
+
+//! Return an in-process ResearcherContext over the global researcher/beacon
+//! registries and the node's single wallet. \p wallet must outlive the object.
+std::unique_ptr<ResearcherContext> MakeResearcherContext(CWallet* wallet);
+
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_RESEARCHER_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -14,6 +14,7 @@
 #include "interfaces/handler.h"
 #include "interfaces/init.h"
 #include "interfaces/mrc.h"
+#include "interfaces/researcher.h"
 #include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
 #include "interfaces/voting.h"
@@ -200,6 +201,11 @@ public:
     std::unique_ptr<VotingManager> makeVotingManager() override
     {
         return MakeVotingManager();
+    }
+
+    std::unique_ptr<ResearcherContext> makeResearcherContext(CWallet* wallet) override
+    {
+        return wallet ? MakeResearcherContext(wallet) : nullptr;
     }
 
     std::unique_ptr<Wallet> makeWallet() override

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -21,6 +21,7 @@
 #include "interfaces/init.h"
 #include "interfaces/mrc.h"
 #include "interfaces/node.h"
+#include "interfaces/researcher.h"
 #include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
 #include "interfaces/voting.h"
@@ -696,12 +697,20 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 if (!voting_manager) {
                     throw std::runtime_error("voting interface unavailable after init");
                 }
+                // The researcher/beacon interface (Phase 1d-iv) over the node's
+                // wallet. Owned here so it outlives the ResearcherModel that drives
+                // it (and the MRCModel/VotingModel that read researcher state).
+                std::unique_ptr<interfaces::ResearcherContext> researcher_context =
+                    interface_init->makeResearcherContext(pwalletMain);
+                if (!researcher_context) {
+                    throw std::runtime_error("researcher interface unavailable after init");
+                }
 
                 ClientModel clientModel(*node, *staking_status, &optionsModel);
                 WalletModel walletModel(*wallet, *wallet_tx_source, pwalletMain, &optionsModel);
-                ResearcherModel researcherModel;
+                ResearcherModel researcherModel(*researcher_context);
                 MRCModel mrcModel(*mrc, &walletModel, &clientModel, &researcherModel);
-                VotingModel votingModel(*voting_manager, clientModel, optionsModel, walletModel);
+                VotingModel votingModel(*voting_manager, *researcher_context, clientModel, optionsModel, walletModel);
 
                 window.setResearcherModel(&researcherModel);
                 window.setClientModel(&clientModel);

--- a/src/qt/researcher/projecttablemodel.cpp
+++ b/src/qt/researcher/projecttablemodel.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "gridcoin/researcher.h"
-
 #include "qt/researcher/projecttablemodel.h"
 #include "qt/researcher/researchermodel.h"
 

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -1,22 +1,9 @@
-// Copyright (c) 2014-2025 The Gridcoin developers
+// Copyright (c) 2014-2026 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <key_io.h>
-#include "chainparams.h"
-#include "main.h"
-#include "gridcoin/beacon.h"
-#include "gridcoin/boinc.h"
-#include "gridcoin/magnitude.h"
-#include "gridcoin/project.h"
-#include "gridcoin/quorum.h"
-#include "gridcoin/researcher.h"
-#include "gridcoin/scraper/scraper.h"
-#include "gridcoin/superblock.h"
-#include "gridcoin/support/xml.h"
-#include "node/ui_interface.h"
-#include "util/strencodings.h"
-#include <util/string.h>
+#include "interfaces/handler.h"
+#include "interfaces/researcher.h"
 
 #include "qt/bitcoinunits.h"
 #include "qt/guiutil.h"
@@ -27,123 +14,27 @@
 #include <QIcon>
 #include <QMessageBox>
 
-extern CWallet* pwalletMain;
-extern ConvergedScraperStats ConvergedScraperStatsCache;
-
-using namespace GRC;
-using LogFlags = BCLog::LogFlags;
-
-namespace {
-constexpr double SECONDS_IN_DAY = 24.0 * 60.0 * 60.0;
-constexpr int64_t BEACON_RENEWAL_WARNING_THRESHOLD = 15 * SECONDS_IN_DAY;
-
-//!
-//! \brief Model callback bound to the \c ResearcherChanged core signal.
-//!
-void ResearcherChanged(ResearcherModel* model)
-{
-    LogPrint(LogFlags::QT, "GUI: received ResearcherChanged() core signal");
-
-    QMetaObject::invokeMethod(
-        model,
-        "resetResearcher",
-        Qt::QueuedConnection,
-        Q_ARG(GRC::ResearcherPtr, Researcher::Get()));
-}
-
-//!
-//! \brief Model callback bound to the \c AccrualChangedFromStakeOrMRC core signal.
-//!
-void AccrualChangedFromStakeOrMRC(ResearcherModel* model)
-{
-    LogPrint(LogFlags::QT, "GUI: received ResearcherChanged() core signal");
-
-    QMetaObject::invokeMethod(model, "accrualChanged", Qt::QueuedConnection);
-}
-
-//!
-//! \brief Model callback bound to the \c BeaconChanged core signal.
-//!
-void BeaconChanged(ResearcherModel* model)
-{
-    LogPrint(LogFlags::QT, "GUI: received BeaconChanged() core signal");
-
-    QMetaObject::invokeMethod(model, "updateBeacon", Qt::QueuedConnection);
-}
-
-//!
-//! \brief Model callback bound to the \c NotifyBlocksChanged core signal.
-//!
-//! Replaces the 30-second wall-clock refresh timer. Per-block events drive
-//! the researcher-state refresh (accrual ticks up, magnitude changes on
-//! superblock activation), so the natural cadence is "every chain tip
-//! advance" rather than "every 30 seconds regardless". The refresh()
-//! slot retains its TRY_LOCK guard for cs_main, so this is safe to fire
-//! during heavy chain catch-up — it bows out cleanly when contended.
-//!
-void NotifyBlocksChangedForResearcher(ResearcherModel* model,
-                                       bool /*syncing*/,
-                                       int /*height*/,
-                                       int64_t /*best_time*/,
-                                       uint32_t /*target_bits*/)
-{
-    QMetaObject::invokeMethod(model, "refresh", Qt::QueuedConnection);
-}
-
-//!
-//! \brief Convert a beacon advertisement error to a beacon status.
-//!
-//! \param error Beacon advertisement error provided the researcher API.
-//!
-//! \return Describes the advertisement error as a beacon status.
-//!
-BeaconStatus MapAdvertiseBeaconError(const BeaconError error)
-{
-    switch (error) {
-        case BeaconError::NONE:               return BeaconStatus::ACTIVE;
-        case BeaconError::INSUFFICIENT_FUNDS: return BeaconStatus::ERROR_INSUFFICIENT_FUNDS;
-        case BeaconError::MISSING_KEY:        return BeaconStatus::ERROR_MISSING_KEY;
-        case BeaconError::NO_CPID:            return BeaconStatus::NO_CPID;
-        case BeaconError::NOT_NEEDED:         return BeaconStatus::ERROR_NOT_NEEDED;
-        case BeaconError::PENDING:            return BeaconStatus::PENDING;
-        case BeaconError::TX_FAILED:          return BeaconStatus::ERROR_TX_FAILED;
-        case BeaconError::V14_NOT_ENABLED:    return BeaconStatus::ERROR_TX_FAILED;
-        case BeaconError::WALLET_LOCKED:      return BeaconStatus::ERROR_WALLET_LOCKED;
-        case BeaconError::ALEADY_IN_MEMPOOL:  return BeaconStatus::ALREADY_IN_MEMPOOL;
-        }
-
-    assert(false); // Suppress warning
-}
-} // anonymous namespace
+#include <cassert>
 
 // -----------------------------------------------------------------------------
 // Class: ResearcherModel
 // -----------------------------------------------------------------------------
 
-ResearcherModel::ResearcherModel()
-    : m_beacon_status(BeaconStatus::UNKNOWN)
-    , m_configured_for_noncruncher_mode(false)
+ResearcherModel::ResearcherModel(interfaces::ResearcherContext& researcher_context)
+    : m_researcher_context(researcher_context)
     , m_wizard_open(false)
-    , m_out_of_sync(true)
-    , m_split_cpid(false)
     , m_privacy_enabled(false)
     , m_theme_suffix("_dark")
 {
-    qRegisterMetaType<ResearcherPtr>("GRC::ResearcherPtr");
-
-    resetResearcher(Researcher::Get());
+    // Prime the cached snapshot before any getter can run, then subscribe.
+    m_snapshot = m_researcher_context.snapshot();
     subscribeToCoreSignals();
 
-    if (GRC::Researcher::ConfiguredForNoncruncherMode()) {
-        m_configured_for_noncruncher_mode = true;
-    }
-
-    // The 30-second polling refresh timer that used to be here is removed in
-    // favour of an event-driven refresh on uiInterface.NotifyBlocksChanged
-    // (subscribed below). Per-block accrual updates now propagate within one
-    // chain-tip-advance event instead of within 30 seconds. Other signals
-    // (ResearcherChanged, AccrualChangedFromStakeOrMRC, BeaconChanged)
-    // continue to drive their own targeted refreshes as before.
+    // The 30-second polling refresh timer that used to live here is gone in
+    // favour of an event-driven refresh on the interface's block-tip
+    // notification (subscribed below). Per-block accrual updates propagate
+    // within one chain-tip-advance event. The researcher/beacon/accrual
+    // notifications drive their own targeted refreshes as before.
 }
 
 ResearcherModel::~ResearcherModel()
@@ -274,168 +165,123 @@ void ResearcherModel::setMaskCpidMagnitudeAccrual(bool privacy)
 
 bool ResearcherModel::configuredForNoncruncherMode() const
 {
-    return m_configured_for_noncruncher_mode;
+    return m_snapshot.configured_for_noncruncher_mode;
 }
 
 bool ResearcherModel::outOfSync() const
 {
-    return m_out_of_sync;
+    return m_snapshot.out_of_sync;
 }
 
 bool ResearcherModel::detectedPoolMode() const
 {
-    return !hasEligibleProjects() && hasPoolProjects();
+    return m_snapshot.detected_pool_mode;
 }
 
 bool ResearcherModel::actionNeeded() const
 {
-    if (outOfSync()) {
-        return false;
-    }
-
-    if (configuredForNoncruncherMode()) {
-        return false;
-    }
-
-    if (hasEligibleProjects()) {
-        return hasSplitCpid() || (!hasActiveBeacon() && !hasPendingBeacon());
-    }
-
-    return !hasPoolProjects();
+    return m_snapshot.action_needed;
 }
 
 bool ResearcherModel::hasEligibleProjects() const
 {
-    return m_researcher->Id().Which() == MiningId::Kind::CPID;
+    return m_snapshot.has_eligible_projects;
 }
 
 bool ResearcherModel::hasPoolProjects() const
 {
-    return m_researcher->Projects().ContainsPool();
+    return m_snapshot.has_pool_projects;
 }
 
 bool ResearcherModel::hasActiveBeacon() const
 {
-    return m_beacon && !m_beacon->Expired(GetAdjustedTime());
+    return m_snapshot.has_active_beacon;
 }
 
 bool ResearcherModel::hasPendingBeacon() const
 {
-    if (!m_pending_beacon.operator bool()) {
-        return false;
-    }
-
-    // If here, a pending beacon is present. Determine if expired
-    // while pending. No need to actually clean the pending entry
-    // up. It will be eventually cleaned by the contract handler via
-    // the ActivatePending call.
-    GRC::PendingBeacon pending_beacon(*m_pending_beacon);
-
-    return !pending_beacon.PendingExpired(GetAdjustedTime());
+    return m_snapshot.has_pending_beacon;
 }
 
 bool ResearcherModel::hasRenewableBeacon() const
 {
-    return m_beacon && m_beacon->Renewable(GetAdjustedTime());
+    return m_snapshot.has_renewable_beacon;
 }
 
 bool ResearcherModel::beaconExpired() const
 {
-    return m_beacon && m_beacon->Expired(GetAdjustedTime());
+    return m_snapshot.beacon_expired;
 }
 
 bool ResearcherModel::hasMagnitude() const
 {
-    return m_researcher->Magnitude() != 0;
+    return m_snapshot.has_magnitude;
 }
 
 bool ResearcherModel::hasRAC() const
 {
-    return m_researcher->HasRAC();
+    return m_snapshot.has_rac;
 }
 
 bool ResearcherModel::hasSplitCpid() const
 {
-    return m_researcher->hasSplitCpid();
+    return m_snapshot.has_split_cpid;
 }
 
 bool ResearcherModel::needsBeaconAuth() const
 {
-    if (!hasPendingBeacon()) {
-        return false;
-    }
-
-    if (!hasActiveBeacon()) {
-        return true;
-    }
-
-    return m_beacon->m_public_key != m_pending_beacon->m_public_key;
+    return m_snapshot.needs_beacon_auth;
 }
 
 std::optional<CAmount> ResearcherModel::accrualNearLimit() const
 {
-    return m_researcher->AccrualNearLimit();
+    return m_snapshot.accrual_near_limit;
 }
 
 CAmount ResearcherModel::getAccrual() const
 {
-    return m_researcher->Accrual();
+    return m_snapshot.accrual;
 }
 
 QString ResearcherModel::email() const
 {
-    return QString::fromStdString(Researcher::Email());
+    return QString::fromStdString(m_snapshot.email);
 }
 
 QString ResearcherModel::formatCpid() const
 {
-    QString text = QString::fromStdString(m_researcher->Id().ToString());
-
     if (m_privacy_enabled) {
-        text = "################################";
+        return "################################";
     }
 
-    return text;
+    return QString::fromStdString(m_snapshot.cpid);
 }
 
 QString ResearcherModel::formatMagnitude() const
 {
-    QString text;
-
     if (outOfSync()) {
-        text = "...";
-    } else if (m_privacy_enabled) {
-        text = "#";
-    } else {
-        text = QString::fromStdString(m_researcher->Magnitude().ToString());
+        return "...";
     }
 
-    return text;
+    if (m_privacy_enabled) {
+        return "#";
+    }
+
+    return QString::fromStdString(m_snapshot.magnitude_text);
 }
 
 QString ResearcherModel::formatAccrual(const int display_unit, bool& near_limit) const
 {
-    QString text;
+    const CAmount accrual = m_snapshot.accrual;
+    const std::optional<CAmount> near_limit_accrual = m_snapshot.accrual_near_limit;
 
-    // We only do the actual accrual calculation once. The AccrualNearLimit() is lighter.
-    CAmount accrual = m_researcher->Accrual();
-    std::optional<CAmount> near_limit_accrual = accrualNearLimit();
-
-    if (near_limit_accrual && accrual >= *near_limit_accrual) {
-        near_limit = true;
-    } else {
-        near_limit = false;
-    }
+    near_limit = near_limit_accrual && accrual >= *near_limit_accrual;
 
     if (outOfSync()) {
-        text = "...";
-    } else {
-        text = BitcoinUnits::formatWithPrivacy(display_unit, accrual, m_privacy_enabled);
+        return "...";
     }
 
-
-
-    return text;
+    return BitcoinUnits::formatWithPrivacy(display_unit, accrual, m_privacy_enabled);
 }
 
 QString ResearcherModel::formatStatus() const
@@ -444,380 +290,211 @@ QString ResearcherModel::formatStatus() const
         return tr("Waiting for sync...");
     }
 
-    // TODO: The getstakinginfo RPC shares this global. Refactor to remove it:
-    std::string status;
-    {
-        LOCK(cs_msMiningErrors);
-        status = msMiningErrors;
-    }
-    return QString::fromStdString(status);
+    return QString::fromStdString(m_snapshot.mining_status);
 }
 
 QString ResearcherModel::formatBoincPath() const
 {
-    return GUIUtil::boostPathToQString(GetBoincDataDir());
+    return QString::fromStdString(m_snapshot.boinc_data_dir);
 }
 
 BeaconStatus ResearcherModel::getBeaconStatus() const
 {
-    return m_beacon_status;
+    return m_snapshot.beacon_status;
 }
 
 QString ResearcherModel::formatBeaconStatus() const
 {
-    return mapBeaconStatus(m_beacon_status);
+    return mapBeaconStatus(m_snapshot.beacon_status);
 }
 
 QIcon ResearcherModel::getBeaconStatusIcon() const
 {
-    return mapBeaconStatusIcon(m_beacon_status);
+    return mapBeaconStatusIcon(m_snapshot.beacon_status);
 }
 
 QString ResearcherModel::formatBeaconAge() const
 {
-    if (!m_beacon) {
+    if (!m_snapshot.beacon_present) {
         return QString();
     }
 
-    return GUIUtil::formatDurationStr(m_beacon->Age(GetAdjustedTime()));
+    return GUIUtil::formatDurationStr(m_snapshot.beacon_age);
 }
 
 QString ResearcherModel::formatTimeToBeaconExpiration() const
 {
-    if (!m_beacon) {
+    if (!m_snapshot.beacon_present) {
         return QString();
     }
 
-    return GUIUtil::formatDurationStr(Beacon::MAX_AGE - m_beacon->Age(GetAdjustedTime()));
+    return GUIUtil::formatDurationStr(m_snapshot.time_to_beacon_expiration);
 }
 
 QString ResearcherModel::formatTimeToPendingBeaconExpiration() const
 {
-    if (!m_pending_beacon) {
+    if (!m_snapshot.pending_beacon_present) {
         return QString();
     }
 
-    return GUIUtil::formatDurationStr(PendingBeacon::RETENTION_AGE - m_pending_beacon->Age(GetAdjustedTime()));
+    return GUIUtil::formatDurationStr(m_snapshot.time_to_pending_beacon_expiration);
 }
 
 QString ResearcherModel::formatBeaconAddress() const
 {
-    if (!m_beacon) {
+    if (!m_snapshot.beacon_present) {
         return QString();
     }
 
-    return QString::fromStdString(EncodeDestination(m_beacon->GetAddress()));
+    return QString::fromStdString(m_snapshot.beacon_address);
 }
 
 QString ResearcherModel::formatBeaconVerificationCode() const
 {
-    if (!m_pending_beacon) {
+    if (!m_snapshot.pending_beacon_present) {
         return QString();
     }
 
-    return QString::fromStdString(m_pending_beacon->GetVerificationCode());
+    return QString::fromStdString(m_snapshot.beacon_verification_code);
+}
+
+ProjectRow ResearcherModel::mapProjectRow(const interfaces::ResearcherProjectRow& src) const
+{
+    using WS = interfaces::ResearcherProjectRow::WhitelistStatus;
+    using EK = interfaces::ResearcherProjectRow::ErrorKind;
+
+    ProjectRow row;
+    // The node sends the display name in original case; lower it here with
+    // QString::toLower() (Unicode-aware), matching the former buildProjectTable.
+    row.m_name = QString::fromStdString(src.name).toLower();
+    row.m_cpid = QString::fromStdString(src.cpid);
+    row.m_magnitude = src.magnitude;
+    row.m_rac = src.rac;
+    row.m_gdpr_controls = src.gdpr_controls;
+
+    switch (src.whitelisted) {
+        case WS::NOT_WHITELISTED:          row.m_whitelisted = ProjectRow::False; break;
+        case WS::EXCLUDED:                 row.m_whitelisted = ProjectRow::Excluded; break;
+        case WS::MANUALLY_GREYLISTED:      row.m_whitelisted = ProjectRow::Manually_Greylisted; break;
+        case WS::AUTOMATICALLY_GREYLISTED: row.m_whitelisted = ProjectRow::Automatically_Greylisted; break;
+        case WS::WHITELISTED:              row.m_whitelisted = ProjectRow::True; break;
+    }
+
+    // The greylisted/excluded labels are derived from the status (single source
+    // of truth); every other label comes from the node-side error kind.
+    switch (src.whitelisted) {
+        case WS::MANUALLY_GREYLISTED:
+            row.m_error = tr("Manually Greylisted");
+            break;
+        case WS::AUTOMATICALLY_GREYLISTED:
+            row.m_error = tr("Automatically Greylisted");
+            break;
+        case WS::EXCLUDED:
+            row.m_error = tr("Excluded");
+            break;
+        default:
+            switch (src.error_kind) {
+                case EK::NONE:
+                    break;
+                case EK::CORE_MESSAGE:
+                    row.m_error = QString::fromStdString(src.error_message);
+                    break;
+                case EK::NOT_WHITELISTED:
+                    row.m_error = tr("Not whitelisted");
+                    break;
+                case EK::NOT_ATTACHED:
+                    row.m_error = tr("Not attached");
+                    break;
+                case EK::USES_EXTERNAL_ADAPTER:
+                    row.m_error = tr("Uses external adapter");
+                    break;
+            }
+            break;
+    }
+
+    return row;
 }
 
 std::vector<ProjectRow> ResearcherModel::buildProjectTable(bool extended) const
 {
-    // We do a funny dance here to link-up three loosly-related record types:
-    //
-    //   - Local BOINC projects detected from client_state.xml
-    //   - Projects on the Gridcoin whitelist
-    //   - Project magnitude statistics produced by the scrapers
-    //
-    // ...into an overview of all three that shows how a participant's attached
-    // projects behave in the network.
-    //
+    std::vector<ProjectRow> rows;
 
-    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED);
-    std::vector<std::string> excluded_projects;
-
-    {
-        LOCK(cs_ConvergedScraperStatsCache);
-
-        excluded_projects = ConvergedScraperStatsCache.Convergence.vExcludedProjects;
+    for (const auto& src : m_researcher_context.projects(extended)) {
+        rows.push_back(mapProjectRow(src));
     }
 
-    // This is temporary implementation of the suppression of "not attached" for projects that
-    // are whitelisted that require an external adapter, and so will not be attached as a native
-    // BOINC project. This will be replaced by a field in the Projects class at the next mandatory
-    // (5.5.0.0).
-    std::vector<std::string> external_adapter_projects = GetProjectsExternalAdapterRequired();
-
-    std::vector<ExplainMagnitudeProject> explain_mag;
-    std::map<std::string, ProjectRow> rows;
-
-    if (extended) {
-        if (const CpidOption cpid = m_researcher->Id().TryCpid()) {
-            explain_mag = GRC::Quorum::ExplainMagnitude(*cpid);
-        }
-    }
-
-    for (const auto& project_pair : m_researcher->Projects()) {
-        const MiningProject& project = project_pair.second;
-
-        ProjectRow row;
-
-        if (!project.m_cpid.IsZero()) {
-            row.m_cpid = QString::fromStdString(project.m_cpid.ToString());
-        }
-
-        if (!project.Eligible()) {
-            row.m_error = QString::fromStdString(project.ErrorMessage());
-        }
-
-        // Project whitelist contracts may not contain names that match the
-        // project names in BOINC's client_state.xml file. We use a routine
-        // that also compares the project URL to establish the relationship
-        // between local projects and whitelisted projects:
-        //
-        if (const ProjectEntry* whitelist_project = project.TryWhitelist(whitelist)) {
-            if (whitelist_project->m_status == ProjectEntryStatus::MAN_GREYLISTED) {
-                row.m_whitelisted = ProjectRow::WhiteListStatus::Manually_Greylisted;
-                row.m_error = tr("Manually Greylisted");
-            } else if (whitelist_project->m_status == ProjectEntryStatus::AUTO_GREYLISTED) {
-                row.m_whitelisted = ProjectRow::WhiteListStatus::Automatically_Greylisted;
-                row.m_error = tr("Automatically Greylisted");
-                   // Only mark as excluded if the project is not greylisted. A greylisted project will
-                   // have the same effect on statistics from a CPID perspective whether the project is
-                   // excluded by the scrapers.
-            } else if (std::find(excluded_projects.begin(), excluded_projects.end(), whitelist_project->m_name)
-                       != excluded_projects.end()
-                       && !(whitelist_project->m_status == ProjectEntryStatus::AUTO_GREYLISTED)
-                       && !(whitelist_project->m_status == ProjectEntryStatus::MAN_GREYLISTED)) {
-                row.m_whitelisted = ProjectRow::WhiteListStatus::Excluded;
-                row.m_error = tr("Excluded");
-                   // an unknown status should never happen for a project record on the main chain, but to be
-                   // thorough, handle that here.
-            } else if (whitelist_project->m_status == ProjectEntryStatus::UNKNOWN){
-                row.m_whitelisted = ProjectRow::WhiteListStatus::False;
-            } else {
-                // This covers the remaining REG_ACTIVE and AUTO_GREYLIST_OVERRIDE, which is the same
-                // as the whitelist filter of ACTIVE.
-                row.m_whitelisted = ProjectRow::WhiteListStatus::True;
-            }
-
-            row.m_name = QString::fromStdString(whitelist_project->DisplayName()).toLower();
-
-            for (const auto& explain_mag_project : explain_mag) {
-                if (explain_mag_project.m_name == whitelist_project->m_name) {
-                    row.m_magnitude = explain_mag_project.m_magnitude;
-                    row.m_rac = explain_mag_project.m_rac;
-                    break;
-                }
-            }
-
-            row.m_gdpr_controls = whitelist_project->HasGDPRControls();
-
-            rows.emplace(whitelist_project->m_name, std::move(row));
-        } else {
-            row.m_whitelisted = ProjectRow::WhiteListStatus::False;
-            row.m_name = QString::fromStdString(project.m_name).toLower();
-            row.m_rac = project.m_rac;
-
-            if (project.Eligible()) {
-                row.m_error = tr("Not whitelisted");
-            }
-
-            rows.emplace(project.m_name, std::move(row));
-        }
-    }
-
-    // Add any whitelisted projects not detected from the local BOINC client:
-    //
-    for (const auto& project : GetWhitelist().Snapshot(ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED)) {
-        if (rows.find(project.m_name) != rows.end()) {
-            continue;
-        }
-
-        ProjectRow row;
-        row.m_gdpr_controls = project.HasGDPRControls();
-
-        row.m_name = QString::fromStdString(project.DisplayName()).toLower();
-        row.m_magnitude = 0.0;
-
-        // the external adapter code below only appears here because if the project is in BOINC it does not need
-        // an external adapter.
-
-        bool project_requires_external_adapter = (project.RequiresExtAdapter().has_value() && project.RequiresExtAdapter().value());
-
-        bool legacy_external_adapter_project_found = (std::find(external_adapter_projects.begin(),
-                                                              external_adapter_projects.end(),
-                                                              project.m_name) != external_adapter_projects.end());
-
-        if (project_requires_external_adapter || legacy_external_adapter_project_found) {
-            row.m_error = tr("Uses external adapter");
-        } else {
-            row.m_error = tr("Not attached");
-        }
-
-        if (project.m_status == ProjectEntryStatus::MAN_GREYLISTED) {
-            row.m_whitelisted = ProjectRow::WhiteListStatus::Manually_Greylisted;
-            row.m_error = tr("Manually Greylisted");
-        } else if (project.m_status == ProjectEntryStatus::AUTO_GREYLISTED) {
-            row.m_whitelisted = ProjectRow::WhiteListStatus::Automatically_Greylisted;
-            row.m_error = tr("Automatically Greylisted");
-               // Only mark as excluded if the project is not greylisted. A greylisted project will
-               // have the same effect on statistics from a CPID perspective whether the project is
-               // excluded by the scrapers.
-        } else if (std::find(excluded_projects.begin(), excluded_projects.end(), project.m_name)
-                       != excluded_projects.end()
-                   && !(project.m_status == ProjectEntryStatus::AUTO_GREYLISTED)
-                   && !(project.m_status == ProjectEntryStatus::MAN_GREYLISTED)) {
-            row.m_whitelisted = ProjectRow::WhiteListStatus::Excluded;
-            row.m_error = tr("Excluded");
-               // an unknown status should never happen for a project record on the main chain, but to be
-               // thorough, handle that here.
-        } else if (project.m_status == ProjectEntryStatus::UNKNOWN){
-            row.m_whitelisted = ProjectRow::WhiteListStatus::False;
-        } else {
-            // This covers the remaining REG_ACTIVE and AUTO_GREYLIST_OVERRIDE, which is the same
-            // as the whitelist filter of ACTIVE.
-            row.m_whitelisted = ProjectRow::WhiteListStatus::True;
-        }
-
-        for (const auto& explain_mag_project : explain_mag) {
-            if (explain_mag_project.m_name == project.m_name) {
-                row.m_magnitude = explain_mag_project.m_magnitude;
-                row.m_rac = explain_mag_project.m_rac;
-                break;
-            }
-        }
-
-        rows.emplace(project.m_name, std::move(row));
-    }
-
-    std::vector<ProjectRow> rows_out;
-    rows_out.reserve(rows.size());
-
-    for (auto& row_pair : rows) {
-        rows_out.emplace_back(std::move(row_pair.second));
-    }
-
-    return rows_out;
+    return rows;
 }
 
 void ResearcherModel::reload()
 {
-    {
-        LOCK(cs_main);
-        Researcher::Reload();
-    }
-    resetResearcher(Researcher::Get());
+    m_researcher_context.reload();
+    onResearcherChanged();
 }
 
 void ResearcherModel::refresh()
 {
-    const bool out_of_sync = OutOfSyncByAge();
+    // Cheap, lock-free sync-state check first, mirroring the former refresh():
+    // the "Waiting for sync..." state must update even when cs_main is contended.
+    const bool out_of_sync = m_researcher_context.outOfSync();
 
-    if (out_of_sync != m_out_of_sync) {
-        m_out_of_sync = out_of_sync;
+    if (out_of_sync != m_snapshot.out_of_sync) {
+        m_snapshot.out_of_sync = out_of_sync;
         emit researcherChanged();
     }
 
-    TRY_LOCK(cs_main, lockMain);
-
-    if (!lockMain) {
-        return;
+    // Full refresh via TRY_LOCK: bow out cleanly under cs_main contention rather
+    // than stalling the GUI thread during heavy chain catch-up.
+    if (auto snap = m_researcher_context.trySnapshot()) {
+        m_snapshot = std::move(*snap);
+        emit magnitudeChanged();
+        emit accrualChanged();
+        emit beaconChanged();
     }
+}
 
-    updateBeacon();
+void ResearcherModel::onResearcherChanged()
+{
+    // A researcher-context change is significant and infrequent; take the full
+    // (blocking) snapshot and repaint everything, matching the former
+    // resetResearcher() -> emit researcherChanged() + updateBeacon() sequence.
+    m_snapshot = m_researcher_context.snapshot();
 
+    emit researcherChanged();
+    emit beaconChanged();
     emit magnitudeChanged();
     emit accrualChanged();
 }
 
-void ResearcherModel::resetResearcher(ResearcherPtr researcher)
-{
-    m_researcher = std::move(researcher);
-    m_out_of_sync = OutOfSyncByAge();
-
-    emit researcherChanged();
-
-    updateBeacon();
-}
-
 bool ResearcherModel::switchToSolo(const QString& email)
 {
-    m_configured_for_noncruncher_mode = false;
+    // Optimistically clear the noncruncher flag so the wizard's immediately
+    // following page selection sees the new mode (the former model set the
+    // member directly before calling ChangeMode).
+    m_snapshot.configured_for_noncruncher_mode = false;
 
-    return m_researcher->ChangeMode(ResearcherMode::SOLO, email.toStdString());
+    return m_researcher_context.switchMode(interfaces::ResearcherMode::SOLO, email.toStdString());
 }
 
 bool ResearcherModel::switchToPool()
 {
-    m_configured_for_noncruncher_mode = false;
+    m_snapshot.configured_for_noncruncher_mode = false;
 
-    return m_researcher->ChangeMode(ResearcherMode::POOL, std::string());
+    return m_researcher_context.switchMode(interfaces::ResearcherMode::POOL, std::string());
 }
 
 bool ResearcherModel::switchToNoncruncher()
 {
-    m_configured_for_noncruncher_mode = true;
+    m_snapshot.configured_for_noncruncher_mode = true;
 
-    return m_researcher->ChangeMode(ResearcherMode::NONCRUNCHER, std::string());
+    return m_researcher_context.switchMode(interfaces::ResearcherMode::NONCRUNCHER, std::string());
 }
 
 void ResearcherModel::updateBeacon()
 {
-    const CpidOption cpid = m_researcher->Id().TryCpid();
-
-    if (!cpid) {
-        commitBeacon(BeaconStatus::NO_CPID);
-        emit beaconChanged();
-        emit researcherChanged();
-        return;
-    }
-
-    if (outOfSync()) {
-        commitBeacon(BeaconStatus::UNKNOWN);
-        emit beaconChanged();
-        emit researcherChanged();
-        return;
-    }
-
-    bool beacon_key_present = false;
-    std::unique_ptr<Beacon> beacon = nullptr;
-    std::unique_ptr<Beacon> pending_beacon = nullptr;
-
-    if (auto beacon_option = m_researcher->TryBeacon()) {
-        beacon.reset(new Beacon(std::move(*beacon_option)));
-        beacon_key_present = beacon->WalletHasPrivateKey(pwalletMain);
-    }
-
-    if (auto beacon_option = m_researcher->TryPendingBeacon()) {
-        pending_beacon.reset(new Beacon(std::move(*beacon_option)));
-        beacon_key_present = pending_beacon->WalletHasPrivateKey(pwalletMain);
-    }
-
-    BeaconStatus beacon_status;
-
-    if (beacon_key_present) {
-        beacon_status = MapAdvertiseBeaconError(m_researcher->BeaconError());
-    } else if (!beacon && !pending_beacon) {
-        beacon_status = BeaconStatus::NO_BEACON;
-    } else {
-        beacon_status = BeaconStatus::ERROR_MISSING_KEY;
-    }
-
-    if (beacon_status != BeaconStatus::ACTIVE) {
-        commitBeacon(beacon_status, beacon, pending_beacon);
-    } else if (pending_beacon) {
-        commitBeacon(BeaconStatus::PENDING, beacon, pending_beacon);
-    } else if (beacon) {
-        const int64_t now = GetAdjustedTime();
-
-        if (beacon->Expired(now + BEACON_RENEWAL_WARNING_THRESHOLD)) {
-            commitBeacon(BeaconStatus::RENEWAL_NEEDED, beacon, pending_beacon);
-        } else if (beacon->Renewable(now)) {
-            commitBeacon(BeaconStatus::RENEWAL_POSSIBLE, beacon, pending_beacon);
-        } else if (m_researcher->Magnitude() == 0) {
-            commitBeacon(BeaconStatus::NO_MAGNITUDE, beacon, pending_beacon);
-        } else {
-            commitBeacon(BeaconStatus::ACTIVE, beacon, pending_beacon);
-        }
-    }
+    // Beacon state lives in the snapshot; refetch (blocking — beacon changes are
+    // infrequent) and repaint the beacon display.
+    m_snapshot = m_researcher_context.snapshot();
 
     emit beaconChanged();
     emit researcherChanged();
@@ -825,48 +502,26 @@ void ResearcherModel::updateBeacon()
 
 BeaconStatus ResearcherModel::advertiseBeacon()
 {
-    const AdvertiseBeaconResult result = m_researcher->AdvertiseBeacon();
-
-    return MapAdvertiseBeaconError(result.Error());
+    return m_researcher_context.advertiseBeacon().status;
 }
 
 bool ResearcherModel::isV14Enabled() const
 {
-    LOCK(cs_main);
-    return IsV14Enabled(nBestHeight);
+    return m_snapshot.is_v14_enabled;
 }
 
 bool ResearcherModel::hasV3CapableProjects() const
 {
-    return !GetProjectsWithOwnershipProofSupport().empty();
+    return m_researcher_context.hasV3CapableProjects();
 }
 
 std::vector<std::pair<QString, QString>> ResearcherModel::buildV3ProjectList() const
 {
-    const std::set<std::string> v3_urls = GetProjectsWithOwnershipProofSupport();
-
-    if (v3_urls.empty()) {
-        return {};
-    }
-
-    const WhitelistSnapshot whitelist = GetWhitelist().Snapshot(
-        ProjectEntry::ProjectFilterFlag::ALL_BUT_DELETED);
-
     std::vector<std::pair<QString, QString>> result;
 
-    for (const auto& project : whitelist) {
-        std::string base_url = project.BaseUrl();
-
-        // Normalize: ensure trailing slash for comparison.
-        if (!base_url.empty() && base_url.back() != '/') {
-            base_url += '/';
-        }
-
-        if (v3_urls.count(base_url) > 0) {
-            result.emplace_back(
-                QString::fromStdString(project.DisplayName()),
-                QString::fromStdString(project.DisplayUrl()));
-        }
+    for (const auto& project : m_researcher_context.v3CapableProjects()) {
+        result.emplace_back(QString::fromStdString(project.name),
+                            QString::fromStdString(project.url));
     }
 
     return result;
@@ -874,20 +529,12 @@ std::vector<std::pair<QString, QString>> ResearcherModel::buildV3ProjectList() c
 
 QString ResearcherModel::generateBeaconKeyForV3()
 {
-    const CpidOption cpid = m_researcher->Id().TryCpid();
+    const std::string public_key_hex = m_researcher_context.generateBeaconKeyForV3();
 
-    // The wizard flow requires a CPID before reaching the beacon page, so
-    // this is not reachable in practice. Defensive check only.
-    if (!cpid) {
-        return QString();
-    }
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    AdvertiseBeaconResult result = GenerateBeaconKey(*cpid);
-
-    if (auto public_key = result.TryPublicKey()) {
-        m_cached_beacon_pubkey_hex = QString::fromStdString(HexStr(*public_key));
+    // Only cache on success (non-empty), matching the former model: a failed
+    // regeneration must not clear a previously generated key.
+    if (!public_key_hex.empty()) {
+        m_cached_beacon_pubkey_hex = QString::fromStdString(public_key_hex);
         return m_cached_beacon_pubkey_hex;
     }
 
@@ -896,64 +543,7 @@ QString ResearcherModel::generateBeaconKeyForV3()
 
 BeaconStatus ResearcherModel::advertiseBeaconV3(const QString& ownership_proof_xml)
 {
-    const CpidOption cpid = m_researcher->Id().TryCpid();
-
-    if (!cpid) {
-        return BeaconStatus::NO_CPID;
-    }
-
-    const std::string xml = ownership_proof_xml.toStdString();
-
-    const std::string master_url = TrimString(ExtractXML(xml, "<master_url>", "</master_url>"));
-    const std::string msg = TrimString(ExtractXML(xml, "<msg>", "</msg>"));
-    const std::string sig_b64 = TrimString(ExtractXML(xml, "<signature>", "</signature>"));
-
-    if (master_url.empty() || msg.empty() || sig_b64.empty()) {
-        return BeaconStatus::ERROR_INVALID_PROOF_XML;
-    }
-
-    // Parse the msg field: "{account_id} {beacon_public_key_hex}"
-    const size_t space_pos = msg.find(' ');
-
-    if (space_pos == std::string::npos || space_pos + 1 >= msg.size()) {
-        return BeaconStatus::ERROR_INVALID_PROOF_XML;
-    }
-
-    uint32_t account_id = 0;
-    if (!ParseUInt32(msg.substr(0, space_pos), &account_id) || account_id == 0) {
-        return BeaconStatus::ERROR_INVALID_PROOF_XML;
-    }
-
-    const std::string public_key_hex = msg.substr(space_pos + 1);
-    const std::vector<uint8_t> pubkey_bytes = ParseHex(public_key_hex);
-    CPubKey beacon_pubkey(pubkey_bytes);
-
-    if (!beacon_pubkey.IsValid()) {
-        return BeaconStatus::ERROR_INVALID_PROOF_XML;
-    }
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    if (!pwalletMain->HaveKey(beacon_pubkey.GetID())) {
-        return BeaconStatus::ERROR_MISSING_KEY;
-    }
-
-    bool b64_invalid = false;
-    const std::vector<uint8_t> rsa_sig_bytes = DecodeBase64(sig_b64.c_str(), &b64_invalid);
-
-    if (b64_invalid || rsa_sig_bytes.empty()) {
-        return BeaconStatus::ERROR_INVALID_PROOF_XML;
-    }
-
-    Beacon beacon(beacon_pubkey);
-    OwnershipProof proof;
-    proof.m_master_url = master_url;
-    proof.m_account_id = account_id;
-    proof.m_rsa_signature = rsa_sig_bytes;
-
-    AdvertiseBeaconResult result = SendBeaconContractV3(*cpid, beacon, std::move(proof));
-
-    return MapAdvertiseBeaconError(result.Error());
+    return m_researcher_context.advertiseBeaconV3(ownership_proof_xml.toStdString()).status;
 }
 
 QString ResearcherModel::cachedBeaconPubKeyHex() const
@@ -969,51 +559,29 @@ void ResearcherModel::onWizardClose()
 
 void ResearcherModel::subscribeToCoreSignals()
 {
-    // Connect signals to client, retaining each connection so it is severed in
-    // unsubscribeFromCoreSignals() (from ~ResearcherModel). Every callback below
-    // captures `this`; a signal firing after this object is gone would otherwise
-    // invoke a slot on freed memory.
-    m_handlers.emplace_back(uiInterface.ResearcherChanged_connect(std::bind(ResearcherChanged, this)));
-    m_handlers.emplace_back(uiInterface.AccrualChangedFromStakeOrMRC_connect(std::bind(AccrualChangedFromStakeOrMRC, this)));
-    m_handlers.emplace_back(uiInterface.BeaconChanged_connect(std::bind(BeaconChanged, this)));
-    m_handlers.emplace_back(uiInterface.NotifyBlocksChanged_connect(std::bind(NotifyBlocksChangedForResearcher, this,
-                                                     std::placeholders::_1, std::placeholders::_2,
-                                                     std::placeholders::_3, std::placeholders::_4)));
+    // Subscribe to the interface notifications, retaining each handler so it is
+    // severed in unsubscribeFromCoreSignals() (from ~ResearcherModel). The
+    // callbacks fire on a core thread, so each marshals to the GUI thread via a
+    // queued invocation of the matching slot; a signal firing after this object
+    // is gone would otherwise touch freed memory (issue #3129).
+    m_handlers.emplace_back(m_researcher_context.handleResearcherChanged(
+        [this]() { QMetaObject::invokeMethod(this, "onResearcherChanged", Qt::QueuedConnection); }));
+
+    m_handlers.emplace_back(m_researcher_context.handleBeaconChanged(
+        [this]() { QMetaObject::invokeMethod(this, "updateBeacon", Qt::QueuedConnection); }));
+
+    m_handlers.emplace_back(m_researcher_context.handleAccrualChanged(
+        [this]() { QMetaObject::invokeMethod(this, "refresh", Qt::QueuedConnection); }));
+
+    m_handlers.emplace_back(m_researcher_context.handleBlocksChanged(
+        [this](bool, int, int64_t, uint32_t) {
+            QMetaObject::invokeMethod(this, "refresh", Qt::QueuedConnection);
+        }));
 }
 
 void ResearcherModel::unsubscribeFromCoreSignals()
 {
-    // Disconnect signals from client: clearing the retained connections runs
-    // each scoped_connection's destructor, which disconnects it (issue #3129).
+    // Clearing the retained handlers runs each Handler's destructor, which
+    // disconnects it (issue #3129).
     m_handlers.clear();
-}
-
-void ResearcherModel::commitBeacon(const BeaconStatus beacon_status)
-{
-    std::unique_ptr<Beacon> current_beacon;
-    std::unique_ptr<Beacon> pending_beacon;
-    commitBeacon(beacon_status, current_beacon, pending_beacon);
-}
-
-void ResearcherModel::commitBeacon(
-    const BeaconStatus beacon_status,
-    std::unique_ptr<Beacon>& current_beacon,
-    std::unique_ptr<Beacon>& pending_beacon)
-{
-    const auto beacon_changed = [](const Beacon* const a, const Beacon* const b) {
-        return (a && b && a->m_timestamp != b->m_timestamp) || (a && !b) || (!a && b);
-    };
-
-    const bool changed = beacon_status != m_beacon_status
-        || beacon_changed(current_beacon.get(), m_beacon.get())
-        || beacon_changed(pending_beacon.get(), m_pending_beacon.get());
-
-    m_beacon_status = beacon_status;
-    m_beacon = std::move(current_beacon);
-    m_pending_beacon = std::move(pending_beacon);
-
-    if (changed) {
-        emit beaconChanged();
-        emit researcherChanged();
-    }
 }

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -11,6 +11,7 @@
 #include "qt/researcher/researcherwizard.h"
 
 #include <QApplication>
+#include <QDateTime>
 #include <QIcon>
 #include <QMessageBox>
 
@@ -319,7 +320,13 @@ QString ResearcherModel::formatBeaconAge() const
         return QString();
     }
 
-    return GUIUtil::formatDurationStr(m_snapshot.beacon_age);
+    // Compute the age live from the beacon timestamp so the 60s beacon-tooltip
+    // timer ticks between snapshot refreshes (the former model recomputed
+    // Beacon::Age() on each call). Local wall-clock time is used rather than the
+    // node's network-adjusted time; the difference is at most a few seconds and
+    // invisible at formatDurationStr's granularity.
+    const int64_t age = QDateTime::currentSecsSinceEpoch() - m_snapshot.beacon_timestamp;
+    return GUIUtil::formatDurationStr(age);
 }
 
 QString ResearcherModel::formatTimeToBeaconExpiration() const
@@ -328,7 +335,12 @@ QString ResearcherModel::formatTimeToBeaconExpiration() const
         return QString();
     }
 
-    return GUIUtil::formatDurationStr(m_snapshot.time_to_beacon_expiration);
+    // Recompute the remaining time live for the same reason. The beacon's max age
+    // is constant, recovered here as (snapshot age + snapshot remaining) so no
+    // core constant has to cross the interface boundary.
+    const int64_t max_age = m_snapshot.beacon_age + m_snapshot.time_to_beacon_expiration;
+    const int64_t age = QDateTime::currentSecsSinceEpoch() - m_snapshot.beacon_timestamp;
+    return GUIUtil::formatDurationStr(max_age - age);
 }
 
 QString ResearcherModel::formatTimeToPendingBeaconExpiration() const

--- a/src/qt/researcher/researchermodel.h
+++ b/src/qt/researcher/researchermodel.h
@@ -1,18 +1,20 @@
-// Copyright (c) 2014-2025 The Gridcoin developers
+// Copyright (c) 2014-2026 The Gridcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #ifndef GRIDCOIN_QT_RESEARCHER_RESEARCHERMODEL_H
 #define GRIDCOIN_QT_RESEARCHER_RESEARCHERMODEL_H
 
+#include "amount.h"
+#include "interfaces/researcher.h"
+
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
-#include <boost/signals2/connection.hpp>
-#include "amount.h"
+
 #include <QObject>
 #include <QString>
-#include <optional>
 
 QT_BEGIN_NAMESPACE
 class QIcon;
@@ -21,37 +23,14 @@ QT_END_NAMESPACE
 class ResearcherWizard;
 class WalletModel;
 
-namespace GRC {
-class Beacon;
-class Researcher;
-
-//!
-//! \brief A smart pointer around the global BOINC researcher context.
-//!
-typedef std::shared_ptr<Researcher> ResearcherPtr;
-}
-
 //!
 //! \brief Describes the researcher's current beacon status.
 //!
-enum class BeaconStatus
-{
-    ACTIVE,
-    ERROR_INSUFFICIENT_FUNDS,
-    ERROR_MISSING_KEY,
-    ERROR_NOT_NEEDED,
-    ERROR_TX_FAILED,
-    ERROR_INVALID_PROOF_XML,
-    ERROR_WALLET_LOCKED,
-    NO_BEACON,
-    NO_CPID,
-    NO_MAGNITUDE,
-    PENDING,
-    RENEWAL_NEEDED,
-    RENEWAL_POSSIBLE,
-    ALREADY_IN_MEMPOOL,
-    UNKNOWN,
-};
+//! The enumeration now lives in the interfaces layer (Phase 1d-iv) so the node
+//! side can classify it; this alias keeps the existing GUI references
+//! (\c BeaconStatus::ACTIVE, etc.) unchanged.
+//!
+using BeaconStatus = interfaces::BeaconStatus;
 
 //!
 //! \brief Combined information about a BOINC project to display in a table.
@@ -61,6 +40,10 @@ enum class BeaconStatus
 //!  - The Gridcoin whitelist
 //!  - Local BOINC projects detected in client_state.xml
 //!  - Scraper magnitude values for a CPID
+//!
+//! The fusion is performed node-side by interfaces::ResearcherContext::projects();
+//! ResearcherModel maps each interfaces::ResearcherProjectRow into one of these Qt
+//! rows (translating the whitelist status and error label).
 //!
 class ProjectRow
 {
@@ -86,12 +69,18 @@ public:
 //!
 //! \brief Presents researcher context state for UI components.
 //!
+//! Backed by an interfaces::ResearcherContext (Phase 1d-iv): the model caches a
+//! value ResearcherSnapshot refreshed on the researcher/beacon/accrual/tip
+//! notifications, and every getter reads that snapshot instead of a
+//! GRC::Researcher / GRC::Beacon. Beacon/mode operations and the project-table
+//! fusion run node-side behind the interface.
+//!
 class ResearcherModel : public QObject
 {
     Q_OBJECT
 
 public:
-    ResearcherModel();
+    explicit ResearcherModel(interfaces::ResearcherContext& researcher_context);
     ~ResearcherModel();
 
     static QString mapBeaconStatus(const BeaconStatus status);
@@ -110,7 +99,7 @@ public:
     bool hasActiveBeacon() const;
 
     //!
-    //! \brief hasPendingBeacon returns true if m_pending_beacon is not null and also not expired while pending.
+    //! \brief hasPendingBeacon returns true if a pending beacon is present and also not expired while pending.
     //! \return boolean
     //!
     bool hasPendingBeacon() const;
@@ -151,14 +140,13 @@ public:
     QString cachedBeaconPubKeyHex() const;
 
 private:
-    GRC::ResearcherPtr m_researcher;
-    std::unique_ptr<GRC::Beacon> m_beacon;
-    std::unique_ptr<GRC::Beacon> m_pending_beacon;
-    BeaconStatus m_beacon_status;
-    bool m_configured_for_noncruncher_mode;
+    interfaces::ResearcherContext& m_researcher_context;
+
+    //! Cached value snapshot of the researcher/beacon context. Refreshed on the
+    //! interface notifications (and by the wizard commands); every getter reads it.
+    interfaces::ResearcherSnapshot m_snapshot;
+
     bool m_wizard_open;
-    bool m_out_of_sync;
-    bool m_split_cpid;
     bool m_privacy_enabled;
     QString m_theme_suffix;
     QString m_cached_beacon_pubkey_hex;
@@ -166,16 +154,14 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
-    //! Retained core-signal connections, cleared on teardown so a signal that
-    //! fires after this model is destroyed cannot invoke a slot bound to freed
-    //! memory. scoped_connection disconnects on destruction (issue #3129).
-    std::vector<boost::signals2::scoped_connection> m_handlers;
+    //! Retained interface-notification handlers, cleared on teardown so a signal
+    //! that fires after this model is destroyed cannot invoke a slot bound to
+    //! freed memory (issue #3129).
+    std::vector<std::unique_ptr<interfaces::Handler>> m_handlers;
 
-    void commitBeacon(const BeaconStatus beacon_status);
-    void commitBeacon(
-        const BeaconStatus beacon_status,
-        std::unique_ptr<GRC::Beacon>& current_beacon,
-        std::unique_ptr<GRC::Beacon>& pending_beacon);
+    //! Map one node-side project row into a Qt ProjectRow, translating the
+    //! whitelist status and resolving the (translatable) error label.
+    ProjectRow mapProjectRow(const interfaces::ResearcherProjectRow& src) const;
 
 signals:
     void researcherChanged();
@@ -186,7 +172,7 @@ signals:
 public slots:
     void reload();
     void refresh();
-    void resetResearcher(GRC::ResearcherPtr researcher);
+    void onResearcherChanged();
     bool switchToSolo(const QString& email);
     bool switchToPool();
     bool switchToNoncruncher();

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -3,9 +3,9 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "amount.h"
-#include "gridcoin/project.h"
 #include "gridcoin/voting/poll.h"
 #include "interfaces/handler.h"
+#include "interfaces/researcher.h"
 #include "interfaces/voting.h"
 #include "logging.h"
 #include "optionsmodel.h"
@@ -95,10 +95,12 @@ PollItem MapToPollItem(const interfaces::PollTableItem& src)
 
 VotingModel::VotingModel(
     interfaces::VotingManager& voting_manager,
+    interfaces::ResearcherContext& researcher_context,
     ClientModel& client_model,
     OptionsModel& options_model,
     WalletModel& wallet_model)
     : m_voting(voting_manager)
+    , m_researcher_context(researcher_context)
     , m_client_model(client_model)
     , m_options_model(options_model)
     , m_wallet_model(wallet_model)
@@ -186,22 +188,22 @@ int VotingModel::maxPollAdditionalFieldValueLength()
     return Poll::AdditionalField::MAX_VALUE_SIZE;
 }
 
-int VotingModel::maxPollProjectNameLength()
+int VotingModel::maxPollProjectNameLength() const
 {
     // Not strictly accurate: the protocol limits the max length in bytes, but
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Project::MAX_NAME_SIZE;
+    return m_researcher_context.maxProjectNameLength();
 }
 
-int VotingModel::maxPollProjectUrlLength()
+int VotingModel::maxPollProjectUrlLength() const
 {
     // Not strictly accurate: the protocol limits the max length in bytes, but
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Project::MAX_URL_SIZE;
+    return m_researcher_context.maxProjectUrlLength();
 }
 
 OptionsModel& VotingModel::getOptionsModel()
@@ -220,8 +222,10 @@ QStringList VotingModel::getActiveProjectNames() const
 {
     QStringList names;
 
-    for (const auto& project : GetWhitelist().Snapshot().Sorted()) {
-        names << QString::fromStdString(project.m_name);
+    // The whitelist read moved node-side (Phase 1d-iv); whitelistProjects()
+    // preserves the former ACTIVE-filter, Sorted(), raw-m_name semantics.
+    for (const auto& project : m_researcher_context.whitelistProjects()) {
+        names << QString::fromStdString(project.name);
     }
 
     return names;
@@ -231,8 +235,8 @@ QStringList VotingModel::getActiveProjectUrls() const
 {
     QStringList Urls;
 
-    for (const auto& project : GetWhitelist().Snapshot().Sorted()) {
-        Urls << QString::fromStdString(project.m_url);
+    for (const auto& project : m_researcher_context.whitelistProjects()) {
+        Urls << QString::fromStdString(project.url);
     }
 
     return Urls;

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -22,6 +22,7 @@
 
 namespace interfaces {
 class Handler;
+class ResearcherContext;
 class VotingManager;
 } // namespace interfaces
 
@@ -142,6 +143,7 @@ class VotingModel : public QObject
 public:
     VotingModel(
         interfaces::VotingManager& voting_manager,
+        interfaces::ResearcherContext& researcher_context,
         ClientModel& client_model,
         OptionsModel& options_model,
         WalletModel& wallet_model);
@@ -155,8 +157,10 @@ public:
     static int maxPollChoiceLabelLength();
     static int maxPollAdditionalFieldNameLength();
     static int maxPollAdditionalFieldValueLength();
-    static int maxPollProjectNameLength();
-    static int maxPollProjectUrlLength();
+    // Non-static (unlike the other max* limits): these read GRC::Project field
+    // sizes through the researcher interface rather than gridcoin/project.h.
+    int maxPollProjectNameLength() const;
+    int maxPollProjectUrlLength() const;
 
     OptionsModel& getOptionsModel();
     QString getCurrentPollTitle() const;
@@ -204,6 +208,12 @@ private:
     //! result cache, poll/vote submission, and the new-poll / new-vote
     //! notifications. Owned by the process and outlives this model.
     interfaces::VotingManager& m_voting;
+
+    //! The researcher/beacon boundary (Phase 1d-iv). Used here only for the poll
+    //! wizard's active-project pickers (getActiveProjectNames/getActiveProjectUrls),
+    //! which read the whitelist through it. Owned by the process; outlives this model.
+    interfaces::ResearcherContext& m_researcher_context;
+
     ClientModel& m_client_model;
     OptionsModel& m_options_model;
     WalletModel& m_wallet_model;

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -100,19 +100,6 @@ src/qt/psgtpooltablemodel.cpp:wallet/wallet.h
 src/qt/psgtpooltablemodel.h:node/psgt_pool.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/qtipcserver.cpp:util.h
-src/qt/researcher/projecttablemodel.cpp:gridcoin/researcher.h
-src/qt/researcher/researchermodel.cpp:chainparams.h
-src/qt/researcher/researchermodel.cpp:gridcoin/beacon.h
-src/qt/researcher/researchermodel.cpp:gridcoin/boinc.h
-src/qt/researcher/researchermodel.cpp:gridcoin/magnitude.h
-src/qt/researcher/researchermodel.cpp:gridcoin/project.h
-src/qt/researcher/researchermodel.cpp:gridcoin/quorum.h
-src/qt/researcher/researchermodel.cpp:gridcoin/researcher.h
-src/qt/researcher/researchermodel.cpp:gridcoin/scraper/scraper.h
-src/qt/researcher/researchermodel.cpp:gridcoin/superblock.h
-src/qt/researcher/researchermodel.cpp:gridcoin/support/xml.h
-src/qt/researcher/researchermodel.cpp:main.h
-src/qt/researcher/researchermodel.cpp:node/ui_interface.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
 src/qt/rpcconsole.cpp:banman.h
 src/qt/rpcconsole.cpp:rpc/client.h
@@ -133,7 +120,6 @@ src/qt/voting/polltablemodel.cpp:util.h
 src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
 src/qt/voting/poll_types.cpp:gridcoin/voting/poll.h
 src/qt/voting/pollwizarddetailspage.cpp:main.h
-src/qt/voting/votingmodel.cpp:gridcoin/project.h
 src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
 src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
 src/qt/voting/votingmodel.h:gridcoin/voting/poll.h


### PR DESCRIPTION
## Phase 1d-iv — Researcher / Beacon / Scraper interface migration

Part of the multiprocess GUI/node separation (RFC #2937), following #3167 (1d-iii Voting). Migrates `ResearcherModel` off direct core globals onto a new `interfaces::ResearcherContext`. The survey confirmed this is really a **`ResearcherModel` migration**: beacon access is entirely inside that model, the scraper was ~90% migrated in 1c (only `buildProjectTable`'s excluded-projects read remained), and the whitelist accessors deferred from 1d-iii live here too — so one boundary covers all three.

### What moves node-side
- **Snapshot** — `ResearcherModel` caches a value `ResearcherSnapshot` (identity / magnitude / accrual / mode / beacon status, with the beacon epochs as Unix seconds) refreshed on the researcher/beacon/accrual/tip notifications. Every getter reads the snapshot; the model holds no `GRC::Researcher` / `GRC::Beacon`. `BeaconStatus` now lives in `interfaces::` (the GUI aliases it).
- **Project table** — the four-source fusion (`Researcher::Projects` + whitelist + `Quorum::ExplainMagnitude` + scraper `vExcludedProjects`) runs node-side in `projects()`; the GUI maps value rows to its Qt `ProjectRow`. This absorbs the **last raw scraper read** (`ConvergedScraperStatsCache`) off the GUI.
- **Beacon commands** — `advertiseBeacon`, `generateBeaconKeyForV3`, `advertiseBeaconV3` (the `LOCK2(cs_main, cs_wallet)` / `SendBeaconContractV3` ownership-proof paths), and the SOLO/POOL/NONCRUNCHER mode switches.
- **Whitelist (decision A)** — `whitelistProjects()` + `maxProject{Name,Url}Length()` back `VotingModel`'s poll-wizard project pickers, closing the last 1d-iii ratchet loose end: `votingmodel.cpp` no longer includes `gridcoin/project.h`.

### Snapshot locking
`snapshot()` blocks on `cs_main`; `trySnapshot()` uses `TRY_LOCK(cs_main)` and bows out on contention (preserving the former `refresh()`'s non-blocking per-block behaviour so the GUI thread never stalls during catch-up); `outOfSync()` is lock-free. The whole snapshot is built under one `cs_main` hold for a consistent tip. The `ResearcherChanged` marshal is now payload-free — the `GRC::ResearcherPtr` no longer crosses the boundary.

### Ratchet
Removes **14** `lint-qt-includes` allowlist entries: the 12 `researchermodel.cpp` core includes, the `votingmodel.cpp:gridcoin/project.h` entry, and a stale `projecttablemodel.cpp:gridcoin/researcher.h` include.

### Testing
- Qt6 (`-DUSE_QT6=ON`) GUI build clean; `ctest` — `gridcoin_tests`, `gridcoin_qt_tests`, `functional_tests` all pass.
- `lint-all.sh` clean (including the qt-includes ratchet).
- Self-reviewed (adversarial pass); mesh soak to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
