### PR TITLE
gui: migrate the address-book model onto interfaces::Wallet

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -347,8 +347,11 @@ public:
     //! Set (create or overwrite) the address book label for the encoded address.
     virtual void setAddressBook(const std::string& address, const std::string& label) = 0;
 
-    //! Remove the encoded address from the address book. Returns false when the
-    //! address does not parse.
+    //! Remove the encoded address from the address book. Removing an entry that
+    //! is not present is treated as success by the wallet DB layer. Returns
+    //! false when the address does not parse, or when the underlying wallet
+    //! erase fails (e.g. a non-file-backed wallet or a DB write error) -- note a
+    //! false return does not necessarily mean the in-memory entry survived.
     virtual bool delAddressBook(const std::string& address) = 0;
 
     //! Reserve a fresh key from the pool and return its encoded destination. The

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -53,6 +53,19 @@ struct WalletOutput
     bool immature{false};
 };
 
+//! Value snapshot of one address-book entry for the GUI address table. The
+//! destination is carried as an already-encoded string so the GUI needs no
+//! core key_io/ismine headers.
+struct WalletAddress
+{
+    //! Encoded destination.
+    std::string address;
+    //! Address-book label (name); empty when the entry has no label.
+    std::string label;
+    //! Owned by this wallet (IsMine != ISMINE_NO): receiving vs sending.
+    bool is_mine{false};
+};
+
 //! The GUI's coin-selection value: the outpoints coin selection is pinned to,
 //! plus the change-destination override. This IS the selection container the
 //! coin-control dialogs build and mutate directly (replacing the core
@@ -317,6 +330,36 @@ public:
     //! interface only so the GUI needs no core message-magic/recover headers.
     virtual MessageVerifyStatus verifyMessage(const std::string& address, const std::string& message,
                                               const std::vector<unsigned char>& signature) = 0;
+
+    //! Snapshot of the whole address book for the GUI address table. Each entry
+    //! carries its encoded destination, label, and ownership flag.
+    virtual std::vector<WalletAddress> getAddresses() = 0;
+
+    //! Look up an address-book entry by encoded address. Returns false (and
+    //! leaves label_out unchanged) when the address is not in the book or does
+    //! not parse; otherwise fills label_out with its label.
+    virtual bool getAddressLabel(const std::string& address, std::string& label_out) = 0;
+
+    //! Whether the encoded address is owned by this wallet (IsMine != ISMINE_NO),
+    //! regardless of whether it is in the address book.
+    virtual bool isMine(const std::string& address) = 0;
+
+    //! Set (create or overwrite) the address book label for the encoded address.
+    virtual void setAddressBook(const std::string& address, const std::string& label) = 0;
+
+    //! Remove the encoded address from the address book. Returns false when the
+    //! address does not parse.
+    virtual bool delAddressBook(const std::string& address) = 0;
+
+    //! Reserve a fresh key from the pool and return its encoded destination. The
+    //! wallet must already be unlocked (the GUI holds an UnlockContext); the key
+    //! never crosses the boundary. Returns false on key-generation failure. Does
+    //! not touch the address book -- the caller labels the address separately.
+    virtual bool getNewReceiveAddress(std::string& address_out) = 0;
+
+    //! Owned addresses with a positive balance that are not yet in the address
+    //! book (encoded), for the "add existing receive address" picker.
+    virtual std::vector<std::string> getUnbookedReceiveAddresses() = 0;
 
     //! Register a handler for encryption/lock status changes.
     using StatusChangedFn = std::function<void()>;

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -3,9 +3,7 @@
 #include "guiutil.h"
 #include "walletmodel.h"
 
-#include "wallet/wallet.h"
-#include <key_io.h>
-#include "util.h"
+#include "interfaces/wallet.h"
 
 #include <QFont>
 #include <QColor>
