### PR TITLE
gui: migrate OptionsModel core settings onto interfaces::Node

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1025,20 +1025,25 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
                     std::vector<std::string>& no_change_out,
                     std::vector<std::string>& immediate_out,
                     std::vector<std::string>& requires_restart_list_out,
+                    bool& invalid_input_out,
                     std::string& error_out)
 {
     requires_restart_out = false;
+    // Phase-1 failures are caller/validation errors; a phase-2 storage failure
+    // flips this back to false.
+    invalid_input_out = true;
 
     // -------- name ------------ value - value_changed - immediate_effect
     std::map<std::string, std::tuple<std::string, bool, bool>> valid_settings;
 
-    // Phase 1: validate everything before mutating anything.
+    // Phase 1: fully validate (name and, for the knobs that would break on
+    // restart, the value) before mutating anything.
     for (const auto& setting : settings) {
         const std::string& name = setting.first;
         const std::string& value = setting.second;
 
-        if (!name.empty() && name[0] == '-') {
-            error_out = "Incorrectly formatted setting name: " + name;
+        if (name.empty() || name[0] == '-') {
+            error_out = "Incorrectly formatted setting name: '" + name + "'";
             return false;
         }
 
@@ -1046,6 +1051,24 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
         if (!flags) {
             error_out = "Invalid setting: " + name;
             return false;
+        }
+
+        // Value validation for the push-model network/staking knobs whose bad
+        // value would otherwise persist and fail at the next startup (the config
+        // consumers assert/InitError on a malformed value). An empty value erases
+        // and needs no check. GetBoolArg/GetArg coerce the rest leniently.
+        if (!value.empty()) {
+            if (name == "proxy" && !CService(LookupNumeric(value.c_str(), 9050)).IsValid()) {
+                error_out = "Invalid proxy address: " + value;
+                return false;
+            }
+            if (name == "reservebalance") {
+                int64_t parsed = 0;
+                if (!ParseMoney(value, parsed)) {
+                    error_out = "Invalid reservebalance amount: " + value;
+                    return false;
+                }
+            }
         }
 
         // GetArg is overloaded; one of these succeeds (matches the changesettings RPC).
@@ -1066,7 +1089,8 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
         }
     }
 
-    // Phase 2: apply.
+    // Phase 2: apply. A failure here is a storage error, not a caller error.
+    invalid_input_out = false;
     for (const auto& setting : valid_settings) {
         const std::string& name = setting.first;
         const std::string& value = std::get<0>(setting.second);
@@ -1076,9 +1100,7 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
 
         // An empty value erases the setting (unset → default); a null
         // SettingsValue removes the key from gridcoinsettings.json.
-        if (value.empty()) {
-            updateRwSetting(name, util::SettingsValue());
-        } else if (!updateRwSetting(name, value)) {
+        if (!updateRwSetting(name, value.empty() ? util::SettingsValue() : util::SettingsValue(value))) {
             error_out = "Error storing setting in read-write settings file: " + name;
             return false;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1032,7 +1032,13 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
                     bool& invalid_input_out,
                     std::string& error_out)
 {
+    // Reset all outputs so results are well-defined even if the caller reuses
+    // the vectors across calls (or on an early-return failure).
     requires_restart_out = false;
+    no_change_out.clear();
+    immediate_out.clear();
+    requires_restart_list_out.clear();
+    error_out.clear();
     // Phase-1 failures are caller/validation errors; a phase-2 storage failure
     // flips this back to false.
     invalid_input_out = true;
@@ -1088,7 +1094,7 @@ bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& sett
 
         if (!valid_settings.insert(std::make_pair(
                 name, std::make_tuple(value, value_changed, immediate_effect))).second) {
-            error_out = "changeSettings does not support more than one instance of the same setting: " + name;
+            error_out = "The same setting was specified more than once: " + name;
             return false;
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -515,7 +515,7 @@ void SetupServerArgs()
     argsman.AddArg("-blockmaxsize=<n>", strprintf("Set maximum block size in bytes (default: %u)", MAX_BLOCK_SIZE_GEN/2),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-disableupdatecheck", "Optional: Disable update checks by wallet",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::OPTIONS);
     argsman.AddArg("-updatecheckinterval=<n>", "Optional: Check for updates every <n> hours (default: 120, minimum: 1)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-updatecheckurl=<url>", "Optional: URL for the update version checks (ex: "
@@ -581,6 +581,8 @@ void SetupServerArgs()
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
     argsman.AddArg("-minstakesplitvalue=<n>", strprintf("Specify minimum output value for post split output when stake "
                                                         "splitting (default: %" PRId64 "GRC)", MIN_STAKE_SPLIT_VALUE_GRC),
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
+    argsman.AddArg("-reservebalance=<amt>", "Keep <amt> GRC unspent and unstaked (reserve). Applied live when changed.",
                    ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::STAKING);
 
     // Scraper
@@ -664,7 +666,7 @@ void SetupServerArgs()
                                        " a peer may be inactive before the connection to it is dropped. (minimum: 1, default:"
                                        " 45)",
                    ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
-    argsman.AddArg("-proxy=<ip:port>", "Connect through SOCKS5 proxy", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-proxy=<ip:port>", "Connect through SOCKS5 proxy", ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::CONNECTION);
     argsman.AddArg("-tor=<ip:port>", "Use proxy to reach Tor onion services (default: same as -proxy)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-dns", "Allow DNS lookups for -addnode, -seednode and -connect",
@@ -712,10 +714,10 @@ void SetupServerArgs()
 #ifdef USE_UPNP
 #if USE_UPNP
     argsman.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::CONNECTION);
 #else
     argsman.AddArg("-upnp", "Use UPnP to map the listening port (default: 0)",
-                   ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+                   ArgsManager::ALLOW_ANY | ArgsManager::IMMEDIATE_EFFECT, OptionsCategory::CONNECTION);
 #endif
 #else
     hidden_args.emplace_back("-upnp");
@@ -984,6 +986,120 @@ void InitLogging()
 }
 
 
+
+void ApplyRwSettingSideEffect(const std::string& name)
+{
+    if (name == "proxy") {
+        // Enable/redirect the SOCKS proxy live from the current -proxy value. An
+        // empty value means "off"; netbase has no primitive to clear a live
+        // proxy, so disabling is (as it always was) effective on restart, when
+        // the erased setting leaves -proxy unset.
+        const std::string proxy_arg = gArgs.GetArg("-proxy", "");
+        if (!proxy_arg.empty()) {
+            CService addrProxy(LookupNumeric(proxy_arg.c_str(), 9050));
+            if (addrProxy.IsValid()) {
+                if (!IsLimited(NET_IPV4)) SetProxy(NET_IPV4, addrProxy);
+                if (!IsLimited(NET_IPV6)) SetProxy(NET_IPV6, addrProxy);
+                SetNameProxy(addrProxy);
+            }
+        }
+    } else if (name == "upnp") {
+        if (g_connman) {
+            g_connman->SetUseUPnP(gArgs.GetBoolArg("-upnp", USE_UPNP));
+            MapPort(); // starts or stops the port-map thread to match the flag
+        }
+    } else if (name == "reservebalance") {
+        // Empty/unset → 0 (no reserve). ParseMoney fills reserve on success.
+        int64_t reserve = 0;
+        const std::string reserve_arg = gArgs.GetArg("-reservebalance", "");
+        if (reserve_arg.empty() || ParseMoney(reserve_arg, reserve)) {
+            nReserveBalance = reserve;
+        }
+    }
+    // else: pull-model setting (staking cluster, disableupdatecheck, ...) whose
+    // consumers re-read gArgs on use; nothing to apply here.
+}
+
+bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& settings,
+                    bool& requires_restart_out,
+                    std::vector<std::string>& no_change_out,
+                    std::vector<std::string>& immediate_out,
+                    std::vector<std::string>& requires_restart_list_out,
+                    std::string& error_out)
+{
+    requires_restart_out = false;
+
+    // -------- name ------------ value - value_changed - immediate_effect
+    std::map<std::string, std::tuple<std::string, bool, bool>> valid_settings;
+
+    // Phase 1: validate everything before mutating anything.
+    for (const auto& setting : settings) {
+        const std::string& name = setting.first;
+        const std::string& value = setting.second;
+
+        if (!name.empty() && name[0] == '-') {
+            error_out = "Incorrectly formatted setting name: " + name;
+            return false;
+        }
+
+        std::optional<unsigned int> flags = gArgs.GetArgFlags('-' + name);
+        if (!flags) {
+            error_out = "Invalid setting: " + name;
+            return false;
+        }
+
+        // GetArg is overloaded; one of these succeeds (matches the changesettings RPC).
+        std::string current_value;
+        try {
+            current_value = gArgs.GetArg(name, "never_used_default");
+        } catch (...) {
+            current_value = ToString(gArgs.GetArg(name, 1));
+        }
+
+        const bool value_changed = (current_value != value);
+        const bool immediate_effect = *flags & ArgsManager::IMMEDIATE_EFFECT;
+
+        if (!valid_settings.insert(std::make_pair(
+                name, std::make_tuple(value, value_changed, immediate_effect))).second) {
+            error_out = "changeSettings does not support more than one instance of the same setting: " + name;
+            return false;
+        }
+    }
+
+    // Phase 2: apply.
+    for (const auto& setting : valid_settings) {
+        const std::string& name = setting.first;
+        const std::string& value = std::get<0>(setting.second);
+        const bool value_changed = std::get<1>(setting.second);
+        const bool immediate_effect = std::get<2>(setting.second);
+        const std::string param = name + "=" + value;
+
+        // An empty value erases the setting (unset → default); a null
+        // SettingsValue removes the key from gridcoinsettings.json.
+        if (value.empty()) {
+            updateRwSetting(name, util::SettingsValue());
+        } else if (!updateRwSetting(name, value)) {
+            error_out = "Error storing setting in read-write settings file: " + name;
+            return false;
+        }
+
+        if (value_changed) {
+            gArgs.ForceSetArg(name, value);
+
+            if (immediate_effect) {
+                ApplyRwSettingSideEffect(name);
+                immediate_out.push_back(param);
+            } else {
+                requires_restart_list_out.push_back(param);
+                requires_restart_out = true;
+            }
+        } else {
+            no_change_out.push_back(param);
+        }
+    }
+
+    return true;
+}
 
 void ThreadAppInit2(ThreadHandlerPtr th)
 {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1004,10 +1004,14 @@ void ApplyRwSettingSideEffect(const std::string& name)
             }
         }
     } else if (name == "upnp") {
+#ifdef USE_UPNP
+        // USE_UPNP is only defined when UPnP support is compiled in; without it
+        // there is nothing to toggle and SetUseUPnP/MapPort do not apply.
         if (g_connman) {
             g_connman->SetUseUPnP(gArgs.GetBoolArg("-upnp", USE_UPNP));
             MapPort(); // starts or stops the port-map thread to match the flag
         }
+#endif
     } else if (name == "reservebalance") {
         // Empty/unset → 0 (no reserve). ParseMoney fills reserve on success.
         int64_t reserve = 0;

--- a/src/init.h
+++ b/src/init.h
@@ -50,19 +50,23 @@ void ApplyRwSettingSideEffect(const std::string& name);
 
 //! Validate, persist to gridcoinsettings.json, force-set into the running args,
 //! and apply one or more settings given as name/value strings. Two-phase: every
-//! setting is validated before any is applied; on a validation error returns
-//! false with error_out set and nothing changed. An EMPTY value erases the
-//! setting (unset → default), which is how "off"/default is expressed for knobs
-//! like -proxy/-reservebalance and avoids persisting a value that would fail
-//! validation on restart. On success, each name is categorized into
+//! setting is fully validated (name is a known arg; proxy/reservebalance values
+//! must parse) before any is applied, so a validation failure changes nothing.
+//! An EMPTY value erases the setting (unset → default), which is how "off"/default
+//! is expressed for knobs like -proxy/-reservebalance and avoids persisting a
+//! value that would fail on restart. On success, each name is categorized into
 //! no_change_out / immediate_out / requires_restart_list_out and
-//! requires_restart_out is set. Shared core of the changesettings RPC and
-//! interfaces::Node::changeSettings.
+//! requires_restart_out is set. On failure returns false with error_out set and
+//! invalid_input_out distinguishing a caller/validation error (true; nothing was
+//! changed) from an internal storage error (false; the settings file write
+//! failed and some earlier settings in the batch may already be applied). Shared
+//! core of the changesettings RPC and interfaces::Node::changeSettings.
 bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& settings,
                     bool& requires_restart_out,
                     std::vector<std::string>& no_change_out,
                     std::vector<std::string>& immediate_out,
                     std::vector<std::string>& requires_restart_list_out,
+                    bool& invalid_input_out,
                     std::string& error_out);
 
 extern bool fResetBlockchainRequest;

--- a/src/init.h
+++ b/src/init.h
@@ -9,6 +9,10 @@
 #include "wallet/wallet.h"
 #include <boost/thread.hpp>
 
+#include <string>
+#include <utility>
+#include <vector>
+
 //! Default value for -daemon option
 static constexpr bool DEFAULT_DAEMON = false;
 //! Default value for -daemonwait option
@@ -35,6 +39,31 @@ void SetupServerArgs();
 
 std::string VersionMessage();
 std::string LogSomething();
+
+//! Apply the immediate side effect of a changed read-write setting for the
+//! "push-model" knobs whose consumers do not re-read gArgs live (currently
+//! -proxy and -reservebalance apply here; -upnp restarts the port-map thread).
+//! No-op for pull-model settings (the staking cluster etc., which re-read gArgs
+//! on use). Shared by the changesettings RPC and interfaces::Node::changeSettings
+//! so a live edit takes effect without a restart in both paths.
+void ApplyRwSettingSideEffect(const std::string& name);
+
+//! Validate, persist to gridcoinsettings.json, force-set into the running args,
+//! and apply one or more settings given as name/value strings. Two-phase: every
+//! setting is validated before any is applied; on a validation error returns
+//! false with error_out set and nothing changed. An EMPTY value erases the
+//! setting (unset → default), which is how "off"/default is expressed for knobs
+//! like -proxy/-reservebalance and avoids persisting a value that would fail
+//! validation on restart. On success, each name is categorized into
+//! no_change_out / immediate_out / requires_restart_list_out and
+//! requires_restart_out is set. Shared core of the changesettings RPC and
+//! interfaces::Node::changeSettings.
+bool ChangeSettings(const std::vector<std::pair<std::string, std::string>>& settings,
+                    bool& requires_restart_out,
+                    std::vector<std::string>& no_change_out,
+                    std::vector<std::string>& immediate_out,
+                    std::vector<std::string>& requires_restart_list_out,
+                    std::string& error_out);
 
 extern bool fResetBlockchainRequest;
 #endif

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -72,11 +72,15 @@ struct RpcConsoleResult
     std::string output;
 };
 
-//! Result of Node::changeSettings, mirroring the changesettings RPC. `ok`
-//! false means a validation error (no setting was changed) with `error` set.
+//! Result of Node::changeSettings, mirroring the changesettings RPC. `ok` false
+//! means the change failed with `error` set: when `invalid_input` is true it was
+//! a caller/validation error and nothing was changed; when false it was an
+//! internal settings-file write error (and some earlier settings in the batch
+//! may already have been applied).
 struct SettingChangeResult
 {
     bool ok = false;
+    bool invalid_input = false;
     std::string error;
     //! At least one changed setting does not take effect until restart.
     bool requires_restart = false;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <utility>
 #include <memory>
 #include <optional>
 #include <string>
@@ -69,6 +70,20 @@ struct RpcConsoleResult
     //! Formatted reply text on success, or the formatted error message on
     //! failure ("<message> (code <n>)", or raw JSON / "Error: <what>").
     std::string output;
+};
+
+//! Result of Node::changeSettings, mirroring the changesettings RPC. `ok`
+//! false means a validation error (no setting was changed) with `error` set.
+struct SettingChangeResult
+{
+    bool ok = false;
+    std::string error;
+    //! At least one changed setting does not take effect until restart.
+    bool requires_restart = false;
+    //! name=value strings, categorized like the changesettings RPC.
+    std::vector<std::string> no_change;
+    std::vector<std::string> immediate;
+    std::vector<std::string> requires_restart_settings;
 };
 
 //! Value snapshot of the scraper convergence status consumed by the GUI
@@ -182,6 +197,34 @@ public:
 
     //! The list of RPC command names, for the console's autocomplete.
     virtual std::vector<std::string> listRpcCommands() = 0;
+
+    //! Read the current effective value of a read-write/config setting, typed.
+    //! `name` is the bare arg name without the leading dash. `default_val` is
+    //! returned when the setting is unset. These forward to the node's argument
+    //! store so the GUI (a separate process) never reads gArgs directly.
+    virtual bool getSettingBool(const std::string& name, bool default_val) = 0;
+    virtual int64_t getSettingInt(const std::string& name, int64_t default_val) = 0;
+    virtual std::string getSettingStr(const std::string& name, const std::string& default_val) = 0;
+
+    //! Whether the setting is explicitly set (config file, command line, or the
+    //! read-write settings file) rather than falling back to its default. Used
+    //! by the one-time GUI-settings migration to avoid overriding a value the
+    //! user already set in gridcoinresearch.conf.
+    virtual bool isSettingSet(const std::string& name) = 0;
+
+    //! Change one or more settings (name/value, no leading dash). The node
+    //! validates, persists to gridcoinsettings.json, and applies immediate side
+    //! effects -- the same path as the changesettings RPC. An empty value erases
+    //! the setting (unset -> default). This is deliberately a generic catch-all:
+    //! the caller (OptionsModel) is typed and formats each value; the transport
+    //! is name/value strings; the node coerces at read time.
+    virtual SettingChangeResult changeSettings(
+        const std::vector<std::pair<std::string, std::string>>& settings) = 0;
+
+    //! Register a handler fired when the read-write settings file changes, so the
+    //! GUI can refetch. Payload-free (bridges uiInterface.RwSettingsUpdated).
+    using RwSettingsUpdatedFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleRwSettingsUpdated(RwSettingsUpdatedFn fn) = 0;
 
     //! Value snapshot of the scraper convergence status.
     virtual ScraperConvergenceSnapshot getScraperConvergenceSnapshot() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -282,7 +282,7 @@ public:
     {
         SettingChangeResult out;
         out.ok = ChangeSettings(settings, out.requires_restart, out.no_change, out.immediate,
-                                out.requires_restart_settings, out.error);
+                                out.requires_restart_settings, out.invalid_input, out.error);
         return out;
     }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -257,6 +257,40 @@ public:
         return tableRPC.listCommands();
     }
 
+    bool getSettingBool(const std::string& name, bool default_val) override
+    {
+        return gArgs.GetBoolArg("-" + name, default_val);
+    }
+
+    int64_t getSettingInt(const std::string& name, int64_t default_val) override
+    {
+        return gArgs.GetArg("-" + name, default_val);
+    }
+
+    std::string getSettingStr(const std::string& name, const std::string& default_val) override
+    {
+        return gArgs.GetArg("-" + name, default_val);
+    }
+
+    bool isSettingSet(const std::string& name) override
+    {
+        return gArgs.IsArgSet("-" + name);
+    }
+
+    SettingChangeResult changeSettings(
+        const std::vector<std::pair<std::string, std::string>>& settings) override
+    {
+        SettingChangeResult out;
+        out.ok = ChangeSettings(settings, out.requires_restart, out.no_change, out.immediate,
+                                out.requires_restart_settings, out.error);
+        return out;
+    }
+
+    std::unique_ptr<Handler> handleRwSettingsUpdated(RwSettingsUpdatedFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(std::move(fn)));
+    }
+
     ScraperConvergenceSnapshot getScraperConvergenceSnapshot() override
     {
         LOCK(cs_ConvergedScraperStatsCache);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -363,10 +363,16 @@ int main(int argc, char *argv[])
     // instead of a locally-minted one.
     std::unique_ptr<interfaces::Init> gui_init = interfaces::MakeGridcoinInit();
     std::unique_ptr<interfaces::SideStakeManager> sidestake_manager = gui_init->makeSideStakeManager();
+    // Settings command/query surface for OptionsModel. Minted here (like the
+    // sidestake manager) so it outlives optionsModel; Phase 2 hands this out from
+    // the single process Init. The node wraps globals and reads them at call time,
+    // so it is safe to construct before core init -- OptionsModel only reads/writes
+    // settings through it later (dialog open, migrateCoreSettings()).
+    std::unique_ptr<interfaces::Node> gui_node = gui_init->makeNode();
 
     // Load the optionsModel. This has to be loaded before the translations, because the language selection is
     // a setting that can be stored in options.
-    OptionsModel optionsModel(*sidestake_manager);
+    OptionsModel optionsModel(*gui_node, *sidestake_manager);
 
     // Get desired locale (e.g. "de_DE") from command line or use system locale
     QString lang_territory = QString::fromStdString(gArgs.GetArg("-lang", QLocale::system().name().toStdString()));
@@ -466,6 +472,11 @@ int main(int argc, char *argv[])
                               QObject::tr("Error initializing settings: %1").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
     }
+
+    // Now that the config file, network selection and read-write settings file
+    // are loaded, migrate any proxy / UPnP / reservebalance / update-check values
+    // the user had in Gridcoin-Qt.conf into the core read-write settings (one-time).
+    optionsModel.migrateCoreSettings();
 
     // Initialize logging as early as possible.
     InitLogging();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -6,8 +6,11 @@
 #include "bitcoinunits.h"
 #include "guiutil.h"
 #include "interfaces/node.h"
+#include "util/strencodings.h" // For SplitHostPort (IPv6-aware host:port parsing).
 
 #include "miner.h"
+
+#include <utility>
 
 namespace {
 //! Format a satoshi amount as a plain money string (no localization/thousands
@@ -37,6 +40,27 @@ bool PushEffectiveProxy(interfaces::Node& node, QSettings& settings)
     const std::string addr =
         use_proxy ? settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString() : std::string();
     return node.changeSettings({{"proxy", addr}}).ok;
+}
+
+//! Split a stored "host:port" proxy string into host and port, IPv6-aware
+//! (SplitHostPort strips the [] brackets around an IPv6 host and only treats a
+//! colon as the port separator when it is unambiguous). Port defaults to 9050.
+std::pair<QString, int> SplitProxy(const QString& addr)
+{
+    int port = 9050;
+    std::string host;
+    SplitHostPort(addr.toStdString(), port, host);
+    return {QString::fromStdString(host), port};
+}
+
+//! Format host + port back into the stored proxy string, bracketing an IPv6
+//! host (one containing a colon) so it round-trips through SplitProxy and is
+//! accepted by the node's proxy validation -- matching the old
+//! CService::ToStringIPPort() form.
+QString FormatProxy(const QString& host, int port)
+{
+    const QString h = host.contains(':') ? "[" + host + "]" : host;
+    return h + ":" + QString::number(port);
 }
 } // namespace
 
