### PR TITLE
refactor: extract the shutdown-state globals into node/shutdown

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,7 @@ add_library(gridcoin_util STATIC
     node/mempool_persist.cpp
     node/orphan_blocks.cpp
     node/psgt_pool.cpp
+    node/shutdown.cpp
     node/ui_interface.cpp
     noui.cpp
     pbkdf2.cpp

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -17,6 +17,7 @@
 #include "index/txindex.h"
 #include "node/coherence.h"  // GRC::PackBlockFilePos
 #include "txdb.h"
+#include "node/shutdown.h"
 #include "main.h"
 #include "node/blockstorage.h"
 #include "node/chainman.h"
@@ -561,7 +562,7 @@ bool CTxDB::LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         string strType;
         ssKey >> strType;
         // Did we reach the end of the data to read?
-        if (fRequestShutdown || strType != "blockindex")
+        if (ShutdownRequested() || strType != "blockindex")
             break;
         CDiskBlockIndex diskindex;
         ssValue >> diskindex;
@@ -646,7 +647,7 @@ bool CTxDB::LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     for (CBlockIndex* pindex = pindexBest; pindex && pindex->pprev; pindex = pindex->pprev)
     {
         int nCurrentDepth = nBestHeight - pindex->nHeight + 1;
-        if (fRequestShutdown || nCurrentDepth > nCheckDepth)
+        if (ShutdownRequested() || nCurrentDepth > nCheckDepth)
             break;
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus()))
@@ -792,7 +793,7 @@ bool CTxDB::LoadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
     LogPrintf("Time to Verify Blocks %15" PRId64 "ms", GetTimeMillis() - nStart);
 
