### PR TITLE
qt: move MIN_STAKE_SPLIT_VALUE_GRC to amount.h; drop optionsdialog/model miner.h

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -26,4 +26,13 @@ static const CAmount CENT = 1000000;
 static const CAmount MAX_MONEY = 2000000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
+//! Floor for the post-split coinstake UTXO size, in whole GRC (not Halfords) to
+//! match the -minstakesplitvalue config entry. It is a hard clamp, not just a
+//! default: miner.cpp takes max(-minstakesplitvalue, this), so a smaller
+//! configured value is raised to it. Not a consensus or per-network parameter
+//! (same on every chain), so it lives in this stateless header rather than
+//! chainparams or miner.h -- which also lets the GUI options dialog/model read
+//! it without pulling in the mining engine's headers.
+static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
+
 #endif //  BITCOIN_AMOUNT_H

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -188,7 +188,9 @@ bool AppInit(int argc, char* argv[])
             return InitError("Error initializing settings.\n");
         }
 
-        // Command-line RPC  - single commands execute and exit.
+        // Command-line RPC  - single commands execute and exit. Local to this
+        // entry point; formerly a util.h global read nowhere else.
+        bool fCommandLine = false;
         for (int i = 1; i < argc; i++)
             if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "gridcoinresearchd"))
                 fCommandLine = true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -335,7 +335,10 @@ static void HandleSIGTERM(int)
 
 static void HandleSIGHUP(int)
 {
-    fReopenDebugLog = true;
+    // Ask the logger to reopen debug.log on the next write (log rotation). The
+    // flag is a std::atomic<bool>, so setting it from a signal handler is safe;
+    // this replaces the former fReopenDebugLog global, which only shadowed it.
+    LogInstance().m_reopen_file = true;
 }
 #else
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
@@ -884,8 +887,6 @@ static void StartupNotify(const ArgsManager& args)
  */
 void InitLogging()
 {
-    fPrintToConsole = gArgs.GetBoolArg("-printtoconsole");
-    fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", true);
 
     // This is needed because it is difficult to inject the equivalent of -nodebuglogfile in the testing suite for
     // console only logging, so in the testing suite, -debuglogfile=none is used.
@@ -896,8 +897,8 @@ void InitLogging()
     }
 
     LogInstance().m_file_path = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
-    LogInstance().m_print_to_console = fPrintToConsole;
-    LogInstance().m_log_timestamps = fLogTimestamps;
+    LogInstance().m_print_to_console = gArgs.GetBoolArg("-printtoconsole");
+    LogInstance().m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", true);
     LogInstance().m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     LogInstance().m_log_threadnames = gArgs.GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
 
@@ -1310,7 +1311,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         int nNewTimeout = gArgs.GetArg("-timeout", 5000);
         if (nNewTimeout > 0 && nNewTimeout < 600000)
-            nConnectTimeout = nNewTimeout;
+            SetConnectTimeout(nNewTimeout);
     }
 
     if (gArgs.IsArgSet("-peertimeout"))
@@ -1411,14 +1412,14 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     std::ostringstream strErrors;
 
