### PR TITLE
gui: migrate the RPC console command execution onto interfaces::Node

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -59,6 +59,18 @@ struct PeerInfo
     double min_ping = 0;
 };
 
+//! Result of running one RPC-console command. The whole UniValue round trip
+//! (arg conversion, dispatch, result/error formatting) happens node-side; only
+//! the already-formatted text crosses the boundary.
+struct RpcConsoleResult
+{
+    //! false when the command threw (RPC error or std::exception).
+    bool ok = false;
+    //! Formatted reply text on success, or the formatted error message on
+    //! failure ("<message> (code <n>)", or raw JSON / "Error: <what>").
+    std::string output;
+};
+
 //! Value snapshot of the scraper convergence status consumed by the GUI
 //! status icon. Taken under the scraper cache lock inside the implementation;
 //! callers hold nothing.
@@ -160,6 +172,16 @@ public:
     //! Disconnect the peer with the given connection id. Returns whether a peer
     //! was disconnected.
     virtual bool disconnectNode(int64_t node_id) = 0;
+
+    //! Run one RPC-console command: convert the positional string args per the
+    //! command's conversion table, dispatch it, and format the reply/error. All
+    //! UniValue handling stays node-side. Blocks while the command runs, so the
+    //! GUI calls it from its off-thread RPC executor.
+    virtual RpcConsoleResult executeRpcConsoleCommand(const std::string& method,
+                                                      const std::vector<std::string>& args) = 0;
+
+    //! The list of RPC command names, for the console's autocomplete.
+    virtual std::vector<std::string> listRpcCommands() = 0;
 
     //! Value snapshot of the scraper convergence status.
     virtual ScraperConvergenceSnapshot getScraperConvergenceSnapshot() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -25,8 +25,12 @@
 #include "net.h"
 #include "netbase.h"
 #include "node/ui_interface.h"
+#include "rpc/client.h"
+#include "rpc/server.h"
 #include "sync.h"
 #include "util.h"
+
+#include <univalue.h>
 
 #include <memory>
 #include <optional>
@@ -211,6 +215,46 @@ public:
     bool disconnectNode(int64_t node_id) override
     {
         return g_connman && g_connman->DisconnectNode(node_id);
+    }
+
+    RpcConsoleResult executeRpcConsoleCommand(const std::string& method,
+                                              const std::vector<std::string>& args) override
+    {
+        RpcConsoleResult out;
+
+        try {
+            // Convert the positional string args in the command-dependent way,
+            // dispatch, and format the reply -- all UniValue handling stays here.
+            UniValue result = tableRPC.execute(method, RPCConvertValues(method, args));
+
+            if (result.isNull()) {
+                out.output.clear();
+            } else if (result.isStr()) {
+                out.output = result.get_str();
+            } else {
+                out.output = result.write(2);
+            }
+            out.ok = true;
+        } catch (UniValue& objError) {
+            try { // Nice formatting for a standard-format error
+                const int code = find_value(objError, "code").get_int();
+                const std::string message = find_value(objError, "message").get_str();
+                out.output = strprintf("%s (code %d)", message, code);
+            } catch (const std::runtime_error&) { // missing code/message: raw JSON
+                out.output = objError.write();
+            }
+            out.ok = false;
+        } catch (const std::exception& e) {
+            out.output = std::string("Error: ") + e.what();
+            out.ok = false;
+        }
+
+        return out;
+    }
+
+    std::vector<std::string> listRpcCommands() override
+    {
+        return tableRPC.listCommands();
     }
 
     ScraperConvergenceSnapshot getScraperConvergenceSnapshot() override

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -843,6 +843,13 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
         connect(clientModel, &ClientModel::psgtPoolChanged,
                 this, &BitcoinGUI::handlePSGTPoolChanged);
     }
+    else
+    {
+        // Shutdown teardown: propagate the cleared model so the RPC console
+        // stops its executor thread before the interfaces::Node it references
+        // is destroyed.
+        rpcConsole->setClientModel(nullptr);
+    }
 }
 
 void BitcoinGUI::setPSGTPoolContext(interfaces::PSGTPoolContext *context)

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -6,13 +6,8 @@
 #include "clientmodel.h"
 #include "qt/bantablemodel.h"
 #include "qt/decoration.h"
-#include "rpc/server.h"
-#include "rpc/client.h"
-#include "rpc/protocol.h"
 #include "guiutil.h"
 #endif
-
-#include <stdexcept>
 
 #include <QThread>
 #include <QTextEdit>
