### PR TITLE
gui: route bitcoingui residual core reaches through interfaces (Phase 1e-b)

### DIFF
--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -82,6 +82,8 @@ public:
 
     std::string getErrors() override { return g_miner_status.FormatErrors(); }
 
+    double getCoinWeight() override { return g_miner_status.GetSearchReport().CoinWeight(); }
+
     double getNetworkWeight() override
     {
         LOCK(cs_main);
@@ -1859,6 +1861,41 @@ public:
         }
         LOCK(m_wallet->cs_wallet);
         return PSGTSignedBy(*m_wallet, psgt);
+    }
+
+    bool walletMustSignRevision(const std::string& revision_hex) override
+    {
+        uint256 revision;
+        revision.SetHex(revision_hex);
+
+        const auto entry = g_psgt_pool.GetByRevision(revision);
+        if (!entry) {
+            return false;
+        }
+
+        // Already signed by this wallet? Then there is nothing to prompt for.
+        if (WITH_LOCK(m_wallet->cs_wallet, return PSGTSignedBy(*m_wallet, entry->psgt))) {
+            return false;
+        }
+
+        // Does the wallet hold one of the multisig arrangement's keys?
+        txnouttype script_type;
+        std::vector<std::vector<unsigned char>> solutions;
+        if (entry->psgt.inputs.empty()
+            || !Solver(entry->psgt.inputs[0].redeem_script, script_type, solutions)
+            || script_type != TX_MULTISIG) {
+            return false;
+        }
+
+        LOCK(m_wallet->cs_wallet);
+        for (unsigned int i = 1; i + 1 < solutions.size(); ++i) {
+            const CPubKey pubkey(solutions[i]);
+            if (pubkey.IsValid() && m_wallet->HaveKey(pubkey.GetID())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 private:

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -1865,6 +1865,11 @@ public:
 
     bool walletMustSignRevision(const std::string& revision_hex) override
     {
+        // Validate before SetHex, which silently maps malformed input to 0
+        // (mirrors TryImageFromHex above; a revision hash is a 32-byte uint256).
+        if (revision_hex.size() != 64 || !IsHex(revision_hex)) {
+            return false;
+        }
         uint256 revision;
         revision.SetHex(revision_hex);
 

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -18,6 +18,8 @@ namespace interfaces {
 
 Init::~Init() = default;
 
+bool Init::isCoreReady() { return true; }
+
 std::unique_ptr<Node> Init::makeNode() { return nullptr; }
 
 std::unique_ptr<StakingStatus> Init::makeStakingStatus() { return nullptr; }

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -35,6 +35,12 @@ class Init
 public:
     virtual ~Init();
 
+    //! Whether core initialization (ThreadAppInit2 / AppInit2) has completed. The
+    //! GUI polls this while pumping its event loop, instead of reading the raw
+    //! bGridcoinCoreInitComplete global; a Stage-2 IPC readiness handshake later
+    //! replaces the poll. The default (no core to wait on) reports ready.
+    virtual bool isCoreReady();
+
     //! The defaults return nullptr and are defined out of line (init.cpp):
     //! inline definitions would require every includer to see the complete
     //! interface types just to instantiate the unique_ptr deleters.

--- a/src/interfaces/psgt.h
+++ b/src/interfaces/psgt.h
@@ -289,6 +289,13 @@ public:
     //! Whether this wallet already contributed at least one valid signature
     //! (PSGTSignedBy) — the pool-submit precondition.
     virtual bool walletHasSignature(const PSGTBytes& psgt) = 0;
+
+    //! Whether the pool entry with this revision hash still needs a signature
+    //! from THIS wallet: the wallet holds one of the multisig arrangement's
+    //! keys and has not yet signed the entry. Gates the "signature requested"
+    //! toast. Returns false for an unknown revision, a non-multisig input, or
+    //! an entry this wallet has already signed.
+    virtual bool walletMustSignRevision(const std::string& revision_hex) = 0;
 };
 
 //! Return an in-process PSGTPoolContext over the global PSGT pool and the node's

--- a/src/interfaces/staking.h
+++ b/src/interfaces/staking.h
@@ -31,6 +31,12 @@ public:
     //! there is nothing to report).
     virtual std::string getErrors() = 0;
 
+    //! Coin weight of the UTXOs searched in the last miner cycle (since block
+    //! version 8, approximately the total GRC value of the staked UTXOs).
+    //! Non-blocking: MinerStatus guards its own state, so this takes no chain
+    //! lock.
+    virtual double getCoinWeight() = 0;
+
     //! Estimated network staking weight. Blocking: takes cs_main.
     virtual double getNetworkWeight() = 0;
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -211,6 +211,15 @@ public:
                                       const std::optional<WalletCoinControl>& coin_control,
                                       int64_t accepted_fee) = 0;
 
+    //! Back up the wallet .dat file to dest. Returns false on I/O failure.
+    virtual bool backupWallet(const std::string& dest) = 0;
+
+    //! Back up the active config file to dest. Returns false on I/O failure.
+    //! Paired with backupWallet in the GUI backup action; the config file
+    //! belongs to the same node, so it stays behind the wallet boundary
+    //! rather than requiring a separate node reach for one file copy.
+    virtual bool backupConfigFile(const std::string& dest) = 0;
+
     //! Register a handler for encryption/lock status changes.
     using StatusChangedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -34,6 +34,7 @@
 // The converged scraper stats cache has no header declaration; every consumer
 // declares the extern locally (quorum.cpp, scraper_net.cpp, rpc/blockchain.cpp).
 extern ConvergedScraperStats ConvergedScraperStatsCache;
+extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 namespace interfaces {
 namespace {
@@ -185,6 +186,8 @@ public:
 class InitImpl : public Init
 {
 public:
+    bool isCoreReady() override { return bGridcoinCoreInitComplete; }
+
     std::unique_ptr<Node> makeNode() override { return MakeNode(); }
 
     std::unique_ptr<StakingStatus> makeStakingStatus() override { return MakeStakingStatus(); }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -186,7 +186,7 @@ public:
 class InitImpl : public Init
 {
 public:
-    bool isCoreReady() override { return bGridcoinCoreInitComplete; }
+    bool isCoreReady() override { return bGridcoinCoreInitComplete.load(); }
 
     std::unique_ptr<Node> makeNode() override { return MakeNode(); }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -82,7 +82,6 @@ Q_IMPORT_PLUGIN(QSvgIconPlugin);
 #endif
 
 extern bool fQtActive;
-extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;
@@ -639,8 +638,15 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
         }
         else
         {
+            // The monolithic-build interface implementations the models consume
+            // core state through (doc/multiprocess_design.md). Created here, before
+            // the readiness wait, so the GUI polls interface_init->isCoreReady()
+            // rather than the raw bGridcoinCoreInitComplete global; it outlives
+            // every model constructed below.
+            std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
+
              //10-31-2015
-            while (!bGridcoinCoreInitComplete)
+            while (!interface_init->isCoreReady())
             {
                 app.processEvents();
 
@@ -654,13 +660,9 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 splash.finish(&window);
 
             if (!fRequestShutdown) {
-                // Put this in a block, so that the Model objects are cleaned up before
-                // calling Shutdown().
-
-                // The monolithic-build interface implementations the models
-                // consume core state through (doc/multiprocess_design.md).
-                // These must outlive every model constructed below.
-                std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
+                // Put this in a block, so that the Model objects are cleaned up
+                // before calling Shutdown(). interface_init (created above, ahead
+                // of the readiness wait) outlives every model constructed here.
                 std::unique_ptr<interfaces::Node> node = interface_init->makeNode();
                 std::unique_ptr<interfaces::StakingStatus> staking_status = interface_init->makeStakingStatus();
                 // Wallet startup completed above, so pwalletMain is set and

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -638,11 +638,12 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
         }
         else
         {
-            // The monolithic-build interface implementations the models consume
-            // core state through (doc/multiprocess_design.md). Created here, before
-            // the readiness wait, so the GUI polls interface_init->isCoreReady()
-            // rather than the raw bGridcoinCoreInitComplete global; it outlives
-            // every model constructed below.
+            // The monolithic-build interface implementations that the models
+            // consume core state through (doc/multiprocess_design.md). Created
+            // here, before the readiness wait, so the GUI polls
+            // interface_init->isCoreReady() rather than the raw
+            // bGridcoinCoreInitComplete global; it outlives every model
+            // constructed below.
             std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
 
              //10-31-2015

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -25,8 +25,7 @@
 #include "voting/votingpage.h"
 #include "psgtpoolpage.h"
 
-#include <node/psgt_pool.h>
-#include <script/standard.h>
+#include "interfaces/psgt.h"
 #include "clientmodel.h"
 #include "walletmodel.h"
 #include "researcher/researchermodel.h"
@@ -42,9 +41,7 @@
 #include "notificator.h"
 #include "guiutil.h"
 #include "rpcconsole.h"
-#include "wallet/wallet.h"
 #include "init.h"
-#include "main.h"
 #include "clicklabel.h"
 #include "upgradeqt.h"
 #include "voting/votingmodel.h"
@@ -90,13 +87,9 @@
 
 #include <boost/lexical_cast.hpp>
 
-#include "gridcoin/backup.h"
-#include "gridcoin/staking/difficulty.h"
-
 #include <boost/algorithm/string/join.hpp>
 #include "util.h"
 
-extern CWallet* pwalletMain;
 extern std::string FromQString(QString qs);
 
 BitcoinGUI::BitcoinGUI(QWidget* parent)
@@ -863,6 +856,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
 
 void BitcoinGUI::setPSGTPoolContext(interfaces::PSGTPoolContext *context)
 {
+    m_psgt_pool_context = context;
     psgtPoolPage->setPSGTPoolContext(context);
     multisignDialog->setPSGTPoolContext(context);
 }
@@ -1229,7 +1223,7 @@ void BitcoinGUI::setMinerStatus(
 #ifdef Q_OS_MAC
     if (staking) {
         m_app_nap_inhibitor->disableAppNap();
-    } else if (!OutOfSyncByAge()) {
+    } else if (!clientModel->node().isOutOfSyncByAge()) {
         m_app_nap_inhibitor->enableAppNap();
     }
 #endif
@@ -1445,10 +1439,10 @@ void BitcoinGUI::setPrivacy()
 
     clientModel->getOptionsModel()->setMaskValues(privacy_mode);
 
-    // Need to call updateMinerStatus from here to feed back in the Coin Weight to the overview screen.
+    // Need to refresh the miner status from here to feed back in the Coin Weight to the overview screen.
     // Not ideal, but the normal trigger to update the Staking fields on the overview screen normally come from
     // the core, not the GUI. Here the privacy state change is coming from the GUI.
-    clientModel->updateMinerStatus(g_miner_status.StakingActive(), g_miner_status.GetSearchReport().CoinWeight());
+    clientModel->refreshMinerStatus();
 }
 
 bool BitcoinGUI::tryQuit()
@@ -1684,35 +1678,11 @@ void BitcoinGUI::handlePSGTPoolChanged(QString revision_hash, quint8 change_type
     Q_UNUSED(reason);
 
     // Toast only for an entry that newly needs THIS wallet's signature.
-    if (change_type == CT_DELETED || !clientModel) {
+    if (change_type == CT_DELETED || !clientModel || !m_psgt_pool_context) {
         return;
     }
 
-    uint256 revision;
-    revision.SetHex(revision_hash.toStdString());
-    const auto entry = g_psgt_pool.GetByRevision(revision);
-    if (!entry || !pwalletMain) {
-        return;
-    }
-
-    const bool needs_me = WITH_LOCK(pwalletMain->cs_wallet,
-                                    return !PSGTSignedBy(*pwalletMain, entry->psgt))
-        && [&] {
-            // Wallet holds a key of the arrangement?
-            txnouttype script_type;
-            std::vector<std::vector<unsigned char>> vSolutions;
-            if (entry->psgt.inputs.empty()
-                || !Solver(entry->psgt.inputs[0].redeem_script, script_type, vSolutions)
-                || script_type != TX_MULTISIG) {
-                return false;
-            }
-            LOCK(pwalletMain->cs_wallet);
-            for (unsigned int i = 1; i + 1 < vSolutions.size(); ++i) {
-                const CPubKey pubkey(vSolutions[i]);
-                if (pubkey.IsValid() && pwalletMain->HaveKey(pubkey.GetID())) return true;
-            }
-            return false;
-        }();
+    const bool needs_me = m_psgt_pool_context->walletMustSignRevision(revision_hash.toStdString());
 
     if (needs_me && notificator) {
         notificator->notify(
@@ -1829,16 +1799,18 @@ void BitcoinGUI::encryptWallet()
 
 void BitcoinGUI::backupWallet()
 {
+    if (!walletModel) return;
+
     QString saveDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     QString walletfilename = QFileDialog::getSaveFileName(this, tr("Backup Wallet"), saveDir, tr("Wallet Data (*.dat)"));
     if(!walletfilename.isEmpty()) {
-        if(!GRC::BackupWallet(*pwalletMain, FromQString(walletfilename))) {
+        if(!walletModel->backupWallet(FromQString(walletfilename))) {
             QMessageBox::warning(this, tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."));
         }
     }
     QString configfilename = QFileDialog::getSaveFileName(this, tr("Backup Config"), saveDir, tr("Wallet Config (*.conf)"));
     if(!configfilename.isEmpty()) {
-        if(!GRC::BackupConfigFile(FromQString(configfilename))) {
+        if(!walletModel->backupConfigFile(FromQString(configfilename))) {
             QMessageBox::warning(this, tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."));
         }
     }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1440,7 +1440,7 @@ void BitcoinGUI::setPrivacy()
     clientModel->getOptionsModel()->setMaskValues(privacy_mode);
 
     // Need to refresh the miner status from here to feed back in the Coin Weight to the overview screen.
-    // Not ideal, but the normal trigger to update the Staking fields on the overview screen normally come from
+    // Not ideal, but the normal trigger to update the Staking fields on the overview screen normally comes from
     // the core, not the GUI. Here the privacy state change is coming from the GUI.
     clientModel->refreshMinerStatus();
 }
@@ -1811,7 +1811,7 @@ void BitcoinGUI::backupWallet()
     QString configfilename = QFileDialog::getSaveFileName(this, tr("Backup Config"), saveDir, tr("Wallet Config (*.conf)"));
     if(!configfilename.isEmpty()) {
         if(!walletModel->backupConfigFile(FromQString(configfilename))) {
-            QMessageBox::warning(this, tr("Backup Failed"), tr("There was an error trying to save the wallet data to the new location."));
+            QMessageBox::warning(this, tr("Backup Failed"), tr("There was an error trying to save the config file to the new location."));
         }
     }
 }

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -124,6 +124,7 @@ protected:
 private:
     ClientModel *clientModel;
     WalletModel *walletModel;
+    interfaces::PSGTPoolContext *m_psgt_pool_context = nullptr;
     ResearcherModel *researcherModel;
     MRCModel *m_mrc_model;
     VotingModel *votingModel;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -186,6 +186,14 @@ void ClientModel::updateMinerStatus(bool staking, double coin_weight)
     emit minerStatusChanged(staking, getNetWeight(), coin_weight, m_cached_etts_days);
 }
 
+void ClientModel::refreshMinerStatus()
+{
+    // Re-feed the current staking state and coin weight to the overview. Used
+    // when a GUI-side change (e.g. privacy mode) must refresh the staking
+    // fields that are normally pushed from the core via MinerStatusChanged.
+    updateMinerStatus(m_staking_status.isStaking(), m_staking_status.getCoinWeight());
+}
+
 void ClientModel::updateScraper(int scraperEventtype, int status, const QString message)
 {
     if (scraperEventtype == (int)scrapereventtypes::Log)

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -63,6 +63,11 @@ public:
     //! Get miner and staking status warnings
     QString getMinerWarnings() const;
 
+    //! Re-feed the current staking state and coin weight to the overview
+    //! (used when a GUI-side change, e.g. privacy mode, must refresh the
+    //! staking fields normally pushed from the core).
+    void refreshMinerStatus();
+
     QString formatFullVersion() const;
     QString clientName() const;
     QString formatClientStartupTime() const;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -420,6 +420,16 @@ bool WalletModel::changePassphrase(const SecureString &oldPass, const SecureStri
     return m_wallet.changeWalletPassphrase(oldPass, newPass);
 }
 
+bool WalletModel::backupWallet(const std::string& dest)
+{
+    return m_wallet.backupWallet(dest);
+}
+
+bool WalletModel::backupConfigFile(const std::string& dest)
+{
+    return m_wallet.backupConfigFile(dest);
+}
+
 // The tx-table producer-side handlers (NotifyTransactionChanged /
 // NotifyBlocksChangedForWallet) and their subscriptions moved node-side into
 // the WalletTxSource in Phase 1c-ii, so this model no longer touches the raw

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -136,6 +136,12 @@ public:
                          bool stakingOnly = false);
     bool changePassphrase(const SecureString& oldPass, const SecureString& newPass);
 
+    // Back up the wallet .dat / config file to dest (pass-throughs to the
+    // wallet interface, used by the GUI backup action). Return false on
+    // I/O failure.
+    bool backupWallet(const std::string& dest);
+    bool backupConfigFile(const std::string& dest);
+
     // RAI object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -4,6 +4,7 @@
 
 #include "interfaces/wallet.h"
 
+#include "gridcoin/backup.h"
 #include "gridcoin/tx_message.h"
 #include "interfaces/handler.h"
 #include "key_io.h"
@@ -125,6 +126,16 @@ public:
         LOCK(m_wallet->cs_wallet);
         m_wallet->Lock(); // Make sure wallet is locked before attempting pass change
         return m_wallet->ChangeWalletPassphrase(old_passphrase, new_passphrase);
+    }
+
+    bool backupWallet(const std::string& dest) override
+    {
+        return GRC::BackupWallet(*m_wallet, dest);
+    }
+
+    bool backupConfigFile(const std::string& dest) override
+    {
+        return GRC::BackupConfigFile(dest);
     }
 
     bool getPubKey(const CKeyID& address, CPubKey& pub_key_out) override

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -41,14 +41,8 @@ src/qt/bitcoin.cpp:policy/fees.h
 src/qt/bitcoin.cpp:txdb.h
 src/qt/bitcoin.cpp:util.h
 src/qt/bitcoin.cpp:validation.h
-src/qt/bitcoingui.cpp:gridcoin/backup.h
-src/qt/bitcoingui.cpp:gridcoin/staking/difficulty.h
 src/qt/bitcoingui.cpp:init.h
-src/qt/bitcoingui.cpp:main.h
-src/qt/bitcoingui.cpp:node/psgt_pool.h
-src/qt/bitcoingui.cpp:script/standard.h
 src/qt/bitcoingui.cpp:util.h
-src/qt/bitcoingui.cpp:wallet/wallet.h
 src/qt/coincontroldialog.cpp:policy/fees.h
 src/qt/coincontroldialog.cpp:policy/policy.h
 src/qt/coincontroldialog.cpp:validation.h


### PR DESCRIPTION
## Summary

Phase 1e-b of the GUI/node `interfaces::` migration (RFC #2937). Routes the **last three residual direct-core reaches** in `src/qt/bitcoingui.cpp` through the `interfaces::` layer, then retires the now-dead includes and their ratchet entries.

**Stacked on #3170 (Phase 1e-a).** Until #3170 merges into `development`, this PR's diff includes 1e-a's commit; it collapses to the single 1e-b commit automatically once #3170 lands. Review the tip commit `gui: route bitcoingui residual core reaches through interfaces (Phase 1e-b)`.

## What moves behind the boundary

1. **Staking refresh** — the privacy-mode handler read `g_miner_status.StakingActive()/GetSearchReport().CoinWeight()` directly. New `interfaces::StakingStatus::getCoinWeight()` + `ClientModel::refreshMinerStatus()`; the handler now calls the latter.
2. **PSGT "signature requested" toast** — the "does this wallet still need to sign this revision" decision (over `g_psgt_pool` + `PSGTSignedBy` + `Solver` + `pwalletMain->HaveKey`) moves behind new `interfaces::PSGTPoolContext::walletMustSignRevision(revision_hex)`. `cs_wallet` lock scopes preserved per-section (not widened).
3. **Wallet/config backup** — `GRC::BackupWallet(*pwalletMain, …)` / `GRC::BackupConfigFile(…)` → new `interfaces::Wallet::backupWallet`/`backupConfigFile` with `WalletModel` pass-throughs. `FromQString` path encoding unchanged.

The mac-only App Nap gate now reads `OutOfSyncByAge()` via `interfaces::Node::isOutOfSyncByAge()`.

## Cleanup

Removes `extern CWallet* pwalletMain;` and **6 forbidden includes** from `bitcoingui.cpp` (`main.h`, `wallet/wallet.h`, `node/psgt_pool.h`, `script/standard.h`, `gridcoin/backup.h`, `gridcoin/staking/difficulty.h`) and drops their entries from the `lint-qt-includes` ratchet — `init.h` and `util.h` remain.

## Behavioral equivalence

No functional change: each migrated path returns the same value(s) to the same call site. Verified by an adversarial self-review pass (lock scopes, the `!PSGTSignedBy` inversion, multisig loop bounds, null-guard provenance via the `node/interfaces.cpp` wallet check, and `getCoinWeight`/`GetSearchReport` internal locking).

## Testing

- Native Qt6 GUI + tests build clean (`build_targets.sh TARGET=native BUILD_TYPE=RelWithDebInfo USE_QT6=ON`).
- `test/lint/lint-all.sh` passes (incl. `lint-qt-includes` ratchet consistency).