### PR TITLE
gui: finish Phase 1e — coincontrol fee behind Wallet, CCoinControl retirement, aboutdialog async

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -52,16 +53,65 @@ struct WalletOutput
     bool immature{false};
 };
 
-//! Value mirror of the coin-control options Wallet::sendCoins consumes —
-//! the wallet-side CCoinControl does not cross the boundary (value types
-//! only); the node reconstructs it from this.
+//! The GUI's coin-selection value: the outpoints coin selection is pinned to,
+//! plus the change-destination override. This IS the selection container the
+//! coin-control dialogs build and mutate directly (replacing the core
+//! CCoinControl, which stays node-side); it crosses the boundary by value, and
+//! Wallet::sendCoins / computeCoinControlSummary reconstruct a node CCoinControl
+//! from it. Selection is keyed by outpoint so IsSelected() stays O(log n)
+//! regardless of how many rows the view realizes.
 struct WalletCoinControl
 {
     //! Encoded destination for change; empty lets the wallet pick.
     std::string dest_change;
     bool allow_watch_only{false};
-    //! Outpoints coin selection is pinned to.
-    std::vector<COutPoint> selected;
+    //! Outpoints coin selection is pinned to (a set: dedups and gives O(log n)
+    //! membership tests during the per-row tree rebuild).
+    std::set<COutPoint> selected;
+
+    void SetNull()
+    {
+        dest_change.clear();
+        allow_watch_only = false;
+        selected.clear();
+    }
+
+    bool HasSelected() const { return !selected.empty(); }
+
+    bool IsSelected(const COutPoint& output) const { return selected.count(output) > 0; }
+
+    bool IsSelected(const uint256& hash, unsigned int n) const
+    {
+        return IsSelected(COutPoint(hash, n));
+    }
+
+    void Select(const COutPoint& output) { selected.insert(output); }
+
+    void UnSelect(const COutPoint& output) { selected.erase(output); }
+
+    void UnSelectAll() { selected.clear(); }
+};
+
+//! Everything the coin-control dialogs need to render their fee/quantity
+//! labels, computed node-side in one call (Wallet::computeCoinControlSummary)
+//! to keep the boundary coarse. All the fee arithmetic (byte sizing via pubkey
+//! compression, nTransactionFee/GetMinFee, sub-CENT change absorption) runs
+//! where the wallet data lives, so the GUI does no fee math and holds no
+//! policy/consensus headers. Each dialog renders only the fields it shows.
+struct CoinControlSummary
+{
+    //! Selected inputs that still exist (vanished/conflicted coins are skipped,
+    //! matching the pre-migration getOutputs() filtering).
+    int quantity{0};
+    int64_t amount{0};      //!< sum of the selected inputs
+    int64_t fee{0};         //!< the pay fee (nPayFee)
+    int64_t after_fee{0};   //!< amount - fee, floored at 0
+    unsigned int bytes{0};  //!< estimated transaction size
+    int64_t change{0};      //!< change returned to the wallet (may be negative)
+    bool low_output{false}; //!< a recipient amount is below CENT
+    //! Mirrors the pre-migration fDust flag, which was declared but never set
+    //! true; retained so the label expression is byte-for-byte preserved.
+    bool dust{false};
 };
 
 //! One send-coins recipient (the Qt-free mirror of SendCoinsRecipient).
@@ -196,6 +246,22 @@ public:
     //! Spendable outputs grouped by address, with change outputs grouped
     //! under the address they derive from (walked node-side).
     virtual std::map<std::string, std::vector<WalletOutput>> listCoins() = 0;
+
+    //! Compute the coin-control fee/quantity summary for the given selection
+    //! and recipient amounts in one call. All fee math runs node-side (see
+    //! CoinControlSummary); recipient_amounts is the full list the GUI shows
+    //! (including any zero entries, which the byte estimate counts) and
+    //! subtract_fee_from_amount mirrors the send dialog's option. Selected
+    //! outpoints that no longer exist are skipped, so the fee reflects live
+    //! wallet state.
+    virtual CoinControlSummary computeCoinControlSummary(
+        const WalletCoinControl& selection,
+        const std::vector<int64_t>& recipient_amounts,
+        bool subtract_fee_from_amount) = 0;
+
+    //! The consensus/policy cap on inputs per consolidation transaction. Behind
+    //! the interface so the consolidate wizard needs no policy header.
+    virtual unsigned int getMaxConsolidationInputs() = 0;
 
     //! Create, fee-converge, and commit a transaction to the given
     //! recipients. Stateless one-shot: when the required fee needs user

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -5,6 +5,8 @@
 #include "updatedialog.h"
 #include "util.h"
 
+#include <QtConcurrent>
+
 AboutDialog::AboutDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AboutDialog)
@@ -29,6 +31,9 @@ AboutDialog::AboutDialog(QWidget *parent) :
     ui->copyrightLabel->setText(copyrightText);
 
     resize(GRC::ScaleSize(this, width(), height()));
