### PR TITLE
gui: route GUI logging through a shim (qt/guilog) instead of the core logger

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(gridcoinqt STATIC
     editaddressdialog.cpp
     editsidestakedialog.cpp
     favoritespage.cpp
+    guilog.cpp
     guiutil.cpp
     intro.cpp
     monitoreddatamapper.cpp

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -1,4 +1,5 @@
 #include "addresstablemodel.h"
+#include "qt/guilog.h"
 #include "guiutil.h"
 #include "walletmodel.h"
 
@@ -92,7 +93,7 @@ public:
         case CT_NEW:
             if(inModel)
             {
-                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_NEW, but entry is already in model");
+                GUILogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_NEW, but entry is already in model");
                 break;
             }
             parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
@@ -102,7 +103,7 @@ public:
         case CT_UPDATED:
             if(!inModel)
             {
-                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_UPDATED, but entry is not in model");
+                GUILogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_UPDATED, but entry is not in model");
                 break;
             }
             lower->type = newEntryType;
@@ -112,7 +113,7 @@ public:
         case CT_DELETED:
             if(!inModel)
             {
-                LogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_DELETED, but entry is not in model");
+                GUILogPrintf("Warning: AddressTablePriv::updateEntry: Got CT_DELETED, but entry is not in model");
                 break;
             }
             parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex-1);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -4,6 +4,7 @@
 
 
 #include <QApplication>
+#include "qt/guilog.h"
 #include <QTimer>
 
 #include "bitcoingui.h"
@@ -135,7 +136,7 @@ static void ThreadSafeMessageBox(const std::string& message, const std::string& 
     }
     else
     {
-        LogPrintf("%s: %s", caption, message);
+        GUILogPrintf("%s: %s", caption, message);
         tfm::format(std::cerr, "%s: %s\n", caption.c_str(), message.c_str());
     }
 }
@@ -175,7 +176,7 @@ static void UpdateMessageBox(const std::string& version, const int& update_versi
 
     else
     {
-        LogPrintf("\r\n%s:\r\n%s", caption, message);
+        GUILogPrintf("\r\n%s:\r\n%s", caption, message);
         tfm::format(std::cerr, "\r\n%s:\r\n%s\r\n", caption.c_str(), message.c_str());
     }
 }
@@ -204,9 +205,9 @@ static void DebugMessageHandler(QtMsgType type, const QMessageLogContext& contex
 {
     Q_UNUSED(context);
     if (type == QtDebugMsg) {
-        LogPrint(BCLog::LogFlags::QT, "GUI: %s\n", msg.toStdString());
+        GUILogPrint(GUILogCategory::QT, "GUI: %s\n", msg.toStdString());
     } else {
-        LogPrintf("GUI: %s\n", msg.toStdString());
+        GUILogPrintf("GUI: %s\n", msg.toStdString());
     }
 }
 
@@ -478,11 +479,11 @@ int main(int argc, char *argv[])
         GRC::Upgrade resetblockchain;
 
         if (resetblockchain.ResetBlockchainData())
-            LogPrintf("ResetBlockchainData: success");
+            GUILogPrintf("ResetBlockchainData: success");
 
         else
         {
-            LogPrintf("ResetBlockchainData: failed to clean up blockchain data");
+            GUILogPrintf("ResetBlockchainData: failed to clean up blockchain data");
 
             std::string inftext = resetblockchain.ResetBlockchainMessages(resetblockchain.CleanUp);
 
@@ -512,10 +513,10 @@ int main(int argc, char *argv[])
         CTxDB().Close();
 
         if (resetblockchain.ResetBlockchain(app))
-            LogPrintf("ResetBlockchainData: success");
+            GUILogPrintf("ResetBlockchainData: success");
 
         else
-            LogPrintf("ResetBlockchainData: failed");
+            GUILogPrintf("ResetBlockchainData: failed");
     }
 
     return EXIT_SUCCESS;
@@ -557,11 +558,11 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
         BitcoinGUI window;
         guiref = &window;
 
-        LogPrintf("Starting Gridcoin");
+        GUILogPrintf("Starting Gridcoin");
 
         if (!threads->createThread(ThreadAppInit2,threads,"AppInit2 Thread"))
         {
-                LogPrintf("Error; NewThread(ThreadAppInit2) failed");
+                GUILogPrintf("Error; NewThread(ThreadAppInit2) failed");
                 return EXIT_FAILURE;
         }
         else
@@ -698,7 +699,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("%1 didn't yet exit safely...").arg(QObject::tr(PACKAGE_NAME)), (HWND)window.winId());
 #endif
 
-                LogPrintf("GUI loaded.");
+                GUILogPrintf("GUI loaded.");
 
                 // Regenerate startup link, to fix links to old versions
                 GUIUtil::SetStartOnSystemStartup(optionsModel.getStartAtStartup(), optionsModel.getStartMin());
@@ -729,7 +730,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 guiref = nullptr;
             }
             // Shutdown the core and its threads, but don't exit Bitcoin-Qt here