@@ -125,10 +149,12 @@ void OptionsModel::migrateCoreSettings()
     if (!m_node.isSettingSet("disableupdatecheck") && settings.contains("fDisableUpdateCheck")) {
         migrate.emplace_back("disableupdatecheck", settings.value("fDisableUpdateCheck").toBool() ? "1" : "0");
     }
-    if (!migrate.empty()) {
-        m_node.changeSettings(migrate);
+    // Only mark the migration done once it has actually been persisted. If the
+    // node write fails, leave the flag unset so the next launch retries rather
+    // than permanently dropping the user's old Gridcoin-Qt.conf values.
+    if (migrate.empty() || m_node.changeSettings(migrate).ok) {
+        settings.setValue("coreSettingsMigrated", true);
     }
-    settings.setValue("coreSettingsMigrated", true);
 }
 
 int OptionsModel::rowCount(const QModelIndex & parent) const
@@ -163,16 +189,10 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             // GUI editing state: whether the user enabled the proxy. The effective
             // proxy address is mirrored to the core -proxy setting on change.
             return settings.value("fUseProxy", false);
-        case ProxyIP: {
-            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
-            const int colon = ap.lastIndexOf(':');
-            return QVariant(colon >= 0 ? ap.left(colon) : ap);
-        }
-        case ProxyPort: {
-            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
-            const int colon = ap.lastIndexOf(':');
-            return QVariant(colon >= 0 ? ap.mid(colon + 1).toInt() : 9050);
-        }
+        case ProxyIP:
+            return QVariant(SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).first);
+        case ProxyPort:
+            return QVariant(SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).second);
         case ReserveBalance: {
             qint64 sat = 0;
             BitcoinUnits::parse(BitcoinUnits::BTC,
@@ -265,7 +285,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case MapPortUPnP:
             // Core setting: the node applies it (SetUseUPnP + MapPort start/stop
             // the port-map thread) via the immediate-effect hook.
-            m_node.changeSettings({{"upnp", value.toBool() ? "1" : "0"}});
+            successful = m_node.changeSettings({{"upnp", value.toBool() ? "1" : "0"}}).ok;
             break;
         case MinimizeOnClose:
             fMinimizeOnClose = value.toBool();
@@ -276,20 +296,17 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             successful = PushEffectiveProxy(m_node, settings);
             break;
         case ProxyIP: {
-            // Replace the host part of the stored address; port is kept.
-            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
-            const int colon = ap.lastIndexOf(':');
-            const QString port = colon >= 0 ? ap.mid(colon + 1) : QString("9050");
-            settings.setValue("addrProxy", value.toString() + ":" + port);
+            // Replace the host part of the stored address; port is kept. IPv6-aware
+            // via SplitProxy/FormatProxy (brackets round-trip correctly).
+            const int port = SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).second;
+            settings.setValue("addrProxy", FormatProxy(value.toString(), port));
             successful = PushEffectiveProxy(m_node, settings);
         }
         break;
         case ProxyPort: {
             // Replace the port part of the stored address; host is kept.
-            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
-            const int colon = ap.lastIndexOf(':');
-            const QString host = colon >= 0 ? ap.left(colon) : ap;
-            settings.setValue("addrProxy", host + ":" + QString::number(value.toInt()));
+            const QString host = SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).first;
+            settings.setValue("addrProxy", FormatProxy(host, value.toInt()));
             successful = PushEffectiveProxy(m_node, settings);
         }
         break;