@@ -50,27 +48,21 @@ struct AddressTableEntryLessThan
 class AddressTablePriv
 {
 public:
-    CWallet *wallet;
+    WalletModel *walletModel;
     QList<AddressTableEntry> cachedAddressTable;
     AddressTableModel *parent;
 
-    AddressTablePriv(CWallet *wallet, AddressTableModel *parent):
-        wallet(wallet), parent(parent) {}
+    AddressTablePriv(WalletModel *walletModel, AddressTableModel *parent):
+        walletModel(walletModel), parent(parent) {}
 
     void refreshAddressTable()
     {
         cachedAddressTable.clear();
+        for (const interfaces::WalletAddress& address : walletModel->wallet().getAddresses())
         {
-            LOCK(wallet->cs_wallet);
-            for (auto const &item : wallet->mapAddressBook)
-            {
-                const CTxDestination& address = item.first;
-                const std::string& strName = item.second.name;
-                isminetype fMine = IsMine(*wallet, address);
-                cachedAddressTable.append(AddressTableEntry((fMine != ISMINE_NO) ? AddressTableEntry::Receiving : AddressTableEntry::Sending,
-                                  QString::fromStdString(strName),
-                                  QString::fromStdString(EncodeDestination(address))));
-            }
+            cachedAddressTable.append(AddressTableEntry(address.is_mine ? AddressTableEntry::Receiving : AddressTableEntry::Sending,
+                              QString::fromStdString(address.label),
+                              QString::fromStdString(address.address)));
         }
         // std::lower_bound() and std::upper_bound() require our cachedAddressTable list to be sorted in asc order
         std::sort(cachedAddressTable.begin(), cachedAddressTable.end(), AddressTableEntryLessThan());
@@ -141,14 +133,13 @@ public:
     }
 };
 
-AddressTableModel::AddressTableModel(CWallet* wallet, WalletModel* parent)
+AddressTableModel::AddressTableModel(WalletModel* parent)
                : QAbstractTableModel(parent)
                , walletModel(parent)
-               , wallet(wallet)
                , priv(nullptr)
 {
     columns << tr("Label") << tr("Address");
-    priv = new AddressTablePriv(wallet, this);
+    priv = new AddressTablePriv(parent, this);
     priv->refreshAddressTable();
 }
 
@@ -234,12 +225,6 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
 
     editStatus = OK;
 
-    auto address_count = [this](const QVariant &value) {
-        LOCK(wallet->cs_wallet);
-
-        return wallet->mapAddressBook.count(DecodeDestination(value.toString().toStdString()));
-    };
-
     if (role == Qt::EditRole)
     {
         switch(index.column())
@@ -251,11 +236,15 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
                 editStatus = NO_CHANGES;
                 return false;
             }
-            wallet->SetAddressBookName(DecodeDestination(rec->address.toStdString()), value.toString().toStdString());
+            walletModel->wallet().setAddressBook(rec->address.toStdString(), value.toString().toStdString());
             break;
         case Address:
-            // Do nothing, if old address == new address
-            if(DecodeDestination(rec->address.toStdString()) == DecodeDestination(value.toString().toStdString()))
+        {
+            std::string existingLabel;
+            // Do nothing, if old address == new address. (Compares the canonical
+            // encoded strings; the same destination re-typed in a non-canonical
+            // form falls through to the duplicate check below, which rejects it.)
+            if(rec->address == value.toString())
             {
                 editStatus = NO_CHANGES;
                 return false;
@@ -268,7 +257,7 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
             }
             // Check for duplicate addresses to prevent accidental deletion of addresses, if you try
             // to paste an existing address over another address (with a different label)
-            else if(address_count(value))
+            else if(walletModel->wallet().getAddressLabel(value.toString().toStdString(), existingLabel))
             {
                 editStatus = DUPLICATE_ADDRESS;
                 return false;
@@ -276,15 +265,12 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
             // Double-check that we're not overwriting a receiving address
             else if(rec->type == AddressTableEntry::Sending)
             {
-                {
-                    LOCK(wallet->cs_wallet);
-                    // Remove old entry
-                    wallet->DelAddressBookName(DecodeDestination(rec->address.toStdString()));
-                    // Add new entry with new address
-                    wallet->SetAddressBookName(DecodeDestination(value.toString().toStdString()), rec->label.toStdString());
-                }
+                // Remove old entry, add new entry with new address
+                walletModel->wallet().delAddressBook(rec->address.toStdString());
+                walletModel->wallet().setAddressBook(value.toString().toStdString(), rec->label.toStdString());
             }
             break;
+        }
         }
         return true;
     }
