### PR TITLE
gui: migrate the peer table + RPC-console peer detail onto interfaces::PeerInfo

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -33,6 +33,32 @@ struct BannedNode
     int64_t ban_until = 0; //!< Ban expiry, seconds since epoch.
 };
 
+//! Value snapshot of one connected peer's stats, as the GUI peer table and the
+//! RPC-console peer-detail panel display them (the Qt-free mirror of the fields
+//! the GUI read from the core CNodeStats). id is the connection's NodeId, which
+//! the ban/disconnect commands act on.
+struct PeerInfo
+{
+    int64_t id = 0;
+    std::string addr_name;   //!< Display address (host:port).
+    std::string addr_local;  //!< Local address the peer sees us as.
+    std::string subversion;  //!< Reported user agent.
+    uint64_t services = 0;
+    int version = 0;
+    int starting_height = 0;
+    int misbehavior = 0;     //!< Ban score.
+    bool inbound = false;
+    int64_t last_send = 0;
+    int64_t last_recv = 0;
+    uint64_t send_bytes = 0;
+    uint64_t recv_bytes = 0;
+    int64_t time_connected = 0;
+    int64_t time_offset = 0;
+    double ping_time = 0;
+    double ping_wait = 0;
+    double min_ping = 0;
+};
+
 //! Value snapshot of the scraper convergence status consumed by the GUI
 //! status icon. Taken under the scraper cache lock inside the implementation;
 //! callers hold nothing.
@@ -116,6 +142,24 @@ public:
 
     //! Current ban list.
     virtual std::vector<BannedNode> getBanned() = 0;
+
+    //! Value snapshots of all currently-connected peers, for the peer table and
+    //! the RPC-console peer-detail panel. Empty when the connection manager is
+    //! not up.
+    virtual std::vector<PeerInfo> getPeers() = 0;
+
+    //! Ban and disconnect the peer with the given connection id for ban_time
+    //! seconds (mirrors the GUI's ban action, which bans the address and drops
+    //! the connection). No-op for an unknown id.
+    virtual void banNode(int64_t node_id, int64_t ban_time_seconds) = 0;
+
+    //! Remove a ban on the given subnet/address string (from the ban table).
+    //! Returns false if the string is not a valid subnet or was not banned.
+    virtual bool unban(const std::string& subnet) = 0;
+
+    //! Disconnect the peer with the given connection id. Returns whether a peer
+    //! was disconnected.
+    virtual bool disconnectNode(int64_t node_id) = 0;
 
     //! Value snapshot of the scraper convergence status.
     virtual ScraperConvergenceSnapshot getScraperConvergenceSnapshot() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -178,15 +178,21 @@ public:
 
         // Look the peer's address up by connection id, then ban it and drop the
         // connection -- mirroring the GUI's ban action (ban address + disconnect).
-        std::vector<CNodeStats> vstats;
-        g_connman->GetNodeStats(vstats);
-
-        for (const CNodeStats& s : vstats) {
-            if (s.id == node_id) {
-                g_banman->Ban(s.addr, BanReasonManuallyAdded, ban_time_seconds);
-                g_connman->DisconnectNode(s.addr);
-                break;
+        // ForEachNode walks m_nodes under m_nodes_mutex; copy out just the address
+        // and do the Ban()/DisconnectNode() afterwards (outside that lock) rather
+        // than snapshotting every peer's full CNodeStats to find one address.
+        CAddress addr;
+        bool found = false;
+        g_connman->ForEachNode([&](CNode* pnode) {
+            if (!found && pnode->GetId() == node_id) {
+                addr = pnode->addr;
+                found = true;
             }
+        });
+
+        if (found) {
+            g_banman->Ban(addr, BanReasonManuallyAdded, ban_time_seconds);
+            g_connman->DisconnectNode(node_id);
         }
     }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -23,6 +23,7 @@
 #include "interfaces/wallet_tx_source.h"
 #include "main.h"
 #include "net.h"
+#include "netbase.h"
 #include "node/ui_interface.h"
 #include "sync.h"
 #include "util.h"
@@ -129,6 +130,81 @@ public:
         }
 
         return banned;