@@ -349,7 +366,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case DisableUpdateCheck:
             // Core read-write setting (the core scheduler and the GUI both read
             // it); route through the node so it persists to gridcoinsettings.json.
-            m_node.changeSettings({{"disableupdatecheck", value.toBool() ? "1" : "0"}});
+            successful = m_node.changeSettings({{"disableupdatecheck", value.toBool() ? "1" : "0"}}).ok;
             break;
         case DataDir:
             // There is no SetArgument here, because the core data directory cannot
@@ -362,22 +379,22 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         // file. The node validates, persists, and force-sets them (the miner
         // re-reads them live on each stake).
         case EnableStaking:
-            m_node.changeSettings({{"staking", value.toBool() ? "1" : "0"}});
+            successful = m_node.changeSettings({{"staking", value.toBool() ? "1" : "0"}}).ok;
             break;
         case EnableStakeSplit:
-            m_node.changeSettings({{"enablestakesplit", value.toBool() ? "1" : "0"}});
+            successful = m_node.changeSettings({{"enablestakesplit", value.toBool() ? "1" : "0"}}).ok;
             break;
         case EnableSideStaking:
-            m_node.changeSettings({{"enablesidestaking", value.toBool() ? "1" : "0"}});
+            successful = m_node.changeSettings({{"enablesidestaking", value.toBool() ? "1" : "0"}}).ok;
             break;
         case StakingEfficiency:
