### PR TITLE
gui: migrate the sign/verify message dialog onto interfaces::Wallet

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -125,6 +125,25 @@ struct WalletSendRecipient
     bool subtract_fee_from_amount{false};
 };
 
+//! Result of Wallet::signMessage. The GUI pre-validates the address and key
+//! type; this covers the wallet/crypto half (the private key never crosses the
+//! boundary -- the signing happens node-side).
+enum class MessageSignStatus
+{
+    OK,
+    KeyNotAvailable, //!< No private key for the address in this wallet.
+    SigningFailed,   //!< SignCompact failed.
+};
+
+//! Result of Wallet::verifyMessage (pure crypto, but kept behind the interface
+//! so the GUI needs no core message-magic/recover headers).
+enum class MessageVerifyStatus
+{
+    OK,
+    RecoverFailed,   //!< The signature did not recover a public key.
+    AddressMismatch, //!< Recovered key does not match the given address.
+};
+
 //! Result statuses for Wallet::sendCoins. GUI-detectable conditions
 //! (duplicate recipient, user abort) are pre-checked by the GUI and never
 //! reach the interface; addresses and amounts are nevertheless re-validated
@@ -285,6 +304,19 @@ public:
     //! belongs to the same node, so it stays behind the wallet boundary
     //! rather than requiring a separate node reach for one file copy.
     virtual bool backupConfigFile(const std::string& dest) = 0;
+
+    //! Sign message with the private key for address (the "sign message" tool).
+    //! The wallet must already be unlocked (the GUI holds an UnlockContext). On
+    //! OK, signature_out is the base64 signature. The private key never leaves
+    //! the node.
+    virtual MessageSignStatus signMessage(const std::string& address, const std::string& message,
+                                          std::string& signature_out) = 0;
+
+    //! Verify that signature (raw bytes) over message was produced by the key
+    //! for address (the "verify message" tool). Stateless crypto; behind the
+    //! interface only so the GUI needs no core message-magic/recover headers.
+    virtual MessageVerifyStatus verifyMessage(const std::string& address, const std::string& message,
+                                              const std::vector<unsigned char>& signature) = 0;
 
     //! Register a handler for encryption/lock status changes.
     using StatusChangedFn = std::function<void()>;

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -4,13 +4,9 @@
 #include "addressbookpage.h"
 #include <key_io.h>
 #include "guiutil.h"
-#include "init.h"
-#include "main.h"
 #include "optionsmodel.h"
 #include "qt/decoration.h"
-#include "streams.h"
 #include "walletmodel.h"
-#include "wallet/wallet.h"
 
 #include <string>
 #include <vector>
@@ -127,30 +123,32 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         return;
     }
 
-    CKey key;
-    if (!pwalletMain->GetKey(*keyID, key))
-    {
+    // The wallet is unlocked (UnlockContext above); signing -- including the
+    // private-key access -- happens node-side, the key never crosses the
+    // boundary. The signature comes back base64-encoded.
+    std::string signature;
+    const interfaces::MessageSignStatus status = model->wallet().signMessage(
+        ui->addressInEdit_SM->text().toStdString(),
+        ui->messageInEdit_SM->document()->toPlainText().toStdString(),
+        signature);
+
+    switch (status) {
+    case interfaces::MessageSignStatus::KeyNotAvailable:
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("Private key for the entered address is not available."));
         return;
-    }
-
-    CDataStream ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << ui->messageInEdit_SM->document()->toPlainText().toStdString();
-
-    std::vector<unsigned char> vchSig;
-    if (!key.SignCompact(Hash(ss), vchSig))
-    {
+    case interfaces::MessageSignStatus::SigningFailed:
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signing failed.") + QString("</nobr>"));
         return;
+    case interfaces::MessageSignStatus::OK:
+        break;
     }
 
     ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
     ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
-    ui->signatureOutEdit_SM->setText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
+    ui->signatureOutEdit_SM->setText(QString::fromStdString(signature));
 }
 
 void SignVerifyMessageDialog::on_copySignatureButton_SM_clicked()
@@ -213,12 +211,15 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
         return;
     }
 
-    CDataStream ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << ui->messageInEdit_VM->document()->toPlainText().toStdString();
+    // Recovering the signer's public key and comparing it to the address is
+    // pure crypto but runs behind the interface so the GUI needs no core
+    // message-magic/recover headers.
+    const interfaces::MessageVerifyStatus status = model->wallet().verifyMessage(
+        ui->addressInEdit_VM->text().toStdString(),
+        ui->messageInEdit_VM->document()->toPlainText().toStdString(),
+        vchSig);
 
-    CPubKey pubkey;
-    if (!pubkey.RecoverCompact(Hash(ss), vchSig))
+    if (status == interfaces::MessageVerifyStatus::RecoverFailed)
     {
         ui->signatureInEdit_VM->setValid(false);
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
@@ -226,7 +227,7 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
         return;
     }
 