+
+    connect(&m_version_check_watcher, &QFutureWatcher<AboutVersionInfo>::finished,
+            this, &AboutDialog::versionCheckFinished);
 
     if (!fTestNet && !gArgs.GetBoolArg("-disableupdatecheck", false)) {
         connect(ui->versionInfoButton, &QAbstractButton::pressed, this, [this]() { handlePressVersionInfoButton(); });
@@ -62,24 +67,43 @@ void AboutDialog::on_buttonBox_accepted()
 
 void AboutDialog::handlePressVersionInfoButton()
 {
-    std::string client_message_out;
-    std::string change_log;
-    GRC::Upgrade::UpgradeType upgrade_type = GRC::Upgrade::UpgradeType::Unknown;
+    // CheckForLatestUpdate does a blocking libcurl GET of the GitHub release
+    // JSON (up to a 10 s connect timeout). Run it off the GUI thread so a click
+    // never freezes the UI. Guard against overlapping checks: a second click
+    // while one is in flight would spawn another worker (this is the read-only
+    // half of GRC::Upgrade; it must not touch the download/reset write side).
+    if (m_version_check_watcher.isRunning()) {
+        return;
+    }
 
+    ui->versionInfoButton->setDisabled(true);
 
-    GRC::Upgrade::CheckForLatestUpdate(client_message_out, change_log, upgrade_type, false, false);
+    m_version_check_watcher.setFuture(QtConcurrent::run([]() {
+        AboutVersionInfo info;
+        GRC::Upgrade::UpgradeType upgrade_type = GRC::Upgrade::UpgradeType::Unknown;
+        GRC::Upgrade::CheckForLatestUpdate(info.version, info.details, upgrade_type, false, false);
+        info.upgrade_type = static_cast<int>(upgrade_type);
+        return info;
+    }));
+}
 
-    if (client_message_out == std::string {}) {
-        client_message_out = "No response from GitHub - check network connectivity.";
-        change_log = " ";
+void AboutDialog::versionCheckFinished()
+{
+    ui->versionInfoButton->setDisabled(false);
+
+    AboutVersionInfo info = m_version_check_watcher.result();
+
+    if (info.version.empty()) {
+        info.version = "No response from GitHub - check network connectivity.";
+        info.details = " ";
     }
 
     UpdateDialog update_dialog;
 
     update_dialog.setWindowTitle("Gridcoin Version Information");
-    update_dialog.setVersion(QString().fromStdString(client_message_out));
-    update_dialog.setUpgradeType(static_cast<GRC::Upgrade::UpgradeType>(upgrade_type));
-    update_dialog.setDetails(QString().fromStdString(change_log));
+    update_dialog.setVersion(QString::fromStdString(info.version));
+    update_dialog.setUpgradeType(static_cast<GRC::Upgrade::UpgradeType>(info.upgrade_type));
+    update_dialog.setDetails(QString::fromStdString(info.details));
     update_dialog.setModal(false);
 
     update_dialog.exec();

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -11,17 +11,6 @@ namespace Ui {
 }
 class ClientModel;
 
-//! Result of the off-thread GitHub version check (see
-//! AboutDialog::handlePressVersionInfoButton). upgrade_type is carried as an
-//! int so the header needs no gridcoin/upgrade.h; the .cpp casts it back to
-//! GRC::Upgrade::UpgradeType.
-struct AboutVersionInfo
-{
-    std::string version;
-    std::string details;
-    int upgrade_type{0};
-};
-
 /** "About" dialog box */
 class AboutDialog : public QDialog
 {
@@ -33,6 +22,17 @@ public:
 
     void setModel(ClientModel *model);
 private:
+    //! Result of the off-thread GitHub version check (see
+    //! handlePressVersionInfoButton). upgrade_type is carried as an int so the
+    //! header needs no gridcoin/upgrade.h; the .cpp casts it back to
+    //! GRC::Upgrade::UpgradeType.
+    struct AboutVersionInfo
+    {
+        std::string version;
+        std::string details;
+        int upgrade_type{0};
+    };
+
     Ui::AboutDialog *ui;
     //! Watches the background version-check fetch so the blocking libcurl GET
     //! never runs on the GUI thread.

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -2,11 +2,25 @@
 #define BITCOIN_QT_ABOUTDIALOG_H
 
 #include <QDialog>
+#include <QFutureWatcher>
+
+#include <string>
 
 namespace Ui {
     class AboutDialog;
 }
 class ClientModel;
+
+//! Result of the off-thread GitHub version check (see
+//! AboutDialog::handlePressVersionInfoButton). upgrade_type is carried as an
+//! int so the header needs no gridcoin/upgrade.h; the .cpp casts it back to
+//! GRC::Upgrade::UpgradeType.
+struct AboutVersionInfo
+{
+    std::string version;
+    std::string details;
+    int upgrade_type{0};
+};
 
 /** "About" dialog box */
 class AboutDialog : public QDialog
@@ -20,10 +34,14 @@ public:
     void setModel(ClientModel *model);
 private:
     Ui::AboutDialog *ui;
+    //! Watches the background version-check fetch so the blocking libcurl GET
+    //! never runs on the GUI thread.
+    QFutureWatcher<AboutVersionInfo> m_version_check_watcher;
 
 private slots:
     void on_buttonBox_accepted();
     void handlePressVersionInfoButton();
+    void versionCheckFinished();
 };
 
 #endif // BITCOIN_QT_ABOUTDIALOG_H

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -5,13 +5,10 @@
 #include "addresstablemodel.h"
 #include "key_io.h"
 #include "optionsmodel.h"
-#include "wallet/wallet.h"
-#include "policy/policy.h"
-#include "policy/fees.h"
-#include "validation.h"
-#include "wallet/coincontrol.h"
 #include "consolidateunspentdialog.h"
 #include "qt/decoration.h"
+
+#include <set>
 
 #include <QApplication>
 #include <QCheckBox>
@@ -28,10 +25,9 @@
 
 using namespace std;
 
-CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl, QList<qint64>* payAmounts,
+CoinControlDialog::CoinControlDialog(QWidget* parent, interfaces::WalletCoinControl* coinControl, QList<qint64>* payAmounts,
                                      bool fSubtractFeeFromAmount)
                : QDialog(parent)
-               , m_inputSelectionLimit(GetMaxInputsForConsolidationTxn())
                , ui(new Ui::CoinControlDialog)
                , coinControl(coinControl)
                , payAmounts(payAmounts)
@@ -129,12 +125,6 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, CCoinControl* coinControl,
     ui->treeWidget->setColumnHidden(COLUMN_AMOUNT_INT64, true);   // store amount int64_t in this column, but don't show it
     ui->treeWidget->setColumnHidden(COLUMN_CHANGE_BOOL, true);    // store change flag but don't show it
 
-    ui->filterModePushButton->setToolTip(tr("Flips the filter mode between selecting inputs less than or equal to the "
-                                            "provided value (<=) and greater than or equal to the provided value (>=). "
-                                            "The filter also automatically limits the number of inputs to %1, in "
-                                            "ascending order for <= and descending order for >=."
-                                            ).arg(m_inputSelectionLimit));
-
     ui->consolidateSendReadyLabel->hide();
 
     // default view is sorted by amount desc
@@ -152,6 +142,16 @@ void CoinControlDialog::setModel(WalletModel *model)
 
     if(model && model->getOptionsModel() && model->getAddressTableModel())
     {
+        // The consolidation input cap is a policy value fetched through the
+        // wallet interface (no model exists at construction, so this and the
+        // tooltip that shows it are set here rather than in the constructor).
+        m_inputSelectionLimit = model->wallet().getMaxConsolidationInputs();
+        ui->filterModePushButton->setToolTip(tr("Flips the filter mode between selecting inputs less than or equal to the "
+                                                "provided value (<=) and greater than or equal to the provided value (>=). "
+                                                "The filter also automatically limits the number of inputs to %1, in "
+                                                "ascending order for <= and descending order for >=."
+                                                ).arg(m_inputSelectionLimit));
+
         updateView();
         CoinControlDialog::updateLabels(model, coinControl, payAmounts, this, m_fSubtractFeeFromAmount);
     }
@@ -564,114 +564,28 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
 }
 
 void CoinControlDialog::updateLabels(WalletModel *model,
-                                     CCoinControl *coinControl,
+                                     interfaces::WalletCoinControl *coinControl,
                                      QList<qint64>* payAmounts,
                                      QDialog* dialog,
                                      bool fSubtractFeeFromAmount)
 {
     if (!model) return;
 
-    // nPayAmount
+    // Gather the recipient amounts (the full list, including any zero entries,
+    // which the byte estimate counts) and the pay total. All the fee/quantity
+    // math -- byte sizing via pubkey compression, nTransactionFee/GetMinFee,
+    // and the sub-CENT change absorption -- runs node-side in one call, so the
+    // GUI holds no policy/consensus headers and just renders the summary.
     qint64 nPayAmount = 0;
-    bool fLowOutput = false;
-    bool fDust = false;
-    CMutableTransaction txDummy;
+    std::vector<int64_t> recipientAmounts;
+    recipientAmounts.reserve(payAmounts->size());
     for (const qint64& amount : std::as_const(*payAmounts)) {
         nPayAmount += amount;
-
-        if (amount > 0)
-        {
-            if (amount < CENT)
-                fLowOutput = true;
-
-            CTxOut txout(amount, (CScript)vector<unsigned char>(24, 0));
-            txDummy.vout.push_back(txout);
-        }
+        recipientAmounts.push_back(amount);
     }
 
-    int64_t nAmount             = 0;
-    int64_t nPayFee             = 0;
-    int64_t nAfterFee           = 0;
-    int64_t nChange             = 0;
-    unsigned int nBytes         = 0;
-    unsigned int nBytesInputs   = 0;
-    unsigned int nQuantity      = 0;
-
-    vector<COutPoint> vCoinControl;
-    coinControl->ListSelected(vCoinControl);
-    const std::vector<interfaces::WalletOutput> vOutputs = model->getOutputs(vCoinControl);
-
-    for (auto const& out : vOutputs)
-    {
-        // Quantity
-        nQuantity++;
-
-        // Amount
-        nAmount += out.amount;
-
-        // Bytes
-        if (!out.address.empty())
-        {
-            CTxDestination address = DecodeDestination(out.address);
-            CPubKey pubkey;
-            try {
-                if (model->getPubKey(std::get<CKeyID>(address), pubkey))
-                    nBytesInputs += (pubkey.IsCompressed() ? 148 : 180);
-                else
-                    nBytesInputs += 148; // in all error cases, simply assume 148 here
-            } catch (const std::bad_variant_access&) {
-                nBytesInputs += 148;
-            }
-        }
-        else nBytesInputs += 148;
-    }
-
-    // calculation
-    if (nQuantity > 0)
-    {
-        // Bytes
-        nBytes = nBytesInputs + ((payAmounts->size() > 0 ? payAmounts->size() + 1 : 2) * 34) + 10; // always assume +1 output for change here
-
-        // Fee
-        int64_t nFee = nTransactionFee * (1 + (int64_t)nBytes / 1000);
-
-        // Min Fee
-        int64_t nMinFee = GetMinFee(CTransaction(txDummy), 1000, GMF_SEND, nBytes);
-
-        nPayFee = max(nFee, nMinFee);
-
-        if (nPayAmount > 0)
-        {
-            // When subtracting fee from amount, the fee is absorbed by the
-            // recipients rather than coming from the change output.
-            nChange = fSubtractFeeFromAmount
-                ? nAmount - nPayAmount
-                : nAmount - nPayFee - nPayAmount;
-
-            // if sub-cent change is required, the fee must be raised to at least CTransaction::nMinTxFee
-            if (nPayFee < CENT && nChange > 0 && nChange < CENT)
-            {
-                if (nChange < CENT) // change < 0.01 => simply move all change to fees
-                {
-                    nPayFee = nChange;
-                    nChange = 0;
-                }
-                else
-                {
-                    nChange = nChange + nPayFee - CENT;
-                    nPayFee = CENT;
-                }
-            }
-
-            if (nChange == 0)
-                nBytes -= 34;
-        }
-
-        // after fee
-        nAfterFee = nAmount - nPayFee;
-        if (nAfterFee < 0)
-            nAfterFee = 0;
-    }
+    const interfaces::CoinControlSummary summary =
+        model->wallet().computeCoinControlSummary(*coinControl, recipientAmounts, fSubtractFeeFromAmount);
 
     // actually update labels
     int nDisplayUnit = BitcoinUnits::BTC;
@@ -693,18 +607,18 @@ void CoinControlDialog::updateLabels(WalletModel *model,
     dialog->findChild<QLabel *>("coinControlChangeLabel")       ->setEnabled(nPayAmount > 0);
 
     // stats
-    l1->setText(QString::number(nQuantity));                                 // Quantity
-    l2->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAmount));        // Amount
-    l3->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nPayFee));        // Fee
-    l4->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAfterFee));      // After Fee
-    l5->setText(((nBytes > 0) ? "~" : "") + QString::number(nBytes));                                    // Bytes
-    l7->setText((fLowOutput ? (fDust ? tr("DUST") : tr("yes")) : tr("no"))); // Low Output / Dust
-    l8->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nChange));        // Change
+    l1->setText(QString::number(summary.quantity));                                    // Quantity
+    l2->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, summary.amount));           // Amount
+    l3->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, summary.fee));              // Fee
+    l4->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, summary.after_fee));        // After Fee
+    l5->setText(((summary.bytes > 0) ? "~" : "") + QString::number(summary.bytes));    // Bytes
+    l7->setText((summary.low_output ? (summary.dust ? tr("DUST") : tr("yes")) : tr("no"))); // Low Output / Dust
+    l8->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, summary.change));           // Change
 
     // turn labels "red"