-            m_node.changeSettings({{"stakingefficiency", value.toString().toStdString()}});
+            successful = m_node.changeSettings({{"stakingefficiency", value.toString().toStdString()}}).ok;
             break;
         case MinStakeSplitValue:
-            m_node.changeSettings({{"minstakesplitvalue", value.toString().toStdString()}});
+            successful = m_node.changeSettings({{"minstakesplitvalue", value.toString().toStdString()}}).ok;
             break;
         case ContractChangeToInput:
-            m_node.changeSettings({{"contractchangetoinputaddress", value.toBool() ? "1" : "0"}});
+            successful = m_node.changeSettings({{"contractchangetoinputaddress", value.toBool() ? "1" : "0"}}).ok;
             break;
         default:
             break;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -31,12 +31,12 @@ std::string FormatReserveBalanceSetting(qint64 sat)
 //! gridcoinsettings.json through the node. Empty disables/erases -proxy; netbase
 //! cannot clear a live proxy, so disabling is effective on restart (unchanged
 //! from the previous behavior).
-void PushEffectiveProxy(interfaces::Node& node, QSettings& settings)
+bool PushEffectiveProxy(interfaces::Node& node, QSettings& settings)
 {
     const bool use_proxy = settings.value("fUseProxy", false).toBool();
     const std::string addr =
         use_proxy ? settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString() : std::string();
-    node.changeSettings({{"proxy", addr}});
+    return node.changeSettings({{"proxy", addr}}).ok;
 }
 } // namespace
 
@@ -273,7 +273,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case ProxyUse:
             settings.setValue("fUseProxy", value.toBool());
-            PushEffectiveProxy(m_node, settings);
+            successful = PushEffectiveProxy(m_node, settings);
             break;
         case ProxyIP: {
             // Replace the host part of the stored address; port is kept.
@@ -281,7 +281,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             const int colon = ap.lastIndexOf(':');
             const QString port = colon >= 0 ? ap.mid(colon + 1) : QString("9050");
             settings.setValue("addrProxy", value.toString() + ":" + port);
-            PushEffectiveProxy(m_node, settings);
+            successful = PushEffectiveProxy(m_node, settings);
         }
         break;
         case ProxyPort: {
@@ -290,7 +290,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             const int colon = ap.lastIndexOf(':');
             const QString host = colon >= 0 ? ap.left(colon) : ap;
             settings.setValue("addrProxy", host + ":" + QString::number(value.toInt()));
-            PushEffectiveProxy(m_node, settings);
+            successful = PushEffectiveProxy(m_node, settings);
         }
         break;
         case ReserveBalance: {
@@ -298,8 +298,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             // would reject a "-..." string, leaving the value stale.
             const qint64 sat = value.toLongLong() > 0 ? value.toLongLong() : 0;
             // Store as a plain money string (empty when zero => erase/no reserve).
-            m_node.changeSettings({{"reservebalance", sat > 0 ? FormatReserveBalanceSetting(sat) : std::string()}});
-            emit reserveBalanceChanged(sat);
+            successful = m_node.changeSettings(
+                {{"reservebalance", sat > 0 ? FormatReserveBalanceSetting(sat) : std::string()}}).ok;
+            if (successful) {
+                emit reserveBalanceChanged(sat);
+            }
         }
         break;
         case DisplayUnit:

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -2,41 +2,50 @@
 
 #include <QDebug>
 #include <QSettings>