-            LogPrintf("Main calling Shutdown...");
+            GUILogPrintf("Main calling Shutdown...");
             Shutdown(nullptr);
         }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -205,9 +205,9 @@ static void DebugMessageHandler(QtMsgType type, const QMessageLogContext& contex
 {
     Q_UNUSED(context);
     if (type == QtDebugMsg) {
-        GUILogPrint(GUILogCategory::QT, "GUI: %s\n", msg.toStdString());
+        GUILogPrint(GUILogCategory::QT, "GUI: %s", msg.toStdString());
     } else {
-        GUILogPrintf("GUI: %s\n", msg.toStdString());
+        GUILogPrintf("GUI: %s", msg.toStdString());
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1927,7 +1927,7 @@ void BitcoinGUI::updateScraperIcon(int scraperEventtype, int status)
     }
 
     // If scraper logging category is turned on then show scrapers in tooltip...
-    if (LogInstance().WillLogCategory(BCLog::LogFlags::SCRAPER))
+    if (GUILog::WillLogCategory(GUILogCategory::SCRAPER))
     {
         bDisplayScrapers = true;
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -7,6 +7,7 @@
 
 
 #include <QProcess>
+#include "qt/guilog.h"
 #include <QInputDialog>
 
 #include "qt/decoration.h"
@@ -1871,7 +1872,7 @@ void BitcoinGUI::updateStakingIcon(
     double coin_weight,
     double etts_days)
 {
-    LogPrint(BCLog::MISC, "BitcoinGUI::updateStakingIcon()");
+    GUILogPrint(GUILogCategory::MISC, "BitcoinGUI::updateStakingIcon()");
 
     if (staking)
     {
@@ -1899,7 +1900,7 @@ void BitcoinGUI::updateStakingIcon(
 
 void BitcoinGUI::updateScraperIcon(int scraperEventtype, int status)
 {
-    LogPrint(BCLog::MISC, "BitcoinGUI::updateScraperIcon()");
+    GUILogPrint(GUILogCategory::MISC, "BitcoinGUI::updateScraperIcon()");
 
     // Value snapshot through the node interface; the scraper cache lock is
     // taken node-side and never held here.
@@ -2004,7 +2005,7 @@ void BitcoinGUI::updateScraperIcon(int scraperEventtype, int status)
 
 void BitcoinGUI::updateBeaconIcon()
 {
-    LogPrint(BCLog::MISC, "BitcoinGUI::updateBeaconIcon()");
+    GUILogPrint(GUILogCategory::MISC, "BitcoinGUI::updateBeaconIcon()");
 
     if (researcherModel->configuredForNoncruncherMode()
         || researcherModel->detectedPoolMode())

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -1,4 +1,5 @@
 #include "clientmodel.h"
+#include "qt/guilog.h"
 #include "qt/bantablemodel.h"
 #include "qt/peertablemodel.h"
 #include "guiconstants.h"
@@ -320,14 +321,14 @@ static void NotifyBlocksChanged(
 
 static void NotifyNumConnectionsChanged(ClientModel *clientmodel, int newNumConnections)
 {
-    LogPrint(BCLog::NOISY, "NotifyNumConnectionsChanged %i", newNumConnections);
+    GUILogPrint(GUILogCategory::NOISY, "NotifyNumConnectionsChanged %i", newNumConnections);
     QMetaObject::invokeMethod(clientmodel, "updateNumConnections", Qt::QueuedConnection,
                               Q_ARG(int, newNumConnections));
 }
 
 static void NotifyAlertChanged(ClientModel *clientmodel, const uint256 &hash, ChangeType status)
 {
-    LogPrintf("NotifyAlertChanged %s status=%i", hash.GetHex(), status);
+    GUILogPrintf("NotifyAlertChanged %s status=%i", hash.GetHex(), status);
     QMetaObject::invokeMethod(clientmodel, "updateAlert", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(hash.GetHex())),
                               Q_ARG(int, status));

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -10,7 +10,6 @@
 #include "clientversion.h"
 #include "interfaces/handler.h"
 #include "interfaces/staking.h"
-#include "logging.h"
 #include "util/time.h"
 
 #include <QDateTime>

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -1,4 +1,5 @@
 #include "coincontroldialog.h"
+#include "qt/guilog.h"
 #include "ui_coincontroldialog.h"
 
 #include "bitcoinunits.h"
@@ -330,7 +331,7 @@ bool CoinControlDialog::filterInputsByValue(const bool& less, const CAmount& inp
     {
         if (input_count >= inputSelectionLimit)
         {
-            LogPrint(BCLog::LogFlags::MISC, "INFO: %s: Culled input %u with value %f.",
+            GUILogPrint(GUILogCategory::MISC, "INFO: %s: Culled input %u with value %f.",
                      __func__, input_count, (double) input.first / COIN);
 
             if (coinControl->IsSelected(input.second.second.hash, input.second.second.n))

--- a/src/qt/consolidateunspentdialog.cpp
+++ b/src/qt/consolidateunspentdialog.cpp
@@ -82,7 +82,7 @@ void ConsolidateUnspentDialog::addressSelectionChanged()
 
     m_selectedDestinationAddress = std::make_pair(selectedLabel->text(), selectedAddress->text());
 
-    GUILogPrint(GUILogCategory::MISC, "INFO: %s: Label %, Address %s selected.", __func__,
+    GUILogPrint(GUILogCategory::MISC, "INFO: %s: Label %s, Address %s selected.", __func__,
              m_selectedDestinationAddress.first.toStdString(),
              m_selectedDestinationAddress.second.toStdString());
 }

--- a/src/qt/consolidateunspentdialog.cpp
+++ b/src/qt/consolidateunspentdialog.cpp
@@ -1,4 +1,5 @@
 #include "consolidateunspentdialog.h"
+#include "qt/guilog.h"
 #include "qt/decoration.h"
 #include <QAbstractButton>
 #include "ui_consolidateunspentdialog.h"
@@ -81,7 +82,7 @@ void ConsolidateUnspentDialog::addressSelectionChanged()
 
     m_selectedDestinationAddress = std::make_pair(selectedLabel->text(), selectedAddress->text());
 
-    LogPrint(BCLog::LogFlags::MISC, "INFO: %s: Label %, Address %s selected.", __func__,
+    GUILogPrint(GUILogCategory::MISC, "INFO: %s: Label %, Address %s selected.", __func__,
              m_selectedDestinationAddress.first.toStdString(),
              m_selectedDestinationAddress.second.toStdString());
 }

--- a/src/qt/consolidateunspentwizardselectdestinationpage.cpp
+++ b/src/qt/consolidateunspentwizardselectdestinationpage.cpp
@@ -124,7 +124,7 @@ void ConsolidateUnspentWizardSelectDestinationPage::addressSelectionChanged()
 
     m_selectedDestinationAddress = std::make_pair(selectedLabel->text(), selectedAddress->text());
 
-    GUILogPrint(GUILogCategory::QT, "INFO: %s: Label %, Address %s selected.", __func__,
+    GUILogPrint(GUILogCategory::QT, "INFO: %s: Label %s, Address %s selected.", __func__,
              m_selectedDestinationAddress.first.toStdString(),
              m_selectedDestinationAddress.second.toStdString());
 

--- a/src/qt/consolidateunspentwizardselectdestinationpage.cpp
+++ b/src/qt/consolidateunspentwizardselectdestinationpage.cpp
@@ -1,4 +1,5 @@
 #include "consolidateunspentwizardselectdestinationpage.h"
+#include "qt/guilog.h"
 #include "ui_consolidateunspentwizardselectdestinationpage.h"
 
 #include "util.h"
@@ -73,7 +74,7 @@ void ConsolidateUnspentWizardSelectDestinationPage::setDefaultAddressSelection(Q
 
         m_selectedDestinationAddress = {};
 
-        LogPrint(BCLog::LogFlags::QT, "INFO: %s: Cleared (default) address selection", __func__);
+        GUILogPrint(GUILogCategory::QT, "INFO: %s: Cleared (default) address selection", __func__);
 
         ui->isCompleteCheckBox->setChecked(false);
 
@@ -84,14 +85,14 @@ void ConsolidateUnspentWizardSelectDestinationPage::setDefaultAddressSelection(Q
 
     defaultAddress[0]->setSelected(true);
 
-    LogPrint(BCLog::LogFlags::QT, "INFO: %s: Set default address to %s, QTableWidgetItem %s",
+    GUILogPrint(GUILogCategory::QT, "INFO: %s: Set default address to %s, QTableWidgetItem %s",
               __func__,
               address.toStdString(),
               defaultAddress[0]->text().toStdString());
 
     ui->addressTableWidget->setCurrentItem(defaultAddress[0]);
 
-    LogPrintf("INFO: %s: currentRow = %i", __func__, ui->addressTableWidget->currentRow());
+    GUILogPrintf("INFO: %s: currentRow = %i", __func__, ui->addressTableWidget->currentRow());
 
     emit updateFieldsSignal();
 }
@@ -123,7 +124,7 @@ void ConsolidateUnspentWizardSelectDestinationPage::addressSelectionChanged()
 
     m_selectedDestinationAddress = std::make_pair(selectedLabel->text(), selectedAddress->text());
 
-    LogPrint(BCLog::LogFlags::QT, "INFO: %s: Label %, Address %s selected.", __func__,
+    GUILogPrint(GUILogCategory::QT, "INFO: %s: Label %, Address %s selected.", __func__,
              m_selectedDestinationAddress.first.toStdString(),
              m_selectedDestinationAddress.second.toStdString());
 

--- a/src/qt/consolidateunspentwizardselectinputspage.cpp
+++ b/src/qt/consolidateunspentwizardselectinputspage.cpp
@@ -1,4 +1,5 @@
 #include "coincontroldialog.h"
+#include "qt/guilog.h"
 #include "consolidateunspentwizardselectinputspage.h"
 #include "ui_consolidateunspentwizardselectinputspage.h"
 
@@ -240,7 +241,7 @@ bool ConsolidateUnspentWizardSelectInputsPage::filterInputsByValue(const bool& l
     {
         if (input_count >= inputSelectionLimit)
         {
-            LogPrint(BCLog::LogFlags::QT, "INFO: %s: Culled input %u with value %f.",
+            GUILogPrint(GUILogCategory::QT, "INFO: %s: Culled input %u with value %f.",
                      __func__, input_count, (double) input.first / COIN);
 
             if (coinControl->IsSelected(input.second.second.hash, input.second.second.n))

--- a/src/qt/consolidateunspentwizardsendpage.cpp
+++ b/src/qt/consolidateunspentwizardsendpage.cpp
@@ -1,4 +1,5 @@
 #include "consolidateunspentwizardsendpage.h"
+#include "qt/guilog.h"
 #include "ui_consolidateunspentwizardsendpage.h"
 
 #include "util.h"
@@ -25,7 +26,7 @@ void ConsolidateUnspentWizardSendPage::initializePage()
     ui->destinationAddressLabelLabel->setText(field("selectedAddressLabelField").toString());
     ui->destinationAddressLabel->setText(field("selectedAddressField").toString());
 
-    LogPrint(BCLog::LogFlags::QT, "INFO: %s: destinationAddress = %s",
+    GUILogPrint(GUILogCategory::QT, "INFO: %s: destinationAddress = %s",
              __func__, field("selectedAddressField").toString().toStdString());
 
     qint64 amount = 0;

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "diagnosticsdialog.h"
+#include "qt/guilog.h"
 #include "qt/forms/ui_diagnosticsdialog.h"
 #include "qt/decoration.h"
 #include "qt/researcher/researchermodel.h"
@@ -269,7 +270,7 @@ void DiagnosticsDialog::on_testButton_clicked()
 
     if (GetNumberOfTestsPending())
     {
-        LogPrintf("INFO: DiagnosticsDialog::on_testButton_clicked: Tests still in progress from a prior run: %u",
+        GUILogPrintf("INFO: DiagnosticsDialog::on_testButton_clicked: Tests still in progress from a prior run: %u",
                   GetNumberOfTestsPending());
 
         return;

--- a/src/qt/guilog.cpp
+++ b/src/qt/guilog.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/guilog.h"
+
+#include "logging.h"
+
+namespace {
+//! Map a GUI log category onto its core BCLog counterpart. Confined to this
+//! translation unit -- the rest of the Qt layer never sees BCLog.
+BCLog::LogFlags ToCoreFlag(GUILogCategory category)
+{
+    switch (category) {
+    case GUILogCategory::QT:      return BCLog::LogFlags::QT;
+    case GUILogCategory::VOTE:    return BCLog::LogFlags::VOTE;
+    case GUILogCategory::SCRAPER: return BCLog::LogFlags::SCRAPER;
+    case GUILogCategory::MISC:    return BCLog::LogFlags::MISC;
+    case GUILogCategory::VERBOSE: return BCLog::LogFlags::VERBOSE;
+    case GUILogCategory::NOISY:   return BCLog::LogFlags::NOISY;
+    }
+
+    return BCLog::LogFlags::QT;
+}
+} // namespace
+
+namespace GUILog {
+
+bool WillLogCategory(GUILogCategory category)
+{
+    // Monolithic sink: defer to the core logger's -debug state. A multiprocess
+    // split GUI will consult its own GUI-local logging configuration here.
+    return LogInstance().WillLogCategory(ToCoreFlag(category));
+}
+
+void LogPrintStr(const std::string& line)
+{
+    // Monolithic sink: forward to the core logger (shared debug.log). Matches a
+    // core LogPrintf -- the newline is appended here and the logger adds any
+    // timestamp/thread prefix. A multiprocess split GUI repoints this at a
+    // GUI-local file.
+    if (!LogInstance().Enabled()) {
+        return;
+    }
+
+    LogInstance().LogPrintStr(line + "\n");
+}
+
+} // namespace GUILog

--- a/src/qt/guilog.cpp
+++ b/src/qt/guilog.cpp
@@ -6,9 +6,13 @@
 
 #include "logging.h"
 
+#include <cassert>
+
 namespace {
 //! Map a GUI log category onto its core BCLog counterpart. Confined to this
-//! translation unit -- the rest of the Qt layer never sees BCLog.
+//! translation unit -- the rest of the Qt layer never sees BCLog. No default
+//! case, so -Wswitch flags a new GUILogCategory that is missing a mapping; the
+//! post-switch assert catches it at runtime as a backstop.
 BCLog::LogFlags ToCoreFlag(GUILogCategory category)
 {
     switch (category) {
@@ -20,11 +24,19 @@ BCLog::LogFlags ToCoreFlag(GUILogCategory category)
     case GUILogCategory::NOISY:   return BCLog::LogFlags::NOISY;
     }
 
+    assert(false && "unhandled GUILogCategory");
     return BCLog::LogFlags::QT;
 }
 } // namespace
 
 namespace GUILog {
+
+bool Enabled()
+{
+    // Monolithic sink: defer to the core logger. A multiprocess split GUI will
+    // consult its own GUI-local logging state here.
+    return LogInstance().Enabled();
+}
 
 bool WillLogCategory(GUILogCategory category)
 {
@@ -38,11 +50,7 @@ void LogPrintStr(const std::string& line)
     // Monolithic sink: forward to the core logger (shared debug.log). Matches a
     // core LogPrintf -- the newline is appended here and the logger adds any
     // timestamp/thread prefix. A multiprocess split GUI repoints this at a
-    // GUI-local file.
-    if (!LogInstance().Enabled()) {
-        return;
-    }
-
+    // GUI-local file. (Callers gate on Enabled()/WillLogCategory first.)
     LogInstance().LogPrintStr(line + "\n");
 }
 

--- a/src/qt/guilog.h
+++ b/src/qt/guilog.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_GUILOG_H
+#define GRIDCOIN_QT_GUILOG_H
+
+#include <string>
+
+#include <tinyformat.h>
+
+//! GUI logging shim.
+//!
+//! The Qt layer logs through this shim instead of calling the core logger
+//! (LogPrint/LogPrintf) directly. Logging is a stateless local utility, so this
+//! is deliberately not an interfaces:: boundary type -- it is a thin swap point
+//! that turns the core logger into just one implementation of the GUI's logging
+//! semantic:
+//!
+//!  - Monolithic build (today): the sink forwards to the core logger, so GUI
+//!    lines land in the shared debug.log exactly as before, honouring -debug
+//!    category filtering.
+//!  - Multiprocess split (later): the GUI process has no access to the node's
+//!    debug.log, so the sink is repointed at a GUI-local file. Because logging
+//!    must never depend on the IPC channel (the GUI has to be able to log a
+//!    failed/absent connection), log lines are never shipped over the wire.
+//!
+//! Only qt/guilog.cpp includes the core logging header; every other Qt
+//! translation unit uses these macros and stays off the core logger.
+
+//! GUI log categories, mirroring the BCLog categories the Qt layer uses. Kept
+//! as a small independent enum so no GUI translation unit needs logging.h.
+enum class GUILogCategory {
+    QT,
+    VOTE,
+    SCRAPER,
+    MISC,
+    VERBOSE,
+    NOISY,
+};
+
+namespace GUILog {
+
+//! Whether the given category is currently enabled (mirrors LogAcceptCategory).
+bool WillLogCategory(GUILogCategory category);
+
+//! Emit one already-formatted line to the active sink (adds the newline and any
+//! timestamp/thread prefixing, matching a core LogPrintf). No-op when logging
+//! is disabled.
+void LogPrintStr(const std::string& line);
+
+//! Format and emit an unconditional GUI log line (mirror of LogPrintf). Kept a
+//! template (not a tfm::format macro) so the format-string lint can parse it,
+//! exactly as the core LogPrintf is.
+template <typename... Args>
+void LogPrintf(const char* fmt, const Args&... args)
+{
+    LogPrintStr(tfm::format(fmt, args...));
+}
+
+} // namespace GUILog
+
+//! Unconditional GUI log line (mirror of LogPrintf).
+#define GUILogPrintf(...) GUILog::LogPrintf(__VA_ARGS__)
+
+//! Category-gated GUI log line (mirror of LogPrint).
+#define GUILogPrint(category, ...)                       \
+    do {                                                 \
+        if (GUILog::WillLogCategory(category)) {         \
+            GUILog::LogPrintf(__VA_ARGS__);              \
+        }                                                \
+    } while (0)
+
+#endif // GRIDCOIN_QT_GUILOG_H

--- a/src/qt/guilog.h
+++ b/src/qt/guilog.h
@@ -55,7 +55,8 @@ void LogPrintStr(const std::string& line);
 //! template (not a tfm::format macro) so the format-string lint can parse it,
 //! exactly as the core LogPrintf is. The enabled check comes BEFORE formatting
 //! so disabled logging skips the (possibly expensive, e.g. toStdString())
-//! argument work -- matching the core LogPrintf.
+//! argument work. tfm::format is wrapped so a malformed format string logs an
+//! error rather than aborting the GUI -- both matching the core LogPrintf.
 template <typename... Args>
 void LogPrintf(const char* fmt, const Args&... args)
 {
@@ -63,7 +64,14 @@ void LogPrintf(const char* fmt, const Args&... args)
         return;
     }
 
-    LogPrintStr(tfm::format(fmt, args...));
+    std::string log_msg;
+    try {
+        log_msg = tfm::format(fmt, args...);
+    } catch (tinyformat::format_error& e) {
+        log_msg = "Error \"" + std::string(e.what()) + "\" while formatting GUI log message: " + fmt;
+    }
+
+    LogPrintStr(log_msg);
 }
 
 } // namespace GUILog

--- a/src/qt/guilog.h
+++ b/src/qt/guilog.h
@@ -53,10 +53,11 @@ void LogPrintStr(const std::string& line);
 
 //! Format and emit an unconditional GUI log line (mirror of LogPrintf). Kept a
 //! template (not a tfm::format macro) so the format-string lint can parse it,
-//! exactly as the core LogPrintf is. The enabled check comes BEFORE formatting
-//! so disabled logging skips the (possibly expensive, e.g. toStdString())
-//! argument work. tfm::format is wrapped so a malformed format string logs an
-//! error rather than aborting the GUI -- both matching the core LogPrintf.
+//! exactly as the core LogPrintf is. The enabled check comes BEFORE tfm::format
+//! so disabled logging skips the string-formatting work (the arguments
+//! themselves are evaluated at the call site regardless). tfm::format is wrapped
+//! so a malformed format string logs an error rather than aborting the GUI --
+//! both matching the core LogPrintf.
 template <typename... Args>
 void LogPrintf(const char* fmt, const Args&... args)
 {

--- a/src/qt/guilog.h
+++ b/src/qt/guilog.h
@@ -41,20 +41,28 @@ enum class GUILogCategory {
 
 namespace GUILog {
 
+//! Whether logging is enabled at all (mirrors the core logger's Enabled()).
+bool Enabled();
+
 //! Whether the given category is currently enabled (mirrors LogAcceptCategory).
 bool WillLogCategory(GUILogCategory category);
 
 //! Emit one already-formatted line to the active sink (adds the newline and any
-//! timestamp/thread prefixing, matching a core LogPrintf). No-op when logging
-//! is disabled.
+//! timestamp/thread prefixing, matching a core LogPrintf).
 void LogPrintStr(const std::string& line);
 
 //! Format and emit an unconditional GUI log line (mirror of LogPrintf). Kept a
 //! template (not a tfm::format macro) so the format-string lint can parse it,
-//! exactly as the core LogPrintf is.
+//! exactly as the core LogPrintf is. The enabled check comes BEFORE formatting
+//! so disabled logging skips the (possibly expensive, e.g. toStdString())
+//! argument work -- matching the core LogPrintf.
 template <typename... Args>
 void LogPrintf(const char* fmt, const Args&... args)
 {
+    if (!Enabled()) {
+        return;
+    }
+
     LogPrintStr(tfm::format(fmt, args...));
 }
 

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -5,7 +5,6 @@
 #include "interfaces/handler.h"
 #include "qt/guilog.h"
 #include "interfaces/mrc.h"
-#include "logging.h"
 #include "mrcmodel.h"
 #include "walletmodel.h"
 #include "clientmodel.h"

--- a/src/qt/mrcmodel.cpp
+++ b/src/qt/mrcmodel.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "interfaces/handler.h"
+#include "qt/guilog.h"
 #include "interfaces/mrc.h"
 #include "logging.h"
 #include "mrcmodel.h"
@@ -211,7 +212,7 @@ void MRCModel::subscribeToCoreSignals()
     // notification is marshaled to the GUI thread, so the lambda touches no core
     // state (issue #3129).
     m_mrc_handler = m_mrc.handleMRCChanged([this]() {
-        LogPrint(BCLog::LogFlags::QT, "GUI: received MRCChanged() core signal");
+        GUILogPrint(GUILogCategory::QT, "GUI: received MRCChanged() core signal");
 
         QMetaObject::invokeMethod(this, "mrcChanged", Qt::QueuedConnection);
     });

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -11,7 +11,6 @@
 #include "miner.h"
 #include "sidestaketablemodel.h"
 #include "editsidestakedialog.h"
-#include "logging.h"
 
 #include <QSortFilterProxyModel>
 #include <QDir>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -1,4 +1,5 @@
 #include "optionsdialog.h"
+#include "qt/guilog.h"
 #include "qevent.h"
 #include "ui_optionsdialog.h"
 
@@ -711,12 +712,12 @@ void OptionsDialog::resizeSideStakeTableColumns(const bool& neighbor_pair_adjust
             ui->sidestakingTableView->horizontalHeader()->resizeSection(i, m_table_column_sizes[i]);
 
 
-            LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: section size = %i",
+            GUILogPrint(GUILogCategory::VERBOSE, "INFO: %s: section size = %i",
                      __func__,
                      ui->sidestakingTableView->horizontalHeader()->sectionSize(i));
         }
 
-        LogPrint(BCLog::LogFlags::VERBOSE, "INFO: %s: header width = %i",
+        GUILogPrint(GUILogCategory::VERBOSE, "INFO: %s: header width = %i",
                  __func__,
                  ui->sidestakingTableView->horizontalHeader()->width()
                  );

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -19,7 +19,6 @@
 #include "uint256.h"
 #include "guiutil.h"
 #include "guiconstants.h"
-#include "logging.h"
 
 #include <functional>
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -1,4 +1,5 @@
 #include <QWidget>
+#include "qt/guilog.h"
 #include <QListView>
 
 #include "overviewpage.h"
@@ -247,7 +248,7 @@ int OverviewPage::getNumTransactionsForView()
     // takes up the space and would cause the calculation to be off.
     const size_t contentsHeight = std::max(ui->recentTransactionsFrame->height() - ui->recentTransLabel->height(), 0);
 
-    LogPrint(BCLog::LogFlags::QT, "INFO: %s: contentsHeight = %u, itemHeight = %u",
+    GUILogPrint(GUILogCategory::QT, "INFO: %s: contentsHeight = %u, itemHeight = %u",
              __func__, contentsHeight, itemHeight);
 
     // take one off so that there is not a "half-visible one" there, ensure not below 0.
@@ -263,7 +264,7 @@ void OverviewPage::updateTransactions()
     {
         int numItems = getNumTransactionsForView();
 
-        LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(): numItems = %d, limit = %d",
+        GUILogPrint(GUILogCategory::QT, "OverviewPage::updateTransactions(): numItems = %d, limit = %d",
                  numItems, m_overviewTxModel->limit());
 
         // "Stairstep" the served-window cap with x3..x6 factors so most window
@@ -274,12 +275,12 @@ void OverviewPage::updateTransactions()
         if (m_overviewTxModel->limit() < numItems)
         {
             m_overviewTxModel->setLimit(numItems * 3);
-            LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(), setLimit(%d)", numItems * 3);
+            GUILogPrint(GUILogCategory::QT, "OverviewPage::updateTransactions(), setLimit(%d)", numItems * 3);
         }
         else if (m_overviewTxModel->limit() > numItems * 6)
         {
             m_overviewTxModel->setLimit(numItems * 3);
-            LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(), setLimit(%d)", numItems * 3);
+            GUILogPrint(GUILogCategory::QT, "OverviewPage::updateTransactions(), setLimit(%d)", numItems * 3);
         }
 
         for (int i = 0; i <= m_overviewTxModel->limit(); ++i)
@@ -295,7 +296,7 @@ void OverviewPage::updateTransactions()
         ui->recentTransactionsNoResult->setVisible(m_privacy || !transaction_count);
         ui->listTransactions->setVisible(!m_privacy && transaction_count);
 
-        LogPrint(BCLog::LogFlags::QT, "OverviewPage::updateTransactions(), end update");
+        GUILogPrint(GUILogCategory::QT, "OverviewPage::updateTransactions(), end update");
     }
 }
 
@@ -386,7 +387,7 @@ void OverviewPage::setPrivacy(bool privacy)
     ui->listTransactions->setVisible(!m_privacy && transaction_count);
     if (researcherModel) researcherModel->setMaskCpidMagnitudeAccrual(m_privacy);
 
-    LogPrint(BCLog::LogFlags::QT, "INFO: %s: m_privacy = %u", __func__, m_privacy);
+    GUILogPrint(GUILogCategory::QT, "INFO: %s: m_privacy = %u", __func__, m_privacy);
 
     updateTransactions();
     updateResearcherStatus();
@@ -441,7 +442,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         int num_transactions_for_view = getNumTransactionsForView();
         m_overviewTxModel.reset(new OverviewTxModel(model, num_transactions_for_view));
 
-        LogPrint(BCLog::LogFlags::QT, "INFO: %s: num_transactions_for_view = %i, limit = %i",
+        GUILogPrint(GUILogCategory::QT, "INFO: %s: num_transactions_for_view = %i, limit = %i",
                  __func__, num_transactions_for_view, m_overviewTxModel->limit());
 
         ui->listTransactions->setModel(m_overviewTxModel.get());

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "qtipcserver.h"
+#include "qt/guilog.h"
 #include "guiconstants.h"
 #include "node/ui_interface.h"
 #include "util.h"
@@ -80,12 +81,12 @@ static void ipcThread(void* pArg)
     } catch (...) {
         PrintExceptionContinue(nullptr, "ipcThread()");
     }
-    LogPrintf("ipcThread exited");
+    GUILogPrintf("ipcThread exited");
 }
 
 static void ipcThread2(void* pArg)
 {
-    LogPrint(BCLog::LogFlags::VERBOSE, "ipcThread started");
+    GUILogPrint(GUILogCategory::VERBOSE, "ipcThread started");
 
     message_queue* mq = (message_queue*)pArg;
     char buffer[MAX_URI_LENGTH + 1] = "";
@@ -140,7 +141,7 @@ void ipcInit(int argc, char *argv[])
         mq = new message_queue(open_or_create, BITCOINURI_QUEUE_NAME, 2, MAX_URI_LENGTH);
     }
     catch (interprocess_exception &ex) {
-        LogPrintf("ipcInit() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
+        GUILogPrintf("ipcInit() - boost interprocess exception #%d: %s", ex.get_error_code(), ex.what());
         return;
     }
 

--- a/src/qt/researcher/researcherwizardsummarypage.cpp
+++ b/src/qt/researcher/researcherwizardsummarypage.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "logging.h"
 
 #include "qt/bitcoinunits.h"
 #include "qt/decoration.h"

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1,4 +1,5 @@
 #include "rpcconsole.h"
+#include "qt/guilog.h"
 #include "ui_rpcconsole.h"
 
 #ifndef Q_MOC_RUN
@@ -194,7 +195,7 @@ void RPCExecutor::request(const QString &command)
     }
     catch (UniValue& objError)
     {
-		LogPrintf("gridcoinresearch:  Handling Error [Request %s]...",command.toStdString());
+        GUILogPrintf("gridcoinresearch:  Handling Error [Request %s]...", command.toStdString());
 
         try // Nice formatting for standard-format error
         {
@@ -209,7 +210,7 @@ void RPCExecutor::request(const QString &command)
     }
     catch (std::exception& e)
     {
-		LogPrintf("gridcoinresearch:  Handling Error[2]...");
+        GUILogPrintf("gridcoinresearch:  Handling Error[2]...");
 
         emit reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
     }
@@ -500,7 +501,7 @@ void RPCConsole::setNumBlocks(int count, int countOfPeers)
 
 void RPCConsole::displayScraperLogMessage(const QString& string)
 {
-    // LogPrintf("INFO: RPCConsole::displayScraperLogMessage: %s", string.toStdString());
+    // GUILogPrintf("INFO: RPCConsole::displayScraperLogMessage: %s", string.toStdString());
 
     ui->scraper_log->appendPlainText(string);
 }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -1,4 +1,5 @@
 #include "transactiontablemodel.h"
+#include "qt/guilog.h"
 #include "guiutil.h"
 #include "interfaces/wallet_tx_record.h"
 #include "guiconstants.h"
@@ -78,7 +79,7 @@ public:
      */
     void refreshWallet()
     {
-        LogPrint(BCLog::MISC, "refreshWallet()");
+        GUILogPrint(GUILogCategory::MISC, "refreshWallet()");
 
         parent->beginResetModel();
 
@@ -146,7 +147,7 @@ public:
         // — log and skip — rather than corrupt the heap.
         if (payload.position < 0
                 || static_cast<std::size_t>(payload.position) > cachedWallet.size()) {
-            LogPrintf("ERROR: %s: RowsInserted position %d out of range [0, %u] — skipping",
+            GUILogPrintf("ERROR: %s: RowsInserted position %d out of range [0, %u] — skipping",
                       __func__, payload.position,
                       static_cast<unsigned int>(cachedWallet.size()));
             return;
@@ -175,7 +176,7 @@ public:
         if (payload.position < 0 || payload.count <= 0
                 || static_cast<std::size_t>(payload.position)
                        + static_cast<std::size_t>(payload.count) > cachedWallet.size()) {
-            LogPrintf("ERROR: %s: RowsRemoved range [%d, +%d) out of bounds for %u rows — skipping",
+            GUILogPrintf("ERROR: %s: RowsRemoved range [%d, +%d) out of bounds for %u rows — skipping",
                       __func__, payload.position, payload.count,
                       static_cast<unsigned int>(cachedWallet.size()));
             return;
@@ -238,7 +239,7 @@ TransactionTableModel::~TransactionTableModel()
 
 void TransactionTableModel::applyEventBatch(const std::vector<GRC::WalletEvent>& events)
 {
-    LogPrint(BCLog::LogFlags::VERBOSE, "TransactionTableModel::applyEventBatch(%u events)",
+    GUILogPrint(GUILogCategory::VERBOSE, "TransactionTableModel::applyEventBatch(%u events)",
              static_cast<unsigned int>(events.size()));
 
     priv->applyEventBatch(events);
@@ -251,7 +252,7 @@ void TransactionTableModel::refreshWallet()
 
 void TransactionTableModel::updateConfirmations()
 {
-    LogPrint(BCLog::MISC, "TransactionTableModel::updateConfirmations()");
+    GUILogPrint(GUILogCategory::MISC, "TransactionTableModel::updateConfirmations()");
 
     // Blocks came in since last poll: invalidate the Status (confirmation count)
     // and ToAddress columns for all rows.

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "qt/guiutil.h"
+#include "qt/guilog.h"
 #include "qt/voting/polltablemodel.h"
 #include "qt/voting/votingmodel.h"
 #include "logging.h"
@@ -324,7 +325,7 @@ const PollItem* PollTableModel::rowItem(int row) const
 void PollTableModel::refresh()
 {
     if (!m_voting_model) {
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: no voting model set, skipping refresh",
+        GUILogPrint(GUILogCategory::VOTE, "INFO: %s: no voting model set, skipping refresh",
                  __func__);
 
         return;
@@ -332,13 +333,13 @@ void PollTableModel::refresh()
 
     bool expected = false;
     if (!m_refresh_in_flight.compare_exchange_strong(expected, true)) {
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh already in flight, skipping",
+        GUILogPrint(GUILogCategory::VOTE, "INFO: %s: refresh already in flight, skipping",
                  __func__);
 
         return;
     }
 
-    LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh dispatched", __func__);
+    GUILogPrint(GUILogCategory::VOTE, "INFO: %s: refresh dispatched", __func__);
 
     // Capture the enclosing function name as a string literal so log lines
     // emitted from inside the worker lambda print "PollTableModel::refresh"
@@ -387,7 +388,7 @@ void PollTableModel::refresh()
             },
             Qt::QueuedConnection);
 
-        LogPrint(BCLog::LogFlags::VOTE, "INFO: %s: refresh worker complete", func_name);
+        GUILogPrint(GUILogCategory::VOTE, "INFO: %s: refresh worker complete", func_name);
     });
 }
 

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -6,7 +6,6 @@
 #include "qt/guilog.h"
 #include "qt/voting/polltablemodel.h"
 #include "qt/voting/votingmodel.h"
-#include "logging.h"
 #include "util.h"
 #include "util/threadnames.h"
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -8,7 +8,6 @@
 #include "interfaces/handler.h"
 #include "interfaces/researcher.h"
 #include "interfaces/voting.h"
-#include "logging.h"
 #include "optionsmodel.h"
 #include "qt/clientmodel.h"
 #include "qt/voting/votingmodel.h"
@@ -19,7 +18,6 @@
 #include <optional>
 
 using namespace GRC;
-using LogFlags = BCLog::LogFlags;
 
 namespace {
 //!

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "amount.h"
+#include "qt/guilog.h"
 #include "gridcoin/voting/poll.h"
 #include "interfaces/handler.h"
 #include "interfaces/researcher.h"
@@ -395,12 +396,12 @@ void VotingModel::subscribeToCoreSignals()
     // the Handler on teardown severs the callback before `this` is destroyed
     // (issue #3129).
     m_handlers.emplace_back(m_voting.handleNewPollReceived([this](int64_t poll_time) {
-        LogPrint(LogFlags::QT, "INFO: VotingModel: received NewPollReceived() notification");
+        GUILogPrint(GUILogCategory::QT, "INFO: VotingModel: received NewPollReceived() notification");
         QMetaObject::invokeMethod(this, "handleNewPoll", Qt::QueuedConnection, Q_ARG(int64_t, poll_time));
     }));
 
     m_handlers.emplace_back(m_voting.handleNewVoteReceived([this](std::string poll_txid) {
-        LogPrint(LogFlags::QT, "INFO: VotingModel: received NewVoteReceived() notification");
+        GUILogPrint(GUILogCategory::QT, "INFO: VotingModel: received NewVoteReceived() notification");
         // uint256 is not a registered Qt metatype, so marshal the hex string.
         QMetaObject::invokeMethod(this, "handleNewVote", Qt::QueuedConnection,
                                   Q_ARG(QString, QString::fromStdString(poll_txid)));

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1,4 +1,5 @@
 #include "walletmodel.h"
+#include "qt/guilog.h"
 #include "guiconstants.h"
 #include "optionsmodel.h"
 #include "addresstablemodel.h"
@@ -175,7 +176,7 @@ void WalletModel::drainEventQueue()
         return;
     }
 
-    LogPrint(BCLog::LogFlags::VERBOSE,
+    GUILogPrint(GUILogCategory::VERBOSE,
              "WalletModel::drainEventQueue: applying %u events (front seqno=%llu, back seqno=%llu)",
              static_cast<unsigned int>(events.size()),
              static_cast<unsigned long long>(events.front().seqno),
@@ -449,7 +450,7 @@ void WalletModel::subscribeToCoreSignals()
     // and return — same discipline the raw-signal handlers applied.
     m_wallet_handlers.emplace_back(m_wallet.handleStatusChanged(
         [this]() {
-            LogPrintf("NotifyKeyStoreStatusChanged");
+            GUILogPrintf("NotifyKeyStoreStatusChanged");
             QMetaObject::invokeMethod(this, "updateStatus", Qt::QueuedConnection);
         }));
     m_wallet_handlers.emplace_back(m_wallet.handleAddressBookChanged(
@@ -458,7 +459,7 @@ void WalletModel::subscribeToCoreSignals()
             // `purpose` is accepted to match the 6-arg core signal but is not
             // yet surfaced to the GUI; the updateAddressBook slot remains a
             // 4-arg interface (address, label, isMine, status).
-            LogPrintf("NotifyAddressBookChanged %s %s isMine=%i purpose=%s status=%i",
+            GUILogPrintf("NotifyAddressBookChanged %s %s isMine=%i purpose=%s status=%i",
                       address, label, is_mine, purpose, status);
             QMetaObject::invokeMethod(this, "updateAddressBook", Qt::QueuedConnection,
                                       Q_ARG(QString, QString::fromStdString(address)),

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -23,6 +23,7 @@ FALSE_POSITIVES = [
     ("src/wallet/scriptpubkeyman.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),
     ("src/wallet/scriptpubkeyman.h", "LogPrintf((\"%s \" + fmt).c_str(), m_storage.GetDisplayName(), parameters...)"),
     ("src/logging.h", "LogPrintf(const char* fmt, const Args&... args)"),
+    ("src/qt/guilog.h", "LogPrintf(const char* fmt, const Args&... args)"),
     ("src/logging.h", "LogPrint(Category category, const char* format, TINYFORMAT_VARARGS(n))"),
     ("src/wallet/scriptpubkeyman.h", "WalletLogPrintf(const std::string& fmt, const Params&... parameters)"),
 ]

--- a/test/lint/lint-format-strings.sh
+++ b/test/lint/lint-format-strings.sh
@@ -18,6 +18,8 @@ FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS=(
     "LogConnectFailure,1"
     "LogPrint,1"
     "LogPrintf,0"
+    "GUILogPrint,1"
+    "GUILogPrintf,0"
     "printf,0"
     "snprintf,2"
     "sprintf,1"


### PR DESCRIPTION
## Summary

Introduces a thin **GUI logging shim** (`src/qt/guilog.{h,cpp}`) and migrates all ~61 `LogPrint`/`LogPrintf` call sites across the Qt layer onto `GUILogPrint`/`GUILogPrintf`. First step of the Phase-1f state-vs-utility work (RFC #2937): logging is a stateless local utility, so rather than an `interfaces::` boundary it becomes a **swap point** — the core logger is just one implementation of the GUI's logging semantic.

## Why / design

- **Monolithic (today):** `guilog.cpp` forwards to the core logger, so GUI lines land in the shared `debug.log` exactly as before, honouring `-debug` category filtering. **No behaviour change.**
- **Multiprocess split (later):** the GUI process has no access to the node's `debug.log`, so the sink is repointed at a GUI-local file. Logging deliberately never crosses the IPC channel — the GUI must be able to log a failed/absent node connection, precisely when the wire is down.

`qt/guilog.cpp` is the **only** Qt translation unit that includes the core logging header; every other Qt TU now uses the `GUILogPrint(GUILogCategory::X, …)` / `GUILogPrintf(…)` macros and stays off the core logger. Categories `QT/VOTE/SCRAPER/MISC/VERBOSE/NOISY` are mirrored in `GUILogCategory` and mapped to `BCLog` in that one TU.

`GUILogPrintf` is a **template** (mirroring the core `LogPrintf`) so the format-string lint can parse it; its definition is whitelisted in `lint-format-strings.py` alongside the core `LogPrintf`, exactly as the core is.

## Scope / deferred

Kept focused on the logging shim:
- The 12 `error()` call sites (a distinct bool-returning helper) are a follow-up.
- The lint `FORBIDDEN_RE` re-partition (reclassifying `util.h` and the other stateless utilities as acceptable, and clearing their now-moot ratchet entries) is the **next** 1f step — this PR leaves `util.h` includes and their allowlist entries untouched, so the ratchet is unchanged and still passes.

## Testing

- Native Qt6 GUI + daemon + tests build clean (0 errors); `gridcoin_qt_tests` + `gridcoin_tests` pass. (The one `functional_tests` red in a local run was `p2p_psgt_relay.py`, a known PoS multi-node flake — passes on rerun; this change touches only `src/qt`, no daemon/P2P code.)
- `test/lint/lint-all.sh` passes (incl. `lint-qt-includes` — the shim uses `logging.h`/`tinyformat.h`, neither ratchet-forbidden).
- Verified all migrated categories map to `GUILogCategory` and the build (0 errors) confirms every migrated call compiles.

Based on `development` (Phase 1e + snapshot rip-out already merged).