+    }
+
+    std::vector<PeerInfo> getPeers() override
+    {
+        std::vector<PeerInfo> peers;
+
+        if (!g_connman) {
+            return peers;
+        }
+
+        std::vector<CNodeStats> vstats;
+        g_connman->GetNodeStats(vstats);
+        peers.reserve(vstats.size());
+
+        for (const CNodeStats& s : vstats) {
+            PeerInfo p;
+            p.id = s.id;
+            p.addr_name = s.addrName;
+            p.addr_local = s.addrLocal;
+            p.subversion = s.strSubVer;
+            p.services = s.nServices;
+            p.version = s.nVersion;
+            p.starting_height = s.nStartingHeight;
+            p.misbehavior = s.nMisbehavior;
+            p.inbound = s.fInbound;
+            p.last_send = s.nLastSend;
+            p.last_recv = s.nLastRecv;
+            p.send_bytes = s.nSendBytes;
+            p.recv_bytes = s.nRecvBytes;
+            p.time_connected = s.nTimeConnected;
+            p.time_offset = s.nTimeOffset;
+            p.ping_time = s.dPingTime;
+            p.ping_wait = s.dPingWait;
+            p.min_ping = s.dMinPing;
+            peers.push_back(std::move(p));
+        }
+
+        return peers;
+    }
+
+    void banNode(int64_t node_id, int64_t ban_time_seconds) override
+    {
+        if (!g_connman || !g_banman) {
+            return;
+        }
+
+        // Look the peer's address up by connection id, then ban it and drop the
+        // connection -- mirroring the GUI's ban action (ban address + disconnect).
+        std::vector<CNodeStats> vstats;
+        g_connman->GetNodeStats(vstats);
+
+        for (const CNodeStats& s : vstats) {
+            if (s.id == node_id) {
+                g_banman->Ban(s.addr, BanReasonManuallyAdded, ban_time_seconds);
+                g_connman->DisconnectNode(s.addr);
+                break;
+            }
+        }
+    }
+
+    bool unban(const std::string& subnet) override
+    {
+        if (!g_banman) {
+            return false;
+        }
+
+        CSubNet sub;
+        LookupSubNet(subnet.c_str(), sub);
+
+        return sub.IsValid() && g_banman->Unban(sub);
+    }
+
+    bool disconnectNode(int64_t node_id) override
+    {
+        return g_connman && g_connman->DisconnectNode(node_id);
     }
 
     ScraperConvergenceSnapshot getScraperConvergenceSnapshot() override

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -60,7 +60,9 @@ public:
     {
         cachedNodeStats.clear();
 
-        for (interfaces::PeerInfo& peer : node.getPeers())
+        std::vector<interfaces::PeerInfo> peers = node.getPeers();
+        cachedNodeStats.reserve(peers.size());
+        for (interfaces::PeerInfo& peer : peers)
             cachedNodeStats.append(std::move(peer));
 
         if (sortColumn >= 0)

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -8,17 +8,16 @@
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 
-#include <net.h>
-#include <sync.h>
+#include <interfaces/node.h>
 
 #include <QDebug>
 #include <QList>
 #include <QTimer>
 
-bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombinedStats &right) const
+bool NodeLessThan::operator()(const interfaces::PeerInfo &left, const interfaces::PeerInfo &right) const
 {
-    const CNodeStats *pLeft = &(left.nodeStats);
-    const CNodeStats *pRight = &(right.nodeStats);
+    const interfaces::PeerInfo *pLeft = &left;
+    const interfaces::PeerInfo *pRight = &right;
 
     if (order == Qt::DescendingOrder)
         std::swap(pLeft, pRight);
@@ -27,15 +26,15 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
     case PeerTableModel::NetNodeId:
         return pLeft->id < pRight->id;
     case PeerTableModel::Address:
-        return pLeft->addrName.compare(pRight->addrName) < 0;
+        return pLeft->addr_name.compare(pRight->addr_name) < 0;
     case PeerTableModel::Subversion:
-        return pLeft->strSubVer.compare(pRight->strSubVer) < 0;
+        return pLeft->subversion.compare(pRight->subversion) < 0;
     case PeerTableModel::Ping:
-        return pLeft->dPingTime < pRight->dPingTime;
+        return pLeft->ping_time < pRight->ping_time;
     case PeerTableModel::Sent:
-        return pLeft->nSendBytes < pRight->nSendBytes;
+        return pLeft->send_bytes < pRight->send_bytes;
     case PeerTableModel::Received:
-        return pLeft->nRecvBytes < pRight->nRecvBytes;
+        return pLeft->recv_bytes < pRight->recv_bytes;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -45,38 +44,24 @@ class PeerTablePriv
 {
 public:
     /** Local cache of peer information */
-    QList<CNodeCombinedStats> cachedNodeStats;
+    QList<interfaces::PeerInfo> cachedNodeStats;
     /** Column to sort nodes by (default to unsorted) */
     int sortColumn{-1};
     /** Order (ascending or descending) to sort nodes by */
     Qt::SortOrder sortOrder;
     /** Index of rows by node ID */
-    std::map<NodeId, int> mapNodeRows;
+    std::map<int64_t, int> mapNodeRows;
 
-    /** Pull a full list of peers from the connection manager into our cache */
-    void refreshPeers()
+    /** Pull a full list of peers from the node interface into our cache. Peer
+        stats now cross the boundary as interfaces::PeerInfo value snapshots (the
+        node side reads CNodeStats under the connection manager); the list is
+        empty when the connection manager is not up. */
+    void refreshPeers(interfaces::Node& node)
     {
-        {
-            cachedNodeStats.clear();
+        cachedNodeStats.clear();
 
-            std::vector<CNodeStats> vstats;
-            // Peer stats via the CConnman node-access API (issue #2558 PR 9a);
-            // leaves vstats empty (no peers) when g_connman is not up.
-            if (g_connman) g_connman->GetNodeStats(vstats);
-
-            cachedNodeStats.reserve(vstats.size());
-            for (const auto& node_stats : vstats)
-            {
-                CNodeCombinedStats stats;
-                stats.nodeStats = node_stats;
-                stats.fNodeStateStatsAvailable = false;
-                // For a future Bitcoin backport.
-                // stats.nodeStats = std::get<0>(node_stats);
-                // stats.fNodeStateStatsAvailable = std::get<1>(node_stats);
-                // stats.nodeStateStats = std::get<2>(node_stats);
-                cachedNodeStats.append(stats);
-            }
-        }
+        for (interfaces::PeerInfo& peer : node.getPeers())
+            cachedNodeStats.append(std::move(peer));
 
         if (sortColumn >= 0)
             // sort cacheNodeStats (use stable sort to prevent rows jumping around unnecessarily)
@@ -85,8 +70,8 @@ public:
         // build index map
         mapNodeRows.clear();
         int row = 0;
-        for (const CNodeCombinedStats& stats : std::as_const(cachedNodeStats))
-            mapNodeRows.insert(std::pair<NodeId, int>(stats.nodeStats.id, row++));
+        for (const interfaces::PeerInfo& stats : std::as_const(cachedNodeStats))
+            mapNodeRows.insert(std::pair<int64_t, int>(stats.id, row++));
     }
 
     int size() const
@@ -94,7 +79,7 @@ public:
         return cachedNodeStats.size();
     }
 
-    CNodeCombinedStats *index(int idx)
+    interfaces::PeerInfo *index(int idx)
     {
         if (idx >= 0 && idx < cachedNodeStats.size())
             return &cachedNodeStats[idx];
@@ -156,29 +141,29 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
     if(!index.isValid())
         return QVariant();
 
-    CNodeCombinedStats *rec = static_cast<CNodeCombinedStats*>(index.internalPointer());
+    interfaces::PeerInfo *rec = static_cast<interfaces::PeerInfo*>(index.internalPointer());
 
     const auto column = static_cast<ColumnIndex>(index.column());
     if (role == Qt::DisplayRole) {
         switch (column) {
         case NetNodeId:
-            return (qint64)rec->nodeStats.id;
+            return (qint64)rec->id;
         case Address:
             // prepend to peer address down-arrow symbol for inbound connection and up-arrow for outbound connection
-            return QString(rec->nodeStats.fInbound ? "↓ " : "↑ ") + QString::fromStdString(rec->nodeStats.addrName);
+            return QString(rec->inbound ? "↓ " : "↑ ") + QString::fromStdString(rec->addr_name);
         case Subversion:
-            if (!rec->nodeStats.strSubVer.empty()) {
+            if (!rec->subversion.empty()) {
                 // remove leading and trailing slash
-                return QString::fromStdString(rec->nodeStats.strSubVer.substr(1, rec->nodeStats.strSubVer.length() - 2));
+                return QString::fromStdString(rec->subversion.substr(1, rec->subversion.length() - 2));
             } else {
                 return QString();
             }
         case Ping:
-            return GUIUtil::formatPingTime(rec->nodeStats.dPingTime);
+            return GUIUtil::formatPingTime(rec->ping_time);
         case Sent:
-            return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
+            return GUIUtil::formatBytes(rec->send_bytes);
         case Received:
-            return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
+            return GUIUtil::formatBytes(rec->recv_bytes);
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     } else if (role == Qt::TextAlignmentRole) {
@@ -219,28 +204,30 @@ Qt::ItemFlags PeerTableModel::flags(const QModelIndex &index) const
 QModelIndex PeerTableModel::index(int row, int column, const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    CNodeCombinedStats *data = priv->index(row);
+    interfaces::PeerInfo *data = priv->index(row);
 
     if (data)
         return createIndex(row, column, data);
     return QModelIndex();
 }
 
-const CNodeCombinedStats *PeerTableModel::getNodeStats(int idx)
+const interfaces::PeerInfo *PeerTableModel::getNodeStats(int idx)
 {
     return priv->index(idx);
 }
 
 void PeerTableModel::refresh()
 {
+    if (!clientModel) return;
+
     Q_EMIT layoutAboutToBeChanged();
-    priv->refreshPeers();
+    priv->refreshPeers(clientModel->node());
     Q_EMIT layoutChanged();
 }
 
-int PeerTableModel::getRowByNodeId(NodeId nodeid)
+int PeerTableModel::getRowByNodeId(int64_t nodeid)
 {
-    std::map<NodeId, int>::iterator it = priv->mapNodeRows.find(nodeid);
+    std::map<int64_t, int>::iterator it = priv->mapNodeRows.find(nodeid);
     if (it == priv->mapNodeRows.end())
         return -1;
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -37,6 +37,7 @@ bool NodeLessThan::operator()(const interfaces::PeerInfo &left, const interfaces
         return pLeft->recv_bytes < pRight->recv_bytes;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
+    return false; // keep release (NDEBUG) behavior well-defined; unreachable given the exhaustive switch
 }
 
 // private implementation

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_QT_PEERTABLEMODEL_H
 #define BITCOIN_QT_PEERTABLEMODEL_H
 
-#include <net.h>
+#include <interfaces/node.h>
 
 #include <memory>
 
@@ -19,19 +19,12 @@ QT_BEGIN_NAMESPACE
 class QTimer;
 QT_END_NAMESPACE
 
-struct CNodeCombinedStats {
-    CNodeStats nodeStats;
-    // This is in modern Bitcoin... future port for Gridcoin.
-    // CNodeStateStats nodeStateStats;
-    bool fNodeStateStatsAvailable;
-};
-
 class NodeLessThan
 {
 public:
     NodeLessThan(int nColumn, Qt::SortOrder fOrder) :
         column(nColumn), order(fOrder) {}
-    bool operator()(const CNodeCombinedStats &left, const CNodeCombinedStats &right) const;
+    bool operator()(const interfaces::PeerInfo &left, const interfaces::PeerInfo &right) const;
 
 private:
     int column;
@@ -49,8 +42,8 @@ class PeerTableModel : public QAbstractTableModel
 public:
     explicit PeerTableModel(ClientModel *parent = nullptr);
     ~PeerTableModel();
-    const CNodeCombinedStats *getNodeStats(int idx);
-    int getRowByNodeId(NodeId nodeid);
+    const interfaces::PeerInfo *getNodeStats(int idx);
+    int getRowByNodeId(int64_t nodeid);
     void startAutoRefresh();
     void stopAutoRefresh();
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -3,9 +3,6 @@
 #include "ui_rpcconsole.h"
 
 #ifndef Q_MOC_RUN
-#include "banman.h" // Direct include: previously supplied transitively by the
-                     // pre-interfaces bantablemodel.h; the ban/unban mutations
-                     // here are existing coupling scheduled for Phase 1e.
 #include "clientmodel.h"
 #include "qt/bantablemodel.h"
 #include "qt/decoration.h"
@@ -646,7 +643,7 @@ void RPCConsole::peerSelected(const QItemSelection &selected, const QItemSelecti
     if (!clientModel || !clientModel->getPeerTableModel() || selected.indexes().isEmpty())
         return;
 
-    const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(selected.indexes().first().row());
+    const interfaces::PeerInfo *stats = clientModel->getPeerTableModel()->getNodeStats(selected.indexes().first().row());
     if (stats)
         updateNodeDetail(stats);
 }
@@ -657,8 +654,8 @@ void RPCConsole::peerLayoutAboutToChange()
     cachedNodeids.clear();
     for(int i = 0; i < selected.size(); i++)
     {
-        const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(selected.at(i).row());
-        cachedNodeids.append(stats->nodeStats.id);
+        const interfaces::PeerInfo *stats = clientModel->getPeerTableModel()->getNodeStats(selected.at(i).row());
+        cachedNodeids.append(stats->id);
     }
 }
 
@@ -667,7 +664,7 @@ void RPCConsole::peerLayoutChanged()
     if (!clientModel || !clientModel->getPeerTableModel())
         return;
 
-    const CNodeCombinedStats *stats = nullptr;
+    const interfaces::PeerInfo *stats = nullptr;
     bool fUnselect = false;
     bool fReselect = false;
 
@@ -719,55 +716,38 @@ void RPCConsole::peerLayoutChanged()
         updateNodeDetail(stats);
 }
 
-void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
+void RPCConsole::updateNodeDetail(const interfaces::PeerInfo *stats)
 {
     // update the detail ui with latest node information
-    QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + " ");
-    peerAddrDetails += tr("(node id: %1)").arg(QString::number(stats->nodeStats.id));
-    if (!stats->nodeStats.addrLocal.empty())
-        peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));
+    QString peerAddrDetails(QString::fromStdString(stats->addr_name) + " ");
+    peerAddrDetails += tr("(node id: %1)").arg(QString::number(stats->id));
+    if (!stats->addr_local.empty())
+        peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->addr_local));
     ui->peerHeading->setText(peerAddrDetails);
-    ui->peerServices->setText(GUIUtil::formatServicesStr(stats->nodeStats.nServices));
-    ui->peerLastSend->setText(stats->nodeStats.nLastSend ? GUIUtil::formatDurationStr(GetTimeSeconds() - stats->nodeStats.nLastSend) : tr("never"));
-    ui->peerLastRecv->setText(stats->nodeStats.nLastRecv ? GUIUtil::formatDurationStr(GetTimeSeconds() - stats->nodeStats.nLastRecv) : tr("never"));
-    ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->nodeStats.nSendBytes));
-    ui->peerBytesRecv->setText(GUIUtil::formatBytes(stats->nodeStats.nRecvBytes));
-    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetTimeSeconds() - stats->nodeStats.nTimeConnected));
-    ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingTime));
-    ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingWait));
-    ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.dMinPing));
-    ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
-    ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));
-    if (!stats->nodeStats.strSubVer.empty()) {
+    ui->peerServices->setText(GUIUtil::formatServicesStr(stats->services));
+    ui->peerLastSend->setText(stats->last_send ? GUIUtil::formatDurationStr(GetTimeSeconds() - stats->last_send) : tr("never"));
+    ui->peerLastRecv->setText(stats->last_recv ? GUIUtil::formatDurationStr(GetTimeSeconds() - stats->last_recv) : tr("never"));
+    ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->send_bytes));
+    ui->peerBytesRecv->setText(GUIUtil::formatBytes(stats->recv_bytes));
+    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetTimeSeconds() - stats->time_connected));
+    ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->ping_time));
+    ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->ping_wait));
+    ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->min_ping));
+    ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->time_offset));
+    ui->peerVersion->setText(QString("%1").arg(QString::number(stats->version)));
+    if (!stats->subversion.empty()) {
         // remove leading and trailing slash
-        ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.strSubVer.substr(1, stats->nodeStats.strSubVer.length() - 2)));
+        ui->peerSubversion->setText(QString::fromStdString(stats->subversion.substr(1, stats->subversion.length() - 2)));
     } else {
         ui->peerSubversion->clear();
     }