-#include <univalue.h>
 
 #include "bitcoinunits.h"
 #include "guiutil.h"
-#include "init.h"
+#include "interfaces/node.h"
 
 #include "miner.h"
 
-OptionsModel::OptionsModel(interfaces::SideStakeManager& sidestake_manager, QObject *parent) :
+namespace {
+//! Format a satoshi amount as a plain money string (no localization/thousands
+//! separators) for the -reservebalance setting, matching what the core's
+//! ParseMoney reads. BitcoinUnits::format inserts thin-space separators, so it
+//! cannot be used here.
+std::string FormatReserveBalanceSetting(qint64 sat)
+{
+    const bool negative = sat < 0;
+    const qint64 abs_sat = negative ? -sat : sat;
+    const qint64 coin = BitcoinUnits::factor(BitcoinUnits::BTC);
+    const int decimals = BitcoinUnits::decimals(BitcoinUnits::BTC);
+    QString s = (negative ? "-" : "") + QString::number(abs_sat / coin) + "."
+                + QString::number(abs_sat % coin).rightJustified(decimals, '0');
+    return s.toStdString();
+}
+
+//! Push the effective proxy to the core -proxy setting: the GUI keeps its three
+//! proxy fields (enable + address) as local editing state in QSettings, and the
+//! effective value (the address when enabled, empty when disabled) is mirrored to
+//! gridcoinsettings.json through the node. Empty disables/erases -proxy; netbase
+//! cannot clear a live proxy, so disabling is effective on restart (unchanged
+//! from the previous behavior).
+void PushEffectiveProxy(interfaces::Node& node, QSettings& settings)
+{
+    const bool use_proxy = settings.value("fUseProxy", false).toBool();
+    const std::string addr =
+        use_proxy ? settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString() : std::string();
+    node.changeSettings({{"proxy", addr}});
+}
+} // namespace
+
+OptionsModel::OptionsModel(interfaces::Node& node, interfaces::SideStakeManager& sidestake_manager, QObject *parent) :
     QAbstractListModel(parent),
+    m_node(node),
     m_sidestake_manager(sidestake_manager)
 {
     Init();
-}
-
-bool static ApplyProxySettings()
-{
-    QSettings settings;
-    int port = 9050;
-    std::string hostname = "";
-    SplitHostPort(settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString(), port, hostname);
-    CService addrProxy(LookupNumeric(hostname.c_str(), port));
-    if (!settings.value("fUseProxy", false).toBool()) {
-        addrProxy = CService();
-        return false;
-    }
-    if (!addrProxy.IsValid())
-        return false;
-    if (!IsLimited(NET_IPV4))
-        SetProxy(NET_IPV4, addrProxy);
-    if (!IsLimited(NET_IPV6))
-        SetProxy(NET_IPV6, addrProxy);
-    SetNameProxy(addrProxy);
-    
-    return true;
 }
 
 void OptionsModel::Init()
@@ -58,24 +67,16 @@ void OptionsModel::Init()
     fMaskValues = settings.value("fMaskValues", false).toBool();
     limitTxnDate = settings.value("limitTxnDate", QDate()).toDate();
     pollExpireNotification = settings.value("pollExpireNotification", 8.0).toDouble();
-    nReserveBalance = settings.value("nReserveBalance").toLongLong();
     language = settings.value("language", "").toString();
     walletStylesheet = settings.value("walletStylesheet", "dark").toString();
 
-    // These are shared with core Bitcoin; we want
-    // command-line options to override the GUI settings:
-    if (settings.contains("fUseUPnP")) {
-        gArgs.SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool());
-    }
-    if (settings.contains("addrProxy") && settings.value("fUseProxy").toBool()) {
-        gArgs.SoftSetArg("-proxy", settings.value("addrProxy").toString().toStdString());
-    }
+    // Language stays GUI-local (the core does not read -lang): apply it into this
+    // process's own args for the Qt translator.
     if (!language.isEmpty()) {
         gArgs.SoftSetArg("-lang", language.toStdString());
     }
-    if (settings.contains("fDisableUpdateCheck")) {
-        gArgs.SoftSetBoolArg("-disableupdatecheck", settings.value("fDisableUpdateCheck").toBool());
-    }
+    // DataDir is restart-only and remains a next-launch copy here; the Phase-2
+    // spawn handshake will own the authoritative datadir in the split build.
     if (settings.contains("dataDir") && dataDir != GUIUtil::getDefaultDataDirectory()) {
         // Use ShortPathString to get an 8.3 short path on Windows when the path contains characters
         // outside the system code page. gArgs is a narrow-string store, and fs::path::string() would
@@ -87,6 +88,47 @@ void OptionsModel::Init()
     }
 
     m_sidestake_model = new SideStakeTableModel(m_sidestake_manager, this);
+}
+
+void OptionsModel::migrateCoreSettings()
+{
+    // proxy / UPnP / reservebalance / update-check are now core read-write
+    // settings (gridcoinsettings.json), reached through interfaces::Node. On the
+    // first run after upgrade, move any values the user had in Gridcoin-Qt.conf
+    // into the core so they are not silently dropped, then stop touching them
+    // from QSettings. This runs from the composition root AFTER the config file
+    // and the read-write settings file are loaded and the network is selected --
+    // OptionsModel itself is constructed earlier (before those), so it must not
+    // write settings from its constructor.
+    QSettings settings;
+    if (settings.value("coreSettingsMigrated", false).toBool()) {
+        return;
+    }
+
+    // Only migrate a setting the user has NOT already set in gridcoinresearch.conf
+    // (or on the command line). The old Init() used SoftSet, so a config value
+    // always won over the remembered GUI value; skipping already-set settings
+    // preserves that precedence instead of force-overriding the config file.
+    std::vector<std::pair<std::string, std::string>> migrate;
+    if (!m_node.isSettingSet("proxy")
+            && settings.value("fUseProxy", false).toBool() && settings.contains("addrProxy")) {
+        migrate.emplace_back("proxy", settings.value("addrProxy").toString().toStdString());
+    }
+    if (!m_node.isSettingSet("upnp") && settings.contains("fUseUPnP")) {
+        migrate.emplace_back("upnp", settings.value("fUseUPnP").toBool() ? "1" : "0");
+    }
+    if (!m_node.isSettingSet("reservebalance")
+            && settings.contains("nReserveBalance") && settings.value("nReserveBalance").toLongLong() > 0) {
+        migrate.emplace_back("reservebalance",
+                             FormatReserveBalanceSetting(settings.value("nReserveBalance").toLongLong()));
+    }
+    if (!m_node.isSettingSet("disableupdatecheck") && settings.contains("fDisableUpdateCheck")) {
+        migrate.emplace_back("disableupdatecheck", settings.value("fDisableUpdateCheck").toBool() ? "1" : "0");
+    }
+    if (!migrate.empty()) {
+        m_node.changeSettings(migrate);
+    }
+    settings.setValue("coreSettingsMigrated", true);
 }
 
 int OptionsModel::rowCount(const QModelIndex & parent) const
@@ -114,27 +156,29 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case DisablePollNotifications:
             return QVariant(fDisablePollNotifications);
         case MapPortUPnP:
-            return settings.value("fUseUPnP", gArgs.GetBoolArg("-upnp", true));
+            return QVariant(m_node.getSettingBool("upnp", true));
         case MinimizeOnClose:
             return QVariant(fMinimizeOnClose);
         case ProxyUse:
+            // GUI editing state: whether the user enabled the proxy. The effective
+            // proxy address is mirrored to the core -proxy setting on change.
             return settings.value("fUseProxy", false);
         case ProxyIP: {
-            proxyType proxy;
-            if (GetProxy(NET_IPV4, proxy))
-                return QVariant(QString::fromStdString(proxy.ToStringIP()));
-            else
-                return QVariant(QString::fromStdString("127.0.0.1"));
+            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
+            const int colon = ap.lastIndexOf(':');
+            return QVariant(colon >= 0 ? ap.left(colon) : ap);
         }
         case ProxyPort: {
-            proxyType proxy;
-            if (GetProxy(NET_IPV4, proxy))
-                return QVariant(proxy.GetPort());
-            else
-                return QVariant(9050);
+            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
+            const int colon = ap.lastIndexOf(':');
+            return QVariant(colon >= 0 ? ap.mid(colon + 1).toInt() : 9050);
         }
-        case ReserveBalance:
-            return QVariant((qint64) nReserveBalance);
+        case ReserveBalance: {
+            qint64 sat = 0;
+            BitcoinUnits::parse(BitcoinUnits::BTC,
+                                QString::fromStdString(m_node.getSettingStr("reservebalance", "")), &sat);
+            return QVariant(sat);
+        }
         case DisplayUnit:
             return QVariant(nDisplayUnit);
 		case DisplayAddresses:
@@ -154,27 +198,23 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case PollExpireNotification:
             return QVariant(pollExpireNotification);
         case DisableUpdateCheck:
-            return QVariant(gArgs.GetBoolArg("-disableupdatecheck", false));
+            return QVariant(m_node.getSettingBool("disableupdatecheck", false));
         case DataDir:
             return settings.value("dataDir", GUIUtil::boostPathToQString(GetDataDir()));
         case EnableStaking:
-            // This comes from the core and is a read-write setting (see below).
-            return QVariant(gArgs.GetBoolArg("-staking", true));
+            // These come from the core and are read-write settings, read through
+            // the node so the GUI never touches gArgs directly.
+            return QVariant(m_node.getSettingBool("staking", true));
         case EnableStakeSplit:
-            // This comes from the core and is a read-write setting (see below).
-            return QVariant(gArgs.GetBoolArg("-enablestakesplit"));
+            return QVariant(m_node.getSettingBool("enablestakesplit", false));
         case EnableSideStaking:
-            // This comes from the core and is a read-write setting (see below).
-            return QVariant(gArgs.GetBoolArg("-enablesidestaking"));
+            return QVariant(m_node.getSettingBool("enablesidestaking", false));
         case StakingEfficiency:
-            // This comes from the core and is a read-write setting (see below).
-            return QVariant((double) gArgs.GetArg("-stakingefficiency", (int64_t) 90));
+            return QVariant((double) m_node.getSettingInt("stakingefficiency", 90));
         case MinStakeSplitValue:
-            // This comes from the core and is a read-write setting (see below).
-            return QVariant((qint64) gArgs.GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC));
+            return QVariant((qint64) m_node.getSettingInt("minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC));
         case ContractChangeToInput:
-            // This comes from the core and is a read-write setting (see below).
-            return QVariant(gArgs.GetBoolArg("-contractchangetoinputaddress", false));
+            return QVariant(m_node.getSettingBool("contractchangetoinputaddress", false));
         default:
             return QVariant();
         }
@@ -223,11 +263,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("fDisablePollNotifications", fDisablePollNotifications);
             break;
         case MapPortUPnP:
-            // issue #2558 PR 9d3: the flag lives on CConnman now; MapPort()
-            // applies the change (starts/stops the UPnP thread).
-            if (g_connman) g_connman->SetUseUPnP(value.toBool());
-            settings.setValue("fUseUPnP", value.toBool());
-            MapPort();
+            // Core setting: the node applies it (SetUseUPnP + MapPort start/stop
+            // the port-map thread) via the immediate-effect hook.
+            m_node.changeSettings({{"upnp", value.toBool() ? "1" : "0"}});
             break;
         case MinimizeOnClose:
             fMinimizeOnClose = value.toBool();
@@ -235,34 +273,35 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case ProxyUse:
             settings.setValue("fUseProxy", value.toBool());
-            ApplyProxySettings();
+            PushEffectiveProxy(m_node, settings);
             break;
         case ProxyIP: {
-            proxyType proxy;
-            proxy = LookupNumeric("127.0.0.1", 9050);
-            GetProxy(NET_IPV4, proxy);
-
-            CNetAddr addr;
-            LookupHost(value.toString().toStdString().c_str(), addr, false);
-            proxy.SetIP(addr);
-            settings.setValue("addrProxy", proxy.ToStringIPPort().c_str());
-            successful = ApplyProxySettings();
+            // Replace the host part of the stored address; port is kept.
+            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
+            const int colon = ap.lastIndexOf(':');
+            const QString port = colon >= 0 ? ap.mid(colon + 1) : QString("9050");
+            settings.setValue("addrProxy", value.toString() + ":" + port);
+            PushEffectiveProxy(m_node, settings);
         }
         break;
         case ProxyPort: {
-            proxyType proxy;
-            proxy = LookupNumeric("127.0.0.1", 9050);
-            GetProxy(NET_IPV4, proxy);
-            proxy.SetPort(value.toInt());
-            settings.setValue("addrProxy", proxy.ToStringIPPort().c_str());
-            successful = ApplyProxySettings();
+            // Replace the port part of the stored address; host is kept.
+            const QString ap = settings.value("addrProxy", "127.0.0.1:9050").toString();
+            const int colon = ap.lastIndexOf(':');
+            const QString host = colon >= 0 ? ap.left(colon) : ap;
+            settings.setValue("addrProxy", host + ":" + QString::number(value.toInt()));
+            PushEffectiveProxy(m_node, settings);
         }
         break;
-        case ReserveBalance:
-            nReserveBalance = value.toLongLong();
-            settings.setValue("nReserveBalance", (qint64) nReserveBalance);
-            emit reserveBalanceChanged(nReserveBalance);
-            break;
+        case ReserveBalance: {
+            // Clamp negatives: a reserve is never negative, and core ParseMoney
+            // would reject a "-..." string, leaving the value stale.
+            const qint64 sat = value.toLongLong() > 0 ? value.toLongLong() : 0;
+            // Store as a plain money string (empty when zero => erase/no reserve).
+            m_node.changeSettings({{"reservebalance", sat > 0 ? FormatReserveBalanceSetting(sat) : std::string()}});
+            emit reserveBalanceChanged(sat);
+        }
+        break;
         case DisplayUnit:
             nDisplayUnit = value.toInt();
             settings.setValue("nDisplayUnit", nDisplayUnit);
@@ -305,8 +344,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             settings.setValue("pollExpireNotification", pollExpireNotification);
             break;
         case DisableUpdateCheck:
-            gArgs.ForceSetArg("-disableupdatecheck", value.toBool() ? "1" : "0");
-            settings.setValue("fDisableUpdateCheck", value.toBool());
+            // Core read-write setting (the core scheduler and the GUI both read
+            // it); route through the node so it persists to gridcoinsettings.json.
+            m_node.changeSettings({{"disableupdatecheck", value.toBool() ? "1" : "0"}});
             break;
         case DataDir:
             // There is no SetArgument here, because the core data directory cannot
@@ -314,41 +354,27 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             dataDir = value.toString();
             settings.setValue("dataDir", dataDir);
             break;
+        // The following are core read-write settings stored in
+        // gridcoinsettings.json; a stored value overrides the read-only config
+        // file. The node validates, persists, and force-sets them (the miner
+        // re-reads them live on each stake).
         case EnableStaking:
-            // This is a core setting stored in the read-write settings file and once set will override the read-only
-            //config file.
-            gArgs.ForceSetArg("-staking", value.toBool() ? "1" : "0");
-            updateRwSetting("staking", gArgs.GetBoolArg("-staking", true));
+            m_node.changeSettings({{"staking", value.toBool() ? "1" : "0"}});
             break;
         case EnableStakeSplit:
-            // This is a core setting stored in the read-write settings file and once set will override the read-only
-            //config file.
-            gArgs.ForceSetArg("-enablestakesplit", value.toBool() ? "1" : "0");
-            updateRwSetting("enablestakesplit", gArgs.GetBoolArg("-enablestakesplit"));
+            m_node.changeSettings({{"enablestakesplit", value.toBool() ? "1" : "0"}});
             break;
         case EnableSideStaking:
-            // This is a core setting stored in the read-write settings file and once set will override the read-only
-            //config file.
-            gArgs.ForceSetArg("-enablesidestaking", value.toBool() ? "1" : "0");
-            updateRwSetting("enablesidestaking", gArgs.GetBoolArg("-enablesidestaking"));
+            m_node.changeSettings({{"enablesidestaking", value.toBool() ? "1" : "0"}});
             break;
         case StakingEfficiency:
-            // This is a core setting stored in the read-write settings file and once set will override the read-only
-            //config file.
-            gArgs.ForceSetArg("-stakingefficiency", value.toString().toStdString());
-            updateRwSetting("stakingefficiency", gArgs.GetArg("-stakingefficiency", 90));
+            m_node.changeSettings({{"stakingefficiency", value.toString().toStdString()}});
             break;
         case MinStakeSplitValue:
-            // This is a core setting stored in the read-write settings file and once set will override the read-only
-            //config file.
-            gArgs.ForceSetArg("-minstakesplitvalue", value.toString().toStdString());
-            updateRwSetting("minstakesplitvalue", gArgs.GetArg("-minstakesplitvalue", MIN_STAKE_SPLIT_VALUE_GRC));
+            m_node.changeSettings({{"minstakesplitvalue", value.toString().toStdString()}});
             break;
         case ContractChangeToInput:
-            // This is a core setting stored in the read-write settings file and once set will override the read-only
-            //config file.
-            gArgs.ForceSetArg("-contractchangetoinputaddress", value.toBool() ? "1" : "0");
-            updateRwSetting("contractchangetoinputaddress", gArgs.GetBoolArg("contractchangetoinputaddress"));
+            m_node.changeSettings({{"contractchangetoinputaddress", value.toBool() ? "1" : "0"}});
             break;
         default:
             break;
@@ -366,7 +392,10 @@ qint64 OptionsModel::getTransactionFee()
 
 qint64 OptionsModel::getReserveBalance()
 {
-    return nReserveBalance;
+    qint64 sat = 0;
+    BitcoinUnits::parse(BitcoinUnits::BTC,
+                        QString::fromStdString(m_node.getSettingStr("reservebalance", "")), &sat);
+    return sat;
 }
 
 bool OptionsModel::getCoinControlFeatures()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -6,6 +6,7 @@
 #include <QDate>
 
 namespace interfaces {
+class Node;
 class SideStakeManager;
 } // namespace interfaces
 
@@ -22,7 +23,10 @@ class OptionsModel : public QAbstractListModel
 public:
     //! \p sidestake_manager backs the sidestake table model constructed here; it
     //! is owned by the process and must outlive this OptionsModel.
-    explicit OptionsModel(interfaces::SideStakeManager& sidestake_manager, QObject* parent = nullptr);
+    //! \p node is the settings command/query surface (a separate process in the
+    //! multiprocess build); the core-coupled options route reads and writes
+    //! through it instead of touching gArgs / core globals directly.
+    explicit OptionsModel(interfaces::Node& node, interfaces::SideStakeManager& sidestake_manager, QObject* parent = nullptr);
 
     enum OptionID {
         StartAtStartup,          // bool
@@ -59,6 +63,13 @@ public:
 
     void Init();
 
+    //! One-time migration of the settings that moved from Gridcoin-Qt.conf into
+    //! the core read-write settings file (proxy / UPnP / reservebalance /
+    //! update-check). Must be called from the composition root AFTER the config
+    //! and read-write settings files are loaded and the network is selected --
+    //! never from the constructor, which runs before those.
+    void migrateCoreSettings();
+
     int rowCount(const QModelIndex & parent = QModelIndex()) const;
     QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
@@ -94,6 +105,8 @@ public:
     void toggleCoinControlFeatures();
 
 private:
+    //! Settings command/query surface; owned by the process, outlives this model.
+    interfaces::Node& m_node;
     int nDisplayUnit;
     bool fMinimizeToTray;
     bool fStartAtStartup;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
+#include "init.h"
 #include "protocol.h"
 #include <rpc/util.h>
 #include <util.h>
@@ -170,119 +171,44 @@ UniValue changesettings(const UniValue& params)
     if (params.size() < 1)
         throw runtime_error(changesettings_helpman().ToString());
 
-    // -------- name ------------ value - value_changed - immediate_effect
-    std::map<std::string, std::tuple<std::string, bool, bool>> valid_settings;
+    // Parse the "name=value" positionals into pairs. The shared ChangeSettings()
+    // core (src/init.cpp) does validation, persistence to gridcoinsettings.json,
+    // the ForceSetArg, and the immediate side-effect application -- the same code
+    // path interfaces::Node::changeSettings() uses for the GUI, so the two never
+    // diverge.
+    std::vector<std::pair<std::string, std::string>> settings;
+    settings.reserve(params.size());
 
-    UniValue result(UniValue::VOBJ);
-    UniValue settings_stored_with_no_state_change(UniValue::VARR);
-    UniValue settings_immediate(UniValue::VARR);
-    UniValue settings_applied_requiring_restart(UniValue::VARR);
-    //UniValue invalid_settings_ignored(UniValue::VARR);
-
-    // Validation
     for (unsigned int i = 0; i < params.size(); ++i)
     {
-        std::string param = params[i].get_str();
+        const std::string param = params[i].get_str();
+        const std::string::size_type pos = param.find('=');
 
-        if (param.size() > 0 && param[0] == '-')
+        if (param.empty() || param[0] == '-' || pos == std::string::npos)
         {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Incorrectly formatted setting change: " + param);
         }
 
-        std::string::size_type pos;
-        std::string name;
-        std::string value;
-
-        if ((pos = param.find('=')) != std::string::npos)
-        {
-            name = param.substr(0, pos);
-            value = param.substr(pos + 1);
-        }
-        else
-        {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Incorrectly formatted setting change: " + param);
-        }
-
-        std::optional<unsigned int> flags = gArgs.GetArgFlags('-' + name);
-
-        if (!flags)
-        {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid setting: " + param);
-        }
-
-        // TODO: Record explicit default state for settings.
-        // This currently has a problem that I am not sure yet how to solve. Settings that are defaulted to true, unless
-        // they are set to the contrary, such as -staking, will falsely indicate a change because the defaulted state is
-        // not explicitly stored for comparison. After there is an explicit entry defined in the settings file, it works
-        // correctly.
-
-        // Also, the overloading of GetArg is NOT helpful here...
-        std::string current_value;
-
-        // It is either a string or a number.... One of these will succeed.
-        try
-        {
-            current_value = gArgs.GetArg(name, "never_used_default");
-        }
-        catch (...)
-        {
-            // If it is a number convert back to a string.
-            current_value = ToString(gArgs.GetArg(name, 1));
-        }
-
-        bool value_changed = (current_value != value);
-        bool immediate_effect = *flags & ArgsManager::IMMEDIATE_EFFECT;
-
-        auto insert_pair = valid_settings.insert(std::make_pair(
-                                                     name, std::make_tuple(value, value_changed, immediate_effect)));
-
-        if (!insert_pair.second)
-        {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "changesettings does not support more than one instance of the same "
-                                                      "setting: " + param);
-        }
+        settings.emplace_back(param.substr(0, pos), param.substr(pos + 1));
     }
 
-    // Now that validation is done do the update work.
     bool restart_required = false;
+    std::vector<std::string> no_change, immediate, requiring_restart;
+    std::string error;
 
-    for (const auto& setting : valid_settings)
+    if (!ChangeSettings(settings, restart_required, no_change, immediate, requiring_restart, error))
     {
-        const std::string& name = setting.first;
-        const std::string& value = std::get<0>(setting.second);
-        const bool& value_changed = std::get<1>(setting.second);
-        const bool& immediate_effect = std::get<2>(setting.second);
-
-        std::string param = name + "=" + value;
-
-        // Regardless, store in r-w settings file.
-        if (!updateRwSetting(name, value))
-        {
-            throw JSONRPCError(RPC_MISC_ERROR, "Error storing setting in read-write settings file.");
-        }
-
-        if (value_changed)
-        {
-            gArgs.ForceSetArg(name, value);
-
-            if (immediate_effect)
-            {
-                settings_immediate.push_back(param);
-            }
-            else
-            {
-                settings_applied_requiring_restart.push_back(param);
-
-                // Record if restart required.
-                restart_required |= !immediate_effect;
-            }
-        }
-        else
-        {
-            settings_stored_with_no_state_change.push_back(param);
-        }
+        throw JSONRPCError(RPC_INVALID_PARAMETER, error);
     }
 
+    UniValue settings_stored_with_no_state_change(UniValue::VARR);
+    for (const auto& s : no_change) settings_stored_with_no_state_change.push_back(s);
+    UniValue settings_immediate(UniValue::VARR);
+    for (const auto& s : immediate) settings_immediate.push_back(s);
+    UniValue settings_applied_requiring_restart(UniValue::VARR);
+    for (const auto& s : requiring_restart) settings_applied_requiring_restart.push_back(s);
+
+    UniValue result(UniValue::VOBJ);
     result.pushKV("settings_change_requires_restart", restart_required);
     result.pushKV("settings_stored_with_no_state_change", settings_stored_with_no_state_change);
     result.pushKV("settings_changed_taking_immediate_effect", settings_immediate);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -184,7 +184,8 @@ UniValue changesettings(const UniValue& params)
         const std::string param = params[i].get_str();
         const std::string::size_type pos = param.find('=');
 
-        if (param.empty() || param[0] == '-' || pos == std::string::npos)
+        // Reject a leading dash, a missing '=', and an empty name ("=1").
+        if (param.empty() || param[0] == '-' || pos == std::string::npos || pos == 0)
         {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Incorrectly formatted setting change: " + param);
         }
@@ -194,11 +195,14 @@ UniValue changesettings(const UniValue& params)
 
     bool restart_required = false;
     std::vector<std::string> no_change, immediate, requiring_restart;
+    bool invalid_input = false;
     std::string error;
 
-    if (!ChangeSettings(settings, restart_required, no_change, immediate, requiring_restart, error))
+    if (!ChangeSettings(settings, restart_required, no_change, immediate, requiring_restart, invalid_input, error))
     {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, error);
+        // A caller/validation error is RPC_INVALID_PARAMETER; a settings-file
+        // write failure is an internal error.
+        throw JSONRPCError(invalid_input ? RPC_INVALID_PARAMETER : RPC_MISC_ERROR, error);
     }
 
     UniValue settings_stored_with_no_state_change(UniValue::VARR);

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -53,7 +53,6 @@ src/qt/intro.cpp:chainparams.h
 src/qt/intro.cpp:util.h
 src/qt/optionsdialog.cpp:miner.h
 src/qt/optionsdialog.cpp:netbase.h