@@ -52,11 +47,15 @@ const struct {
 class RPCExecutor: public QObject
 {
     Q_OBJECT
+public:
+    explicit RPCExecutor(interfaces::Node& node) : m_node(node) {}
 public slots:
     void start();
     void request(const QString &command);
 signals:
     void reply(int category, const QString &command);
+private:
+    interfaces::Node& m_node;
 };
 
 #include "rpcconsole.moc"
@@ -171,45 +170,21 @@ void RPCExecutor::request(const QString &command)
     }
     if(args.empty())
         return; // Nothing to do
-    try
+
+    // The dispatch, UniValue conversion and reply/error formatting all happen
+    // node-side; the GUI receives the already-formatted text. This runs on the
+    // executor thread, so a slow command does not block the GUI.
+    const interfaces::RpcConsoleResult result = m_node.executeRpcConsoleCommand(
+        args[0], std::vector<std::string>(args.begin() + 1, args.end()));
+
+    if (result.ok)
     {
-        std::string strPrint;
-        // Convert argument list to JSON objects in method-dependent way,
-        // and pass it along with the method name to the dispatcher.
-        UniValue result = tableRPC.execute(
-            args[0],
-            RPCConvertValues(args[0], std::vector<std::string>(args.begin() + 1, args.end())));
-
-        // Format result reply
-        if (result.isNull())
-            strPrint = "";
-        else if (result.isStr())
-            strPrint = result.get_str();
-        else
-            strPrint = result.write(2);
-
-        emit reply(RPCConsole::CMD_REPLY, QString::fromStdString(strPrint));
+        emit reply(RPCConsole::CMD_REPLY, QString::fromStdString(result.output));
     }
-    catch (UniValue& objError)
+    else
     {
         GUILogPrintf("gridcoinresearch:  Handling Error [Request %s]...", command.toStdString());
-
-        try // Nice formatting for standard-format error
-        {
-            int code = find_value(objError, "code").get_int();
-            std::string message = find_value(objError, "message").get_str();
-            emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
-        }
-        catch(std::runtime_error &) // raised when converting to invalid type, i.e. missing code or message
-        {   // Show raw JSON object
-            emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
-        }
-    }
-    catch (std::exception& e)
-    {
-        GUILogPrintf("gridcoinresearch:  Handling Error[2]...");
-
-        emit reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
+        emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(result.output));
     }
 }
 
@@ -244,7 +219,6 @@ RPCConsole::RPCConsole(QWidget *parent) :
     // set Qt version label
     ui->qtVersion->setText("Qt " + QString::fromLocal8Bit(qVersion()) + " (built against " + QString::fromStdString(QT_VERSION_STR) + ")");
 
-    startExecutor();
 	setTrafficGraphRange(INITIAL_TRAFFIC_GRAPH_MINS);
     clear();
 
@@ -253,7 +227,9 @@ RPCConsole::RPCConsole(QWidget *parent) :
 
 RPCConsole::~RPCConsole()
 {
-    emit stopExecutor();
+    // Normally the executor was already stopped on the setClientModel(nullptr)
+    // teardown path; this is an idempotent backstop.
+    stopExecutorThread();
     delete ui;
 }
 
@@ -306,6 +282,17 @@ void RPCConsole::setClientModel(ClientModel *model)
 
 	clientModel = model;
 	ui->trafficGraph->setClientModel(model);
+
+    if (!model)
+    {
+        // Client model (and the interfaces::Node it exposes) is going away on
+        // the shutdown teardown path: stop the executor thread now, before the
+        // node is destroyed, so an in-flight/queued command cannot dereference
+        // it. Safe no-op if the executor was never started.
+        stopExecutorThread();
+        return;
+    }
+
     if(model && clientModel->getPeerTableModel() && clientModel->getBanTableModel())
     {
         // Subscribe to information, replies, messages, errors
@@ -409,7 +396,7 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         //Setup autocomplete and attach it
         QStringList wordList;
-        std::vector<std::string> commandList = tableRPC.listCommands();
+        std::vector<std::string> commandList = model->node().listRpcCommands();
         for (size_t i = 0; i < commandList.size(); ++i)
         {
             wordList << commandList[i].c_str();
@@ -417,6 +404,12 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         autoCompleter = new QCompleter(wordList, this);
         ui->lineEdit->setCompleter(autoCompleter);
+
+        // Start the RPC executor now that we have a node to run commands
+        // against (the console is unusable without a model). Guarded so a
+        // second setClientModel(model) call cannot spawn a duplicate thread.
+        if (!m_executorThread)
+            startExecutor();
     }
 }
 
