### PR TITLE
gui: route core-initiated shutdown through interfaces::Node (Phase 1e)

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -230,6 +230,18 @@ public:
     using RwSettingsUpdatedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleRwSettingsUpdated(RwSettingsUpdatedFn fn) = 0;
 
+    //! Register a handler fired when the core begins shutting down (RPC `stop`,
+    //! SIGTERM, a low-disk abort, etc.). The GUI reacts by leaving its event loop
+    //! and quitting its own process. This is the core->GUI half of the shutdown
+    //! model: quitting the GUI shuts down only the GUI process, but a
+    //! core-initiated shutdown must tell an attached GUI to follow. Payload-free;
+    //! bridges uiInterface.QueueShutdown today, and in the separated build Phase 2
+    //! delivers it as an IPC callback instead of an in-process signal -- which is
+    //! why the GUI must route it through this interface rather than connecting to
+    //! uiInterface directly.
+    using InitShutdownFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleInitShutdown(InitShutdownFn fn) = 0;
+
     //! Value snapshot of the scraper convergence status.
     virtual ScraperConvergenceSnapshot getScraperConvergenceSnapshot() = 0;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -291,6 +291,11 @@ public:
         return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(std::move(fn)));
     }
 
+    std::unique_ptr<Handler> handleInitShutdown(InitShutdownFn fn) override
+    {
+        return MakeSignalHandler(uiInterface.QueueShutdown_connect(std::move(fn)));
+    }
+
     ScraperConvergenceSnapshot getScraperConvergenceSnapshot() override
     {
         LOCK(cs_ConvergedScraperStatsCache);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -99,7 +99,7 @@ static void RegisterMetaTypes()
     qRegisterMetaType<uint32_t>("uint32_t");
 }
 
-int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel);
+int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel, interfaces::Node& node);
 
 static void SetupUIArgs(ArgsManager& argsman)
 {
@@ -507,7 +507,7 @@ int main(int argc, char *argv[])
     }
 
     /** Start Qt as normal before it was moved into this function **/
-    StartGridcoinQt(argc, argv, app, optionsModel);
+    StartGridcoinQt(argc, argv, app, optionsModel, *gui_node);
 
     // We received a request to remove blockchain data so client user can start to sync from 0
     if (fResetBlockchainRequest)
@@ -534,7 +534,7 @@ int main(int argc, char *argv[])
     return EXIT_SUCCESS;
 }
 
-int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel)
+int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel, interfaces::Node& node)
 {
     // Set global boolean to indicate intended presence of GUI to core.
     fQtActive = true;
@@ -548,8 +548,17 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
     uiInterface.ThreadSafeMessageBox_connect(ThreadSafeMessageBox);
     uiInterface.ThreadSafeHandleURI_connect(ThreadSafeHandleURI);
     uiInterface.InitMessage_connect(InitMessage);
-    uiInterface.QueueShutdown_connect(QueueShutdown);
     uiInterface.Translate_connect(Translate);
+
+    // Core-initiated shutdown (RPC stop / SIGTERM / low-disk abort) -> quit the
+    // GUI. Routed through the node interface rather than a raw
+    // uiInterface.QueueShutdown_connect so Phase 2 can deliver it over IPC. The
+    // handler must outlive app.exec(), so it is held for this function's scope;
+    // the node reference (main()'s gui_node) outlives this call. Wired here,
+    // before AppInit2, so a shutdown requested during core init still reaches the
+    // GUI.
+    std::unique_ptr<interfaces::Handler> shutdown_handler =
+        node.handleInitShutdown(QueueShutdown);
 
     uiInterface.UpdateMessageBox_connect(UpdateMessageBox);
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -99,7 +99,7 @@ static void RegisterMetaTypes()
     qRegisterMetaType<uint32_t>("uint32_t");
 }
 
-int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel, interfaces::Node& node);
+int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel, interfaces::Node& gui_node);
 
 static void SetupUIArgs(ArgsManager& argsman)
 {
@@ -534,7 +534,7 @@ int main(int argc, char *argv[])
     return EXIT_SUCCESS;
 }
 