-    if (pindexFork && !fRequestShutdown)
+    if (pindexFork && !ShutdownRequested())
     {
         // Reorg back to the fork
         LogPrintf("LoadBlockIndex() : *** moving best chain pointer back to block %d", pindexFork->nHeight);

--- a/src/gridcoin/scraper/scraper.cpp
+++ b/src/gridcoin/scraper/scraper.cpp
@@ -4,6 +4,7 @@
 
 #include "main.h"
 #include "node/ui_interface.h"
+#include "node/shutdown.h"
 #include "random.h"
 #include "rpc/util.h"
 
@@ -1549,7 +1550,7 @@ void Scraper(bool bSingleShot)
     uint256 nmScraperFileManifestHash;
 
     // The scraper thread loop...
-    while (!fShutdown)
+    while (!ShutdownInProgress())
     {
         // Only proceed if wallet is in sync. Check every 8 seconds since no callback is available.
         // We do NOT want to filter statistics with an out-of-date beacon list or project whitelist.
@@ -1796,7 +1797,7 @@ void ScraperSubscriber()
 
     auto scraper_sleep = []() { LOCK(cs_ScraperGlobals); return nScraperSleep; };
 
-    while(!fShutdown)
+    while(!ShutdownInProgress())
     {
         // Only proceed if wallet is in sync. Check every 8 seconds since no callback is available.
         // We do NOT want to filter statistics with an out-of-date beacon list or project whitelist.

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -17,6 +17,7 @@
 #include "txdb.h"
 #include "wallet/walletdb.h"
 #include "init.h"
+#include "node/shutdown.h"
 #include "rpc/server.h"
 #include "rpc/client.h"
 #include "node/ui_interface.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -9,6 +9,7 @@
 #include "dbwrapper.h"
 #include "gridcoin/support/block_finder.h"
 #include "util.h"
+#include "node/shutdown.h"
 #include "util/threadnames.h"
 #include "net.h"
 #include "wallet/walletdb.h"
@@ -141,11 +142,6 @@ static void ShutdownNotify(const ArgsManager& args)
 }
 #endif
 
-bool ShutdownRequested()
-{
-    return fRequestShutdown;
-}
-
 void StartShutdown()
 {
 
@@ -156,7 +152,7 @@ void StartShutdown()
         uiInterface.QueueShutdown();
     else
         // Without UI, shutdown is initiated and shutdown() is called in AppInit
-        fRequestShutdown = true;
+        SetShutdownRequested();
 }
 
 void Shutdown(void* parg)
@@ -185,7 +181,7 @@ void Shutdown(void* parg)
             ShutdownNotify(gArgs);
         #endif
 
-        fShutdown = true;
+        SetShutdownInProgress();
 
         // Signal to the scheduler to stop. Guarded because Shutdown() can run
         // after an early AppInit2 failure, before the scheduler is constructed.
@@ -214,8 +210,8 @@ void Shutdown(void* parg)
         LogPrintf("INFO: %s: Stopping net (node) threads.", __func__);
         StopNode();
 
-        // The stake miner exits via fShutdown plus the g_thread_interrupt()
-        // call above, which wakes its MilliSleep.
+        // The stake miner exits via ShutdownInProgress() plus the
+        // g_thread_interrupt() call above, which wakes its MilliSleep.
         LogPrintf("INFO: %s: Stopping the stake miner thread.", __func__);
         if (g_stake_miner_thread.joinable()) {
             g_stake_miner_thread.join();
@@ -334,7 +330,7 @@ void Shutdown(void* parg)
 #ifndef WIN32
 static void HandleSIGTERM(int)
 {
-    fRequestShutdown = true;
+    SetShutdownRequested();
 }
 
 static void HandleSIGHUP(int)
@@ -344,7 +340,7 @@ static void HandleSIGHUP(int)
 #else
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
 {
-    fRequestShutdown = true;
+    SetShutdownRequested();
     Sleep(INFINITE);
     return true;
 }
@@ -1144,7 +1140,7 @@ void ThreadAppInit2(ThreadHandlerPtr th)
     LogPrintf("Initializing Core...");
 
     if (!AppInit2(th)) {
-        fRequestShutdown = true;
+        SetShutdownRequested();
     }
 
     LogPrintf("Core Initialized...");
@@ -1634,13 +1630,13 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     uiInterface.InitMessage(_("Loading block index..."));
     LogPrintf("Loading block index...");
-    if (!LoadBlockIndex() && !fRequestShutdown)
+    if (!LoadBlockIndex() && !ShutdownRequested())
         return InitError(_("Error loading blkindex.dat"));
 
     // as LoadBlockIndex can take several minutes, it's possible the user
     // requested to kill bitcoin-qt during the last operation. If so, exit.
     // As the program has not fully started yet, Shutdown() is possibly overkill.
-    if (fRequestShutdown)
+    if (ShutdownRequested())
     {
         LogPrintf("Shutdown requested. Exiting.");
         return false;

--- a/src/init.h
+++ b/src/init.h
@@ -24,8 +24,6 @@ void InitLogging();
 
 void StartShutdown();
 
-bool ShutdownRequested();
-
 void Shutdown(void* parg);
 bool AppInit2(ThreadHandlerPtr threads);
 void ThreadAppInit2(ThreadHandlerPtr th);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -8,6 +8,7 @@
 #include "consensus/merkle.h"
 #include "consensus/tx_verify.h"
 #include "txdb.h"
+#include "node/shutdown.h"
 #include "miner.h"
 #include "main.h"
 #include "node/chainman.h"
@@ -1504,7 +1505,7 @@ void StakeMiner(CWallet *pwallet)
     std::string function = __func__;
     function += ": ";
 
-    while (!fShutdown)
+    while (!ShutdownInProgress())
     {
         // nMinStakeSplitValue and dEfficiency are out parameters.
         // cs_main is required for the GetAverageDifficulty(160) lookup inside;
@@ -1681,7 +1682,7 @@ void StakeMiner(CWallet *pwallet)
         g_miner_status.UpdateLastStake(StakeBlock.vtx[1].GetHash());
 
         g_timer.GetTimes(function + "ProcessBlock", "miner");
-    } //end while(!fShutdown)
+    } //end while(!ShutdownInProgress())
 }
 
 // Regtest helper: run one iteration of the staking pipeline and emit the

--- a/src/miner.h
+++ b/src/miner.h
@@ -82,7 +82,7 @@ bool TryMineRegtestBlock(CWallet* pwallet,
                          std::string& err,
                          int stake_time_slot_offset = 0);
 
-//! \brief The proof-of-stake miner loop. Runs until \ref fShutdown is set.
+//! \brief The proof-of-stake miner loop. Runs until ShutdownInProgress().
 void StakeMiner(CWallet* pwallet);
 
 //! \brief Thread entry point wrapping StakeMiner. \p parg is the CWallet to

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -10,6 +10,7 @@
 #include "wallet/db.h"
 #include "banman.h"
 #include "net.h"
+#include "node/shutdown.h"
 #include "net_processing.h"
 #include "init.h"
 #include "node/ui_interface.h"
@@ -851,13 +852,13 @@ void CConnman::ThreadSocketHandler2()
         }
         else if (!Sock::WaitMany(timeout, events_per_sock))
         {
-            if (fShutdown)
+            if (ShutdownInProgress())
                 return;
             LogPrint(BCLog::LogFlags::NET, "socket wait error %d", WSAGetLastError());
             if (!MilliSleep(timeout.count())) return;
             continue; // rebuild the wait set next iteration
         }
-        if (fShutdown)
+        if (ShutdownInProgress())
             return;
 
 
@@ -969,7 +970,7 @@ void CConnman::ThreadSocketHandler2()
         }
         for (auto const& pnode : vNodesCopy)
         {
-            if (fShutdown)
+            if (ShutdownInProgress())
                 return;
 
             //
@@ -1213,7 +1214,7 @@ void ThreadMapPort2(void* parg)
         int i = 1;
         while (true)
         {
-            if (fShutdown || !g_connman || !g_connman->GetUseUPnP())
+            if (ShutdownInProgress() || !g_connman || !g_connman->GetUseUPnP())
             {
                 r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", nullptr);
                 LogPrintf("UPNP_DeletePortMapping() returned : %d", r);
@@ -1251,7 +1252,7 @@ void ThreadMapPort2(void* parg)
             FreeUPNPUrls(&urls);
         while (true)
         {
-            if (fShutdown || !g_connman || !g_connman->GetUseUPnP()) return;
+            if (ShutdownInProgress() || !g_connman || !g_connman->GetUseUPnP()) return;
             if (!MilliSleep(2000)) return;
         }
     }
@@ -1378,7 +1379,7 @@ void DumpAddresses()
 
 void ThreadDumpAddress2(void* parg)
 {
-    while (!fShutdown)
+    while (!ShutdownInProgress())
     {
         DumpAddresses();
         if (!MilliSleep(600000)) return;
@@ -1492,7 +1493,7 @@ void CConnman::ThreadOpenConnections2()
                 for (int i = 0; i < 10 && i < nLoop; i++)
                 {
                     UninterruptibleSleep(std::chrono::milliseconds{500});
-                    if (fShutdown)
+                    if (ShutdownInProgress())
                         return;
                 }
             }
@@ -1507,11 +1508,11 @@ void CConnman::ThreadOpenConnections2()
         ProcessOneShot();
         UninterruptibleSleep(std::chrono::milliseconds{500});
 
-        if (fShutdown)
+        if (ShutdownInProgress())
             return;
 
         CSemaphoreGrant grant(*semOutbound);
-        if (fShutdown)
+        if (ShutdownInProgress())
             return;
 
         // Add seed nodes
@@ -1625,7 +1626,7 @@ void CConnman::ThreadOpenAddedConnections2()
         return;
 
     if (HaveNameProxy()) {
-        while(!fShutdown) {
+        while(!ShutdownInProgress()) {
             for (auto const& strAddNode : gArgs.GetArgs("-addnode")) {
                 CAddress addr;
                 CSemaphoreGrant grant(*semOutbound);
@@ -1675,11 +1676,11 @@ void CConnman::ThreadOpenAddedConnections2()
             CSemaphoreGrant grant(*semOutbound);
             OpenNetworkConnection(CAddress(*(vserv.begin())), &grant);
             UninterruptibleSleep(std::chrono::milliseconds{500});
-            if (fShutdown) return;
+            if (ShutdownInProgress()) return;
         }
-        if (fShutdown) return;
+        if (ShutdownInProgress()) return;
         if (!MilliSleep(120000)) return; // Retry every 2 minutes
-        if (fShutdown) return;
+        if (ShutdownInProgress()) return;
     }
 }
 
@@ -1689,7 +1690,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGran
     //
     // Initiate outbound network connection
     //
-    if (fShutdown)
+    if (ShutdownInProgress())
         return false;
     if (!strDest)
         if (IsLocal(addrConnect) ||
@@ -1700,7 +1701,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGran
         return false;
 
     std::shared_ptr<CNode> pnode = ConnectNode(addrConnect, strDest);
-    if (fShutdown)
+    if (ShutdownInProgress())
         return false;
     if (!pnode)
         return false;
@@ -1742,7 +1743,7 @@ void CConnman::ThreadMessageHandler()
 void CConnman::ThreadMessageHandler2()
 {
     LogPrint(BCLog::LogFlags::NET, "ThreadMessageHandler started");
-    while (!fShutdown)
+    while (!ShutdownInProgress())
     {
         // Drive message processing through the connection manager's configured
         // NetEventsInterface (issue #2558 PR 8c) rather than naming g_peerman
@@ -1776,7 +1777,7 @@ void CConnman::ThreadMessageHandler2()
                         pnode->CloseSocketDisconnect();
             }
 
-            if (fShutdown)
+            if (ShutdownInProgress())
                 return;
 
             // Send messages
@@ -1800,17 +1801,17 @@ void CConnman::ThreadMessageHandler2()
                 }
             }
 
-            if (fShutdown)
+            if (ShutdownInProgress())
                 return;
         }
         // vNodesCopy released as it leaves scope at the next iteration (issue #3066).
 
         // Wait and allow messages to bunch up.
-        // we're sleeping, but we must always check fShutdown after doing this.
+        // we're sleeping, but we must always check ShutdownInProgress() after doing this.
         UninterruptibleSleep(std::chrono::milliseconds{100});
-        if (fRequestShutdown)
+        if (ShutdownRequested())
             StartShutdown();
-        if (fShutdown)
+        if (ShutdownInProgress())
             return;
     }
 }
@@ -2196,7 +2197,7 @@ void CConnman::RelayAddress(const CAddress& addr, bool fReachable)
 
 bool CConnman::Start()
 {
-    fShutdown = false;
+    SetShutdownInProgress(false);
     MAX_OUTBOUND_CONNECTIONS = m_options.nMaxOutbound;
     int max_connections = m_options.nMaxConnections;
     int nMaxOutbound = 0;
@@ -2219,7 +2220,7 @@ bool CConnman::Start()
     //
 
     // Net threads now run as std::thread members owned by CConnman (issue
-    // #2558 PR 4). Each loop exits on fShutdown; its interruptible MilliSleep
+    // #2558 PR 4). Each loop exits on ShutdownInProgress(); its interruptible MilliSleep
     // is woken by the global g_thread_interrupt fired in Shutdown(). The
     // optional ThreadMapPort still launches on netThreads (on demand, including
     // the Qt UPnP toggle) and is joined via netThreads->removeAll() in Stop().
@@ -2253,7 +2254,7 @@ bool CConnman::Start()
 
 void CConnman::Interrupt()
 {
-    fShutdown = true;
+    SetShutdownInProgress(true);
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
             semOutbound->post();
@@ -2263,7 +2264,7 @@ void CConnman::Stop()
 {
     Interrupt();
 
-    // Join the std::thread net threads. They wake via fShutdown plus the global
+    // Join the std::thread net threads. They wake via ShutdownInProgress() plus the global
     // g_thread_interrupt (already fired in Shutdown before StopNode), so the
     // interruptible MilliSleep loops return promptly.
     for (auto& thread : m_net_threads) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -11,6 +11,7 @@
 #include "consensus/tx_verify.h"
 #include "gridcoin/voting/registry.h"
 #include "util.h"
+#include "node/shutdown.h"
 #include "net.h"
 #include "streams.h"
 #include "alert.h"
@@ -628,7 +629,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         int64_t nSince = nNow - 10 * 60;
         for (auto &addr : vAddr)
         {
-            if (fShutdown)
+            if (ShutdownInProgress())
                 return true;
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)
                 addr.nTime = nNow - 5 * 24 * 60 * 60;
@@ -676,7 +677,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             const CInv &inv = vInv[nInv];
 
-            if (fShutdown) return true;
+            if (ShutdownInProgress()) return true;
 
             // cs_main lock here must be tightly scoped and not be concatenated outside the cs_mapManifest lock, because
             // that will lead to a deadlock. In the original position above the for loop, cs_main is taken first here, then
@@ -763,7 +764,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         for (auto const& inv : vInv)
         {
-            if (fShutdown)
+            if (ShutdownInProgress())
                 return true;
             if (vInv.size() == 1)
             {
@@ -1345,7 +1346,7 @@ static bool ProcessMessages(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(pfrom->cs_vRe
         try
         {
             fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime);
-            if (fShutdown)
+            if (ShutdownInProgress())
                 break;
         }
         catch (std::ios_base::failure& e)

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "node/blockstorage.h"
+#include "node/shutdown.h"
 
 #include "chainparams.h"
 #include "clientversion.h"
@@ -139,7 +140,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes)
     // Check for nMinDiskSpace bytes (currently 50MB)
     if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
     {
-        fShutdown = true;
+        SetShutdownInProgress();
         std::string strMessage = _("Warning: Disk space is low!");
         strMiscWarning = strMessage;
         LogPrintf("*** %s", strMessage);
@@ -216,7 +217,7 @@ bool LoadExternalBlockFile(FILE* fileIn, size_t file_size, unsigned int percent_
         try {
             CAutoFile blkdat(fileIn, SER_DISK, CLIENT_VERSION);
             unsigned int nPos = 0;
-            while (nPos != (unsigned int)-1 && !fRequestShutdown)
+            while (nPos != (unsigned int)-1 && !ShutdownRequested())
             {
                 unsigned char pchData[65536];
                 do {
@@ -239,7 +240,7 @@ bool LoadExternalBlockFile(FILE* fileIn, size_t file_size, unsigned int percent_
                     }
                     else
                         nPos += sizeof(pchData) - CMessageHeader::MESSAGE_START_SIZE + 1;
-                } while(!fRequestShutdown);
+                } while(!ShutdownRequested());
 
                 if (nPos == (unsigned int)-1) {
                     if (display_progress) {
@@ -377,7 +378,7 @@ bool LoadBlockIndex(bool fAllowNew)
         }
     }
 
-    if (fRequestShutdown) {
+    if (ShutdownRequested()) {
         return true;
     }
 

--- a/src/node/shutdown.cpp
+++ b/src/node/shutdown.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "node/shutdown.h"
+
+#include <atomic>
+
+namespace {
+//! Set when a shutdown is requested; polled by the daemon main loop. Written
+//! from POSIX/Windows signal handlers, so it must be a lock-free atomic (which
+//! is async-signal-safe); this replaces the former plain-bool fRequestShutdown.
+std::atomic<bool> g_shutdown_requested{false};
+
+//! Set once node teardown begins; observed by worker threads as their loop-exit
+//! condition. Replaces the former std::atomic<bool> fShutdown.
+std::atomic<bool> g_shutdown_in_progress{false};
+} // namespace
+
+void SetShutdownRequested()
+{
+    g_shutdown_requested = true;
+}
+
+bool ShutdownRequested()
+{
+    return g_shutdown_requested;
+}
+
+void SetShutdownInProgress(bool in_progress)
+{
+    g_shutdown_in_progress = in_progress;
+}
+
+bool ShutdownInProgress()
+{
+    return g_shutdown_in_progress;
+}

--- a/src/node/shutdown.cpp
+++ b/src/node/shutdown.cpp
@@ -16,24 +16,36 @@ std::atomic<bool> g_shutdown_requested{false};
 //! Set once node teardown begins; observed by worker threads as their loop-exit
 //! condition. Replaces the former std::atomic<bool> fShutdown.
 std::atomic<bool> g_shutdown_in_progress{false};
+
+// SetShutdownRequested() is called from the POSIX/Windows signal handlers, where
+// only lock-free atomic operations are async-signal-safe. Enforce that the
+// platform actually provides a lock-free bool atomic at compile time rather than
+// relying on the assumption silently. std::atomic<bool> is always lock-free on
+// every platform this project targets, so this never fires in practice.
+static_assert(std::atomic<bool>::is_always_lock_free,
+              "shutdown flags must be lock-free: they are written from signal handlers");
 } // namespace
 
 void SetShutdownRequested()
 {
-    g_shutdown_requested = true;
+    // Relaxed: this flag carries no data dependency with other memory; the
+    // daemon main loop and worker threads only need to observe the value change
+    // eventually, and a relaxed store is what keeps the signal-handler path
+    // async-signal-safe.
+    g_shutdown_requested.store(true, std::memory_order_relaxed);
 }
 
 bool ShutdownRequested()
 {
-    return g_shutdown_requested;
+    return g_shutdown_requested.load(std::memory_order_relaxed);
 }
 
 void SetShutdownInProgress(bool in_progress)
 {
-    g_shutdown_in_progress = in_progress;
+    g_shutdown_in_progress.store(in_progress, std::memory_order_relaxed);
 }
 
 bool ShutdownInProgress()
 {
-    return g_shutdown_in_progress;
+    return g_shutdown_in_progress.load(std::memory_order_relaxed);
 }

--- a/src/node/shutdown.h
+++ b/src/node/shutdown.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Copyright (c) 2014-2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_SHUTDOWN_H
+#define BITCOIN_NODE_SHUTDOWN_H
+
+//! Node shutdown state, extracted from the former util.h fRequestShutdown /
+//! fShutdown globals (multiprocess Phase 1e) so the GUI can no longer read core
+//! lifecycle state as a process global. Core code queries and mutates the
+//! shutdown state exclusively through these functions; the GUI observes a
+//! core-initiated shutdown through interfaces:: (uiInterface.QueueShutdown
+//! today), never these.
+//!
+//! Two distinct concepts are tracked:
+//!  - "requested": someone asked the node to stop -- the RPC `stop` command (via
+//!    StartShutdown), SIGTERM, the console control handler, or an init failure.
+//!    The daemon main loop polls ShutdownRequested() and then runs Shutdown().
+//!  - "in progress": Shutdown() has begun tearing the node down; worker threads
+//!    observe ShutdownInProgress() to break their loops.
+
+//! Request that the node begin shutting down (idempotent). Unlike
+//! StartShutdown() (init.h), this does not perform the Qt marshalling that makes
+//! the GUI leave its event loop; it only sets the request flag. Used by the
+//! POSIX/Windows signal handlers, the init-failure paths, and StartShutdown()'s
+//! non-GUI (daemon) branch.
+void SetShutdownRequested();
+
+//! Whether a shutdown has been requested.
+bool ShutdownRequested();
+
+//! Set whether node teardown is in progress. Passed \c true at the top of
+//! Shutdown() (and by the low-disk abort in CheckDiskSpace); reset to \c false
+//! by CConnman::Start(), which re-arms the flag for an in-process restart of
+//! the connection manager (e.g. the blockchain-reset path). Defaults to \c true
+//! so the common "begin teardown" call sites read cleanly.
+void SetShutdownInProgress(bool in_progress = true);
+
+//! Whether node teardown is in progress. Worker threads use this as their
+//! loop-exit condition.
+bool ShutdownInProgress();
+
+#endif // BITCOIN_NODE_SHUTDOWN_H

--- a/src/node/shutdown.h
+++ b/src/node/shutdown.h
@@ -9,9 +9,12 @@
 //! Node shutdown state, extracted from the former util.h fRequestShutdown /
 //! fShutdown globals (multiprocess Phase 1e) so the GUI can no longer read core
 //! lifecycle state as a process global. Core code queries and mutates the
-//! shutdown state exclusively through these functions; the GUI observes a
+//! shutdown state through these functions. GUI code should generally observe a
 //! core-initiated shutdown through interfaces:: (uiInterface.QueueShutdown
-//! today), never these.
+//! today) rather than polling these directly; the one narrowly-scoped exception
+//! is the composition root (qt/bitcoin.cpp), which constructs both the core and
+//! the GUI in the monolithic build and may query ShutdownRequested() while
+//! sequencing startup/teardown.
 //!
 //! Two distinct concepts are tracked:
 //!  - "requested": someone asked the node to stop -- the RPC `stop` command (via

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -30,6 +30,7 @@
 #include "interfaces/wallet.h"
 #include "interfaces/wallet_tx_source.h"
 #include "init.h"
+#include "node/shutdown.h"
 #include "node/ui_interface.h"
 #include "qtipcserver.h"
 #include "txdb.h"
@@ -603,7 +604,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
             if (splashref)
                 splash.finish();
 
-            if (!fRequestShutdown) {
+            if (!ShutdownRequested()) {
                 // Put this in a block, so that the Model objects are cleaned up
                 // before calling Shutdown(). interface_init (created above, ahead
                 // of the readiness wait) outlives every model constructed here.
@@ -719,6 +720,11 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 GUIUtil::SetStartOnSystemStartup(optionsModel.getStartAtStartup(), optionsModel.getStartMin());
 
                 app.exec();
+
+                // Stop the GUI-process-local URI-listener thread now that the
+                // event loop has returned (it no longer reads the core shutdown
+                // state; see qtipcserver ipcShutdown()).
+                ipcShutdown();
 
                 window.hide();
                 window.setClientModel(nullptr);

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -8,6 +8,8 @@
 #include "node/ui_interface.h"
 #include "util.h"
 
+#include <atomic>
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
@@ -26,8 +28,21 @@ using namespace boost::posix_time;
 
 void ipcScanRelay(int argc, char *argv[]) { }
 void ipcInit(int argc, char *argv[]) { }
+void ipcShutdown() { }
 
 #else
+
+//! GUI-process-local stop flag for the URI-listener thread (grc-gui-ipc). Set by
+//! ipcShutdown() when the GUI event loop returns; the thread polls it once per
+//! 100 ms receive timeout. Replaces the former read of the core fShutdown global
+//! -- the URI server is owned by this GUI process, so its exit is gated on the
+//! GUI quitting, never on core teardown state.
+static std::atomic<bool> g_ipc_shutdown{false};
+
+void ipcShutdown()
+{
+    g_ipc_shutdown = true;
+}
 
 static void ipcThread2(void* pArg);
 
@@ -102,7 +117,7 @@ static void ipcThread2(void* pArg)
             UninterruptibleSleep(std::chrono::seconds{1});
         }
 
-        if (fShutdown)
+        if (g_ipc_shutdown)
             break;
     }
 

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -7,4 +7,11 @@
 void ipcScanRelay(int argc, char *argv[]);
 void ipcInit(int argc, char *argv[]);
 
+//! Signal the URI-listener thread started by ipcInit() to exit. Called from the
+//! GUI composition root once the Qt event loop has returned. This is a
+//! GUI-process-local stop flag: the URI server belongs to this GUI process, so
+//! its lifetime is bounded by the GUI quitting, not by core shutdown state (a
+//! separate process in the multiprocess build).
+void ipcShutdown();
+
 #endif // BITCOIN_QT_QTIPCSERVER_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -7,6 +7,7 @@
 #include "amount.h"
 #include <base58.h>
 #include "init.h"
+#include "node/shutdown.h"
 #include "sync.h"
 #include <key_io.h>
 #include "node/ui_interface.h"
@@ -1021,7 +1022,7 @@ static string JSONRPCExecBatch(const UniValue& vReq)
 void ServiceConnection(AcceptedConnection *conn)
 {
     bool fRun = true;
-    while (fRun && !fShutdown)
+    while (fRun && !ShutdownInProgress())
     {
         int nProto = 0;
         map<string, string> mapHeaders;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -28,8 +28,6 @@
 using namespace std;
 
 bool fPrintToConsole = false;
-bool fRequestShutdown = false;
-std::atomic<bool> fShutdown = false;
 bool fCommandLine = false;
 bool fTestNet = false;
 bool fNoListen = false;

--- a/src/util.h
+++ b/src/util.h
@@ -80,8 +80,6 @@
 extern int GetDayOfYear(int64_t timestamp);
 
 extern bool fPrintToConsole;
-extern bool fRequestShutdown;
-extern std::atomic<bool> fShutdown;
 extern bool fCommandLine;
 extern bool fTestNet;
 extern bool fNoListen;

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "wallet/db.h"
+#include "node/shutdown.h"
 #include "dbwrapper.h"
 #include "net.h"
 #include "main.h"
@@ -61,7 +62,7 @@ bool CDBEnv::Open(fs::path pathEnv_)
     if (fDbEnvInit)
         return true;
 
-    if (fShutdown)
+    if (ShutdownInProgress())
         return false;
 
     pathEnv = pathEnv_;
@@ -134,7 +135,7 @@ void CDBEnv::MakeMock()
     if (fDbEnvInit)
         throw runtime_error("CDBEnv::MakeMock(): already initialized");
 
-    if (fShutdown)
+    if (ShutdownInProgress())
         throw runtime_error("CDBEnv::MakeMock(): during shutdown");
 
     LogPrint(BCLog::LogFlags::WALLETDB, "CDBEnv::MakeMock()");
@@ -372,7 +373,7 @@ bool CDBEnv::RemoveDb(const string& strFile)
 
 bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 {
-    while (!fShutdown)
+    while (!ShutdownInProgress())
     {
         {
             LOCK(bitdb.cs_db);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include "amount.h"
+#include "node/shutdown.h"
 #include "consensus/tx_verify.h"
 #include "gridcoin/staking/status.h"
 #include "main.h"
@@ -648,7 +649,7 @@ public:
 
     ~CReserveKey()
     {
-        if (!fShutdown)
+        if (!ShutdownInProgress())
             ReturnKey();
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -6,6 +6,7 @@
 #include "streams.h"
 #include "wallet/walletdb.h"
 #include "wallet/wallet.h"
+#include "node/shutdown.h"
 #include "init.h"
 
 #include <stdexcept>
@@ -690,7 +691,7 @@ void ThreadFlushWalletDB(void* parg)
     unsigned int nLastSeen = nWalletDBUpdated;
     unsigned int nLastFlushed = nWalletDBUpdated;
     int64_t nLastWalletUpdate = GetTime();
-    while (!fShutdown)
+    while (!ShutdownInProgress())
     {
         UninterruptibleSleep(std::chrono::milliseconds{500});
 
@@ -714,7 +715,7 @@ void ThreadFlushWalletDB(void* parg)
                     mi++;
                 }
 
-                if (nRefCount == 0 && !fShutdown)
+                if (nRefCount == 0 && !ShutdownInProgress())
                 {
                     map<string, int>::iterator mi = bitdb.mapFileUseCount.find(strFile);
                     if (mi != bitdb.mapFileUseCount.end())

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -33,6 +33,7 @@ src/qt/bitcoin.cpp:chainparams.h
 src/qt/bitcoin.cpp:gridcoin/gridcoin.h
 src/qt/bitcoin.cpp:gridcoin/upgrade.h
 src/qt/bitcoin.cpp:init.h
+src/qt/bitcoin.cpp:node/shutdown.h
 src/qt/bitcoin.cpp:node/ui_interface.h
 src/qt/bitcoin.cpp:policy/fees.h
 src/qt/bitcoin.cpp:txdb.h


### PR DESCRIPTION
## Summary

`fRequestShutdown` and `fShutdown` lived in `util.h` — a grab-bag header the GUI includes — so core lifecycle state was readable by the GUI as a process global. Per the multiprocess separation rule (state crossing the core/GUI boundary must go through `interfaces::`; only stateless utilities may be consumed directly), these are core state and must live somewhere core-owned.

This moves both into a new core TU **`node/shutdown.{h,cpp}`** as file-static atomics, fronted by accessors:

```cpp
void SetShutdownRequested();                        // fRequestShutdown = true
bool ShutdownRequested();                           // read
void SetShutdownInProgress(bool in_progress = true);// fShutdown = true/false
bool ShutdownInProgress();                          // read
```

The two concepts the globals conflated are now named explicitly:
- **requested** — someone asked the node to stop (RPC `stop` via `StartShutdown`, SIGTERM, console-ctrl, init failure); polled by the daemon main loop.
- **in progress** — `Shutdown()` has begun tearing down; worker threads observe it to exit their loops.

`fRequestShutdown` was a plain `bool` written from the POSIX/Windows signal handlers; the replacement is a lock-free `std::atomic<bool>` — async-signal-safe, a strict improvement. `SetShutdownInProgress` takes a bool because `CConnman::Start()` resets the flag to re-arm for an in-process connection-manager restart.

## Scope

- All ~13 core reader TUs switch to the accessors and `#include "node/shutdown.h"`.
- `ShutdownRequested()`'s declaration moves from `init.h` to `node/shutdown.h` (its one caller, `gridcoinresearchd.cpp`, includes the new header). `StartShutdown()` and `Shutdown()` stay in `init.h` as the Qt-aware orchestration entry points.
- **GUI severing:**
  - `qtipcserver`'s URI-listener loop stopped reading the core `fShutdown` global. It is a GUI-process-local thread, so its exit is gated on a GUI-local `g_ipc_shutdown` atomic set by a new `ipcShutdown()`, which the composition root (`bitcoin.cpp`) calls once `app.exec()` returns — earlier than the former core-teardown timing, so no URI is handled during model teardown.
  - `bitcoin.cpp`'s post-init "was shutdown requested?" gate reads `ShutdownRequested()` (composition root; already reaches `init.h`/`validation.h` directly). New ratchet allowlist entry `bitcoin.cpp:node/shutdown.h` under the pre-existing-coupling exception (the include moved from `util.h`; the coupling is old).
- The `CDBEnv::Flush(bool fShutdown)` **parameter** is unrelated to the global and left unchanged (it previously shadowed the global, so those in-function references always meant the param — byte-identical).

## Testing

- Native RelWithDebInfo build clean (0 errors, Qt6).
- Unit + functional tests: 100% pass (3/3 suites).
- `lint-qt-includes.sh` ratchet passes; `lint-whitespace.sh` / `lint-include-guards.sh` clean.
- Adversarial parity review across all conversion sites: no swapped mappings, no dropped negations, no missed readers, no semantic change from the `bool`→`atomic` conversion.

Part of the Phase 1 GUI/node multiprocess separation (RFC #2937). This is the second global extraction (after fTestNet #3204); the `interfaces::Node` shutdown-notification (the core→GUI "I'm stopping, quit yourself" reverse signal, generalizing `uiInterface.QueueShutdown`) is a separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)