### PR TITLE
gui: custom splash screen so block-loading progress stays on top (Xwayland fix)

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(gridcoinqt STATIC
     sendcoinsentry.cpp
     sidestaketablemodel.cpp
     signverifymessagedialog.cpp
+    splashscreen.cpp
     multisigndialog.cpp
     psgtpoolpage.cpp
     psgtpooltablemodel.cpp

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -51,7 +51,7 @@
 #include <QTextCodec>
 #include <QLocale>
 #include <QTranslator>
-#include <QSplashScreen>
+#include "qt/splashscreen.h"
 #include <QLibraryInfo>
 #include <QProcess>
 
@@ -86,7 +86,7 @@ extern bool fQtActive;
 
 // Need a global reference for the notifications to find the GUI
 static BitcoinGUI *guiref;
-static QSplashScreen *splashref;
+static SplashScreen *splashref;
 
 static void RegisterMetaTypes()
 {
@@ -541,10 +541,13 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
 
     uiInterface.UpdateMessageBox_connect(UpdateMessageBox);
 
-    QSplashScreen splash(QPixmap(":/images/splash"));
+    // Custom splash (a normal top-level QWidget, not a QSplashScreen) so the
+    // block-loading progress stays on top under Xwayland, where the
+    // Qt::SplashScreen window type is dropped behind the other windows -- see
+    // qt/splashscreen.h.
+    SplashScreen splash;
     if (gArgs.GetBoolArg("-splash", true) && !gArgs.GetBoolArg("-min"))
     {
-        splash.setEnabled(false);
         splash.show();
         splashref = &splash;
     }
@@ -587,7 +590,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
             }
 
             if (splashref)
-                splash.finish(&window);
+                splash.finish();
 
             if (!fRequestShutdown) {
                 // Put this in a block, so that the Model objects are cleaned up

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2011-2024 The Bitcoin Core developers
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/splashscreen.h"
+
+#include <QGuiApplication>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QRect>
+#include <QScreen>
+
+SplashScreen::SplashScreen(QWidget* parent)
+    : QWidget(parent)
+{
+    m_pixmap = QPixmap(":/images/splash");
+
+    // Normal top-level window (NOT Qt::SplashScreen), frameless and above the
+    // other windows -- see the class comment for the Xwayland rationale.
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
+
+    if (!m_pixmap.isNull()) {
+        setFixedSize(m_pixmap.size());
+        if (QScreen* screen = QGuiApplication::primaryScreen()) {
+            const QRect r(QPoint(), m_pixmap.size());
+            move(screen->geometry().center() - r.center());
+        }
+    }
+}
+
+void SplashScreen::finish()
+{
+    hide();
+}
+
+void SplashScreen::showMessage(const QString& message, int alignment)
+{
+    m_message = message;
+    m_alignment = alignment;
+    update();
+}
+
+void SplashScreen::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.drawPixmap(0, 0, m_pixmap);
+    if (!m_message.isEmpty()) {
+        // Inset a little from the edges so the text is not flush against them,
+        // matching the old QSplashScreen bottom-centered status line.
+        const QRect r = rect().adjusted(5, 5, -5, -5);
+        painter.setPen(m_color);
+        painter.drawText(r, m_alignment, m_message);
+    }
+}

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2011-2024 The Bitcoin Core developers
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SPLASHSCREEN_H
+#define BITCOIN_QT_SPLASHSCREEN_H
+
+#include <QColor>
+#include <QPixmap>
+#include <QString>
+#include <QWidget>
+
+/** Startup splash screen showing the block-loading progress.
+ *
+ * Intentionally NOT a QSplashScreen. A QSplashScreen has the Qt::SplashScreen
+ * window type, which KWin (and other compositors) mishandle for Xwayland
+ * clients -- the window is dropped behind the other windows and given a taskbar
+ * entry, hiding the block-index progress. A plain top-level QWidget is treated
+ * as a normal window (the app's first window gets initial focus and is placed
+ * on top), which behaves correctly under Xwayland while still working natively.
+ * It keeps the frameless, always-on-top look of the old splash.
+ */
+class SplashScreen : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SplashScreen(QWidget* parent = nullptr);
+
+    //! Close the splash once the main window is ready.
+    void finish();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+public Q_SLOTS:
+    //! Show a status message on the splash. Arg types (QString, int) match the
+    //! queued uiInterface InitMessage bridge in bitcoin.cpp.
+    void showMessage(const QString& message, int alignment);
+
+private:
+    QPixmap m_pixmap;
+    QString m_message;
+    int m_alignment{0};
+    QColor m_color{Qt::black};
+};
+
+#endif // BITCOIN_QT_SPLASHSCREEN_H


### PR DESCRIPTION
## Summary

The startup splash (a `QSplashScreen`) is dropped behind the other desktop windows and given a taskbar entry when the GUI runs the **xcb** platform under a **Wayland** compositor (Xwayland + KWin). The `Qt::SplashScreen` window type is mishandled by the compositor's Xwayland path, so the block-index loading progress is hidden behind everything.

It renders correctly under native Wayland and under native X11 — only the **Xwayland bridge** misclassifies the splash-type window. Running xcb under Wayland is a legitimate configuration (among other things, it's what lets the GUI remember and restore its own window positions across sessions).

## Fix

Replace the `QSplashScreen` with a small custom `SplashScreen` — a plain top-level `QWidget` (frameless + always-on-top), **not** the `Qt::SplashScreen` window type — following the Bitcoin Core pattern (their `SplashScreen` is likewise "intentionally not a `QSplashScreen`"). A normal top-level window is treated as the application's first window and placed on top by the compositor, which behaves correctly across **native X11, native Wayland, and Xwayland**, while keeping the old frameless look.

It draws the existing splash pixmap and the current `InitMessage` status line (the block-loading progress), centered on the primary screen.

### Files
- `src/qt/splashscreen.{h,cpp}` — new `SplashScreen` widget (`showMessage` slot + `paintEvent` + `finish()`).
- `src/qt/bitcoin.cpp` — construct/`show()`/`finish()` the new widget instead of `QSplashScreen`; `splashref` type change. The queued `uiInterface.InitMessage` → `showMessage(QString, int)` bridge is unchanged.
- `src/qt/CMakeLists.txt` — add the new source (AUTOMOC picks up the header).

## Testing

- Native Qt6 `RelWithDebInfo` build clean; `ctest` 100% (3/3); `lint-qt-includes` clean (the new widget uses only Qt headers, no core coupling).
- Verified on the isolated testnet: the splash now stays on top and shows the block count during load under **xcb-on-Wayland (Xwayland)**, where the old `QSplashScreen` sank behind the desktop. Confirmed the old build regressed only under Xwayland (native Wayland was unaffected), isolating the cause to the splash window type on the Xwayland path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)