-    fDevbuildCripple = false;
+    SetDevbuildCripple(false);
     if ((CLIENT_VERSION_BUILD != 0) && !OnTestnet())
     {
-        fDevbuildCripple = true;
+        SetDevbuildCripple(true);
         if ((gArgs.GetArg("-devbuild", "") == "override"))
         {
             LogInstance().EnableCategory(BCLog::LogFlags::VERBOSE);
-            fDevbuildCripple = false;
+            SetDevbuildCripple(false);
             LogPrintf("WARNING: Running development version outside of testnet in override mode!\n"
                       "VERBOSE logging is enabled.");
         }
@@ -1526,12 +1527,12 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     // see Step 2: parameter interactions for more information about these
-    fNoListen = !gArgs.GetBoolArg("-listen", true);
+    SetListenDisabled(!gArgs.GetBoolArg("-listen", true));
     fDiscover = gArgs.GetBoolArg("-discover", true);
-    fNameLookup = gArgs.GetBoolArg("-dns", true);
+    SetNameLookup(gArgs.GetBoolArg("-dns", true));
 
     bool fBound = false;
-    if (!fNoListen)
+    if (!IsListenDisabled())
     {
         std::string strError;
         if (gArgs.GetArgs("-bind").size()) {
@@ -1559,7 +1560,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         for (auto const& strAddr : gArgs.GetArgs("-externalip"))
         {
             CService addrLocal;
-            if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
+            if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), GetNameLookup()) && addrLocal.IsValid())
                 AddLocal(addrLocal, LOCAL_MANUAL);
             else
                 return InitError(strprintf(_("Cannot resolve -externalip address: '%s'"), strAddr));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -45,6 +45,12 @@ using namespace std;
 
 unsigned int nMinerSleep;
 
+// Development-build staking cripple; see miner.h. Extracted from the former
+// util.h global. Set from init (AppInit2 devbuild/testnet gating).
+static bool fDevbuildCripple = false;
+bool GetDevbuildCripple() { return fDevbuildCripple; }
+void SetDevbuildCripple(bool crippled) { fDevbuildCripple = crippled; }
+
 std::atomic<int> g_stakelimit_height{0};
 
 int32_t ComputeBlockVersion(int height)
@@ -1421,7 +1427,7 @@ bool IsMiningAllowed(CWallet *pwallet)
         g_miner_status.AddError(GRC::MinerStatus::WALLET_LOCKED);
     }
 
