### PR TITLE
gui: route core-init readiness through interfaces::Init (Phase 1e-a)

### DIFF
--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -18,6 +18,8 @@ namespace interfaces {
 
 Init::~Init() = default;
 
+bool Init::isCoreReady() { return true; }
+
 std::unique_ptr<Node> Init::makeNode() { return nullptr; }
 
 std::unique_ptr<StakingStatus> Init::makeStakingStatus() { return nullptr; }

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -35,6 +35,12 @@ class Init
 public:
     virtual ~Init();
 
+    //! Whether core initialization (ThreadAppInit2 / AppInit2) has completed. The
+    //! GUI polls this while pumping its event loop, instead of reading the raw
+    //! bGridcoinCoreInitComplete global; a Stage-2 IPC readiness handshake later
+    //! replaces the poll. The default (no core to wait on) reports ready.
+    virtual bool isCoreReady();
+
     //! The defaults return nullptr and are defined out of line (init.cpp):
     //! inline definitions would require every includer to see the complete
     //! interface types just to instantiate the unique_ptr deleters.

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -34,6 +34,7 @@
 // The converged scraper stats cache has no header declaration; every consumer
 // declares the extern locally (quorum.cpp, scraper_net.cpp, rpc/blockchain.cpp).
 extern ConvergedScraperStats ConvergedScraperStatsCache;
+extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 namespace interfaces {
 namespace {
@@ -185,6 +186,8 @@ public:
 class InitImpl : public Init
 {
 public:
+    bool isCoreReady() override { return bGridcoinCoreInitComplete; }
+
     std::unique_ptr<Node> makeNode() override { return MakeNode(); }
 
     std::unique_ptr<StakingStatus> makeStakingStatus() override { return MakeStakingStatus(); }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -186,7 +186,7 @@ public:
 class InitImpl : public Init
 {
 public:
-    bool isCoreReady() override { return bGridcoinCoreInitComplete; }
+    bool isCoreReady() override { return bGridcoinCoreInitComplete.load(); }
 
     std::unique_ptr<Node> makeNode() override { return MakeNode(); }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -82,7 +82,6 @@ Q_IMPORT_PLUGIN(QSvgIconPlugin);
 #endif
 
 extern bool fQtActive;
-extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;
@@ -639,8 +638,15 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
         }
         else
         {
+            // The monolithic-build interface implementations the models consume
+            // core state through (doc/multiprocess_design.md). Created here, before
+            // the readiness wait, so the GUI polls interface_init->isCoreReady()
+            // rather than the raw bGridcoinCoreInitComplete global; it outlives
+            // every model constructed below.
+            std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
+
              //10-31-2015
-            while (!bGridcoinCoreInitComplete)
+            while (!interface_init->isCoreReady())
             {
                 app.processEvents();
 
@@ -654,13 +660,9 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 splash.finish(&window);
 
             if (!fRequestShutdown) {
-                // Put this in a block, so that the Model objects are cleaned up before
-                // calling Shutdown().
-
-                // The monolithic-build interface implementations the models
-                // consume core state through (doc/multiprocess_design.md).
-                // These must outlive every model constructed below.
-                std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
+                // Put this in a block, so that the Model objects are cleaned up
+                // before calling Shutdown(). interface_init (created above, ahead
+                // of the readiness wait) outlives every model constructed here.
                 std::unique_ptr<interfaces::Node> node = interface_init->makeNode();
                 std::unique_ptr<interfaces::StakingStatus> staking_status = interface_init->makeStakingStatus();
                 // Wallet startup completed above, so pwalletMain is set and

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -638,11 +638,12 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
         }
         else
         {
-            // The monolithic-build interface implementations the models consume
-            // core state through (doc/multiprocess_design.md). Created here, before
-            // the readiness wait, so the GUI polls interface_init->isCoreReady()
-            // rather than the raw bGridcoinCoreInitComplete global; it outlives
-            // every model constructed below.
+            // The monolithic-build interface implementations that the models
+            // consume core state through (doc/multiprocess_design.md). Created
+            // here, before the readiness wait, so the GUI polls
+            // interface_init->isCoreReady() rather than the raw
+            // bGridcoinCoreInitComplete global; it outlives every model
+            // constructed below.
             std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
 
              //10-31-2015


### PR DESCRIPTION
## Phase 1e-a — core-init readiness through interfaces::Init

Part of the multiprocess GUI/node separation (RFC #2937). First of the 1e (composition-root cleanup) sub-items.

`StartGridcoinQt` polled the raw `bGridcoinCoreInitComplete` global in a spin loop to know when core init (`ThreadAppInit2` → `AppInit2`) finished. This routes that readiness check through the interface layer:

- Adds `interfaces::Init::isCoreReady()` — the node `InitImpl` override returns the `bGridcoinCoreInitComplete` atomic; the base default reports ready (never hit in the monolith, since `MakeGridcoinInit()` returns `InitImpl`).
- `interface_init` is now created **before** the readiness loop (it already had to be constructed to build the models; it just moves up), and the loop polls `interface_init->isCoreReady()`.
- The local `extern std::atomic<bool> bGridcoinCoreInitComplete;` is dropped from `bitcoin.cpp`.

### What deliberately does NOT change
- The GUI keeps its `processEvents()` + 100 ms sleep pump **on the GUI thread** — a blocking readiness call would freeze the UI during init. Only the readiness *read* moves behind the interface; this is the seam a Stage-2 IPC readiness handshake later replaces.
- `interface_init` now lives in the enclosing scope and still outlives every model constructed in the `if (!fRequestShutdown)` block.
- **Untouched:** the snapshot/reset request→teardown→restart cycle (`fSnapshotRequest`/`fResetBlockchainRequest`) and the `-snapshotdownload` / `-resetblockchaindata` CLI paths — a high-blast-radius subsystem kept strictly out of 1e's scope.

### Testing
- Qt6 GUI build clean; `lint-all.sh` clean.
- Behavior-preserving: the poll reads the same atomic via the interface; init/shutdown sequencing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