@@ -355,13 +341,11 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
             return QString();
         }
         // Check for duplicate addresses
+        std::string existingLabel;
+        if(walletModel->wallet().getAddressLabel(strAddress, existingLabel))
         {
-            LOCK(wallet->cs_wallet);
-            if(wallet->mapAddressBook.count(DecodeDestination(strAddress)))
-            {
-                editStatus = DUPLICATE_ADDRESS;
-                return QString();
-            }
+            editStatus = DUPLICATE_ADDRESS;
+            return QString();
         }
     }
     else if(type == Receive)
@@ -374,13 +358,11 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
             editStatus = WALLET_UNLOCK_FAILURE;
             return QString();
         }
-        CPubKey newKey;
-        if(!wallet->GetKeyFromPool(newKey, true))
+        if(!walletModel->wallet().getNewReceiveAddress(strAddress))
         {
             editStatus = KEY_GENERATION_FAILURE;
             return QString();
         }
-        strAddress = EncodeDestination(newKey.GetID());
     }
     else if(type == ReceiveExisting)
     {
@@ -389,14 +371,13 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
             editStatus = INVALID_ADDRESS;
             return QString();
         }
-        LOCK(wallet->cs_wallet);
-        CTxDestination dest = DecodeDestination(strAddress);
-        if(IsMine(*wallet, dest) == ISMINE_NO)
+        if(!walletModel->wallet().isMine(strAddress))
         {
             editStatus = NOT_MINE;
             return QString();
         }
-        if(wallet->mapAddressBook.count(dest))
+        std::string existingLabel;
+        if(walletModel->wallet().getAddressLabel(strAddress, existingLabel))
         {
             editStatus = DUPLICATE_ADDRESS;
             return QString();
@@ -408,10 +389,7 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
     }
 
     // Add entry
-    {
-        LOCK(wallet->cs_wallet);
-        wallet->SetAddressBookName(DecodeDestination(strAddress), strLabel);
-    }
+    walletModel->wallet().setAddressBook(strAddress, strLabel);
     return QString::fromStdString(strAddress);
 }
 
@@ -425,24 +403,15 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
         // Also refuse to remove receiving addresses.
         return false;
     }
