### PR TITLE
gridcoin: versioned 24-word seed phrase scheme + RFC 7914 scrypt (#2739 part 2)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(gridcoin_util STATIC
     gridcoin/cpid.cpp
     gridcoin/gridcoin.cpp
     gridcoin/interfaces.cpp
+    gridcoin/mnemonics.cpp
     gridcoin/mrc.cpp
     gridcoin/pool.cpp
     gridcoin/project.cpp

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(gridcoin_crypto_base STATIC
     hmac_sha512.cpp
     poly1305.cpp
     ripemd160.cpp
+    scrypt.cpp
     sha1.cpp
     sha256.cpp
     sha3.cpp

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+//
+// RFC 7914 scrypt. The Salsa20/8 core below follows the public domain
+// implementation lineage of Colin Percival (Tarsnap) as adapted by ArtForz
+// and pooler; see src/scrypt.cpp for the original notice.
+
+#include <crypto/scrypt.h>
+
+#include <crypto/common.h>
+#include <crypto/hmac_sha256.h>
+#include <support/cleanse.h>
+
+#include <stdexcept>
+#include <stdint.h>
+#include <vector>
+
+namespace {
+
+//! B = Salsa20/8(B ^ Bx). Operates on 16 native 32-bit words.
+void xor_salsa8(uint32_t B[16], const uint32_t Bx[16])
+{
+    uint32_t x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11, x12, x13, x14, x15;
+
+    x00 = (B[0] ^= Bx[0]);
+    x01 = (B[1] ^= Bx[1]);
+    x02 = (B[2] ^= Bx[2]);
+    x03 = (B[3] ^= Bx[3]);
+    x04 = (B[4] ^= Bx[4]);
+    x05 = (B[5] ^= Bx[5]);
+    x06 = (B[6] ^= Bx[6]);
+    x07 = (B[7] ^= Bx[7]);
+    x08 = (B[8] ^= Bx[8]);
+    x09 = (B[9] ^= Bx[9]);
+    x10 = (B[10] ^= Bx[10]);
+    x11 = (B[11] ^= Bx[11]);
+    x12 = (B[12] ^= Bx[12]);
+    x13 = (B[13] ^= Bx[13]);
+    x14 = (B[14] ^= Bx[14]);
+    x15 = (B[15] ^= Bx[15]);
+
+    const auto R = [](uint32_t a, int b) -> uint32_t { return (a << b) | (a >> (32 - b)); };
+
+    for (int i = 0; i < 8; i += 2) {
+        /* Operate on columns. */
+        x04 ^= R(x00 + x12, 7);  x09 ^= R(x05 + x01, 7);
+        x14 ^= R(x10 + x06, 7);  x03 ^= R(x15 + x11, 7);
+
+        x08 ^= R(x04 + x00, 9);  x13 ^= R(x09 + x05, 9);
+        x02 ^= R(x14 + x10, 9);  x07 ^= R(x03 + x15, 9);
+
+        x12 ^= R(x08 + x04, 13); x01 ^= R(x13 + x09, 13);
+        x06 ^= R(x02 + x14, 13); x11 ^= R(x07 + x03, 13);
+
+        x00 ^= R(x12 + x08, 18); x05 ^= R(x01 + x13, 18);
+        x10 ^= R(x06 + x02, 18); x15 ^= R(x11 + x07, 18);
+
+        /* Operate on rows. */
+        x01 ^= R(x00 + x03, 7);  x06 ^= R(x05 + x04, 7);
+        x11 ^= R(x10 + x09, 7);  x12 ^= R(x15 + x14, 7);
+
+        x02 ^= R(x01 + x00, 9);  x07 ^= R(x06 + x05, 9);
+        x08 ^= R(x11 + x10, 9);  x13 ^= R(x12 + x15, 9);
+
+        x03 ^= R(x02 + x01, 13); x04 ^= R(x07 + x06, 13);
+        x09 ^= R(x08 + x11, 13); x14 ^= R(x13 + x12, 13);
+
+        x00 ^= R(x03 + x02, 18); x05 ^= R(x04 + x07, 18);
+        x10 ^= R(x09 + x08, 18); x15 ^= R(x14 + x13, 18);
+    }
+
+    B[0] += x00;
+    B[1] += x01;
+    B[2] += x02;
+    B[3] += x03;
+    B[4] += x04;
+    B[5] += x05;
+    B[6] += x06;
+    B[7] += x07;
+    B[8] += x08;
+    B[9] += x09;
+    B[10] += x10;
+    B[11] += x11;
+    B[12] += x12;
+    B[13] += x13;
+    B[14] += x14;
+    B[15] += x15;
+}
+
+//! PBKDF2-HMAC-SHA256 with an iteration count of one, the only count scrypt
+//! uses (RFC 7914 sections 2 and 6).
+void PBKDF2_SHA256_C1(Span<const std::byte> pass, Span<const std::byte> salt, Span<std::byte> out)
+{
+    const unsigned char* pass_data = reinterpret_cast<const unsigned char*>(pass.data());
+    const unsigned char* salt_data = reinterpret_cast<const unsigned char*>(salt.data());
+
+    unsigned char block[CHMAC_SHA256::OUTPUT_SIZE];
+    uint32_t block_index = 1;
+
+    size_t remaining = out.size();
+    std::byte* dest = out.data();
+    while (remaining > 0) {
+        unsigned char index_be[4];
+        WriteBE32(index_be, block_index);
+
+        CHMAC_SHA256(pass_data, pass.size())
+            .Write(salt_data, salt.size())
+            .Write(index_be, sizeof(index_be))
+            .Finalize(block);
+
+        const size_t chunk = remaining < sizeof(block) ? remaining : sizeof(block);
+        for (size_t i = 0; i < chunk; ++i) {
+            dest[i] = static_cast<std::byte>(block[i]);
+        }
+
+        dest += chunk;
+        remaining -= chunk;
+        ++block_index;
+    }
+
+    memory_cleanse(block, sizeof(block));
+}
+
+//! scryptBlockMix (RFC 7914 section 4). B is 32 * r words; Y is scratch of the
+//! same size.
+void BlockMix(uint32_t* B, uint32_t* Y, unsigned int r)
+{
+    const unsigned int blocks = 2 * r; // 64-byte (16-word) sub-blocks
+
+    // X starts as the last sub-block of B.
+    uint32_t X[16];
+    for (int i = 0; i < 16; ++i) {
+        X[i] = B[(blocks - 1) * 16 + i];
+    }
+
+    // X = Salsa(X ^ B[i]); interleave even/odd sub-blocks into the output
+    // order Y[0], Y[2], ..., Y[1], Y[3], ... directly.
+    for (unsigned int i = 0; i < blocks; ++i) {
+        xor_salsa8(X, &B[i * 16]);
+        const unsigned int dest = (i / 2) + (i & 1) * r;
+        for (int j = 0; j < 16; ++j) {
+            Y[dest * 16 + j] = X[j];
+        }
+    }
+
+    for (unsigned int i = 0; i < blocks * 16; ++i) {
+        B[i] = Y[i];
+    }
+
+    memory_cleanse(X, sizeof(X));
+}
+
+//! scryptROMix (RFC 7914 section 5). B is 32 * r words; V is scratch of
+//! N * 32 * r words; Y is scratch of 32 * r words.
+void ROMix(uint32_t* B, uint32_t* V, uint32_t* Y, unsigned int N, unsigned int r)
+{
+    const unsigned int words = 32 * r;
+
+    for (unsigned int i = 0; i < N; ++i) {
+        for (unsigned int j = 0; j < words; ++j) {
+            V[i * words + j] = B[j];
+        }
+        BlockMix(B, Y, r);
+    }
+
+    for (unsigned int i = 0; i < N; ++i) {
+        // Integerify: the first 8 bytes of the last 64-byte sub-block as a
+        // little-endian integer. The words are already little-endian decoded.
+        const uint64_t idx = (uint64_t{B[words - 16]} | (uint64_t{B[words - 15]} << 32)) & (N - 1);
+        for (unsigned int j = 0; j < words; ++j) {
+            B[j] ^= V[idx * words + j];
+        }
+        BlockMix(B, Y, r);
+    }
+}
+
+} // anonymous namespace
+
+void ScryptRFC7914(Span<const std::byte> pass, Span<const std::byte> salt,
+                   unsigned int N, unsigned int r, unsigned int p,
+                   Span<std::byte> out)
+{
+    // Enforce the RFC 7914 section 2 parameter domain unconditionally rather
+    // than with assert(): out-of-domain values would otherwise overflow the
+    // size arithmetic below. r * p < 2^30 is the RFC's own constraint. The
+    // scratch cap bounds the AGGREGATE allocation -- B (128 * r * p) plus V
+    // (128 * r * N) plus the lane and Y buffers (128 * r each), i.e.
+    // 128 * r * (N + p + 2) bytes -- using division so that no product in the
+    // validation itself can wrap. N and p are bounded by the r * p and
+    // power-of-two checks before they are summed.
+    constexpr uint64_t MAX_SCRATCH_BYTES = uint64_t{1} << 32; // 4 GiB
+
+    if (N <= 1 || (N & (N - 1)) != 0 || r == 0 || p == 0
+        || uint64_t{r} * p >= (uint64_t{1} << 30)
+        || uint64_t{128} * r > MAX_SCRATCH_BYTES / (uint64_t{N} + p + 2)
+        || out.size() == 0) {
+        throw std::invalid_argument("ScryptRFC7914: invalid parameters");
+    }
+
+    const size_t lane_bytes = 128 * static_cast<size_t>(r);
+    const size_t lane_words = lane_bytes / 4;
+
+    // B = PBKDF2-SHA256(pass, salt, c=1, p * 128 * r)
+    std::vector<std::byte> B(p * lane_bytes);
+    PBKDF2_SHA256_C1(pass, salt, MakeWritableByteSpan(B));
+
+    std::vector<uint32_t> lane(lane_words);
+    std::vector<uint32_t> V(static_cast<size_t>(N) * lane_words);
+    std::vector<uint32_t> Y(lane_words);
+
+    for (unsigned int i = 0; i < p; ++i) {
+        std::byte* lane_start = B.data() + i * lane_bytes;
+
+        // Decode the lane to native words (scrypt is little-endian).
+        for (size_t j = 0; j < lane_words; ++j) {
+            lane[j] = ReadLE32(reinterpret_cast<const unsigned char*>(lane_start) + 4 * j);
+        }
+
+        ROMix(lane.data(), V.data(), Y.data(), N, r);
+
+        for (size_t j = 0; j < lane_words; ++j) {
+            WriteLE32(reinterpret_cast<unsigned char*>(lane_start) + 4 * j, lane[j]);
+        }
+    }
+
+    // out = PBKDF2-SHA256(pass, B, c=1, dkLen)
+    PBKDF2_SHA256_C1(pass, MakeByteSpan(B), out);
+
+    memory_cleanse(B.data(), B.size());
+    memory_cleanse(lane.data(), lane.size() * sizeof(uint32_t));
+    memory_cleanse(V.data(), V.size() * sizeof(uint32_t));
+    memory_cleanse(Y.data(), Y.size() * sizeof(uint32_t));
+}

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_CRYPTO_SCRYPT_H
+#define GRIDCOIN_CRYPTO_SCRYPT_H
+
+#include <span.h>
+
+#include <cstddef>
+
+/**
+ * The scrypt password-based key derivation function as specified by RFC 7914,
+ * with parameterizable cost factors.
+ *
+ * This is distinct from the legacy fixed-parameter (N=1024, r=1, p=1) scrypt
+ * hasher in src/scrypt.{h,cpp}, which dates from the proof-of-work era and is
+ * retained for the wallet crypter. New uses of scrypt as a KDF (e.g. the seed
+ * phrase scheme) should use this implementation: it is endian-correct on all
+ * platforms and supports the memory-hard parameter ranges recommended for
+ * password hashing.
+ *
+ * \param pass   The password.
+ * \param salt   The salt.
+ * \param N      CPU/memory cost. Must be a power of two, greater than 1.
+ * \param r      Block size factor. Memory usage is roughly 128 * r * N bytes.
+ * \param p      Parallelization factor (lanes are computed sequentially).
+ * \param out    Receives the derived key; any length > 0 is permitted.
+ *
+ * \throws std::invalid_argument if the parameters are outside the RFC 7914
+ * domain (including r * p >= 2^30) or would require more than 4 GiB of
+ * scratch memory. Validation is unconditional, not assert()-based.
+ */
+void ScryptRFC7914(Span<const std::byte> pass, Span<const std::byte> salt,
+                   unsigned int N, unsigned int r, unsigned int p,
+                   Span<std::byte> out);
+
+#endif // GRIDCOIN_CRYPTO_SCRYPT_H

--- a/src/gridcoin/mnemonics.cpp
+++ b/src/gridcoin/mnemonics.cpp
@@ -1,0 +1,610 @@
+// Copyright (c) 2024-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <gridcoin/mnemonics.h>
+
+#include <crypto/chacha20.h>
+#include <crypto/chacha20poly1305.h>
+#include <crypto/scrypt.h>
+#include <crypto/sha256.h>
+#include <key.h>
+#include <random.h>
+#include <span.h>
+#include <support/cleanse.h>
+#include <util/time.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <iterator>
+
+using namespace GRC::Mnemonics;
+
+namespace {
+
+//! Length of the longest word in the wordlist.
+constexpr unsigned LONGEST_WORD_LENGTH = 8;
+
+//! The BIP39 English wordlist, used here purely as a well-vetted encoding
+//! alphabet (2048 words; no word is a prefix of another within the first four
+//! letters; edit-distance screened). The phrase payload is NOT
+//! BIP39-compatible. Verified against the canonical english.txt
+//! (SHA256 2f5eed53a4727b4bf8880d8f3f199efc90e58503646d9ff8eff3a2ed3b24dbda).
+constexpr const char* WORDLIST[2048] = {
+    "abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract",
+    "absurd", "abuse", "access", "accident", "account", "accuse", "achieve", "acid",
+    "acoustic", "acquire", "across", "act", "action", "actor", "actress", "actual",
+    "adapt", "add", "addict", "address", "adjust", "admit", "adult", "advance",
+    "advice", "aerobic", "affair", "afford", "afraid", "again", "age", "agent",
+    "agree", "ahead", "aim", "air", "airport", "aisle", "alarm", "album",
+    "alcohol", "alert", "alien", "all", "alley", "allow", "almost", "alone",
+    "alpha", "already", "also", "alter", "always", "amateur", "amazing", "among",
+    "amount", "amused", "analyst", "anchor", "ancient", "anger", "angle", "angry",
+    "animal", "ankle", "announce", "annual", "another", "answer", "antenna", "antique",
+    "anxiety", "any", "apart", "apology", "appear", "apple", "approve", "april",
+    "arch", "arctic", "area", "arena", "argue", "arm", "armed", "armor",
+    "army", "around", "arrange", "arrest", "arrive", "arrow", "art", "artefact",
+    "artist", "artwork", "ask", "aspect", "assault", "asset", "assist", "assume",
+    "asthma", "athlete", "atom", "attack", "attend", "attitude", "attract", "auction",
+    "audit", "august", "aunt", "author", "auto", "autumn", "average", "avocado",
+    "avoid", "awake", "aware", "away", "awesome", "awful", "awkward", "axis",
+    "baby", "bachelor", "bacon", "badge", "bag", "balance", "balcony", "ball",
+    "bamboo", "banana", "banner", "bar", "barely", "bargain", "barrel", "base",
+    "basic", "basket", "battle", "beach", "bean", "beauty", "because", "become",
+    "beef", "before", "begin", "behave", "behind", "believe", "below", "belt",
+    "bench", "benefit", "best", "betray", "better", "between", "beyond", "bicycle",
+    "bid", "bike", "bind", "biology", "bird", "birth", "bitter", "black",
+    "blade", "blame", "blanket", "blast", "bleak", "bless", "blind", "blood",
+    "blossom", "blouse", "blue", "blur", "blush", "board", "boat", "body",
+    "boil", "bomb", "bone", "bonus", "book", "boost", "border", "boring",
+    "borrow", "boss", "bottom", "bounce", "box", "boy", "bracket", "brain",
+    "brand", "brass", "brave", "bread", "breeze", "brick", "bridge", "brief",
+    "bright", "bring", "brisk", "broccoli", "broken", "bronze", "broom", "brother",
+    "brown", "brush", "bubble", "buddy", "budget", "buffalo", "build", "bulb",
+    "bulk", "bullet", "bundle", "bunker", "burden", "burger", "burst", "bus",
+    "business", "busy", "butter", "buyer", "buzz", "cabbage", "cabin", "cable",
+    "cactus", "cage", "cake", "call", "calm", "camera", "camp", "can",
+    "canal", "cancel", "candy", "cannon", "canoe", "canvas", "canyon", "capable",
+    "capital", "captain", "car", "carbon", "card", "cargo", "carpet", "carry",
+    "cart", "case", "cash", "casino", "castle", "casual", "cat", "catalog",
+    "catch", "category", "cattle", "caught", "cause", "caution", "cave", "ceiling",
+    "celery", "cement", "census", "century", "cereal", "certain", "chair", "chalk",
+    "champion", "change", "chaos", "chapter", "charge", "chase", "chat", "cheap",
+    "check", "cheese", "chef", "cherry", "chest", "chicken", "chief", "child",
+    "chimney", "choice", "choose", "chronic", "chuckle", "chunk", "churn", "cigar",
+    "cinnamon", "circle", "citizen", "city", "civil", "claim", "clap", "clarify",
+    "claw", "clay", "clean", "clerk", "clever", "click", "client", "cliff",
+    "climb", "clinic", "clip", "clock", "clog", "close", "cloth", "cloud",
+    "clown", "club", "clump", "cluster", "clutch", "coach", "coast", "coconut",
+    "code", "coffee", "coil", "coin", "collect", "color", "column", "combine",
+    "come", "comfort", "comic", "common", "company", "concert", "conduct", "confirm",
+    "congress", "connect", "consider", "control", "convince", "cook", "cool", "copper",
+    "copy", "coral", "core", "corn", "correct", "cost", "cotton", "couch",
+    "country", "couple", "course", "cousin", "cover", "coyote", "crack", "cradle",
+    "craft", "cram", "crane", "crash", "crater", "crawl", "crazy", "cream",
+    "credit", "creek", "crew", "cricket", "crime", "crisp", "critic", "crop",
+    "cross", "crouch", "crowd", "crucial", "cruel", "cruise", "crumble", "crunch",
+    "crush", "cry", "crystal", "cube", "culture", "cup", "cupboard", "curious",
+    "current", "curtain", "curve", "cushion", "custom", "cute", "cycle", "dad",
+    "damage", "damp", "dance", "danger", "daring", "dash", "daughter", "dawn",
+    "day", "deal", "debate", "debris", "decade", "december", "decide", "decline",
+    "decorate", "decrease", "deer", "defense", "define", "defy", "degree", "delay",
+    "deliver", "demand", "demise", "denial", "dentist", "deny", "depart", "depend",
+    "deposit", "depth", "deputy", "derive", "describe", "desert", "design", "desk",
+    "despair", "destroy", "detail", "detect", "develop", "device", "devote", "diagram",
+    "dial", "diamond", "diary", "dice", "diesel", "diet", "differ", "digital",
+    "dignity", "dilemma", "dinner", "dinosaur", "direct", "dirt", "disagree", "discover",
+    "disease", "dish", "dismiss", "disorder", "display", "distance", "divert", "divide",
+    "divorce", "dizzy", "doctor", "document", "dog", "doll", "dolphin", "domain",
+    "donate", "donkey", "donor", "door", "dose", "double", "dove", "draft",
+    "dragon", "drama", "drastic", "draw", "dream", "dress", "drift", "drill",
+    "drink", "drip", "drive", "drop", "drum", "dry", "duck", "dumb",
+    "dune", "during", "dust", "dutch", "duty", "dwarf", "dynamic", "eager",
+    "eagle", "early", "earn", "earth", "easily", "east", "easy", "echo",
+    "ecology", "economy", "edge", "edit", "educate", "effort", "egg", "eight",
+    "either", "elbow", "elder", "electric", "elegant", "element", "elephant", "elevator",
+    "elite", "else", "embark", "embody", "embrace", "emerge", "emotion", "employ",
+    "empower", "empty", "enable", "enact", "end", "endless", "endorse", "enemy",
+    "energy", "enforce", "engage", "engine", "enhance", "enjoy", "enlist", "enough",
+    "enrich", "enroll", "ensure", "enter", "entire", "entry", "envelope", "episode",
+    "equal", "equip", "era", "erase", "erode", "erosion", "error", "erupt",
+    "escape", "essay", "essence", "estate", "eternal", "ethics", "evidence", "evil",
+    "evoke", "evolve", "exact", "example", "excess", "exchange", "excite", "exclude",
+    "excuse", "execute", "exercise", "exhaust", "exhibit", "exile", "exist", "exit",
+    "exotic", "expand", "expect", "expire", "explain", "expose", "express", "extend",
+    "extra", "eye", "eyebrow", "fabric", "face", "faculty", "fade", "faint",
+    "faith", "fall", "false", "fame", "family", "famous", "fan", "fancy",
+    "fantasy", "farm", "fashion", "fat", "fatal", "father", "fatigue", "fault",
+    "favorite", "feature", "february", "federal", "fee", "feed", "feel", "female",
+    "fence", "festival", "fetch", "fever", "few", "fiber", "fiction", "field",
+    "figure", "file", "film", "filter", "final", "find", "fine", "finger",
+    "finish", "fire", "firm", "first", "fiscal", "fish", "fit", "fitness",
+    "fix", "flag", "flame", "flash", "flat", "flavor", "flee", "flight",
+    "flip", "float", "flock", "floor", "flower", "fluid", "flush", "fly",
+    "foam", "focus", "fog", "foil", "fold", "follow", "food", "foot",
+    "force", "forest", "forget", "fork", "fortune", "forum", "forward", "fossil",
+    "foster", "found", "fox", "fragile", "frame", "frequent", "fresh", "friend",
+    "fringe", "frog", "front", "frost", "frown", "frozen", "fruit", "fuel",
+    "fun", "funny", "furnace", "fury", "future", "gadget", "gain", "galaxy",
+    "gallery", "game", "gap", "garage", "garbage", "garden", "garlic", "garment",
+    "gas", "gasp", "gate", "gather", "gauge", "gaze", "general", "genius",
+    "genre", "gentle", "genuine", "gesture", "ghost", "giant", "gift", "giggle",
+    "ginger", "giraffe", "girl", "give", "glad", "glance", "glare", "glass",
+    "glide", "glimpse", "globe", "gloom", "glory", "glove", "glow", "glue",
+    "goat", "goddess", "gold", "good", "goose", "gorilla", "gospel", "gossip",
+    "govern", "gown", "grab", "grace", "grain", "grant", "grape", "grass",
+    "gravity", "great", "green", "grid", "grief", "grit", "grocery", "group",
+    "grow", "grunt", "guard", "guess", "guide", "guilt", "guitar", "gun",
+    "gym", "habit", "hair", "half", "hammer", "hamster", "hand", "happy",
+    "harbor", "hard", "harsh", "harvest", "hat", "have", "hawk", "hazard",
+    "head", "health", "heart", "heavy", "hedgehog", "height", "hello", "helmet",
+    "help", "hen", "hero", "hidden", "high", "hill", "hint", "hip",
+    "hire", "history", "hobby", "hockey", "hold", "hole", "holiday", "hollow",
+    "home", "honey", "hood", "hope", "horn", "horror", "horse", "hospital",
+    "host", "hotel", "hour", "hover", "hub", "huge", "human", "humble",
+    "humor", "hundred", "hungry", "hunt", "hurdle", "hurry", "hurt", "husband",
+    "hybrid", "ice", "icon", "idea", "identify", "idle", "ignore", "ill",
+    "illegal", "illness", "image", "imitate", "immense", "immune", "impact", "impose",
+    "improve", "impulse", "inch", "include", "income", "increase", "index", "indicate",
+    "indoor", "industry", "infant", "inflict", "inform", "inhale", "inherit", "initial",
+    "inject", "injury", "inmate", "inner", "innocent", "input", "inquiry", "insane",
+    "insect", "inside", "inspire", "install", "intact", "interest", "into", "invest",
+    "invite", "involve", "iron", "island", "isolate", "issue", "item", "ivory",
+    "jacket", "jaguar", "jar", "jazz", "jealous", "jeans", "jelly", "jewel",
+    "job", "join", "joke", "journey", "joy", "judge", "juice", "jump",
+    "jungle", "junior", "junk", "just", "kangaroo", "keen", "keep", "ketchup",
+    "key", "kick", "kid", "kidney", "kind", "kingdom", "kiss", "kit",
+    "kitchen", "kite", "kitten", "kiwi", "knee", "knife", "knock", "know",
+    "lab", "label", "labor", "ladder", "lady", "lake", "lamp", "language",
+    "laptop", "large", "later", "latin", "laugh", "laundry", "lava", "law",
+    "lawn", "lawsuit", "layer", "lazy", "leader", "leaf", "learn", "leave",
+    "lecture", "left", "leg", "legal", "legend", "leisure", "lemon", "lend",
+    "length", "lens", "leopard", "lesson", "letter", "level", "liar", "liberty",
+    "library", "license", "life", "lift", "light", "like", "limb", "limit",
+    "link", "lion", "liquid", "list", "little", "live", "lizard", "load",
+    "loan", "lobster", "local", "lock", "logic", "lonely", "long", "loop",
+    "lottery", "loud", "lounge", "love", "loyal", "lucky", "luggage", "lumber",
+    "lunar", "lunch", "luxury", "lyrics", "machine", "mad", "magic", "magnet",
+    "maid", "mail", "main", "major", "make", "mammal", "man", "manage",
+    "mandate", "mango", "mansion", "manual", "maple", "marble", "march", "margin",
+    "marine", "market", "marriage", "mask", "mass", "master", "match", "material",
+    "math", "matrix", "matter", "maximum", "maze", "meadow", "mean", "measure",
+    "meat", "mechanic", "medal", "media", "melody", "melt", "member", "memory",
+    "mention", "menu", "mercy", "merge", "merit", "merry", "mesh", "message",
+    "metal", "method", "middle", "midnight", "milk", "million", "mimic", "mind",
+    "minimum", "minor", "minute", "miracle", "mirror", "misery", "miss", "mistake",
+    "mix", "mixed", "mixture", "mobile", "model", "modify", "mom", "moment",
+    "monitor", "monkey", "monster", "month", "moon", "moral", "more", "morning",
+    "mosquito", "mother", "motion", "motor", "mountain", "mouse", "move", "movie",
+    "much", "muffin", "mule", "multiply", "muscle", "museum", "mushroom", "music",
+    "must", "mutual", "myself", "mystery", "myth", "naive", "name", "napkin",
+    "narrow", "nasty", "nation", "nature", "near", "neck", "need", "negative",
+    "neglect", "neither", "nephew", "nerve", "nest", "net", "network", "neutral",
+    "never", "news", "next", "nice", "night", "noble", "noise", "nominee",
+    "noodle", "normal", "north", "nose", "notable", "note", "nothing", "notice",
+    "novel", "now", "nuclear", "number", "nurse", "nut", "oak", "obey",
+    "object", "oblige", "obscure", "observe", "obtain", "obvious", "occur", "ocean",
+    "october", "odor", "off", "offer", "office", "often", "oil", "okay",
+    "old", "olive", "olympic", "omit", "once", "one", "onion", "online",
+    "only", "open", "opera", "opinion", "oppose", "option", "orange", "orbit",
+    "orchard", "order", "ordinary", "organ", "orient", "original", "orphan", "ostrich",
+    "other", "outdoor", "outer", "output", "outside", "oval", "oven", "over",
+    "own", "owner", "oxygen", "oyster", "ozone", "pact", "paddle", "page",
+    "pair", "palace", "palm", "panda", "panel", "panic", "panther", "paper",
+    "parade", "parent", "park", "parrot", "party", "pass", "patch", "path",
+    "patient", "patrol", "pattern", "pause", "pave", "payment", "peace", "peanut",
+    "pear", "peasant", "pelican", "pen", "penalty", "pencil", "people", "pepper",
+    "perfect", "permit", "person", "pet", "phone", "photo", "phrase", "physical",
+    "piano", "picnic", "picture", "piece", "pig", "pigeon", "pill", "pilot",
+    "pink", "pioneer", "pipe", "pistol", "pitch", "pizza", "place", "planet",
+    "plastic", "plate", "play", "please", "pledge", "pluck", "plug", "plunge",
+    "poem", "poet", "point", "polar", "pole", "police", "pond", "pony",
+    "pool", "popular", "portion", "position", "possible", "post", "potato", "pottery",
+    "poverty", "powder", "power", "practice", "praise", "predict", "prefer", "prepare",
+    "present", "pretty", "prevent", "price", "pride", "primary", "print", "priority",
+    "prison", "private", "prize", "problem", "process", "produce", "profit", "program",
+    "project", "promote", "proof", "property", "prosper", "protect", "proud", "provide",
+    "public", "pudding", "pull", "pulp", "pulse", "pumpkin", "punch", "pupil",
+    "puppy", "purchase", "purity", "purpose", "purse", "push", "put", "puzzle",
+    "pyramid", "quality", "quantum", "quarter", "question", "quick", "quit", "quiz",
+    "quote", "rabbit", "raccoon", "race", "rack", "radar", "radio", "rail",
+    "rain", "raise", "rally", "ramp", "ranch", "random", "range", "rapid",
+    "rare", "rate", "rather", "raven", "raw", "razor", "ready", "real",
+    "reason", "rebel", "rebuild", "recall", "receive", "recipe", "record", "recycle",
+    "reduce", "reflect", "reform", "refuse", "region", "regret", "regular", "reject",
+    "relax", "release", "relief", "rely", "remain", "remember", "remind", "remove",
+    "render", "renew", "rent", "reopen", "repair", "repeat", "replace", "report",
+    "require", "rescue", "resemble", "resist", "resource", "response", "result", "retire",
+    "retreat", "return", "reunion", "reveal", "review", "reward", "rhythm", "rib",
+    "ribbon", "rice", "rich", "ride", "ridge", "rifle", "right", "rigid",
+    "ring", "riot", "ripple", "risk", "ritual", "rival", "river", "road",
+    "roast", "robot", "robust", "rocket", "romance", "roof", "rookie", "room",
+    "rose", "rotate", "rough", "round", "route", "royal", "rubber", "rude",
+    "rug", "rule", "run", "runway", "rural", "sad", "saddle", "sadness",
+    "safe", "sail", "salad", "salmon", "salon", "salt", "salute", "same",
+    "sample", "sand", "satisfy", "satoshi", "sauce", "sausage", "save", "say",
+    "scale", "scan", "scare", "scatter", "scene", "scheme", "school", "science",
+    "scissors", "scorpion", "scout", "scrap", "screen", "script", "scrub", "sea",
+    "search", "season", "seat", "second", "secret", "section", "security", "seed",
+    "seek", "segment", "select", "sell", "seminar", "senior", "sense", "sentence",
+    "series", "service", "session", "settle", "setup", "seven", "shadow", "shaft",
+    "shallow", "share", "shed", "shell", "sheriff", "shield", "shift", "shine",
+    "ship", "shiver", "shock", "shoe", "shoot", "shop", "short", "shoulder",
+    "shove", "shrimp", "shrug", "shuffle", "shy", "sibling", "sick", "side",
+    "siege", "sight", "sign", "silent", "silk", "silly", "silver", "similar",
+    "simple", "since", "sing", "siren", "sister", "situate", "six", "size",
+    "skate", "sketch", "ski", "skill", "skin", "skirt", "skull", "slab",
+    "slam", "sleep", "slender", "slice", "slide", "slight", "slim", "slogan",
+    "slot", "slow", "slush", "small", "smart", "smile", "smoke", "smooth",
+    "snack", "snake", "snap", "sniff", "snow", "soap", "soccer", "social",
+    "sock", "soda", "soft", "solar", "soldier", "solid", "solution", "solve",
+    "someone", "song", "soon", "sorry", "sort", "soul", "sound", "soup",
+    "source", "south", "space", "spare", "spatial", "spawn", "speak", "special",
+    "speed", "spell", "spend", "sphere", "spice", "spider", "spike", "spin",
+    "spirit", "split", "spoil", "sponsor", "spoon", "sport", "spot", "spray",
+    "spread", "spring", "spy", "square", "squeeze", "squirrel", "stable", "stadium",
+    "staff", "stage", "stairs", "stamp", "stand", "start", "state", "stay",
+    "steak", "steel", "stem", "step", "stereo", "stick", "still", "sting",
+    "stock", "stomach", "stone", "stool", "story", "stove", "strategy", "street",
+    "strike", "strong", "struggle", "student", "stuff", "stumble", "style", "subject",
+    "submit", "subway", "success", "such", "sudden", "suffer", "sugar", "suggest",
+    "suit", "summer", "sun", "sunny", "sunset", "super", "supply", "supreme",
+    "sure", "surface", "surge", "surprise", "surround", "survey", "suspect", "sustain",
+    "swallow", "swamp", "swap", "swarm", "swear", "sweet", "swift", "swim",
+    "swing", "switch", "sword", "symbol", "symptom", "syrup", "system", "table",
+    "tackle", "tag", "tail", "talent", "talk", "tank", "tape", "target",
+    "task", "taste", "tattoo", "taxi", "teach", "team", "tell", "ten",
+    "tenant", "tennis", "tent", "term", "test", "text", "thank", "that",
+    "theme", "then", "theory", "there", "they", "thing", "this", "thought",
+    "three", "thrive", "throw", "thumb", "thunder", "ticket", "tide", "tiger",
+    "tilt", "timber", "time", "tiny", "tip", "tired", "tissue", "title",
+    "toast", "tobacco", "today", "toddler", "toe", "together", "toilet", "token",
+    "tomato", "tomorrow", "tone", "tongue", "tonight", "tool", "tooth", "top",
+    "topic", "topple", "torch", "tornado", "tortoise", "toss", "total", "tourist",
+    "toward", "tower", "town", "toy", "track", "trade", "traffic", "tragic",
+    "train", "transfer", "trap", "trash", "travel", "tray", "treat", "tree",
+    "trend", "trial", "tribe", "trick", "trigger", "trim", "trip", "trophy",
+    "trouble", "truck", "true", "truly", "trumpet", "trust", "truth", "try",
+    "tube", "tuition", "tumble", "tuna", "tunnel", "turkey", "turn", "turtle",
+    "twelve", "twenty", "twice", "twin", "twist", "two", "type", "typical",
+    "ugly", "umbrella", "unable", "unaware", "uncle", "uncover", "under", "undo",
+    "unfair", "unfold", "unhappy", "uniform", "unique", "unit", "universe", "unknown",
+    "unlock", "until", "unusual", "unveil", "update", "upgrade", "uphold", "upon",
+    "upper", "upset", "urban", "urge", "usage", "use", "used", "useful",
+    "useless", "usual", "utility", "vacant", "vacuum", "vague", "valid", "valley",
+    "valve", "van", "vanish", "vapor", "various", "vast", "vault", "vehicle",
+    "velvet", "vendor", "venture", "venue", "verb", "verify", "version", "very",
+    "vessel", "veteran", "viable", "vibrant", "vicious", "victory", "video", "view",
+    "village", "vintage", "violin", "virtual", "virus", "visa", "visit", "visual",
+    "vital", "vivid", "vocal", "voice", "void", "volcano", "volume", "vote",
+    "voyage", "wage", "wagon", "wait", "walk", "wall", "walnut", "want",
+    "warfare", "warm", "warrior", "wash", "wasp", "waste", "water", "wave",
+    "way", "wealth", "weapon", "wear", "weasel", "weather", "web", "wedding",
+    "weekend", "weird", "welcome", "west", "wet", "whale", "what", "wheat",
+    "wheel", "when", "where", "whip", "whisper", "wide", "width", "wife",
+    "wild", "will", "win", "window", "wine", "wing", "wink", "winner",
+    "winter", "wire", "wisdom", "wise", "wish", "witness", "wolf", "woman",
+    "wonder", "wood", "wool", "word", "work", "world", "worry", "worth",
+    "wrap", "wreck", "wrestle", "wrist", "write", "wrong", "yard", "year",
+    "yellow", "you", "young", "youth", "zebra", "zero", "zone", "zoo"
+};
+
+static_assert((1u << WORDLIST_BIT_LENGTH) == std::size(WORDLIST));
+
+//! LONGEST_WORD_LENGTH is load-bearing: it sizes the word-selection buffer in
+//! EncodeSeedPhrase and bounds the separator scan window. Pin it against the
+//! actual wordlist at compile time.
+constexpr bool WordlistLengthsValid()
+{
+    for (unsigned i = 0; i < std::size(WORDLIST); ++i) {
+        unsigned length = 0;
+        while (WORDLIST[i][length] != '\0') {
+            ++length;
+        }
+        if (length == 0 || length > LONGEST_WORD_LENGTH) {
+            return false;
+        }
+    }
+    return true;
+}
+static_assert(WordlistLengthsValid(),
+              "every wordlist entry must be between 1 and LONGEST_WORD_LENGTH characters");
+
+//! Timing attack safe word to index mapper. Returns -1 if the word is not found.
+int timingsafe_wordfind(const SecureString& phrase, int word_start, int word_end)
+{
+    int ret = -1;
+    const int word_length = word_end - word_start;
+    const int last_char_index = std::min(word_end - 1, (int)phrase.size() - 1);
+
+    for (int i = 0; i < (int)std::size(WORDLIST); ++i) {
+        const int other_last_char_index = (int)strlen(WORDLIST[i]) - 1;
+        bool found = word_length == other_last_char_index + 1;
+
+        for (int j = 0; j < (int)LONGEST_WORD_LENGTH + 1; ++j) {
+            found &= (phrase[std::min(word_start + j, last_char_index)]
+                      == WORDLIST[i][std::min(j, other_last_char_index)]);
+        }
+
+        found &= (ret == -1);
+        ret = found * i + (1 - found) * ret;
+    }
+
+    return ret;
+}
+
+//! Timing attack safe space finder for splitting the words. Points to the end if not found.
+int timingsafe_spacefind(const SecureString& phrase, int start)
+{
+    int ret = -1;
+    const int last_char_index = phrase.size() - 1;
+
+    for (int i = start; i < start + (int)LONGEST_WORD_LENGTH + 1; ++i) {
+        bool is_whitespace = (phrase[std::min(i, last_char_index)] == ' ');
+        is_whitespace &= (ret == -1);
+        ret = is_whitespace * i + (1 - is_whitespace) * ret;
+    }
+
+    const bool found = ret != -1;
+    return found * ret + (1 - found) * (int)phrase.size();
+}
+
+//! Constant-time byte comparison. Returns 0 when equal.
+int timingsafe_bcmp(const std::byte* b1, const std::byte* b2, size_t n)
+{
+    unsigned char ret = 0;
+    for (; n > 0; --n) {
+        ret |= std::to_integer<unsigned char>(*b1++) ^ std::to_integer<unsigned char>(*b2++);
+    }
+    return ret != 0;
+}
+
+//! Read the 11-bit word index at word position `word`. Bit 0 is the most
+//! significant bit of the first byte.
+unsigned GetWordBits(Span<const std::byte> data, unsigned word)
+{
+    unsigned index = 0;
+    for (unsigned b = 0; b < WORDLIST_BIT_LENGTH; ++b) {
+        const unsigned bit = word * WORDLIST_BIT_LENGTH + b;
+        index = (index << 1) | ((std::to_integer<unsigned>(data[bit / 8]) >> (7 - bit % 8)) & 1u);
+    }
+    return index;
+}
+
+//! Write the 11-bit word index at word position `word`. The destination must
+//! start zeroed. Branchless: no secret-dependent control flow.
+void SetWordBits(Span<std::byte> data, unsigned word, unsigned index)
+{
+    for (unsigned b = 0; b < WORDLIST_BIT_LENGTH; ++b) {
+        const unsigned bit = word * WORDLIST_BIT_LENGTH + b;
+        const unsigned value = (index >> (WORDLIST_BIT_LENGTH - 1 - b)) & 1u;
+        data[bit / 8] |= std::byte(value << (7 - bit % 8));
+    }
+}
+
+//! Derive the AEAD key from the password and salt with scrypt.
+void DeriveKey(const SecureString& password, Span<const std::byte> salt, Span<std::byte> key_out)
+{
+    ScryptRFC7914(Span{reinterpret_cast<const std::byte*>(password.data()), password.size()},
+                  salt, SCRYPT_N, SCRYPT_R, SCRYPT_P, key_out);
+}
+
+//! Derive the wallet key from the entropy (inner version 0).
+bool DeriveWalletKey(Span<const std::byte> entropy, CKey& key_out)
+{
+    unsigned char key_data[CSHA256::OUTPUT_SIZE];
+    CSHA256().Write(UCharCast(entropy.data()), entropy.size()).Finalize(key_data);
+    key_out.Set(std::begin(key_data), std::end(key_data), /*fCompressedIn=*/true);
+    memory_cleanse(key_data, sizeof(key_data));
+    return key_out.IsValid();
+}
+
+} // anonymous namespace
+
+bool GRC::Mnemonics::DecodeSeedPhrase(const SecureString& seed_phrase, Span<std::byte> data_out)
+{
+    assert(data_out.size() == ENCIPHERED_LENGTH);
+    std::fill(data_out.begin(), data_out.end(), std::byte{0});
+
+    // No valid phrase exceeds WORD_COUNT longest words plus separators (one
+    // trailing separator tolerated). Rejecting oversized input up front also
+    // keeps the int index arithmetic in the scanners trivially in range.
+    if (seed_phrase.empty()
+        || seed_phrase.size() > WORD_COUNT * (LONGEST_WORD_LENGTH + 1)) {
+        return false;
+    }
+
+    unsigned word_count = 0;
+    SecureString::size_type word_start = 0;
+    do {
+        const int word_end = timingsafe_spacefind(seed_phrase, word_start);
+
+        // An empty segment (leading, doubled or misplaced separator): reject
+        // before the word scan, which requires a non-empty candidate.
+        if (word_end == (int)word_start) {
+            std::fill(data_out.begin(), data_out.end(), std::byte{0});
+            return false;
+        }
+
+        const int index = timingsafe_wordfind(seed_phrase, word_start, word_end);
+
+        if (index == -1 || word_count >= WORD_COUNT) {
+            std::fill(data_out.begin(), data_out.end(), std::byte{0});
+            return false;
+        }
+
+        SetWordBits(data_out, word_count, index);
+
+        word_start = word_end + 1;
+        ++word_count;
+    } while (word_start < seed_phrase.size());
+
+    if (word_count != WORD_COUNT) {
+        std::fill(data_out.begin(), data_out.end(), std::byte{0});
+        return false;
+    }
+
+    return true;
+}
+
+SecureString GRC::Mnemonics::EncodeSeedPhrase(Span<const std::byte> data_in)
+{
+    assert(data_in.size() == ENCIPHERED_LENGTH);
+
+    SecureString seed_phrase;
+    seed_phrase.reserve(WORD_COUNT * (LONGEST_WORD_LENGTH + 1));
+
+    for (unsigned i = 0; i < WORD_COUNT; ++i) {
+        const unsigned index = GetWordBits(data_in, i);
+
+        // Select the word by scanning the whole (public) table with branchless
+        // accumulation, so the secret index is not exposed through a single
+        // indexed load.
+        char buffer[LONGEST_WORD_LENGTH] = {};
+        int length = 0;
+        for (unsigned w = 0; w < std::size(WORDLIST); ++w) {
+            const int selected = (w == index);
+            const int word_length = (int)strlen(WORDLIST[w]);
+            for (int j = 0; j < (int)LONGEST_WORD_LENGTH; ++j) {
+                const char c = WORDLIST[w][std::min(j, word_length - 1)];
+                buffer[j] = (char)(selected * c + (1 - selected) * buffer[j]);
+            }
+            length = selected * word_length + (1 - selected) * length;
+        }
+
+        if (i != 0) {
+            seed_phrase += ' ';
+        }
+        seed_phrase.append(buffer, length);
+        memory_cleanse(buffer, sizeof(buffer));
+    }
+
+    return seed_phrase;
+}
+
+SecureString GRC::Mnemonics::BuildSeedPhrase(Span<const std::byte> entropy, uint16_t birthday_days,
+                                             Span<const std::byte> salt, const SecureString& password)
+{
+    assert(entropy.size() == ENTROPY_LENGTH);
+    assert(salt.size() == SALT_LENGTH);
+
+    std::byte plain[PLAINTEXT_LENGTH];
+    std::byte blob[ENCIPHERED_LENGTH];
+    std::byte key[AEADChaCha20Poly1305::KEYLEN];
+    std::byte cipher[PLAINTEXT_LENGTH + AEADChaCha20Poly1305::EXPANSION];
+
+    plain[0] = std::byte{0}; // inner version
+    plain[1] = std::byte(birthday_days & 0xFF);
+    plain[2] = std::byte(birthday_days >> 8);
+    std::copy(entropy.begin(), entropy.end(), plain + 3);
+
+    blob[0] = std::byte{0}; // outer version
+    std::copy(salt.begin(), salt.end(), blob + 1);
+
+    DeriveKey(password, salt, key);
+
+    // Zero nonce: the key is derived from a fresh salt and used exactly once.
+    // AAD covers the outer version and salt so the tag authenticates them too.
+    AEADChaCha20Poly1305 aead{key};
+    aead.Encrypt(plain, Span{blob, 1 + SALT_LENGTH}, {0, 0}, cipher);
+
+    // The ciphertext followed by the leading TAG_LENGTH bytes of the tag.
+    std::copy(cipher, cipher + PLAINTEXT_LENGTH + TAG_LENGTH, blob + 1 + SALT_LENGTH);
+
+    SecureString seed_phrase = EncodeSeedPhrase(blob);
+
+    memory_cleanse(plain, sizeof(plain));
+    memory_cleanse(blob, sizeof(blob));
+    memory_cleanse(key, sizeof(key));
+    memory_cleanse(cipher, sizeof(cipher));
+
+    return seed_phrase;
+}
+
+SecureString GRC::Mnemonics::GenerateSeedPhrase(const SecureString& password, CKey& key_out)
+{
+    std::byte entropy[ENTROPY_LENGTH];
+    std::byte salt[SALT_LENGTH];
+
+    do {
+        GetStrongRandBytes({UCharCast(entropy), sizeof(entropy)});
+    } while (!DeriveWalletKey(entropy, key_out));
+
+    GetStrongRandBytes({UCharCast(salt), sizeof(salt)});
+
+    int64_t days = (GetTime() - BIRTHDAY_EPOCH) / (24 * 60 * 60);
+    days = std::max<int64_t>(0, std::min<int64_t>(days, 0xFFFF));
+
+    SecureString seed_phrase = BuildSeedPhrase(entropy, (uint16_t)days, salt, password);
+
+    memory_cleanse(entropy, sizeof(entropy));
+    memory_cleanse(salt, sizeof(salt));
+
+    return seed_phrase;
+}
+
+bool GRC::Mnemonics::ParseSeedPhrase(const SecureString& seed_phrase, const SecureString& password,
+                                     CKey& key_out, int64_t* birthday_out)
+{
+    std::byte blob[ENCIPHERED_LENGTH];
+    std::byte key[AEADChaCha20Poly1305::KEYLEN];
+    std::byte plain[PLAINTEXT_LENGTH];
+    std::byte cipher[PLAINTEXT_LENGTH + AEADChaCha20Poly1305::EXPANSION];
+
+    bool ok = false;
+    int64_t birthday = 0;
+
+    if (!DecodeSeedPhrase(seed_phrase, blob)) {
+        goto cleanup;
+    }
+
+    // Outer version selects the decoding format; only version 0 exists.
+    if (blob[0] != std::byte{0}) {
+        goto cleanup;
+    }
+
+    DeriveKey(password, Span{blob + 1, SALT_LENGTH}, key);
+
+    {
+        // Decrypt: the payload keystream starts at block 1 (RFC 8439 reserves
+        // block 0 for the Poly1305 key).
+        ChaCha20 chacha{key};
+        chacha.Seek({0, 0}, 1);
+        chacha.Crypt(Span{blob + 1 + SALT_LENGTH, PLAINTEXT_LENGTH}, plain);
+
+        // Verify the truncated tag: re-encrypt the recovered plaintext (the
+        // ciphertext necessarily matches -- same key, nonce and keystream) and
+        // compare the leading TAG_LENGTH bytes of the full tag, constant time.
+        AEADChaCha20Poly1305 aead{key};
+        aead.Encrypt(plain, Span{blob, 1 + SALT_LENGTH}, {0, 0}, cipher);
+
+        if (timingsafe_bcmp(cipher + PLAINTEXT_LENGTH,
+                            blob + 1 + SALT_LENGTH + PLAINTEXT_LENGTH, TAG_LENGTH) != 0) {
+            goto cleanup;
+        }
+    }
+
+    // Inner version selects the key derivation; only version 0 exists.
+    if (plain[0] != std::byte{0}) {
+        goto cleanup;
+    }
+
+    birthday = BIRTHDAY_EPOCH
+        + ((int64_t)std::to_integer<unsigned>(plain[1])
+           | ((int64_t)std::to_integer<unsigned>(plain[2]) << 8)) * 24 * 60 * 60;
+
+    ok = DeriveWalletKey(Span{plain + 3, ENTROPY_LENGTH}, key_out);
+
+    if (ok && birthday_out != nullptr) {
+        *birthday_out = birthday;
+    }
+
+cleanup:
+    memory_cleanse(blob, sizeof(blob));
+    memory_cleanse(key, sizeof(key));
+    memory_cleanse(plain, sizeof(plain));
+    memory_cleanse(cipher, sizeof(cipher));
+
+    return ok;
+}

--- a/src/gridcoin/mnemonics.h
+++ b/src/gridcoin/mnemonics.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2024-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_MNEMONICS_H
+#define GRIDCOIN_MNEMONICS_H
+
+#include <key.h>
+#include <span.h>
+#include <support/allocators/secure.h>
+
+#include <cstdint>
+
+namespace GRC {
+namespace Mnemonics {
+
+//! \brief Gridcoin's versioned seed phrase scheme.
+//!
+//! A seed phrase is 24 words from the BIP39 English wordlist encoding a
+//! 33-byte blob (24 * 11 bits = 264 bits, with no padding):
+//!
+//!   outer version (1) || salt (5) || ciphertext (19) || tag (8)
+//!
+//! The ciphertext is the ChaCha20Poly1305 (RFC 8439) encryption -- with the
+//! tag truncated to 8 bytes -- of:
+//!
+//!   inner version (1) || wallet birthday in days, LE (2) || entropy (16)
+//!
+//! under a key derived from the user's password with scrypt (RFC 7914,
+//! N=32768/r=8/p=1), a zero nonce (the key is used exactly once per salt),
+//! and the outer version plus salt as additional authenticated data.
+//!
+//! The outer version fixes the decoding format, wordlist, KDF and cipher; the
+//! inner version fixes how keys are derived from the entropy. Both are 0.
+//! Unlike BIP39, a wrong password fails authentication explicitly rather than
+//! silently deriving a different wallet.
+
+//! \brief Number of bits encoded per word; the wordlist has 2^11 = 2048 words.
+constexpr unsigned WORDLIST_BIT_LENGTH = 11;
+
+//! \brief Length of the entropy the phrase protects.
+constexpr unsigned ENTROPY_LENGTH = 16;
+
+//! \brief plaintext: 1 byte inner version || 2 byte birthday || 16 byte entropy.
+constexpr unsigned PLAINTEXT_LENGTH = 1 + 2 + ENTROPY_LENGTH;
+
+//! \brief Length of the KDF salt, which doubles as the AEAD's authenticated data.
+constexpr unsigned SALT_LENGTH = 5;
+
+//! \brief Length of the (truncated) Poly1305 authentication tag.
+constexpr unsigned TAG_LENGTH = 8;
+
+//! \brief enciphered: outer version || salt || ciphertext || tag = 33 bytes.
+constexpr unsigned ENCIPHERED_LENGTH = 1 + SALT_LENGTH + PLAINTEXT_LENGTH + TAG_LENGTH;
+
+//! \brief 33 bytes = 264 bits = exactly 24 words.
+constexpr unsigned WORD_COUNT = ENCIPHERED_LENGTH * 8 / WORDLIST_BIT_LENGTH;
+static_assert(WORD_COUNT * WORDLIST_BIT_LENGTH == ENCIPHERED_LENGTH * 8,
+              "the enciphered blob must pack into whole words with no padding");
+
+//! \brief Epoch for the 16-bit wallet birthday (in days): the mainnet genesis
+//! block time. 16 bits of days covers about 179 years.
+constexpr int64_t BIRTHDAY_EPOCH = 1413149999;
+
+//! \brief scrypt cost parameters for the password KDF under outer version 0
+//! (the aezeed parameters; roughly 32 MiB of scratch memory).
+constexpr unsigned SCRYPT_N = 32768;
+constexpr unsigned SCRYPT_R = 8;
+constexpr unsigned SCRYPT_P = 1;
+
+//! \brief Convert a seed phrase to the 33-byte enciphered blob.
+//!
+//! \param seed_phrase Words separated by single spaces. A single trailing
+//!                    separator is tolerated; empty segments (leading or
+//!                    doubled separators) are rejected.
+//! \param data_out    Receives the blob; must be ENCIPHERED_LENGTH bytes.
+//!
+//! \return False if any word is not in the wordlist or the phrase does not
+//! contain exactly WORD_COUNT words.
+bool DecodeSeedPhrase(const SecureString& seed_phrase, Span<std::byte> data_out);
+
+//! \brief Convert a 33-byte enciphered blob to a seed phrase.
+//!
+//! \param data_in The blob; must be ENCIPHERED_LENGTH bytes.
+SecureString EncodeSeedPhrase(Span<const std::byte> data_in);
+
+//! \brief Deterministically construct a seed phrase from its parts. Exposed
+//! for tests and fixed vectors; use GenerateSeedPhrase() to create one.
+//!
+//! \warning The AEAD nonce is fixed at zero on the premise that a
+//! password+salt pair keys exactly one encryption. Reusing a salt with the
+//! same password for different plaintexts reuses the keystream; callers must
+//! supply a fresh random salt per phrase, as GenerateSeedPhrase() does.
+//!
+//! \param entropy       ENTROPY_LENGTH bytes of entropy.
+//! \param birthday_days Days since BIRTHDAY_EPOCH at wallet creation.
+//! \param salt          SALT_LENGTH bytes of KDF salt.
+//! \param password      Password protecting the phrase. May be empty.
+SecureString BuildSeedPhrase(Span<const std::byte> entropy, uint16_t birthday_days,
+                             Span<const std::byte> salt, const SecureString& password);
+
+//! \brief Generate a new random seed phrase and the key it protects.
+//!
+//! \param password Password protecting the phrase. May be empty.
+//! \param key_out  Receives the derived key (SHA256 of the entropy under
+//!                 inner version 0), intended as the wallet's HD master seed.
+SecureString GenerateSeedPhrase(const SecureString& password, CKey& key_out);
+
+//! \brief Recover the key protected by a seed phrase.
+//!
+//! \param seed_phrase  The 24-word phrase.
+//! \param password     The password it was generated with.
+//! \param key_out      Receives the derived key on success.
+//! \param birthday_out If non-null, receives the wallet birthday as a Unix
+//!                     timestamp (day resolution) for bounding rescans.
+//!
+//! \return False if the phrase is malformed, the password is wrong (the tag
+//! fails to authenticate), or a version byte is unknown.
+bool ParseSeedPhrase(const SecureString& seed_phrase, const SecureString& password,
+                     CKey& key_out, int64_t* birthday_out = nullptr);
+
+} // namespace Mnemonics
+} // namespace GRC
+
+#endif // GRIDCOIN_MNEMONICS_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_gridcoin
     gridcoin/cpid_tests.cpp
     gridcoin/enumbytes_tests.cpp
     gridcoin/magnitude_tests.cpp
+    gridcoin/mnemonics_tests.cpp
     gridcoin/mrc_tests.cpp
     gridcoin/poll_result_cache_tests.cpp
     gridcoin/pool_tests.cpp

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -9,6 +9,7 @@
 #include <crypto/hmac_sha512.h>
 #include <crypto/poly1305.h>
 #include <crypto/ripemd160.h>
+#include <crypto/scrypt.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
 #include <crypto/sha3.h>
@@ -1104,6 +1105,31 @@ BOOST_AUTO_TEST_CASE(chacha20poly1305_testvectors)
                            "30a6757ff8439b975363f166a0fa0e36722ab35936abd704297948f45083f4d4"
                            "99433137ce931f7fca28a0acd3bc30f57b550acbc21cbd45bbef0739d9caf30c"
                            "14b94829deb27f0b1923a2af704ae5d6");
+}
+
+static void TestScryptRFC7914(const std::string& pass, const std::string& salt,
+                              unsigned int N, unsigned int r, unsigned int p,
+                              const std::string& out_hex)
+{
+    const std::vector<unsigned char> expected = ParseHex(out_hex);
+    std::vector<std::byte> out(expected.size());
+    ScryptRFC7914(MakeByteSpan(pass), MakeByteSpan(salt), N, r, p, MakeWritableByteSpan(out));
+    BOOST_CHECK_EQUAL(HexStr(out), out_hex);
+}
+
+BOOST_AUTO_TEST_CASE(scrypt_rfc7914_testvectors)
+{
+    // RFC 7914 section 12 test vectors (the fourth, N=1048576, needs 1 GiB of
+    // memory and is omitted).
+    TestScryptRFC7914("", "", 16, 1, 1,
+                      "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442"
+                      "fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906");
+    TestScryptRFC7914("password", "NaCl", 1024, 8, 16,
+                      "fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b373162"
+                      "2eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640");
+    TestScryptRFC7914("pleaseletmein", "SodiumChloride", 16384, 8, 1,
+                      "7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2"
+                      "d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887");
 }
 
 BOOST_AUTO_TEST_CASE(countbits_tests)