-    ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
-    ui->peerHeight->setText(QString("%1").arg(QString::number(stats->nodeStats.nStartingHeight)));
-    // ui->peerWhitelisted->setText(stats->nodeStats.fWhitelisted ? tr("Yes") : tr("No"));
-    // Ban score is init to 0
-    ui->peerBanScore->setText(QString("%1").arg(stats->nodeStats.nMisbehavior));
+    ui->peerDirection->setText(stats->inbound ? tr("Inbound") : tr("Outbound"));
+    ui->peerHeight->setText(QString("%1").arg(QString::number(stats->starting_height)));
+    ui->peerBanScore->setText(QString("%1").arg(stats->misbehavior));
 
-    // This check fails for example if the lock was busy and
-    // nodeStateStats couldn't be fetched.
-    if (stats->fNodeStateStatsAvailable) {
-        // Ban score is init to 0
-        // ui->peerBanScore->setText(QString("%1").arg(stats->nodeStats.nMisbehavior));
-
-        // Sync height is init to -1
-        // (stats->nodeStats.nSyncHeight > -1)
-        //    ui->peerSyncHeight->setText(QString("%1").arg(stats->nodeStats.nSyncHeight));
-        //else
-            ui->peerSyncHeight->setText(tr("Unknown"));
-
-        // Common height is init to -1
-        //if (stats->nodeStateStats.nCommonHeight > -1)
-        //    ui->peerCommonHeight->setText(QString("%1").arg(stats->nodeStats.nCommonHeight));
-        //else
-            ui->peerCommonHeight->setText(tr("Unknown"));
-    }
+    // Sync/common height are not tracked yet (there is no CNodeStateStats), so
+    // the peerSyncHeight/peerCommonHeight labels keep their designer default and
+    // are intentionally left untouched here.
 
     ui->peerDetailWidget->show();
 }