-    {
-        LOCK(wallet->cs_wallet);
-        wallet->DelAddressBookName(DecodeDestination(rec->address.toStdString()));
-    }
+    walletModel->wallet().delAddressBook(rec->address.toStdString());
     return true;
 }
 
 QStringList AddressTableModel::unbookedReceiveAddresses() const
 {
     QStringList result;
-    {
-        LOCK(wallet->cs_wallet);
-        std::map<CTxDestination, int64_t> balances = wallet->GetAddressBalances();
-        for (const auto& [dest, balance] : balances) {
-            if (balance > 0 && wallet->mapAddressBook.count(dest) == 0) {
-                result.append(QString::fromStdString(EncodeDestination(dest)));
-            }
-        }
+    for (const std::string& address : walletModel->wallet().getUnbookedReceiveAddresses()) {
+        result.append(QString::fromStdString(address));
     }
     result.sort();
     return result;
@@ -452,14 +421,10 @@ QStringList AddressTableModel::unbookedReceiveAddresses() const
  */
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
+    std::string label;
+    if (walletModel->wallet().getAddressLabel(address.toStdString(), label))
     {
-        LOCK(wallet->cs_wallet);
-        CTxDestination address_parsed = DecodeDestination(address.toStdString());
-        auto mi = wallet->mapAddressBook.find(address_parsed);
-        if (mi != wallet->mapAddressBook.end())
-        {
-            return QString::fromStdString(mi->second.name);
-        }
+        return QString::fromStdString(label);
     }
     return QString();
 }

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -14,7 +14,9 @@ class AddressTableModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
-    explicit AddressTableModel(WalletModel* parent = nullptr);
+    // parent is required: the model reaches the wallet through parent->wallet(),
+    // so it is dereferenced unconditionally (no default null).
+    explicit AddressTableModel(WalletModel* parent);
     ~AddressTableModel();
 
     enum ColumnIndex {

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -4,10 +4,7 @@
 #include <QAbstractTableModel>
 #include <QStringList>
 
-#include "wallet/ismine.h"
-
 class AddressTablePriv;
-class CWallet;
 class WalletModel;
 
 /**
@@ -17,7 +14,7 @@ class AddressTableModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
-    explicit AddressTableModel(CWallet* wallet, WalletModel* parent = nullptr);
+    explicit AddressTableModel(WalletModel* parent = nullptr);
     ~AddressTableModel();
 
     enum ColumnIndex {
@@ -80,7 +77,6 @@ public:
 
 private:
     WalletModel *walletModel;
-    CWallet *wallet;
     AddressTablePriv *priv;
     QStringList columns;
     EditStatus editStatus;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -30,7 +30,7 @@ WalletModel::WalletModel(interfaces::Wallet& wallet, interfaces::WalletTxSource&
          , cachedEncryptionStatus(Unencrypted)
          , cachedNumBlocks(0)
 {
-    addressTableModel = new AddressTableModel(core_wallet, this);
+    addressTableModel = new AddressTableModel(this);
     // TransactionTableModel's ctor performs the initial load via
     // txSource().reloadAndSnapshot(). The source's store-worker is already
     // running (started in the WalletTxSource ctor, before this model was

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -261,6 +261,60 @@ BOOST_AUTO_TEST_CASE(wallet_address_book_handler_bridges_value_types)
     BOOST_CHECK_EQUAL(calls, 1);
 }
 
+BOOST_AUTO_TEST_CASE(wallet_address_book_query_surface)
+{
+    BOOST_REQUIRE(pwalletMain != nullptr);
+
+    std::unique_ptr<interfaces::Wallet> wallet = interfaces::MakeWallet(pwalletMain);
+
+    // Reserve a fresh owned address; the private key stays node-side and only
+    // the encoded destination comes back.
+    std::string address;
+    BOOST_REQUIRE(wallet->getNewReceiveAddress(address));
+    BOOST_CHECK(!address.empty());
+    BOOST_CHECK(IsValidDestination(DecodeDestination(address)));
+
+    // It is ours (from the key pool) but not yet in the address book.
+    BOOST_CHECK(wallet->isMine(address));
+    std::string label;
+    BOOST_CHECK(!wallet->getAddressLabel(address, label));
+
+    // Book it: the label round-trips and it shows up in the full snapshot as
+    // an owned (receiving) entry.
+    wallet->setAddressBook(address, "interfaces-book-label");
+    BOOST_REQUIRE(wallet->getAddressLabel(address, label));
+    BOOST_CHECK_EQUAL(label, "interfaces-book-label");
+
+    bool found_in_snapshot = false;
+    for (const interfaces::WalletAddress& entry : wallet->getAddresses()) {
+        if (entry.address == address) {
+            found_in_snapshot = true;
+            BOOST_CHECK(entry.is_mine);
+            BOOST_CHECK_EQUAL(entry.label, "interfaces-book-label");
+        }
+    }
+    BOOST_CHECK(found_in_snapshot);
+
+    // Removing it drops it from the book. The bool return depends on the wallet
+    // being file-backed (the unit-test wallet is not), so assert via the book
+    // rather than the return value.
+    wallet->delAddressBook(address);
+    BOOST_CHECK(!wallet->getAddressLabel(address, label));
+
+    // Failure cases: an unparseable address is not mine, has no label, and
+    // cannot be removed.
+    const std::string bogus = "not-a-valid-address";
+    BOOST_CHECK(!wallet->isMine(bogus));
+    BOOST_CHECK(!wallet->getAddressLabel(bogus, label));
+    BOOST_CHECK(!wallet->delAddressBook(bogus));
+
+    // getUnbookedReceiveAddresses is callable and yields well-formed encoded
+    // strings (contents depend on balances the unit-test wallet lacks).
+    for (const std::string& unbooked : wallet->getUnbookedReceiveAddresses()) {
+        BOOST_CHECK(!unbooked.empty());
+    }
+}
+
 BOOST_AUTO_TEST_CASE(node_value_queries_are_safe_in_empty_environment)
 {
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -192,6 +192,105 @@ public:
         return MessageVerifyStatus::OK;
     }
 
+    std::vector<WalletAddress> getAddresses() override
+    {
+        std::vector<WalletAddress> result;
+
+        LOCK(m_wallet->cs_wallet);
+        result.reserve(m_wallet->mapAddressBook.size());
+        for (const auto& item : m_wallet->mapAddressBook) {
+            const CTxDestination& dest = item.first;
+            WalletAddress entry;
+            entry.address = EncodeDestination(dest);
+            entry.label = item.second.name;
+            entry.is_mine = IsMine(*m_wallet, dest) != ISMINE_NO;
+            result.push_back(std::move(entry));
+        }
+
+        return result;
+    }
+
+    bool getAddressLabel(const std::string& address, std::string& label_out) override
+    {
+        const CTxDestination dest = DecodeDestination(address);
+        if (!IsValidDestination(dest)) {
+            return false;
+        }
+
+        LOCK(m_wallet->cs_wallet);
+        const auto it = m_wallet->mapAddressBook.find(dest);
+        if (it == m_wallet->mapAddressBook.end()) {
+            return false;
+        }
+
+        label_out = it->second.name;
+        return true;
+    }
+
+    bool isMine(const std::string& address) override
+    {
+        const CTxDestination dest = DecodeDestination(address);
+        if (!IsValidDestination(dest)) {
+            return false;
+        }
+
+        LOCK(m_wallet->cs_wallet);
+        return IsMine(*m_wallet, dest) != ISMINE_NO;
+    }
+
+    void setAddressBook(const std::string& address, const std::string& label) override
+    {
+        const CTxDestination dest = DecodeDestination(address);
+        if (!IsValidDestination(dest)) {
+            return;
+        }
+
+        // SetAddressBookName takes cs_wallet itself and fires NotifyAddressBookChanged.
+        m_wallet->SetAddressBookName(dest, label);
+    }
+
+    bool delAddressBook(const std::string& address) override
+    {
+        const CTxDestination dest = DecodeDestination(address);
+        if (!IsValidDestination(dest)) {
+            return false;
+        }
+
+        // DelAddressBookName takes cs_wallet itself and fires NotifyAddressBookChanged.
+        return m_wallet->DelAddressBookName(dest);
+    }
+
+    bool getNewReceiveAddress(std::string& address_out) override
+    {
+        // The wallet is unlocked by the GUI's UnlockContext before this call; the
+        // reserved key stays node-side and only its encoded address is returned.
+        // fAllowReuse=true matches the old GUI addRow() behavior.
+        CPubKey new_key;
+        if (!m_wallet->GetKeyFromPool(new_key, true)) {
+            return false;
+        }
+
+        address_out = EncodeDestination(new_key.GetID());
+        return true;
+    }
+
+    std::vector<std::string> getUnbookedReceiveAddresses() override
+    {
+        std::vector<std::string> result;
+
+        // cs_wallet is recursive, so it covers both GetAddressBalances (which
+        // re-locks internally) and the mapAddressBook membership test below.
+        LOCK(m_wallet->cs_wallet);
+        const std::map<CTxDestination, int64_t> balances = m_wallet->GetAddressBalances();
+        for (const auto& [dest, balance] : balances) {
+            if (balance > 0 && m_wallet->mapAddressBook.count(dest) == 0) {
+                result.push_back(EncodeDestination(dest));
+            }
+        }
+
+        return result;
+    }
+
     bool getPubKey(const CKeyID& address, CPubKey& pub_key_out) override
     {
         return m_wallet->GetPubKey(address, pub_key_out);

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -28,9 +28,6 @@ FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validati
 # rpcconsole.cpp:banman.h -- the coupling is old, only the include is new.)
 ALLOWLIST="\
 src/qt/aboutdialog.cpp:util.h
-src/qt/addresstablemodel.cpp:util.h
-src/qt/addresstablemodel.cpp:wallet/wallet.h
-src/qt/addresstablemodel.h:wallet/ismine.h
 src/qt/bitcoin.cpp:chainparamsbase.h
 src/qt/bitcoin.cpp:chainparams.h
 src/qt/bitcoin.cpp:gridcoin/gridcoin.h


### PR DESCRIPTION
## Summary

Part of Phase 1 of the multiprocess GUI/node separation (RFC #2937). Moves `AddressTableModel` off its direct `CWallet*` access and behind the `interfaces::Wallet` boundary, so `src/qt/addresstablemodel.{h,cpp}` no longer include `wallet/wallet.h`, `util.h`, or `wallet/ismine.h`.

## What changed

New interface surface (declared in `src/interfaces/wallet.h`, implemented in `src/wallet/interfaces.cpp`) plus a `WalletAddress` value snapshot:

```cpp
std::vector<WalletAddress> getAddresses();
bool getAddressLabel(const std::string& address, std::string& label_out);
bool isMine(const std::string& address);
void setAddressBook(const std::string& address, const std::string& label);
bool delAddressBook(const std::string& address);
bool getNewReceiveAddress(std::string& address_out);   // reserved key stays node-side
std::vector<std::string> getUnbookedReceiveAddresses();
```

- All address encoding/decoding, `IsMine`, `mapAddressBook` access, key-pool reservation and the `cs_wallet` locking now happen **node-side**; addresses cross the boundary as encoded strings, and the reserved receive key never leaves the node.
- `AddressTableModel` drops its `CWallet*` member and constructor argument and reaches the wallet through its owning `WalletModel`'s `wallet()` accessor.
- **Behavior preserved**: the Send/Receive/ReceiveExisting edit flows, the duplicate / `NOT_MINE` / wallet-unlock checks, the address-book change signal path (`CT_NEW`/`CT_UPDATED`/`CT_DELETED`, already flowing through the interface), and the unbooked-receive-address picker are unchanged.

Retires three `lint-qt-includes.sh` ratchet entries (`addresstablemodel.cpp` → `util.h`, `wallet/wallet.h`; `addresstablemodel.h` → `wallet/ismine.h`).

## Notes / review points

- The `setData` Address-edit "no change" check now compares the canonical encoded strings rather than decoded destinations. For Base58Check addresses (no alternate encodings) this is equivalent; a same-destination re-typed in a non-canonical form would fall through to the duplicate check, which also rejects it. Documented inline.
- As with every interface-boundary migration, a single `cs_wallet` critical section that previously spanned check-then-mutate is now split across separate interface calls. Benign for GUI-driven single-address edits.

## Testing

- Native Qt6 `RelWithDebInfo` build clean; `ctest` 100% (3/3).
- `lint-qt-includes.sh` and `lint-all.sh` clean.
- Adversarial self-review vs `origin/development`: no runtime behavior-changing bug found; all lock/addRow/duplicate-check/filter/sort semantics verified preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)