--- a/src/test/gridcoin/mnemonics_tests.cpp
+++ b/src/test/gridcoin/mnemonics_tests.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2024-2025 The Gridcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <gridcoin/mnemonics.h>
+#include <key.h>
+#include <util/strencodings.h>
+
+#include <test/test_gridcoin.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace GRC::Mnemonics;
+
+namespace {
+
+SecureString ToSecure(const std::string& str)
+{
+    return SecureString(str.begin(), str.end());
+}
+
+std::vector<std::byte> BlobWithWordIndex(unsigned word, unsigned index)
+{
+    // Build a 33-byte blob whose 11-bit group at position `word` equals
+    // `index` and whose other groups are zero.
+    std::vector<std::byte> blob(ENCIPHERED_LENGTH, std::byte{0});
+    for (unsigned b = 0; b < WORDLIST_BIT_LENGTH; ++b) {
+        const unsigned bit = word * WORDLIST_BIT_LENGTH + b;
+        const unsigned value = (index >> (WORDLIST_BIT_LENGTH - 1 - b)) & 1u;
+        blob[bit / 8] |= std::byte(value << (7 - bit % 8));
+    }
+    return blob;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(mnemonics_tests)
+
+BOOST_AUTO_TEST_CASE(encode_produces_known_words_at_wordlist_boundaries)
+{
+    // All-zero blob: every 11-bit group is 0 -> the first wordlist entry.
+    const std::vector<std::byte> zeroes(ENCIPHERED_LENGTH, std::byte{0});
+    SecureString phrase = EncodeSeedPhrase(zeroes);
+    BOOST_CHECK_EQUAL(std::string(phrase.begin(), phrase.end()),
+                      "abandon abandon abandon abandon abandon abandon abandon abandon "
+                      "abandon abandon abandon abandon abandon abandon abandon abandon "
+                      "abandon abandon abandon abandon abandon abandon abandon abandon");
+
+    // All-ones blob: every group is 2047 -> the last wordlist entry.
+    const std::vector<std::byte> ones(ENCIPHERED_LENGTH, std::byte{0xFF});
+    phrase = EncodeSeedPhrase(ones);
+    BOOST_CHECK_EQUAL(std::string(phrase.begin(), phrase.end()),
+                      "zoo zoo zoo zoo zoo zoo zoo zoo "
+                      "zoo zoo zoo zoo zoo zoo zoo zoo "
+                      "zoo zoo zoo zoo zoo zoo zoo zoo");
+
+    // Spot checks at the ends of the wordlist.
+    SecureString one_word = EncodeSeedPhrase(BlobWithWordIndex(0, 1));
+    BOOST_CHECK_EQUAL(std::string(one_word.begin(), one_word.end()).substr(0, 8), "ability ");
+    one_word = EncodeSeedPhrase(BlobWithWordIndex(0, 2046));
+    BOOST_CHECK_EQUAL(std::string(one_word.begin(), one_word.end()).substr(0, 5), "zone ");
+}
+
+BOOST_AUTO_TEST_CASE(encode_decode_roundtrip_covers_every_word_index)
+{
+    // Exercise all 2048 wordlist entries through encode -> decode, at varying
+    // word positions.
+    for (unsigned index = 0; index < 2048; ++index) {
+        const std::vector<std::byte> blob = BlobWithWordIndex(index % WORD_COUNT, index);
+        std::vector<std::byte> decoded(ENCIPHERED_LENGTH);
+        BOOST_REQUIRE(DecodeSeedPhrase(EncodeSeedPhrase(blob), decoded));
+        BOOST_REQUIRE(blob == decoded);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(encode_decode_roundtrip_random_blobs)
+{
+    for (int i = 0; i < 100; ++i) {
+        const std::vector<unsigned char> random = InsecureRandBytes(ENCIPHERED_LENGTH);
+        const std::vector<std::byte> blob(reinterpret_cast<const std::byte*>(random.data()),
+                                          reinterpret_cast<const std::byte*>(random.data()) + random.size());
+
+        std::vector<std::byte> decoded(ENCIPHERED_LENGTH);
+        BOOST_REQUIRE(DecodeSeedPhrase(EncodeSeedPhrase(blob), decoded));
+        BOOST_REQUIRE(blob == decoded);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(decode_rejects_malformed_phrases)
+{
+    std::vector<std::byte> blob(ENCIPHERED_LENGTH);
+
+    // Empty phrase.
+    BOOST_CHECK(!DecodeSeedPhrase(SecureString{}, blob));
+
+    // A word not in the wordlist.
+    const std::vector<std::byte> zeroes(ENCIPHERED_LENGTH, std::byte{0});
+    SecureString phrase = EncodeSeedPhrase(zeroes);
+    SecureString corrupted = phrase;
+    corrupted.replace(0, 7, "zzzzzzz");
+    BOOST_CHECK(!DecodeSeedPhrase(corrupted, blob));
+
+    // Too few words (drop the last word).
+    SecureString truncated(phrase.begin(), phrase.begin() + phrase.rfind(' '));
+    BOOST_CHECK(!DecodeSeedPhrase(truncated, blob));
+
+    // Too many words.
+    SecureString extended = phrase;
+    extended += " abandon";
+    BOOST_CHECK(!DecodeSeedPhrase(extended, blob));
+
+    // Garbage.
+    BOOST_CHECK(!DecodeSeedPhrase(ToSecure("not a seed phrase"), blob));
+
+    // Empty word segments: leading, doubled and lone separators must be
+    // rejected without scanning an empty candidate.
+    SecureString leading = phrase;
+    leading.insert(leading.begin(), ' ');
+    BOOST_CHECK(!DecodeSeedPhrase(leading, blob));
+
+    SecureString doubled = phrase;
+    doubled.insert(doubled.find(' '), 1, ' ');
+    BOOST_CHECK(!DecodeSeedPhrase(doubled, blob));
+
+    BOOST_CHECK(!DecodeSeedPhrase(ToSecure(" "), blob));
+
+    // Oversized input is rejected up front: no valid phrase exceeds
+    // WORD_COUNT * (LONGEST_WORD_LENGTH + 1) characters.
+    SecureString oversized(WORD_COUNT * 9 + 1, 'a');
+    BOOST_CHECK(!DecodeSeedPhrase(oversized, blob));
+
+    // A single trailing separator marks the end of the last word and is
+    // tolerated.
+    SecureString trailing = phrase;
+    trailing += ' ';
+    BOOST_CHECK(DecodeSeedPhrase(trailing, blob));
+}
+
+BOOST_AUTO_TEST_CASE(build_and_parse_fixed_vector)
+{
+    // Fixed vector pinning the complete scheme: scrypt KDF, AEAD, truncated
+    // tag, bit packing and wordlist. Any change to any layer changes the
+    // phrase and must bump the outer version instead.
+    const std::vector<unsigned char> entropy = ParseHex("000102030405060708090a0b0c0d0e0f");
+    const std::vector<unsigned char> salt = ParseHex("aabbccddee");
+    const SecureString password = ToSecure("gridcoin");
+    const uint16_t birthday_days = 4242;
+
+    const SecureString phrase = BuildSeedPhrase(MakeByteSpan(entropy), birthday_days,
+                                                MakeByteSpan(salt), password);
+
+    BOOST_CHECK_EQUAL(std::string(phrase.begin(), phrase.end()),
+                      "absent fiction veteran rookie this display improve clock "
+                      "gift same dove apple purpose usual engine survey "
+                      "tenant farm basket aim leisure joke hurry help");
+
+    CKey key;
+    int64_t birthday = 0;
+    BOOST_REQUIRE(ParseSeedPhrase(phrase, password, key, &birthday));
+    BOOST_CHECK(key.IsValid());
+    // SHA256 of the entropy (inner version 0), verified against an
+    // independent implementation.
+    BOOST_CHECK_EQUAL(HexStr(Span{key.begin(), key.size()}),
+                      "be45cb2605bf36bebde684841a28f0fd43c69850a3dce5fedba69928ee3a8991");
+    BOOST_CHECK_EQUAL(birthday, BIRTHDAY_EPOCH + int64_t{birthday_days} * 24 * 60 * 60);
+
+    // The same parts with a different password produce a different phrase,
+    // and the original phrase fails to parse under the wrong password.
+    const SecureString other = BuildSeedPhrase(MakeByteSpan(entropy), birthday_days,
+                                               MakeByteSpan(salt), ToSecure("Gridcoin"));
+    BOOST_CHECK(phrase != other);
+    BOOST_CHECK(!ParseSeedPhrase(phrase, ToSecure("Gridcoin"), key));
+    BOOST_CHECK(!ParseSeedPhrase(phrase, SecureString{}, key));
+}
+
+BOOST_AUTO_TEST_CASE(generate_and_parse_roundtrip)
+{
+    for (const std::string& password_str : {std::string{}, std::string{"correct horse"}}) {
+        const SecureString password = ToSecure(password_str);
+
+        CKey generated;
+        const SecureString phrase = GenerateSeedPhrase(password, generated);
+        BOOST_REQUIRE(generated.IsValid());
+
+        // 24 words.
+        const std::string str(phrase.begin(), phrase.end());
+        BOOST_CHECK_EQUAL(std::count(str.begin(), str.end(), ' '), WORD_COUNT - 1);
+
+        CKey parsed;
+        int64_t birthday = 0;
+        BOOST_REQUIRE(ParseSeedPhrase(phrase, password, parsed, &birthday));
+        BOOST_CHECK(parsed.IsValid());
+        BOOST_CHECK(generated == parsed);
+
+        // The birthday is now, at day resolution.
+        BOOST_CHECK(birthday >= BIRTHDAY_EPOCH);
+        BOOST_CHECK(birthday <= GetTime());
+        BOOST_CHECK(GetTime() - birthday <= 2 * 24 * 60 * 60);
+
+        // Wrong password fails to authenticate.
+        BOOST_CHECK(!ParseSeedPhrase(phrase, ToSecure("wrong"), parsed));
+
+        // A corrupted word fails: swap the first word for a different valid word.
+        SecureString corrupted = phrase;
+        const SecureString::size_type first_space = corrupted.find(' ');
+        corrupted.replace(0, first_space, str.compare(0, first_space, "zoo") == 0 ? "zebra" : "zoo");
+        BOOST_CHECK(!ParseSeedPhrase(corrupted, password, parsed));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Part 2 of the seed-phrase program picking up #2739 (part 1: the crypto ports, #3185, merged). This implements the revised scheme agreed in the #2739 design discussion. Wallet integration (HD master seed from the phrase, create/restore/show flows) follows as part 3.

## The scheme

24 words from the BIP39 English wordlist encoding a 33-byte blob — `24 × 11 bits = 264 bits`, exact, no padding:

```
outer version (1) ‖ salt (5) ‖ ciphertext (19) ‖ truncated tag (8)
```

where the ciphertext is the RFC 8439 ChaCha20Poly1305 encryption of

```
inner version (1) ‖ wallet birthday in days, LE (2) ‖ entropy (16)
```

under `key = scrypt(password, salt, N=32768, r=8, p=1)` (the aezeed parameters, ~32 MiB), a zero nonce (the key is single-use per salt), and the outer version + salt as AAD. Every one of the 33 bytes is authenticated.

Design properties vs the alternatives surveyed in #2739:

| | BIP39 | This scheme |
|---|---|---|
| Versioning | none | two layers (outer = format/KDF/cipher, inner = key derivation) |
| Wrong password | silently derives a different wallet | authenticated failure |
| Wallet birthday | no | 16-bit days (epoch = mainnet genesis) to bound restore rescans |
| Exotic deps | — | none (vs aezeed's aez) |

The Poly1305 tag is truncated to 8 bytes: its role is explicit wrong-password/typo detection, not integrity against an attacker holding the phrase (who can grind the password offline regardless of tag size). Verification decrypts, re-encrypts the recovered plaintext, and compares the leading tag bytes constant-time. The wordlist is the canonical BIP39 English list (verified against `english.txt`, SHA256 `2f5eed53…`) used purely as a vetted encoding alphabet — the payload is deliberately **not** BIP39-compatible, while the 4-letter-prefix uniqueness that metal backup products rely on carries over. Inner version 0 derives the protected key as `SHA256(entropy)`, which part 3 wires in as the wallet's HD master seed.

## The KDF

The legacy `src/scrypt.{h,cpp}` is the proof-of-work-era hasher: hard-wired to N=1024/r=1/p=1 (the wallet-crypter's multiround helper iterates it sequentially — memory-light, so much weaker against GPU attackers than scrypt at proper parameters) with a little-endian host assumption in the generic path. This PR adds a self-contained, endian-correct RFC 7914 implementation in `src/crypto/scrypt.{h,cpp}` supporting the full parameter space; the legacy file is untouched and remains for the crypter.

## Provenance

Based on div72's proof of concept in #2739 (co-authored on the commit): the constant-time word scanning approach and overall API shape survive; the format (32→24 words, KDF, truncated tag, wordlist storage) is revised per the design discussion. One latent bug in the PoC parser was found and fixed during adversarial review: a phrase beginning with a space drove a one-byte out-of-bounds read (`phrase[-1]`) in the word scanner — empty segments are now rejected before scanning, with tests.

## Verification

- RFC 7914 §12 test vectors 1–3 (covering r=8 and p=16); the implementation was additionally **differentially tested against Python's `hashlib.scrypt`** for the paths the RFC vectors don't reach (partial final PBKDF2 block at dklen 1/17/33/63, r=2, multi-lane p=3) — all exact
- Fixed end-to-end vector pinning every layer (scrypt → AEAD → truncation → packing → wordlist), with the derived key cross-checked against an independent SHA256 implementation
- Encode/decode roundtrip over **all 2048 wordlist indices** plus randomized blobs; malformed-phrase rejection (wrong words, wrong counts, empty segments, garbage); wrong-password and corrupted-word authentication failure; birthday recovery
- A compile-time `static_assert` pins every wordlist entry within the buffer-sizing bound
- Full unit suite green; no-GUI and Qt6 GUI builds clean; lints clean
- Independent adversarial review of the branch: scrypt confirmed RFC-exact line-by-line, the truncated-tag construction confirmed sound, the one real finding (the OOB read above) fixed

No RPC changes (heritage ledger unaffected). No consensus impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)