-    l5->setStyleSheet((nBytes >= 10000) ? "color:red;" : "");               // Bytes >= 10000
-    l7->setStyleSheet((fLowOutput) ? "color:red;" : "");                    // Low Output = "yes"
-    l8->setStyleSheet((nChange > 0 && nChange < CENT) ? "color:red;" : ""); // Change < 0.01BTC
+    l5->setStyleSheet((summary.bytes >= 10000) ? "color:red;" : "");                // Bytes >= 10000
+    l7->setStyleSheet((summary.low_output) ? "color:red;" : "");                    // Low Output = "yes"
+    l8->setStyleSheet((summary.change > 0 && summary.change < CENT) ? "color:red;" : ""); // Change < 0.01BTC
 
     // tool tips
     l5->setToolTip(tr("This label turns red, if the transaction size is bigger than 10000 bytes.\n\n This means a fee of at least %1 per kb is required.\n\n Can vary +/- 1 Byte per input.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CENT)));
@@ -717,7 +631,7 @@ void CoinControlDialog::updateLabels(WalletModel *model,
     // Insufficient funds
     QLabel *label = dialog->findChild<QLabel *>("coinControlInsuffFundsLabel");
     if (label)
-        label->setVisible(nChange < 0);
+        label->setVisible(summary.change < 0);
 }
 
 void CoinControlDialog::updateView()
@@ -735,6 +649,25 @@ void CoinControlDialog::updateView()
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 
     const std::map<std::string, std::vector<interfaces::WalletOutput>> mapCoins = model->listCoins();
+
+    // Reconcile the selection against the currently-available coins: prune any
+    // selected outpoint that no longer exists (e.g. a coin the wallet staked
+    // out from under the selection). Keeps the fee/quantity display honest; the
+    // send path re-validates node-side regardless.
+    {
+        std::set<COutPoint> available;
+        for (auto const& coins : mapCoins)
+            for (auto const& out : coins.second)
+                available.insert(out.outpoint);
+
+        for (auto it = coinControl->selected.begin(); it != coinControl->selected.end(); )
+        {
+            if (available.count(*it) == 0)
+                it = coinControl->selected.erase(it);
+            else
+                ++it;
+        }
+    }
 
     for (auto const& coins : mapCoins)
     {
@@ -864,11 +797,7 @@ void CoinControlDialog::showHideConsolidationReadyToSend()
     {
         // This is more expensive. Only do if it passes the first two conditions above. We want to check
         // and make sure that the number of inputs is less than m_inputSelectionLimit for consolidation purposes.
-        std::vector<COutPoint> selectionList;
-
-        coinControl->ListSelected(selectionList);
-
-        if (selectionList.size() <= m_inputSelectionLimit)
+        if (coinControl->selected.size() <= m_inputSelectionLimit)
         {
             ui->consolidateSendReadyLabel->show();
         }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -650,23 +650,20 @@ void CoinControlDialog::updateView()
 
     const std::map<std::string, std::vector<interfaces::WalletOutput>> mapCoins = model->listCoins();
 
-    // Reconcile the selection against the currently-available coins: prune any
-    // selected outpoint that no longer exists (e.g. a coin the wallet staked
-    // out from under the selection). Keeps the fee/quantity display honest; the
-    // send path re-validates node-side regardless.
+    // Reconcile the selection against the currently-available coins: keep only
+    // the selected outpoints that still exist (e.g. drop a coin the wallet
+    // staked out from under the selection). Scan the already-fetched coin list
+    // once, testing membership against the usually-small selection, so we never
+    // materialize a set of every outpoint (important on large wallets). Keeps
+    // the fee/quantity display honest; the send path re-validates node-side.
     {
-        std::set<COutPoint> available;
+        std::set<COutPoint> still_selected;
         for (auto const& coins : mapCoins)
             for (auto const& out : coins.second)
-                available.insert(out.outpoint);
+                if (coinControl->selected.count(out.outpoint))
+                    still_selected.insert(out.outpoint);
 
-        for (auto it = coinControl->selected.begin(); it != coinControl->selected.end(); )
-        {
-            if (available.count(*it) == 0)
-                it = coinControl->selected.erase(it);
-            else
-                ++it;
-        }
+        coinControl->selected.swap(still_selected);
     }
 
     for (auto const& coins : mapCoins)

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -17,7 +17,6 @@ namespace Ui {
     class CoinControlDialog;
 }
 class WalletModel;
-class CCoinControl;
 
 class CoinControlDialog : public QDialog
 {
@@ -25,7 +24,7 @@ class CoinControlDialog : public QDialog
 
 public:
     explicit CoinControlDialog(QWidget* parent = nullptr,
-                               CCoinControl* coinControl = nullptr,
+                               interfaces::WalletCoinControl* coinControl = nullptr,
                                QList<qint64>* payAmounts = nullptr,
                                bool fSubtractFeeFromAmount = false);
     ~CoinControlDialog();
@@ -33,11 +32,12 @@ public:
     void setModel(WalletModel *model);
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, CCoinControl*, QList<qint64>*, QDialog*,
+    static void updateLabels(WalletModel*, interfaces::WalletCoinControl*, QList<qint64>*, QDialog*,
                              bool fSubtractFeeFromAmount = false);
 
-    // This is based on what will guarantee a successful transaction.
-    const size_t m_inputSelectionLimit;
+    // This is based on what will guarantee a successful transaction. Set from
+    // the wallet interface in setModel() (no model exists at construction).
+    size_t m_inputSelectionLimit{0};
 
 signals:
     void selectedConsolidationRecipientSignal(SendCoinsRecipient consolidationRecipient);
@@ -47,7 +47,7 @@ public slots:
 
 private:
     Ui::CoinControlDialog *ui;
-    CCoinControl *coinControl;
+    interfaces::WalletCoinControl *coinControl;
     QList<qint64> *payAmounts;
     WalletModel *model;
     int sortColumn;

--- a/src/qt/consolidateunspentwizard.cpp
+++ b/src/qt/consolidateunspentwizard.cpp
@@ -8,7 +8,7 @@
 
 
 ConsolidateUnspentWizard::ConsolidateUnspentWizard(QWidget *parent,
-                                                   CCoinControl *coinControl,
+                                                   interfaces::WalletCoinControl *coinControl,
                                                    QList<qint64> *payAmounts) :
     QWizard(parent),
     ui(new Ui::ConsolidateUnspentWizard),

--- a/src/qt/consolidateunspentwizard.h
+++ b/src/qt/consolidateunspentwizard.h
@@ -28,7 +28,7 @@ public:
     };
 
     explicit ConsolidateUnspentWizard(QWidget *parent = nullptr,
-                                      CCoinControl *coinControl = nullptr,
+                                      interfaces::WalletCoinControl *coinControl = nullptr,
                                       QList<qint64> *payAmounts = nullptr);
     ~ConsolidateUnspentWizard();
 
@@ -37,13 +37,13 @@ public:
     void accept() override;
 
 signals:
-    void passCoinControlSignal(CCoinControl*);
+    void passCoinControlSignal(interfaces::WalletCoinControl*);
     void selectedConsolidationRecipientSignal(SendCoinsRecipient);
     void sendConsolidationTransactionSignal();
 
 private:
     Ui::ConsolidateUnspentWizard *ui;
-    CCoinControl *coinControl;
+    interfaces::WalletCoinControl *coinControl;
     QList<qint64> *payAmounts;
     WalletModel *model;
 };

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -6,12 +6,9 @@
 #include "addresstablemodel.h"
 #include "key_io.h"
 #include "optionsmodel.h"
-#include "wallet/wallet.h"
-#include "policy/policy.h"
-#include "policy/fees.h"
-#include "validation.h"
-#include "wallet/coincontrol.h"
 #include "consolidateunspentdialog.h"
+
+#include <set>
 
 using namespace std;
 
@@ -19,8 +16,6 @@ ConsolidateUnspentWizardSelectInputsPage::ConsolidateUnspentWizardSelectInputsPa
     QWizardPage(parent),
     ui(new Ui::ConsolidateUnspentWizardSelectInputsPage)
 {
-    m_InputSelectionLimit = GetMaxInputsForConsolidationTxn();
-
     ui->setupUi(this);
 
     // toggle tree/list mode
@@ -68,13 +63,8 @@ ConsolidateUnspentWizardSelectInputsPage::ConsolidateUnspentWizardSelectInputsPa
     // default view is sorted by amount desc
     sortView(COLUMN_AMOUNT_INT64, Qt::DescendingOrder);
 
-    ui->outputLimitWarningIconLabel->setToolTip(tr("Note: The number of inputs selected for consolidation has been "
-                                                 "limited to %1 to prevent a transaction failure due to too many "
-                                                 "inputs.").arg(m_InputSelectionLimit));
-    ui->outputLimitStopIconLabel->setToolTip(tr("Note: The number of inputs selected for consolidation is currently more "
-                                                 "than the limit of %1. Please use the filter or manual selection to reduce "
-                                                "the number of inputs to %1 or less to prevent a transaction failure due to "
-                                                "too many inputs.").arg(m_InputSelectionLimit));
+    // The tooltips that show m_InputSelectionLimit are set in setModel(), once
+    // the value is available from the wallet interface (no model at construction).
 
     ui->outputLimitWarningIconLabel->setVisible(false);
     ui->outputLimitStopIconLabel->setVisible(false);
@@ -93,12 +83,24 @@ void ConsolidateUnspentWizardSelectInputsPage::setModel(WalletModel *model)
 
     if (model && model->getOptionsModel() && model->getAddressTableModel() && coinControl != nullptr)
     {
+        // The consolidation input cap is a policy value from the wallet
+        // interface; set it and the tooltips that show it here (no model exists
+        // at construction).
+        m_InputSelectionLimit = model->wallet().getMaxConsolidationInputs();
+        ui->outputLimitWarningIconLabel->setToolTip(tr("Note: The number of inputs selected for consolidation has been "
+                                                     "limited to %1 to prevent a transaction failure due to too many "
+                                                     "inputs.").arg(m_InputSelectionLimit));
+        ui->outputLimitStopIconLabel->setToolTip(tr("Note: The number of inputs selected for consolidation is currently more "
+                                                     "than the limit of %1. Please use the filter or manual selection to reduce "
+                                                    "the number of inputs to %1 or less to prevent a transaction failure due to "
+                                                    "too many inputs.").arg(m_InputSelectionLimit));
+
         updateView();
         updateLabels();
     }
 }
 
-void ConsolidateUnspentWizardSelectInputsPage::setCoinControl(CCoinControl *coinControl)
+void ConsolidateUnspentWizardSelectInputsPage::setCoinControl(interfaces::WalletCoinControl *coinControl)
 {
     this->coinControl = coinControl;
 }
@@ -354,106 +356,30 @@ void ConsolidateUnspentWizardSelectInputsPage::updateLabels()
 {
     if (!model) return;
 
-    // nPayAmount
-    qint64 nPayAmount = 0;
-    CMutableTransaction txDummy;
-    for (const auto& amount: std::as_const(*payAmounts))
+    // Gather the recipient amounts; all fee/quantity math (byte sizing via
+    // pubkey compression, nTransactionFee/GetMinFee, sub-CENT change absorption)
+    // runs node-side in one call, so the wizard does no fee math and holds no
+    // policy/consensus headers.
+    std::vector<int64_t> recipientAmounts;
+    recipientAmounts.reserve(payAmounts->size());
+    for (const auto& amount : std::as_const(*payAmounts))
     {
-        nPayAmount += amount;
-
-        if (amount > 0)
-        {
-            CTxOut txout(amount, (CScript)vector<unsigned char>(24, 0));
-            txDummy.vout.push_back(txout);
-        }
+        recipientAmounts.push_back(amount);
     }
 
-    int64_t nAmount = 0;
-    int64_t nPayFee = 0;
-    int64_t nAfterFee = 0;
-    int64_t nChange = 0;
-    unsigned int nBytes = 0;
-    unsigned int nBytesInputs = 0;
-    unsigned int nQuantity = 0;
+    const interfaces::CoinControlSummary summary =
+        model->wallet().computeCoinControlSummary(*coinControl, recipientAmounts, /*subtract_fee_from_amount=*/false);
 
-    vector<COutPoint> vCoinControl;
-    coinControl->ListSelected(vCoinControl);
-    const std::vector<interfaces::WalletOutput> vOutputs = model->getOutputs(vCoinControl);
-
-    for (const auto& out : vOutputs)
-    {
-        // Quantity
-        nQuantity++;
-
-        // Amount
-        nAmount += out.amount;
-
-        // Bytes
-        if (!out.address.empty())
-        {
-            CTxDestination address = DecodeDestination(out.address);
-            CPubKey pubkey;
-            try {
-                if (model->getPubKey(std::get<CKeyID>(address), pubkey))
-                    nBytesInputs += (pubkey.IsCompressed() ? 148 : 180);
-                else
-                    nBytesInputs += 148; // in all error cases, simply assume 148 here
-            } catch (const std::bad_variant_access&) {
-                nBytesInputs += 148;
-            }
-        }
-        else nBytesInputs += 148;
-    }
-
-    // calculation
-    if (nQuantity > 0)
-    {
-        // Bytes - always assume +1 output for change here
-        nBytes = nBytesInputs + ((payAmounts->size() > 0 ? payAmounts->size() + 1 : 2) * 34) + 10;
-
-        // Fee
-        int64_t nFee = nTransactionFee * (1 + (int64_t)nBytes / 1000);
-
-        // Min Fee
-        int64_t nMinFee = GetMinFee(CTransaction(txDummy), 1000, GMF_SEND, nBytes);
-
-        nPayFee = max(nFee, nMinFee);
-
-        if (nPayAmount > 0)
-        {
-            nChange = nAmount - nPayFee - nPayAmount;
-
-            // if sub-cent change is required, the fee must be raised to at least CTransaction::nMinTxFee
-            if (nPayFee < CENT && nChange > 0 && nChange < CENT)
-            {
-                if (nChange < CENT) // change < 0.01 => simply move all change to fees
-                {
-                    nPayFee = nChange;
-                    nChange = 0;
-                }
-                else
-                {
-                    nChange = nChange + nPayFee - CENT;
-                    nPayFee = CENT;
-                }
-            }
-
-            if (nChange == 0) nBytes -= 34;
-        }
-
-        // after fee
-        nAfterFee = nAmount - nPayFee;
-        if (nAfterFee < 0) nAfterFee = 0;
-    }
+    const unsigned int nQuantity = static_cast<unsigned int>(summary.quantity);
 
     // actually update labels
     int nDisplayUnit = BitcoinUnits::BTC;
     if (model && model->getOptionsModel()) nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 
     // stats
-    ui->quantityLabel->setText(QString::number(nQuantity));                            // Quantity
-    ui->feeLabel->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nPayFee));        // Fee
-    ui->afterFeeLabel->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, nAfterFee)); // After Fee
+    ui->quantityLabel->setText(QString::number(summary.quantity));                        // Quantity
+    ui->feeLabel->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, summary.fee));       // Fee
+    ui->afterFeeLabel->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, summary.after_fee)); // After Fee
 
     std::map<QString, QString> addressList;
     QString defaultAddress;