@@ -825,24 +805,13 @@ void RPCConsole::banSelectedNode(int bantime)
     if (!clientModel)
         return;
 
-    // Get selected peer addresses
+    // Ban (and disconnect) each selected peer by its connection id. The node
+    // side looks the peer's address up and applies the ban + disconnect.
     QList<QModelIndex> nodes = GUIUtil::getEntryData(ui->peerWidget, PeerTableModel::NetNodeId);
     for(int i = 0; i < nodes.count(); i++)
     {
-        // Get currently selected peer address
-        NodeId id = nodes.at(i).data().toLongLong();
-
-        // Get currently selected peer address
-        int detailNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(id);
-        if (detailNodeRow < 0) return;
-
-        // Find possible nodes, ban it and clear the selected node
-        const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(detailNodeRow);
-        if (stats) {
-            g_banman->Ban(stats->nodeStats.addr, BanReasonManuallyAdded, bantime);
-            // issue #2558 PR 9b: disconnect via the CConnman node-access API.
-            if (g_connman) g_connman->DisconnectNode(stats->nodeStats.addr);
-        }
+        const int64_t id = nodes.at(i).data().toLongLong();
+        clientModel->node().banNode(id, bantime);
     }
     clearSelectedNode();
     clientModel->getBanTableModel()->refresh();