@@ -542,7 +535,8 @@ void RPCConsole::browseHistory(int offset)
 void RPCConsole::startExecutor()
 {
     QThread* thread = new QThread;
-    RPCExecutor *executor = new RPCExecutor();
+    m_executorThread = thread;
+    RPCExecutor *executor = new RPCExecutor(clientModel->node());
     executor->moveToThread(thread);
 
     // Notify executor when thread started (in executor thread)
@@ -562,6 +556,22 @@ void RPCConsole::startExecutor()
     // Default implementation of QThread::run() simply spins up an event loop in the thread,
     // which is what we want.
     thread->start();
+}
+
+void RPCConsole::stopExecutorThread()
+{
+    if (!m_executorThread)
+        return;
+
+    // stopExecutor quits the worker's event loop and queues the executor for
+    // deletion; wait() blocks until run() has returned so no further request()
+    // can dereference the interfaces::Node. If a command is in flight this
+    // drains it first, mirroring how the other GUI workers are quiesced on the
+    // model-teardown path. The thread object self-deletes via finished->
+    // deleteLater; drop our pointer so this is idempotent.
+    emit stopExecutor();
+    m_executorThread->wait();
+    m_executorThread = nullptr;
 }
 
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -18,6 +18,7 @@ class ClientModel;
 QT_BEGIN_NAMESPACE
 class QMenu;
 class QItemSelection;
+class QThread;
 QT_END_NAMESPACE
 
 /** Local Bitcoin RPC console. */
@@ -116,6 +117,13 @@ private:
     void updateNodeDetail(const interfaces::PeerInfo *stats);
 
     void startExecutor();
+    /** Stop the executor thread synchronously (quit + wait). Called when the
+        client model is cleared at shutdown, so a queued/in-flight command can
+        no longer dereference the interfaces::Node after it is destroyed. */
+    void stopExecutorThread();
+
+    //! The executor's worker thread, non-null once startExecutor() has run.
+    QThread *m_executorThread = nullptr;
 
     enum ColumnWidths
     {

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -58,9 +58,6 @@ src/qt/optionsmodel.cpp:miner.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/qtipcserver.cpp:util.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
-src/qt/rpcconsole.cpp:rpc/client.h
-src/qt/rpcconsole.cpp:rpc/protocol.h
-src/qt/rpcconsole.cpp:rpc/server.h
 src/qt/transactiontablemodel.cpp:util.h
 src/qt/transactionview.cpp:util/system.h
 src/qt/updatedialog.h:gridcoin/upgrade.h


### PR DESCRIPTION
## Summary

Part of Phase 1 of the multiprocess GUI/node separation (RFC #2937). Moves the **RPC console command dispatcher** off its direct core coupling and behind `interfaces::Node`, so `rpcconsole.cpp` no longer includes `rpc/server.h`, `rpc/client.h`, or `rpc/protocol.h` (nor the now-unused `<stdexcept>`). This is the command-**execution** surface deferred from the net/peer cluster (#3196).

> **Stacked on #3199** (address-book). Until #3199 merges, this PR's diff shows its commit first; the RPC-console change is the final commit.

## What changed

New node surface (`interfaces/node.h`, implemented in `node/interfaces.cpp`):

```cpp
struct RpcConsoleResult { bool ok; std::string output; };
RpcConsoleResult Node::executeRpcConsoleCommand(const std::string& method,
                                                const std::vector<std::string>& args);
std::vector<std::string> Node::listRpcCommands();
```

- `executeRpcConsoleCommand` does the whole `UniValue` round trip **node-side** — `RPCConvertValues`, `tableRPC.execute`, and result/error formatting — and returns only the already-formatted reply/error text plus an `ok` flag. `UniValue` no longer appears in the GUI.
- The GUI's `RPCExecutor` still runs on its worker thread (so slow commands don't block the GUI) but calls the interface instead of `tableRPC`; the autocomplete's `listCommands` goes through `listRpcCommands()`.

## Executor lifetime (important)

Because the executor now references `interfaces::Node`, its lifetime must end **before** the node is destroyed at shutdown (the old code only touched the process-global `tableRPC`, so it had no such dependency). So:

- `startExecutor()` is now started from `setClientModel()` (once a node exists), guarded so a repeated `setClientModel` cannot spawn a duplicate thread.
- It is stopped **synchronously** on `setClientModel(nullptr)` — the model-teardown hook `BitcoinGUI` already drives before the node is torn down — via a new `stopExecutorThread()` that quits and `wait()`s the worker (draining any in-flight command). This mirrors how the other GUI workers (VotingModel, PSGT) are quiesced on the same teardown path. The destructor calls it as an idempotent backstop.

## Testing

- Native Qt6 `RelWithDebInfo` build clean; `ctest` 100% (3/3).
- `lint-qt-includes.sh` and `lint-all.sh` clean.
- Adversarial self-review vs the stacked base: the one finding (executor holding a node reference that outlived the node at shutdown → potential UAF) is fixed by the synchronous teardown above; behavior/output of the command path verified byte-identical to the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)