-int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel, interfaces::Node& node)
+int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel, interfaces::Node& gui_node)
 {
     // Set global boolean to indicate intended presence of GUI to core.
     fQtActive = true;
@@ -553,12 +553,12 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
     // Core-initiated shutdown (RPC stop / SIGTERM / low-disk abort) -> quit the
     // GUI. Routed through the node interface rather than a raw
     // uiInterface.QueueShutdown_connect so Phase 2 can deliver it over IPC. The
-    // handler must outlive app.exec(), so it is held for this function's scope;
-    // the node reference (main()'s gui_node) outlives this call. Wired here,
-    // before AppInit2, so a shutdown requested during core init still reaches the
-    // GUI.
-    std::unique_ptr<interfaces::Handler> shutdown_handler =
-        node.handleInitShutdown(QueueShutdown);
+    // returned Handler is kept only to keep the subscription alive (RAII): it
+    // must outlive app.exec(), so it lives for this function's scope. gui_node
+    // (main()'s early node) outlives this call. Wired here, before AppInit2, so a
+    // shutdown requested during core init still reaches the GUI.
+    [[maybe_unused]] std::unique_ptr<interfaces::Handler> shutdown_handler =
+        gui_node.handleInitShutdown(QueueShutdown);
 
     uiInterface.UpdateMessageBox_connect(UpdateMessageBox);
 

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -109,6 +109,22 @@ BOOST_AUTO_TEST_CASE(node_handler_bridges_ui_signal)
     BOOST_CHECK_EQUAL(calls, 1);
 }
 
+BOOST_AUTO_TEST_CASE(node_init_shutdown_handler_bridges_queue_shutdown)
+{
+    std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
+    int calls = 0;
+
+    std::unique_ptr<interfaces::Handler> handler =
+        node->handleInitShutdown([&] { ++calls; });
+
+    uiInterface.QueueShutdown();
+    BOOST_CHECK_EQUAL(calls, 1);
+
+    handler->disconnect();
+    uiInterface.QueueShutdown();
+    BOOST_CHECK_EQUAL(calls, 1);
+}
+
 BOOST_AUTO_TEST_CASE(wallet_wraps_cwallet)
 {
     BOOST_REQUIRE(pwalletMain != nullptr);


### PR DESCRIPTION
## Summary

The GUI's reaction to a core-initiated shutdown (RPC `stop`, SIGTERM, a low-disk abort) was wired directly to the core signal:

```cpp
uiInterface.QueueShutdown_connect(QueueShutdown);   // qt/bitcoin.cpp
```

That is the **core→GUI half of the shutdown model** (RFC #2937): quitting the GUI shuts down only the GUI process, but a core-initiated shutdown must tell an attached GUI to follow and quit itself. In the separated multiprocess build that notification arrives over IPC, not as an in-process boost signal, so the GUI must consume it through the `interfaces::` boundary.

## Change

- Add `interfaces::Node::handleInitShutdown(fn)`, implemented (monolith) as `MakeSignalHandler(uiInterface.QueueShutdown_connect(fn))` — the same seam as the other node notifications (`handleBannedListChanged`, `handleRwSettingsUpdated`, …).
- `qt/bitcoin.cpp` subscribes through it instead of touching `uiInterface` directly; the returned `Handler` is held for the GUI event loop's lifetime. Wiring stays before `AppInit2`, so a shutdown requested during core init still reaches the GUI. `StartGridcoinQt()` takes an `interfaces::Node&` (main()'s `gui_node`, which outlives the call) to reach the interface.
- New `interfaces_tests` smoke case: subscribe, fire `uiInterface.QueueShutdown`, assert the bridge fires exactly once and stops after `disconnect()`.

Behavior is **identical in the monolith** (same `QueueShutdown` signal); this only moves the subscription onto the interface so Phase 2 can back it with an IPC callback. This is the counterpart (Decision B) to the shutdown-state extraction in #3206; per the shutdown design there is deliberately **no** GUI→core "stop the core too" path (Decision A).

## Testing

- Native RelWithDebInfo build clean (0 errors, Qt6); unit + functional 100% (3/3); new smoke test passes in isolation; `lint-qt-includes` ratchet passes. Rebased onto current `development` (with #3204/#3206 merged) and re-verified green.

Part of the Phase 1 GUI/node multiprocess separation (RFC #2937).

🤖 Generated with [Claude Code](https://claude.com/claude-code)