-    if (!(CTxDestination(pubkey.GetID()) == addr))
+    if (status == interfaces::MessageVerifyStatus::AddressMismatch)
     {
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_VM->setText(QString("<nobr>") + tr("Message verification failed.") + QString("</nobr>"));

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -6,11 +6,14 @@
 
 #include "gridcoin/backup.h"
 #include "gridcoin/tx_message.h"
+#include "hash.h"
 #include "interfaces/handler.h"
 #include "key_io.h"
 #include "main.h"
 #include "policy/fees.h"
 #include "policy/policy.h"
+#include "streams.h"
+#include "util/strencodings.h"
 #include "wallet/coincontrol.h"
 #include "wallet/wallet.h"
 
@@ -139,6 +142,54 @@ public:
     bool backupConfigFile(const std::string& dest) override
     {
         return GRC::BackupConfigFile(dest);
+    }
+
+    MessageSignStatus signMessage(const std::string& address, const std::string& message,
+                                  std::string& signature_out) override
+    {
+        const CTxDestination dest = DecodeDestination(address);
+        const CKeyID* key_id = std::get_if<CKeyID>(&dest);
+        if (!key_id) {
+            return MessageSignStatus::KeyNotAvailable;
+        }
+
+        CKey key;
+        if (!WITH_LOCK(m_wallet->cs_wallet, return m_wallet->GetKey(*key_id, key))) {
+            return MessageSignStatus::KeyNotAvailable;
+        }
+
+        CDataStream ss(SER_GETHASH, 0);
+        ss << strMessageMagic;
+        ss << message;
+
+        std::vector<unsigned char> signature;
+        if (!key.SignCompact(Hash(ss), signature)) {
+            return MessageSignStatus::SigningFailed;
+        }
+
+        signature_out = EncodeBase64(signature.data(), signature.size());
+        return MessageSignStatus::OK;
+    }
+
+    MessageVerifyStatus verifyMessage(const std::string& address, const std::string& message,
+                                      const std::vector<unsigned char>& signature) override
+    {
+        const CTxDestination dest = DecodeDestination(address);
+
+        CDataStream ss(SER_GETHASH, 0);
+        ss << strMessageMagic;
+        ss << message;
+
+        CPubKey pubkey;
+        if (!pubkey.RecoverCompact(Hash(ss), signature)) {
+            return MessageVerifyStatus::RecoverFailed;
+        }
+
+        if (CTxDestination(pubkey.GetID()) != dest) {
+            return MessageVerifyStatus::AddressMismatch;
+        }
+
+        return MessageVerifyStatus::OK;
     }
 
     bool getPubKey(const CKeyID& address, CPubKey& pub_key_out) override

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -64,9 +64,6 @@ src/qt/researcher/researcherwizardpoolpage.cpp:key.h
 src/qt/rpcconsole.cpp:rpc/client.h
 src/qt/rpcconsole.cpp:rpc/protocol.h
 src/qt/rpcconsole.cpp:rpc/server.h
-src/qt/signverifymessagedialog.cpp:init.h
-src/qt/signverifymessagedialog.cpp:main.h
-src/qt/signverifymessagedialog.cpp:wallet/wallet.h
 src/qt/transactiontablemodel.cpp:util.h
 src/qt/transactionview.cpp:util/system.h
 src/qt/updatedialog.h:gridcoin/upgrade.h


### PR DESCRIPTION
## Summary

Part of Phase 1 of the multiprocess GUI/node separation (RFC #2937). Moves the **Sign Message / Verify Message** tool off its direct core coupling and behind `interfaces::Wallet`, so `signverifymessagedialog.cpp` no longer includes `init.h`, `main.h`, `wallet/wallet.h`, or `streams.h`.

> **Stacked on #3196** (net/peer cluster). Until #3196 merges, this PR's diff shows #3196's commit first; the sign/verify change is the final commit (`gui: migrate sign/verify message dialog onto interfaces::Wallet`).

## What changed

Two new interface methods and their result enums (`src/interfaces/wallet.h`, implemented in `src/wallet/interfaces.cpp`):

```cpp
MessageSignStatus   Wallet::signMessage(address, message, signature_out);
MessageVerifyStatus Wallet::verifyMessage(address, message, signature);
```

- `signMessage` does the private-key lookup, message-magic hashing and `SignCompact` **node-side** and returns the base64 signature — **the private key never crosses the interface boundary**, consistent with the rest of the wallet interface.
- `verifyMessage` does the `RecoverCompact` and address comparison node-side.
- The GUI keeps its own address / key-type pre-validation and the wallet `UnlockContext`, and switches on the returned status enum for its user-facing messages (behavior-preserving).

Retires three `lint-qt-includes.sh` ratchet entries (`signverifymessagedialog.cpp` → `init.h` / `main.h` / `wallet/wallet.h`).

## Testing

- Native Qt6 `RelWithDebInfo` build clean; `ctest` 100% (3/3).
- `lint-qt-includes.sh` and `lint-all.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)