@@ -859,10 +828,8 @@ void RPCConsole::unbanSelectedNode()
     {
         // Get currently selected ban address
         QString strNode = nodes.at(i).data().toString();
-        CSubNet possibleSubnet;
 
-        LookupSubNet(strNode.toStdString().c_str(), possibleSubnet);
-        if (possibleSubnet.IsValid() && g_banman->Unban(possibleSubnet))
+        if (clientModel->node().unban(strNode.toStdString()))
         {
             clientModel->getBanTableModel()->refresh();
         }
@@ -889,17 +856,15 @@ void RPCConsole::showOrHideBanTableIfRequired()
 
 void RPCConsole::disconnectSelectedNode()
 {
-    // Get selected peer addresses
+    if (!clientModel)
+        return;
+
+    // Disconnect each selected peer by its connection id, node-side.
     QList<QModelIndex> nodes = GUIUtil::getEntryData(ui->peerWidget, PeerTableModel::NetNodeId);
     for(int i = 0; i < nodes.count(); i++)
     {
-        // Get currently selected peer address
-        NodeId id = nodes.at(i).data().toLongLong();
-        // Find the node, disconnect it and clear the selected node (issue #2558
-        // PR 9b: disconnect via the CConnman node-access API). g_connman is live
-        // whenever the peers tab is populated, so the guard only no-ops during
-        // shutdown -- where leaving the selection is harmless.
-        if (g_connman && g_connman->DisconnectNode(id))
+        const int64_t id = nodes.at(i).data().toLongLong();
+        if (clientModel->node().disconnectNode(id))
             clearSelectedNode();
     }
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -4,7 +4,6 @@
 #include "qt/guiutil.h"
 #include "qt/peertablemodel.h"
 
-#include "net.h"
 
 #include <QDialog>
 #include <QWidget>
@@ -107,14 +106,14 @@ private:
     ClientModel *clientModel;
     QStringList history;
     int historyPtr = 0;
-    QList<NodeId> cachedNodeids;
+    QList<int64_t> cachedNodeids;
     QMenu *peersTableContextMenu = nullptr;
     QMenu *banTableContextMenu = nullptr;
     QCompleter *autoCompleter;
     static QString FormatBytes(quint64 bytes);
     void setTrafficGraphRange(int mins);
     /** show detailed information on ui about selected node */
-    void updateNodeDetail(const CNodeCombinedStats *stats);
+    void updateNodeDetail(const interfaces::PeerInfo *stats);
 
     void startExecutor();
 

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -58,17 +58,12 @@ src/qt/optionsdialog.cpp:miner.h
 src/qt/optionsdialog.cpp:netbase.h
 src/qt/optionsmodel.cpp:init.h
 src/qt/optionsmodel.cpp:miner.h
-src/qt/peertablemodel.cpp:net.h
-src/qt/peertablemodel.cpp:sync.h
-src/qt/peertablemodel.h:net.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/qtipcserver.cpp:util.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
-src/qt/rpcconsole.cpp:banman.h
 src/qt/rpcconsole.cpp:rpc/client.h
 src/qt/rpcconsole.cpp:rpc/protocol.h
 src/qt/rpcconsole.cpp:rpc/server.h
-src/qt/rpcconsole.h:net.h
 src/qt/signverifymessagedialog.cpp:init.h
 src/qt/signverifymessagedialog.cpp:main.h
 src/qt/signverifymessagedialog.cpp:wallet/wallet.h


### PR DESCRIPTION
## Summary

Migrates the Qt **peer-state cluster** — the peer table and the RPC-console peer-detail panel — off the core net types (`CNodeStats` / `NodeId` / `g_connman` / `g_banman`) onto a value DTO plus interface commands. Part of Phase 1f (RFC #2937): net.h/banman.h are chain/wallet-adjacent *state* headers, so they belong behind `interfaces::`.

Retires **5 ratchet entries**: `peertablemodel.cpp`(net.h, sync.h), `peertablemodel.h`(net.h), `rpcconsole.h`(net.h), `rpcconsole.cpp`(banman.h).

## What moves behind the interface

- **New `interfaces::PeerInfo`** — a Qt-free value snapshot of the `CNodeStats` fields the peer table (id / address / ping / sent / received / subversion) and the peer-detail panel (~18 fields) display.
- **Four new `interfaces::Node` methods:**
  - `getPeers()` → `std::vector<PeerInfo>` (was `g_connman->GetNodeStats`)
  - `banNode(id, ban_time)` — bans the peer's address and disconnects it node-side, by connection id (was `g_banman->Ban(addr)` + `g_connman->DisconnectNode(addr)`)
  - `unban(subnet)` (was `LookupSubNet` + `g_banman->Unban`)
  - `disconnectNode(id)` (was `g_connman->DisconnectNode`)
- **peertablemodel**: `CNodeCombinedStats` replaced by `interfaces::PeerInfo`; refresh pulls `node.getPeers()` via `ClientModel::node()`.
- **rpcconsole**: detail panel + ban/unban/disconnect actions + `cachedNodeids` (now `QList<int64_t>`) go through the interface. The never-executed `fNodeStateStatsAvailable` branch is removed; the sync/common-height labels keep their `.ui` default (unchanged).

## Behavioral equivalence

No functional change: field mapping, sort keys, and the ban/unban/disconnect semantics are behavior-preserving — verified by an adversarial self-review (all 19 PeerInfo fields checked for swaps incl. `min_ping`/`ping_wait`/`ping_time`; ban_time pass-through; refresh-only-on-unban-success; construction-time `node()` validity). Two benign race-window differences (a stale-id ban/disconnect now safely no-ops instead of aborting the loop) are arguably improvements.

## Deferred

`rpcconsole`'s **RPC command execution** (`rpc/client.h`, `rpc/protocol.h`, `rpc/server.h`) — a distinct console-command surface, not peer state — is a separate follow-up.

## Testing

- Native Qt6 GUI + daemon + tests build clean; `functional_tests` + `gridcoin_qt_tests` + `gridcoin_tests` all pass.
- `test/lint/lint-all.sh` passes (incl. `lint-qt-includes` ratchet consistency after removing the 5 entries).

Based on `development` (Phase 1e + snapshot rip-out + logging shim already merged).