-src/qt/optionsmodel.cpp:init.h
 src/qt/optionsmodel.cpp:miner.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/qtipcserver.cpp:util.h


### PR DESCRIPTION
## Summary

Phase 1e (composition root / dialogs / **settings**) of the multiprocess GUI/node separation (RFC #2937). Moves `OptionsModel`'s core-coupled settings off direct `gArgs` / core-global writes and behind a new `interfaces::Node` settings surface, so the options dialog works when the GUI is a separate process. Design note discussed and agreed with the maintainer beforehand.

## New node surface (`interfaces/node.h`, `node/interfaces.cpp`)

```cpp
bool getSettingBool(name, default);  int64_t getSettingInt(name, default);
std::string getSettingStr(name, default);   bool isSettingSet(name);
SettingChangeResult changeSettings(vector<pair<name,value>>);   // generic catch-all
std::unique_ptr<Handler> handleRwSettingsUpdated(fn);           // bridges the signal
```

`changeSettings` mirrors the `changesettings` RPC. To keep the two from diverging, the RPC body was factored into a **shared** core `ChangeSettings()` (`src/init.cpp`, declared in `init.h`) that both the RPC and the node method call: it validates, persists to `gridcoinsettings.json`, force-sets, and applies immediate side effects. This is deliberately a **typeless-transport / typed-endpoint** design (the GUI formats each value, the node coerces at read) — the same proven catch-all shape as the RPC, reusing one code path.

An **empty value erases** the setting (unset → default), which also fixes a latent `changesettings` bug where `proxy=` stored `""` and tripped the invalid-`-proxy` check on the next restart.

## Core settings moved (proxy / UPnP / reservebalance)

- Flagged `IMMEDIATE_EFFECT`; **`-reservebalance` is newly registered via `AddArg`** (it was an unregistered arg the settings system rejected).
- Their apply logic (`SetProxy`/`SetNameProxy`, connman UPnP + `MapPort`, `nReserveBalance`) moved out of `OptionsModel::setData` into a shared core `ApplyRwSettingSideEffect()`, so a live `changesettings`/GUI edit takes effect without a restart. These are *push-model* (consumers read a net global, not `gArgs`); the staking cluster is *pull-model* (the miner re-reads `gArgs` each stake) so it needs no apply hook.

## OptionsModel

Routes proxy / UPnP / reservebalance / the staking cluster / ContractChangeToInput / DisableUpdateCheck through the node. Keeps the three proxy UI fields as local editing state in QSettings and mirrors the effective `-proxy` to the node; reserve balance round-trips satoshis ⇄ a plain money string (`BitcoinUnits::format`'s thin-space separators are unusable, so a local formatter is used, read back via `BitcoinUnits::parse`). A one-time `migrateCoreSettings()` (called from `bitcoin.cpp` after the config and read-write settings files are loaded, since OptionsModel is constructed before those) moves any values the user had in `Gridcoin-Qt.conf` into the core — **skipping any the user already set in `gridcoinresearch.conf`** so the config file keeps precedence (matching the old SoftSet behavior).

## Notes / decisions

- **DisableUpdateCheck stays a core setting** (not GUI-local as first planned): the core scheduler (`gridcoin/gridcoin.cpp`) reads `-disableupdatecheck` too, so it cannot be GUI-local until the update check itself moves GUI-side (separate work).
- **Language stays GUI-local** (translation only; `-lang` is not read by core).
- Two-layer notifications (core `-pollnotify` vs GUI display toggles) left as distinct layers.
- Fixes the `-contractchangetoinputaddress` rw-setting readback key (missing leading dash).
- Retires the `optionsmodel.cpp:init.h` ratchet entry; `miner.h` remains for the `MIN_STAKE_SPLIT_VALUE_GRC` default.

## Testing

- Native Qt6 `RelWithDebInfo` build clean; `ctest` 100% (3/3); `lint-all` clean; `changesettings`/`listsettings` still pass the RPC heritage lint.
- Adversarial self-review (subagent, vs `origin/development`): no crash/data-loss bug. It flagged a migration precedence regression (now fixed with the `isSettingSet` skip) and a latent negative-reservebalance divergence (now clamped). Remaining notes were cosmetic/informational (GUI-set rw keys now serialize as JSON strings, accepted by the read paths).

> **Live-networking touch (proxy/UPnP): warrants isolated-testnet verification before un-drafting.** Proxy *disable* remains restart-effective (netbase has no live-clear primitive), unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)