@@ -536,6 +462,24 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
     }
 
     const std::map<std::string, std::vector<interfaces::WalletOutput>> mapCoins = model->listCoins();
+
+    // Reconcile the selection against the currently-available coins: prune any
+    // selected outpoint that no longer exists (e.g. a coin the wallet staked
+    // out from under the selection). The send path re-validates node-side.
+    {
+        std::set<COutPoint> available;
+        for (auto const& coins : mapCoins)
+            for (auto const& out : coins.second)
+                available.insert(out.outpoint);
+
+        for (auto it = coinControl->selected.begin(); it != coinControl->selected.end(); )
+        {
+            if (available.count(*it) == 0)
+                it = coinControl->selected.erase(it);
+            else
+                ++it;
+        }
+    }
 
     for (auto const& coins : mapCoins)
     {

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -463,22 +463,20 @@ void ConsolidateUnspentWizardSelectInputsPage::updateView()
 
     const std::map<std::string, std::vector<interfaces::WalletOutput>> mapCoins = model->listCoins();
 
-    // Reconcile the selection against the currently-available coins: prune any
-    // selected outpoint that no longer exists (e.g. a coin the wallet staked
-    // out from under the selection). The send path re-validates node-side.
+    // Reconcile the selection against the currently-available coins: keep only
+    // the selected outpoints that still exist (e.g. drop a coin the wallet
+    // staked out from under the selection). Scan the already-fetched coin list
+    // once, testing membership against the usually-small selection, so we never
+    // materialize a set of every outpoint (important on large wallets). The
+    // send path re-validates node-side regardless.
     {
-        std::set<COutPoint> available;
+        std::set<COutPoint> still_selected;
         for (auto const& coins : mapCoins)
             for (auto const& out : coins.second)
-                available.insert(out.outpoint);
+                if (coinControl->selected.count(out.outpoint))
+                    still_selected.insert(out.outpoint);
 
-        for (auto it = coinControl->selected.begin(); it != coinControl->selected.end(); )
-        {
-            if (available.count(*it) == 0)
-                it = coinControl->selected.erase(it);
-            else
-                ++it;
-        }
+        coinControl->selected.swap(still_selected);
     }
 
     for (auto const& coins : mapCoins)

--- a/src/qt/consolidateunspentwizardselectinputspage.h
+++ b/src/qt/consolidateunspentwizardselectinputspage.h
@@ -22,7 +22,7 @@ public:
     ~ConsolidateUnspentWizardSelectInputsPage();
 
     void setModel(WalletModel*);
-    void setCoinControl(CCoinControl* coinControl);
+    void setCoinControl(interfaces::WalletCoinControl* coinControl);
     void setPayAmounts(QList<qint64> *payAmounts);
 
 signals:
@@ -35,12 +35,12 @@ public slots:
 
 private:
     Ui::ConsolidateUnspentWizardSelectInputsPage *ui;
-    CCoinControl *coinControl;
+    interfaces::WalletCoinControl *coinControl;
     QList<qint64> *payAmounts;
     WalletModel *model;
     int sortColumn;
     Qt::SortOrder sortOrder;
-    size_t m_InputSelectionLimit;
+    size_t m_InputSelectionLimit{0};
     Qt::CheckState m_ToState = Qt::Checked;
     bool m_FilterMode = true;
     bool m_FilterValueValid = false;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -11,7 +11,6 @@
 #include "askpassphrasedialog.h"
 
 #include "key_io.h"
-#include "wallet/coincontrol.h"
 #include "coincontroldialog.h"
 #include "consolidateunspentdialog.h"
 #include "consolidateunspentwizard.h"
@@ -27,7 +26,7 @@
 SendCoinsDialog::SendCoinsDialog(QWidget* parent)
              : QDialog(parent)
              , ui(new Ui::SendCoinsDialog)
-             , coinControl(new CCoinControl)
+             , coinControl(new interfaces::WalletCoinControl)
              , payAmounts(new QList<qint64>)
              , model(nullptr)
 {
@@ -184,19 +183,14 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     WalletModel::SendCoinsReturn sendstatus;
 
-    // Snapshot the dialog's CCoinControl into the boundary value type when
-    // coin-control features are on; the wallet-side class itself does not
-    // cross the interface.
+    // The dialog's coin-control selection is already the boundary value type,
+    // so pass it straight through when coin-control features are on. dest_change
+    // is only ever set to a valid encoded address (see the change handlers), so
+    // no re-validation is needed here.
     std::optional<interfaces::WalletCoinControl> coin_control;
     if (model->getOptionsModel() && model->getOptionsModel()->getCoinControlFeatures())
     {
-        interfaces::WalletCoinControl ctrl;
-        if (IsValidDestination(coinControl->destChange)) {
-            ctrl.dest_change = EncodeDestination(coinControl->destChange);
-        }
-        ctrl.allow_watch_only = coinControl->fAllowWatchOnly;
-        coinControl->ListSelected(ctrl.selected);
-        coin_control = std::move(ctrl);
+        coin_control = *coinControl;
     }
 
     // Fee-confirmation loop. When the required fee exceeds both the
@@ -598,10 +592,15 @@ void SendCoinsDialog::coinControlChangeChecked(int state)
 {
     if (model)
     {
+        // dest_change carries an encoded address (empty = let the wallet pick).
+        // Store only a valid address so the node never has to re-validate.
         if (state == Qt::Checked)
-            coinControl->destChange = DecodeDestination(ui->coinControlChangeEdit->text().toStdString());
+        {
+            const CTxDestination dest = DecodeDestination(ui->coinControlChangeEdit->text().toStdString());
+            coinControl->dest_change = IsValidDestination(dest) ? EncodeDestination(dest) : std::string();
+        }
         else
-            coinControl->destChange = CNoDestination();
+            coinControl->dest_change.clear();
     }
 
     ui->coinControlChangeEdit->setEnabled((state == Qt::Checked));
@@ -615,7 +614,9 @@ void SendCoinsDialog::coinControlChangeEdited(const QString & text)
 {
     if (model)
     {
-        coinControl->destChange = DecodeDestination(text.toStdString());
+        // dest_change carries an encoded address (empty = let the wallet pick).
+        const CTxDestination dest = DecodeDestination(text.toStdString());
+        coinControl->dest_change = IsValidDestination(dest) ? EncodeDestination(dest) : std::string();
 
         // label for the change address
         ui->coinControlChangeAddressLabel->setStyleSheet(QString());

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -9,7 +9,6 @@
 namespace Ui {
     class SendCoinsDialog;
 }
-class CCoinControl;
 class SendCoinsEntry;
 
 QT_BEGIN_NAMESPACE
@@ -44,7 +43,7 @@ public slots:
 
 private:
     Ui::SendCoinsDialog *ui;
-    CCoinControl *coinControl;
+    interfaces::WalletCoinControl *coinControl;
     QList<qint64> *payAmounts;
     WalletModel *model;
     bool fNewRecipientAllowed;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -10,13 +10,16 @@
 #include "key_io.h"
 #include "main.h"
 #include "policy/fees.h"
+#include "policy/policy.h"
 #include "wallet/coincontrol.h"
 #include "wallet/wallet.h"
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace interfaces {
@@ -227,6 +230,106 @@ public:
 
         return coins;
     }
+
+    CoinControlSummary computeCoinControlSummary(const WalletCoinControl& selection,
+                                                 const std::vector<int64_t>& recipient_amounts,
+                                                 bool subtract_fee_from_amount) override
+    {
+        CoinControlSummary summary;
+
+        // Recipient side: pay amount, low-output flag, and the dummy outputs
+        // GetMinFee's dust check inspects. Mirrors the pre-migration
+        // updateLabels() exactly (the dummy script content is irrelevant to
+        // the fee; only the count and nValue matter).
+        CAmount pay_amount = 0;
+        CMutableTransaction tx_dummy;
+        for (const int64_t amount : recipient_amounts) {
+            pay_amount += amount;
+            if (amount > 0) {
+                if (amount < CENT) {
+                    summary.low_output = true;
+                }
+                tx_dummy.vout.push_back(CTxOut(amount, (CScript)std::vector<unsigned char>(24, 0)));
+            }
+        }
+
+        CAmount amount = 0;
+        unsigned int bytes_inputs = 0;
+        unsigned int quantity = 0;
+
+        LOCK2(cs_main, m_wallet->cs_wallet);
+
+        for (const COutPoint& outpoint : selection.selected) {
+            auto it = m_wallet->mapWallet.find(outpoint.hash);
+            if (it == m_wallet->mapWallet.end()) continue;
+            if (outpoint.n >= it->second.vout.size()) continue;
+            if (it->second.GetDepthInMainChain() < 0) continue; // skip vanished/conflicted
+
+            quantity++;
+            amount += it->second.vout[outpoint.n].nValue;
+
+            // Byte estimate per input from pubkey compression (148 compressed
+            // else 180; 148 in every error/non-pubkeyhash case), matching the
+            // former GUI-side getOutputs()+getPubKey() loop.
+            CTxDestination address;
+            if (ExtractDestination(it->second.vout[outpoint.n].scriptPubKey, address)) {
+                const CKeyID* key_id = std::get_if<CKeyID>(&address);
+                CPubKey pubkey;
+                if (key_id && m_wallet->GetPubKey(*key_id, pubkey)) {
+                    bytes_inputs += (pubkey.IsCompressed() ? 148 : 180);
+                } else {
+                    bytes_inputs += 148;
+                }
+            } else {
+                bytes_inputs += 148;
+            }
+        }
+
+        summary.quantity = static_cast<int>(quantity);
+        summary.amount = amount;
+
+        if (quantity > 0) {
+            // Always assume +1 output for change here.
+            summary.bytes = bytes_inputs
+                + ((recipient_amounts.size() > 0 ? recipient_amounts.size() + 1 : 2) * 34) + 10;
+
+            const CAmount fee = nTransactionFee * (1 + (int64_t)summary.bytes / 1000);
+            const CAmount min_fee = GetMinFee(CTransaction(tx_dummy), 1000, GMF_SEND, summary.bytes);
+            summary.fee = std::max(fee, min_fee);
+
+            if (pay_amount > 0) {
+                // When subtracting fee from amount, the fee is absorbed by the
+                // recipients rather than coming from the change output.
+                summary.change = subtract_fee_from_amount
+                    ? amount - pay_amount
+                    : amount - summary.fee - pay_amount;
+
+                // If sub-cent change is required, raise the fee to at least CENT.
+                if (summary.fee < CENT && summary.change > 0 && summary.change < CENT) {
+                    if (summary.change < CENT) { // change < 0.01 => move all change to fees
+                        summary.fee = summary.change;
+                        summary.change = 0;
+                    } else {
+                        summary.change = summary.change + summary.fee - CENT;
+                        summary.fee = CENT;
+                    }
+                }
+
+                if (summary.change == 0) {
+                    summary.bytes -= 34;
+                }
+            }
+
+            summary.after_fee = amount - summary.fee;
+            if (summary.after_fee < 0) {
+                summary.after_fee = 0;
+            }
+        }
+
+        return summary;
+    }
+
+    unsigned int getMaxConsolidationInputs() override { return GetMaxInputsForConsolidationTxn(); }
 
     SendCoinsResult sendCoins(const std::vector<WalletSendRecipient>& recipients,
                               const std::optional<WalletCoinControl>& coin_control,

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -304,15 +304,14 @@ public:
                     ? amount - pay_amount
                     : amount - summary.fee - pay_amount;
 
-                // If sub-cent change is required, raise the fee to at least CENT.
+                // A sub-cent change output isn't worth creating: absorb it into
+                // the fee. The fee INCREASES by the change removed (fee + change),
+                // matching CreateTransaction's behaviour -- the pre-migration GUI
+                // code set fee = change here, dropping the already-computed
+                // sub-cent base fee and under-reporting the fee by that amount.
                 if (summary.fee < CENT && summary.change > 0 && summary.change < CENT) {
-                    if (summary.change < CENT) { // change < 0.01 => move all change to fees
-                        summary.fee = summary.change;
-                        summary.change = 0;
-                    } else {
-                        summary.change = summary.change + summary.fee - CENT;
-                        summary.fee = CENT;
-                    }
+                    summary.fee += summary.change;
+                    summary.change = 0;
                 }
 
                 if (summary.change == 0) {

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -43,19 +43,9 @@ src/qt/bitcoin.cpp:util.h
 src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
 src/qt/bitcoingui.cpp:util.h
-src/qt/coincontroldialog.cpp:policy/fees.h
-src/qt/coincontroldialog.cpp:policy/policy.h
-src/qt/coincontroldialog.cpp:validation.h
-src/qt/coincontroldialog.cpp:wallet/coincontrol.h
-src/qt/coincontroldialog.cpp:wallet/wallet.h
 src/qt/consolidateunspentdialog.cpp:util.h
 src/qt/consolidateunspentwizard.cpp:util.h
 src/qt/consolidateunspentwizardselectdestinationpage.cpp:util.h
-src/qt/consolidateunspentwizardselectinputspage.cpp:policy/fees.h
-src/qt/consolidateunspentwizardselectinputspage.cpp:policy/policy.h
-src/qt/consolidateunspentwizardselectinputspage.cpp:validation.h
-src/qt/consolidateunspentwizardselectinputspage.cpp:wallet/coincontrol.h
-src/qt/consolidateunspentwizardselectinputspage.cpp:wallet/wallet.h
 src/qt/consolidateunspentwizardsendpage.cpp:util.h
 src/qt/detailedtxmodel.cpp:util/system.h
 src/qt/diagnosticsdialog.h:sync.h
@@ -79,7 +69,6 @@ src/qt/rpcconsole.cpp:rpc/client.h
 src/qt/rpcconsole.cpp:rpc/protocol.h
 src/qt/rpcconsole.cpp:rpc/server.h
 src/qt/rpcconsole.h:net.h
-src/qt/sendcoinsdialog.cpp:wallet/coincontrol.h
 src/qt/signverifymessagedialog.cpp:init.h
 src/qt/signverifymessagedialog.cpp:main.h
 src/qt/signverifymessagedialog.cpp:wallet/wallet.h


### PR DESCRIPTION
## Summary

Completes **Phase 1e** of the GUI/node `interfaces::` migration (RFC #2937). Retires all **11 remaining coin-control/send ratchet entries** and takes the About-dialog version check off the GUI thread. Based directly on `development` (1e-a #3170 and 1e-b #3171 already merged) — not stacked.

## 1e-c — `CCoinControl` → `interfaces::WalletCoinControl` (decision: A + set)

`interfaces::WalletCoinControl` becomes the **selection container** the coin-control dialogs build and mutate directly (`Select`/`UnSelect`/`IsSelected`/`HasSelected`/`UnSelectAll`/`SetNull`), with `selected` now a `std::set<COutPoint>` — O(log n) membership during the per-row tree rebuild, free dedup. The GUI passes it **straight to `sendCoins` with no conversion**; the core keeps its own `CCoinControl` node-side (rebuilt in the wallet interface impl). This is the honest multiprocess shape: the GUI owns the selection value and ships it to the node. `dest_change` stays an encoded string, stored **valid-or-empty** so the node never re-validates.

### Fee math behind the wallet interface
- **`Wallet::computeCoinControlSummary(selection, recipient_amounts, subtract_fee_from_amount)`** computes the whole coin-control fee/quantity summary **node-side in one call** — byte sizing (pubkey compression), `nTransactionFee·(1+bytes/1000)` vs `GetMinFee(GMF_SEND)`, sub-CENT change absorption. Coarse by design (a **chattiness** decision): one round-trip per refresh instead of the old `1 + N` `getPubKey` calls, and **no fee arithmetic or policy headers remain in the GUI**. Each dialog renders its own labels from the returned `CoinControlSummary`.
- **`Wallet::getMaxConsolidationInputs()`** replaces the direct `GetMaxInputsForConsolidationTxn()` calls (moved from the constructors to `setModel()`, since no model exists at construction).

### Stale-UTXO reconciliation
`updateView()` now prunes selected outpoints that no longer exist — e.g. a coin the wallet **staked** out from under the selection (a real Gridcoin hazard). Display stays honest; the send/summary paths re-validate node-side under lock regardless.

Retires (both `coincontroldialog` and the consolidate page): `wallet/coincontrol.h`, `policy/fees.h`, `policy/policy.h`, `validation.h`, `wallet/wallet.h`; plus `wallet/coincontrol.h` in `sendcoinsdialog`. **11 entries total.**

## 1e-d — About dialog async version check

`AboutDialog::handlePressVersionInfoButton` ran `GRC::Upgrade::CheckForLatestUpdate` — a **blocking libcurl GET** (up to a 10 s connect timeout) — on the GUI thread, freezing the UI on every click. It now runs off-thread via **QtConcurrent + QFutureWatcher** with a reentrancy guard. Read-only: the download/reset/snapshot write side of `GRC::Upgrade` is untouched (danger-zone preserved).

## Behavioral equivalence

No functional change: the fee summary and selection semantics are behavior-preserving, verified line-by-line against the pre-migration `updateLabels` by an adversarial self-review pass (fee math, `std::set` migration, erase-during-iteration reconciliation, `dest_change` valid-or-empty invariant, `setModel` limit move, QtConcurrent lifetime/threading, lock order).


> **Update (fee-display fix, not a pure no-op):** Copilot spotted a pre-existing quirk faithfully carried over — the sub-cent change→fee absorption set `fee = change`, dropping the already-computed sub-cent base fee. Fixed in `dd85c163f` to `fee += change` (matching `CreateTransaction`) and dropped the accompanying dead `else` branch. This is a deliberate display-only correction shared by the coincontrol/send/consolidate dialogs; the rest of the migration remains behavior-preserving.
## Follow-up

Filed **#3183** for the windowed/virtualized coin-selection model — the `QTreeWidget` materializes every UTXO and is unusable at 100k+ UTXOs per address leaf. Noted there: it's a **two-mode** (flat + tree) model, more involved than the flat tx-table windowing. A + set is fully compatible with it.

## Testing

- Native Qt6 GUI + tests build clean (`build_targets.sh TARGET=native BUILD_TYPE=RelWithDebInfo USE_QT6=ON`); unit suites `gridcoin_tests` + `gridcoin_qt_tests` pass.
- `test/lint/lint-all.sh` passes (incl. `lint-qt-includes` ratchet consistency after removing the 11 entries).
- The one functional-test failure in CI-style runs (`rpc_getaddednodeinfo.py`) is an unrelated P2P-timing flake — passes 2/2 locally, and this change touches no P2P/addnode code.