-    if (fDevbuildCripple) {
+    if (GetDevbuildCripple()) {
         g_miner_status.AddError(GRC::MinerStatus::TESTNET_ONLY);
     }
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -40,11 +40,6 @@ int32_t ComputeBlockVersion(int height);
 // (Particl-analog) and consumed in StakeMiner. Unused on testnet / mainnet.
 extern std::atomic<int> g_stakelimit_height;
 
-// Note the below constant controls the minimum value allowed for post
-// split UTXO size. It is int64_t but in GRC so that it matches the entry in the config file.
-// It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
-static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
-
 //! Whether the development-build staking cripple is active. When true,
 //! ThreadStakeMiner refuses to stake and CommitTransaction refuses
 //! reward-bearing sends: a development build disables all staking unless the

--- a/src/miner.h
+++ b/src/miner.h
@@ -45,6 +45,15 @@ extern std::atomic<int> g_stakelimit_height;
 // It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
 static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 
+//! Whether the development-build staking cripple is active. When true,
+//! ThreadStakeMiner refuses to stake and CommitTransaction refuses
+//! reward-bearing sends: a development build disables all staking unless the
+//! hidden `devbuild=override` setting is passed. State lives in miner.cpp;
+//! extracted from the former util.h fDevbuildCripple global so util.h is
+//! stateless. Set from init.
+bool GetDevbuildCripple();
+void SetDevbuildCripple(bool crippled);
+
 void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, int64_t &nReward,
                           bool &fEnableStakeSplit, bool &fEnableSideStaking,
                           int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -55,6 +55,12 @@ void ThreadDNSAddressSeed2(void* parg);
 //
 // Global state variables
 //
+// -listen=0 disables inbound P2P. Extracted from the former util.h fNoListen
+// global (all readers are net / net_processing); set once from init.
+static bool fNoListen = false;
+bool IsListenDisabled() { return fNoListen; }
+void SetListenDisabled(bool disabled) { fNoListen = disabled; }
+
 bool fDiscover = true;
 ServiceFlags nLocalServices = NODE_NETWORK;
 CCriticalSection cs_mapLocalHost;
@@ -122,7 +128,7 @@ void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
 // find 'best' local address for a particular peer
 bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
 {
-    if (fNoListen)
+    if (IsListenDisabled())
         return false;
 
     int nBestScore = -1;
@@ -180,7 +186,7 @@ bool IsPeerAddrLocalGood(CNode *pnode)
 // pushes our own address to a peer
 void AdvertiseLocal(CNode *pnode)
 {
-    if (!fNoListen && pnode->fSuccessfullyConnected)
+    if (!IsListenDisabled() && pnode->fSuccessfullyConnected)
     {
         CAddress addrLocal = GetLocalAddress(&pnode->addr);
 
@@ -1644,7 +1650,7 @@ void CConnman::ThreadOpenAddedConnections2()
         LogPrint(BCLog::LogFlags::NET, "INFO: %s: addnode %s.", __func__, strAddNode);
 
         vector<CService> vservNode(0);
-        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
+        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), GetNameLookup(), 0))
         {
             vservAddressesToAdd.push_back(vservNode);
             {
@@ -1658,7 +1664,7 @@ void CConnman::ThreadOpenAddedConnections2()
     {
         vector<vector<CService> > vservConnectAddresses = vservAddressesToAdd;
         // Attempt to connect to each IP for each addnode entry until at least one is successful per addnode entry
-        // (keeping in mind that addnode entries can have many IPs if fNameLookup)
+        // (keeping in mind that addnode entries can have many IPs if GetNameLookup())
         {
             LOCK(m_nodes_mutex);
             for (auto const& pnode : m_nodes)

--- a/src/net.h
+++ b/src/net.h
@@ -53,6 +53,12 @@ unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));
 void StartNode(void* parg);
 bool StopNode();
+
+//! Whether inbound P2P listening is disabled (-listen=0). State lives in
+//! net.cpp; extracted from the former util.h fNoListen global so util.h is
+//! stateless. Set once from init.
+bool IsListenDisabled();
+void SetListenDisabled(bool disabled);
 // Declared below CNode (the EXCLUSIVE_LOCKS_REQUIRED annotation references
 // pnode->cs_vSend and needs the complete CNode type).
 void SocketSendData(CNode *pnode);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -537,7 +537,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (!pfrom->fInbound)
         {
             // Advertise our address
-            if (!fNoListen && !IsInitialBlockDownload())
+            if (!IsListenDisabled() && !IsInitialBlockDownload())
             {
                 AdvertiseLocal(pfrom);
             }
@@ -1454,7 +1454,7 @@ static bool SendMessages(CNode* pto, bool fSendTrickle)
             // Periodically clear setAddrKnown to allow refresh broadcasts
             //pnode->setAddrKnown.clear();
             // Rebroadcast our address
-            if (!fNoListen)
+            if (!IsListenDisabled())
             {
                 AdvertiseLocal(pto);
                 pto->nNextRebroadcastTime = GetAdjustedTime() + 12*60*60 + GetRand(12*60*60);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -23,8 +23,17 @@ using namespace std;
 static proxyType proxyInfo[NET_MAX];
 static CService nameProxy;
 static CCriticalSection cs_proxyInfos;
-int nConnectTimeout = 5000;
-bool fNameLookup = false;
+// Extracted from the former netbase.h externs so the header carries only
+// stateless declarations; set once from init (-timeout / -dns) and otherwise
+// read-only. Internal readers below use these directly; external callers go
+// through the accessors.
+static int nConnectTimeout = 5000;
+static bool fNameLookup = false;
+
+int GetConnectTimeout() { return nConnectTimeout; }
+void SetConnectTimeout(int timeout) { nConnectTimeout = timeout; }
+bool GetNameLookup() { return fNameLookup; }
+void SetNameLookup(bool enable) { fNameLookup = enable; }
 
 enum Network ParseNetwork(std::string net) {
     net = ToLower(net);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -11,8 +11,12 @@
 #include "netaddress.h"
 #include "serialize.h"
 
-extern int nConnectTimeout;
-extern bool fNameLookup;
+// Network base config, extracted from the former externs to keep this header
+// stateless (the state lives in netbase.cpp). Set once from init.
+int GetConnectTimeout();
+void SetConnectTimeout(int timeout);
+bool GetNameLookup();
+void SetNameLookup(bool enable);
 
 #ifdef WIN32
 // In MSVC, this is defined as a macro, undefine it to prevent a compile and link error
@@ -33,7 +37,7 @@ bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLoo
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
 CService LookupNumeric(const char *pszName, int portDefault = 0);
 bool LookupSubNet(const char *pszName, CSubNet& subnet);
-bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
-bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
+bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = GetConnectTimeout());
+bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = GetConnectTimeout());
 
 #endif

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -8,7 +8,7 @@
 #include "monitoreddatamapper.h"
 #include "optionsmodel.h"
 #include "qt/decoration.h"
-#include "miner.h"
+#include "amount.h" // For MIN_STAKE_SPLIT_VALUE_GRC.
 #include "sidestaketablemodel.h"
 #include "editsidestakedialog.h"
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -8,7 +8,7 @@
 #include "interfaces/node.h"
 #include "util/strencodings.h" // For SplitHostPort (IPv6-aware host:port parsing).
 
-#include "miner.h"
+#include "amount.h" // For MIN_STAKE_SPLIT_VALUE_GRC.
 
 #include <utility>
 
@@ -403,11 +403,6 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
     emit dataChanged(index, index);
 
     return successful;
-}
-
-qint64 OptionsModel::getTransactionFee()
-{
-    return nTransactionFee;
 }
 
 qint64 OptionsModel::getReserveBalance()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -75,7 +75,6 @@ public:
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
 
     /* Explicit getters */
-    qint64 getTransactionFee();
     qint64 getReserveBalance();
     //! Whether the node is on testnet, read through the node interface
     //! (interfaces::Node::isTestNet). Lets dialogs that hold an OptionsModel gate

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -226,7 +226,7 @@ UniValue getaddednodeinfo(const UniValue& params)
     for (auto const& strAddNode : laddedNodes)
     {
         vector<CService> vservNode(0);
-        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
+        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), GetNameLookup(), 0))
             laddedAddresses.push_back(make_pair(strAddNode, vservNode));
         else
         {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -88,6 +88,15 @@ LockData& GetLockData() {
     return lock_data;
 }
 
+namespace {
+// Lock-order debugging flags, extracted from the former sync.h externs so the
+// header carries only the (stateless) lock primitives and macros. Defined ahead
+// of their in-file readers below; toggled from unit tests through the
+// Get/Set accessors (defined at the bottom of the DEBUG_LOCKORDER block).
+bool g_debug_lockorder_abort = false;
+bool g_debug_lockorder_throw_exception = false;
+} // namespace
+
 static void potential_deadlock_detected(const LockPair& mismatch, const LockStack& s1, const LockStack& s2)
 {
     // Identify the two conflicting locks by name. Try s2 (current stack) first,
@@ -297,7 +306,9 @@ bool LockStackEmpty()
     return it->second.empty();
 }
 
-bool g_debug_lockorder_abort = false;
-bool g_debug_lockorder_throw_exception = false;
+bool GetLockOrderDebugAbort() { return g_debug_lockorder_abort; }
+void SetLockOrderDebugAbort(bool enable) { g_debug_lockorder_abort = enable; }
+bool GetLockOrderDebugThrowException() { return g_debug_lockorder_throw_exception; }
+void SetLockOrderDebugThrowException(bool enable) { g_debug_lockorder_throw_exception = enable; }
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/sync.h
+++ b/src/sync.h
@@ -66,8 +66,14 @@ bool LockStackEmpty();
  * just logging information and throwing a logic_error. Defaults to true, and
  * set to false in DEBUG_LOCKORDER unit tests.
  */
-extern bool g_debug_lockorder_abort;
-extern bool g_debug_lockorder_throw_exception;
+// Test-only hooks for the lock-order debugging flags. The state lives in
+// sync.cpp; DEBUG_LOCKORDER unit tests toggle these to exercise the deadlock
+// detector without aborting the process. Kept as functions (not externs) so
+// this header stays stateless.
+bool GetLockOrderDebugAbort();
+void SetLockOrderDebugAbort(bool enable);
+bool GetLockOrderDebugThrowException();
+void SetLockOrderDebugThrowException(bool enable);
 #else
 inline void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 inline void LeaveCritical() {}

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -14,11 +14,11 @@ BOOST_AUTO_TEST_SUITE(sync_tests)
 BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 {
     #ifdef DEBUG_LOCKORDER
-    bool prev_lockorder_abort = g_debug_lockorder_abort;
-    bool prev_lockorder_throw_exception = g_debug_lockorder_throw_exception;
+    bool prev_lockorder_abort = GetLockOrderDebugAbort();
+    bool prev_lockorder_throw_exception = GetLockOrderDebugThrowException();
 
-    g_debug_lockorder_abort = false;
-    g_debug_lockorder_throw_exception = true;
+    SetLockOrderDebugAbort(false);
+    SetLockOrderDebugThrowException(true);
 
     #endif
 
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
     #endif
 
     #ifdef DEBUG_LOCKORDER
-    g_debug_lockorder_abort = prev_lockorder_abort;
-    g_debug_lockorder_throw_exception = prev_lockorder_throw_exception;
+    SetLockOrderDebugAbort(prev_lockorder_abort);
+    SetLockOrderDebugThrowException(prev_lockorder_throw_exception);
     #endif
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,14 +27,7 @@
 
 using namespace std;
 
-bool fPrintToConsole = false;
-bool fCommandLine = false;
-bool fNoListen = false;
-bool fLogTimestamps = false;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
-bool fReopenDebugLog = false;
-
-bool fDevbuildCripple;
 
 /** A map that contains all the currently held directory locks. After
  * successful locking, these will be held here until the global destructor

--- a/src/util.h
+++ b/src/util.h
@@ -79,13 +79,6 @@
 
 extern int GetDayOfYear(int64_t timestamp);
 
-extern bool fPrintToConsole;
-extern bool fCommandLine;
-extern bool fNoListen;
-extern bool fLogTimestamps;
-extern bool fReopenDebugLog;
-extern bool fDevbuildCripple;
-
 void LogException(std::exception* pex, const char* pszThread);
 void PrintException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7,6 +7,7 @@
 #include <key_io.h>
 #include "txdb.h"
 #include "wallet/wallet.h"
+#include "miner.h" // For GetDevbuildCripple() (staking cripple gate).
 #include "wallet/walletdb.h"
 #include "crypter.h"
 #include "node/ui_interface.h"
@@ -3520,7 +3521,7 @@ bool CWallet::CreateTransaction(CScript scriptPubKey, int64_t nValue, CWalletTx&
 // Call after CreateTransaction unless you want to abort
 bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 {
-    if(fDevbuildCripple)
+    if(GetDevbuildCripple())
     {
         return error("CommitTransaction(): Development build restrictions in effect");
     }

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -42,8 +42,6 @@ src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
 src/qt/detailedtxmodel.cpp:util/system.h
 src/qt/diagnosticsdialog.h:wallet/diagnose.h
-src/qt/optionsdialog.cpp:miner.h
-src/qt/optionsmodel.cpp:miner.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
 src/qt/transactionview.cpp:util/system.h

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -19,25 +19,18 @@ export LC_ALL=C
 
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
-FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|netbase\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|chainparams\.h|chainparamsbase\.h|protocol\.h|psgt\.h|sync\.h|util\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
+# chainparams.h / chainparamsbase.h / protocol.h were made stateless by the
+# fTestNet extraction (#3204); netbase.h / sync.h / util.h by the remaining
+# core-global extraction. They expose only stateless declarations now, so the
+# GUI may include them directly and they are no longer forbidden here.
+FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|psgt\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
 
 # file:header pairs present when the ratchet was introduced. DO NOT ADD
 # ENTRIES -- migrate the file onto src/interfaces/*.h instead. (Sole
 # exception: an entry may be added when a migration surfaces PRE-EXISTING
 # coupling that was previously hidden behind a transitive include, e.g.
 # rpcconsole.cpp:banman.h -- the coupling is old, only the include is new.)
-#
-# PERMANENT exception (not a migrate-away target): guiutil.cpp:chainparams.h.
-# GetAutoStartupArguments() must resolve the network THIS GUI process was
-# launched with (its own -testnet/-chain arg) locally, via OnTestnet() over the
-# process's own SelectParams() result. It cannot route through
-# interfaces::Node::isTestNet() because in the separated build no core process
-# exists yet at that point -- the local resolution is what selects WHICH core
-# (mainnet vs testnet) the GUI then connects to. Bootstrap catch-22; keep.
 ALLOWLIST="\
-src/qt/aboutdialog.cpp:util.h
-src/qt/bitcoin.cpp:chainparamsbase.h
-src/qt/bitcoin.cpp:chainparams.h
 src/qt/bitcoin.cpp:gridcoin/gridcoin.h
 src/qt/bitcoin.cpp:gridcoin/upgrade.h
 src/qt/bitcoin.cpp:init.h
@@ -45,34 +38,18 @@ src/qt/bitcoin.cpp:node/shutdown.h
 src/qt/bitcoin.cpp:node/ui_interface.h
 src/qt/bitcoin.cpp:policy/fees.h
 src/qt/bitcoin.cpp:txdb.h
-src/qt/bitcoin.cpp:util.h
 src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
-src/qt/bitcoingui.cpp:util.h
-src/qt/consolidateunspentdialog.cpp:util.h
-src/qt/consolidateunspentwizard.cpp:util.h
-src/qt/consolidateunspentwizardselectdestinationpage.cpp:util.h
-src/qt/consolidateunspentwizardsendpage.cpp:util.h
 src/qt/detailedtxmodel.cpp:util/system.h
-src/qt/diagnosticsdialog.h:sync.h
 src/qt/diagnosticsdialog.h:wallet/diagnose.h
-src/qt/guiutil.cpp:chainparams.h
-src/qt/guiutil.cpp:util.h
-src/qt/intro.cpp:chainparams.h
-src/qt/intro.cpp:util.h
 src/qt/optionsdialog.cpp:miner.h
-src/qt/optionsdialog.cpp:netbase.h
 src/qt/optionsmodel.cpp:miner.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
-src/qt/qtipcserver.cpp:util.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
-src/qt/transactiontablemodel.cpp:util.h
 src/qt/transactionview.cpp:util/system.h
 src/qt/updatedialog.h:gridcoin/upgrade.h
 src/qt/upgradeqt.cpp:gridcoin/upgrade.h
-src/qt/upgradeqt.cpp:util.h
 src/qt/voting/polltab.h:gridcoin/voting/filter.h
-src/qt/voting/polltablemodel.cpp:util.h
 src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
 src/qt/voting/poll_types.cpp:gridcoin/voting/poll.h
 src/qt/voting/pollwizarddetailspage.cpp:main.h
@@ -80,9 +57,7 @@ src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
 src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
 src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
 src/qt/walletmodel.cpp:node/ui_interface.h
-src/qt/walletmodel.cpp:util.h
 src/qt/winshutdownmonitor.cpp:init.h
-src/qt/winshutdownmonitor.cpp:util.h
 "
 
 EXIT_CODE=0


### PR DESCRIPTION
> **Stacked on #3208** (the remaining-globals extraction). Until it merges, the diff below also shows #3208's commit; it reduces to the 6-file change once #3208 lands, at which point I'll rebase and request review. **Do not review/merge yet.**

## Summary

`optionsdialog.cpp` and `optionsmodel.cpp` included the (stateful) `miner.h` only for the `MIN_STAKE_SPLIT_VALUE_GRC` constant.

Per discussion, it's a fixed **clamp floor** for the post-split coinstake UTXO size — `miner.cpp` takes `max(-minstakesplitvalue, this)`, so a smaller configured value is raised to it — **not** a consensus or per-network parameter (same on every chain). So it does not belong in chainparams. Move it to `amount.h` (stateless, already GUI-reachable, and it *is* an amount) and point both GUI files there.

- Drops the two `optionsdialog.cpp:miner.h` / `optionsmodel.cpp:miner.h` ratchet allowlist entries (**25 → 23**).
- Also removes the **dead `OptionsModel::getTransactionFee()`** — no callers; it returned the `main.h` global `nTransactionFee`, which `optionsmodel.cpp` had been reaching only transitively via `miner.h`. Removing it clears that hidden `main.h` coupling the include swap surfaced.

## Testing

Native RelWithDebInfo build clean (0 errors, Qt6); unit + functional 100% (3/3); `lint-qt-includes` ratchet passes.

Part of the Phase 1 GUI/node multiprocess separation (RFC #2937) — shrinks the ratchet allowlist toward the Phase 2 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)