### PR TITLE
qt: fix null-deref when selecting a single sidestake row

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -657,7 +657,7 @@ void OptionsDialog::sidestakeSelectionChanged()
         if (indexes.size() > 1) {
             ui->pushButtonEditSideStake->setEnabled(false);
             ui->pushButtonDeleteSideStake->setEnabled(false);
-        } else if (static_cast<GRC::SideStake*>(indexes.at(0).internalPointer())->IsMandatory()) {
+        } else if (model->getSideStakeTableModel()->isMandatory(indexes.at(0).row())) {
             ui->pushButtonEditSideStake->setEnabled(false);
             ui->pushButtonDeleteSideStake->setEnabled(false);
         } else {

--- a/src/qt/sidestaketablemodel.cpp
+++ b/src/qt/sidestaketablemodel.cpp
@@ -393,6 +393,12 @@ SideStakeTableModel::EditStatus SideStakeTableModel::getEditStatus() const
     return m_edit_status;
 }
 
+bool SideStakeTableModel::isMandatory(int row) const
+{
+    const interfaces::SideStakeEntry* rec = m_priv->at(row);
+    return rec && rec->is_mandatory;
+}
+
 void SideStakeTableModel::refresh()
 {
     Q_EMIT layoutAboutToBeChanged();

--- a/src/qt/sidestaketablemodel.h
+++ b/src/qt/sidestaketablemodel.h
@@ -75,6 +75,12 @@ public:
 
     EditStatus getEditStatus() const;
 
+    //! Whether the entry at \p row is a mandatory (contract) sidestake, which
+    //! cannot be edited or deleted. Reads the interfaces::SideStakeEntry value
+    //! row, so callers need no core sidestake type. Returns false for an
+    //! out-of-range row.
+    bool isMandatory(int row) const;
+
 public Q_SLOTS:
     void refresh();
 


### PR DESCRIPTION
## Summary

`OptionsDialog::sidestakeSelectionChanged()` dereferenced the selected index's `internalPointer()` cast to `GRC::SideStake*`:

```cpp
} else if (static_cast<GRC::SideStake*>(indexes.at(0).internalPointer())->IsMandatory()) {
```

`SideStakeTableModel::index()` builds indexes with the two-argument `createIndex(row, column)`, which leaves `internalPointer()` **null**. The cast therefore yields a null `GRC::SideStake*` and `IsMandatory()` is called on it — **undefined behavior / a crash** — every time the user selects exactly one row in the sidestake table on the Options dialog.

## Fix

Add `SideStakeTableModel::isMandatory(int row)`, which looks the row up in the model's private `interfaces::SideStakeEntry` value rows (the same rows `data()`/`flags()`/`removeRows()` already use) and returns `is_mandatory`, guarding an out-of-range row. Route the selection handler through it **by row** instead of the bogus `internalPointer` cast.

As a bonus this drops the last `GRC::SideStake` usage from `optionsdialog.cpp`, consistent with the ongoing `interfaces::` migration.

## Testing

- Native RelWithDebInfo build clean (0 errors, Qt6).
- Unit + functional tests: 100% pass (3/3 suites).
- Bug and fix verified by code inspection: `SideStakeTableModel::index()` uses the 2-arg `createIndex`, so `internalPointer()` is null on every index; the new `isMandatory(int row)` reads the same `m_priv->at(row)` value row that `data()`/`flags()` already use. Not exercised in a live GUI session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)