### PR TITLE
qt: complete the Phase 1e ratchet burn-down (to the composition-root floor)

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -26,4 +26,13 @@ static const CAmount CENT = 1000000;
 static const CAmount MAX_MONEY = 2000000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
+//! Floor for the post-split coinstake UTXO size, in whole GRC (not Halfords) to
+//! match the -minstakesplitvalue config entry. It is a hard clamp, not just a
+//! default: miner.cpp takes max(-minstakesplitvalue, this), so a smaller
+//! configured value is raised to it. Not a consensus or per-network parameter
+//! (same on every chain), so it lives in this stateless header rather than
+//! chainparams or miner.h -- which also lets the GUI options dialog/model read
+//! it without pulling in the mining engine's headers.
+static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
+
 #endif //  BITCOIN_AMOUNT_H

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -611,6 +611,63 @@ public:
         return 50 * COIN;
     }
 
+    std::vector<PollTypeMeta> getPollTypes() override
+    {
+        // The GUI-facing enum mirrors and limit constants must match the core.
+        static_assert(static_cast<int>(PollFilterFlag::NO_FILTER) == static_cast<int>(GRC::PollFilterFlag::NO_FILTER)
+                      && static_cast<int>(PollFilterFlag::ACTIVE) == static_cast<int>(GRC::PollFilterFlag::ACTIVE)
+                      && static_cast<int>(PollFilterFlag::FINISHED) == static_cast<int>(GRC::PollFilterFlag::FINISHED),
+                      "interfaces::PollFilterFlag must mirror GRC::PollFilterFlag");
+        static_assert(static_cast<int>(PollType::UNKNOWN) == static_cast<int>(GRC::PollType::UNKNOWN)
+                      && static_cast<int>(PollType::SURVEY) == static_cast<int>(GRC::PollType::SURVEY)
+                      && static_cast<int>(PollType::PROJECT) == static_cast<int>(GRC::PollType::PROJECT)
+                      && static_cast<int>(PollType::DEVELOPMENT) == static_cast<int>(GRC::PollType::DEVELOPMENT)
+                      && static_cast<int>(PollType::GOVERNANCE) == static_cast<int>(GRC::PollType::GOVERNANCE)
+                      && static_cast<int>(PollType::MARKETING) == static_cast<int>(GRC::PollType::MARKETING)
+                      && static_cast<int>(PollType::OUTREACH) == static_cast<int>(GRC::PollType::OUTREACH)
+                      && static_cast<int>(PollType::COMMUNITY) == static_cast<int>(GRC::PollType::COMMUNITY)
+                      && static_cast<int>(PollType::OUT_OF_BOUND) == static_cast<int>(GRC::PollType::OUT_OF_BOUND),
+                      "interfaces::PollType must mirror GRC::PollType");
+        static_assert(static_cast<int>(PollWeightType::UNKNOWN) == static_cast<int>(GRC::PollWeightType::UNKNOWN)
+                      && static_cast<int>(PollWeightType::MAGNITUDE) == static_cast<int>(GRC::PollWeightType::MAGNITUDE)
+                      && static_cast<int>(PollWeightType::BALANCE) == static_cast<int>(GRC::PollWeightType::BALANCE)
+                      && static_cast<int>(PollWeightType::BALANCE_AND_MAGNITUDE) == static_cast<int>(GRC::PollWeightType::BALANCE_AND_MAGNITUDE)
+                      && static_cast<int>(PollWeightType::CPID_COUNT) == static_cast<int>(GRC::PollWeightType::CPID_COUNT)
+                      && static_cast<int>(PollWeightType::PARTICIPANT_COUNT) == static_cast<int>(GRC::PollWeightType::PARTICIPANT_COUNT)
+                      && static_cast<int>(PollWeightType::OUT_OF_BOUND) == static_cast<int>(GRC::PollWeightType::OUT_OF_BOUND),
+                      "interfaces::PollWeightType must mirror GRC::PollWeightType");
+        static_assert(poll_limits::MIN_DURATION_DAYS == static_cast<int>(GRC::Poll::MIN_DURATION_DAYS)
+                      && poll_limits::MAX_TITLE_LENGTH == static_cast<int>(GRC::Poll::MAX_TITLE_SIZE)
+                      && poll_limits::MAX_URL_LENGTH == static_cast<int>(GRC::Poll::MAX_URL_SIZE)
+                      && poll_limits::MAX_QUESTION_LENGTH == static_cast<int>(GRC::Poll::MAX_QUESTION_SIZE)
+                      && poll_limits::MAX_CHOICE_LABEL_LENGTH == static_cast<int>(GRC::Poll::Choice::MAX_LABEL_SIZE)
+                      && poll_limits::MAX_ADDITIONAL_FIELD_NAME_LENGTH == static_cast<int>(GRC::Poll::AdditionalField::MAX_NAME_SIZE)
+                      && poll_limits::MAX_ADDITIONAL_FIELD_VALUE_LENGTH == static_cast<int>(GRC::Poll::AdditionalField::MAX_VALUE_SIZE)
+                      && poll_limits::MAX_CHOICES == static_cast<int>(GRC::POLL_MAX_CHOICES_SIZE),
+                      "interfaces::poll_limits must mirror GRC::Poll::MAX_* / MIN_DURATION_DAYS");
+
+        std::vector<PollTypeMeta> types;
+        for (const auto& type : GRC::Poll::POLL_TYPES) {
+            if (type == GRC::PollType::OUT_OF_BOUND) continue;
+
+            PollTypeMeta meta;
+            meta.type = static_cast<int>(type);
+            meta.name = GRC::Poll::PollTypeToString(type);
+            meta.description = GRC::Poll::PollTypeToDescString(type);
+            meta.min_duration_days =
+                static_cast<int>(GRC::Poll::POLL_TYPE_RULES[static_cast<int>(type)].m_mininum_duration);
+            meta.required_fields = GRC::Poll::POLL_TYPE_RULES[static_cast<int>(type)].m_required_fields;
+            types.push_back(std::move(meta));
+        }
+        return types;
+    }
+
+    bool pollV3Enabled() override
+    {
+        LOCK(cs_main);
+        return IsPollV3Enabled(nBestHeight);
+    }
+
     std::string currentPollTitle() override
     {
         // Raw title; the GUI applies its cosmetic formatting (length cap, '_' -> ' ').

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -188,7 +188,9 @@ bool AppInit(int argc, char* argv[])
             return InitError("Error initializing settings.\n");
         }
 
-        // Command-line RPC  - single commands execute and exit.
+        // Command-line RPC  - single commands execute and exit. Local to this
+        // entry point; formerly a util.h global read nowhere else.
+        bool fCommandLine = false;
         for (int i = 1; i < argc; i++)
             if (!IsSwitchChar(argv[i][0]) && !boost::algorithm::istarts_with(argv[i], "gridcoinresearchd"))
                 fCommandLine = true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -335,7 +335,10 @@ static void HandleSIGTERM(int)
 
 static void HandleSIGHUP(int)
 {
-    fReopenDebugLog = true;
+    // Ask the logger to reopen debug.log on the next write (log rotation). The
+    // flag is a std::atomic<bool>, so setting it from a signal handler is safe;
+    // this replaces the former fReopenDebugLog global, which only shadowed it.
+    LogInstance().m_reopen_file = true;
 }
 #else
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
@@ -884,8 +887,6 @@ static void StartupNotify(const ArgsManager& args)
  */
 void InitLogging()
 {
-    fPrintToConsole = gArgs.GetBoolArg("-printtoconsole");
-    fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", true);
 
     // This is needed because it is difficult to inject the equivalent of -nodebuglogfile in the testing suite for
     // console only logging, so in the testing suite, -debuglogfile=none is used.
@@ -896,8 +897,8 @@ void InitLogging()
     }
 
     LogInstance().m_file_path = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
-    LogInstance().m_print_to_console = fPrintToConsole;
-    LogInstance().m_log_timestamps = fLogTimestamps;
+    LogInstance().m_print_to_console = gArgs.GetBoolArg("-printtoconsole");
+    LogInstance().m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", true);
     LogInstance().m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     LogInstance().m_log_threadnames = gArgs.GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
 
@@ -1310,7 +1311,7 @@ bool AppInit2(ThreadHandlerPtr threads)
     {
         int nNewTimeout = gArgs.GetArg("-timeout", 5000);
         if (nNewTimeout > 0 && nNewTimeout < 600000)
-            nConnectTimeout = nNewTimeout;
+            SetConnectTimeout(nNewTimeout);
     }
 
     if (gArgs.IsArgSet("-peertimeout"))
@@ -1411,14 +1412,14 @@ bool AppInit2(ThreadHandlerPtr threads)
 
     std::ostringstream strErrors;
 
-    fDevbuildCripple = false;
+    SetDevbuildCripple(false);
     if ((CLIENT_VERSION_BUILD != 0) && !OnTestnet())
     {
-        fDevbuildCripple = true;
+        SetDevbuildCripple(true);
         if ((gArgs.GetArg("-devbuild", "") == "override"))
         {
             LogInstance().EnableCategory(BCLog::LogFlags::VERBOSE);
-            fDevbuildCripple = false;
+            SetDevbuildCripple(false);
             LogPrintf("WARNING: Running development version outside of testnet in override mode!\n"
                       "VERBOSE logging is enabled.");
         }
@@ -1526,12 +1527,12 @@ bool AppInit2(ThreadHandlerPtr threads)
     }
 
     // see Step 2: parameter interactions for more information about these
-    fNoListen = !gArgs.GetBoolArg("-listen", true);
+    SetListenDisabled(!gArgs.GetBoolArg("-listen", true));
     fDiscover = gArgs.GetBoolArg("-discover", true);
-    fNameLookup = gArgs.GetBoolArg("-dns", true);
+    SetNameLookup(gArgs.GetBoolArg("-dns", true));
 
     bool fBound = false;
-    if (!fNoListen)
+    if (!IsListenDisabled())
     {
         std::string strError;
         if (gArgs.GetArgs("-bind").size()) {
@@ -1559,7 +1560,7 @@ bool AppInit2(ThreadHandlerPtr threads)
         for (auto const& strAddr : gArgs.GetArgs("-externalip"))
         {
             CService addrLocal;
-            if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
+            if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), GetNameLookup()) && addrLocal.IsValid())
                 AddLocal(addrLocal, LOCAL_MANUAL);
             else
                 return InitError(strprintf(_("Cannot resolve -externalip address: '%s'"), strAddr));

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -113,6 +113,45 @@ struct LatestVersionInfo
     int upgrade_type = 0;
 };
 
+//! GUI-facing mirror of DiagnoseLib::Diagnose::TestNames (wallet/diagnose.h). The
+//! diagnostics dialog maps each result to its row label by this id without the
+//! core header. Values match the core enum; runDiagnostics() static_asserts them.
+enum class DiagnosticTest {
+    CheckConnectionCount = 0,
+    CheckOutboundConnectionCount,
+    VerifyWalletIsSynced,
+    CheckClientVersion,
+    VerifyBoincPath,
+    VerifyCPIDHasRAC,
+    VerifyCPIDIsActive,
+    VerifyCPIDValid,
+    VerifyClock,
+    VerifyTCPPort,
+    CheckDifficulty,
+    CheckETTS,
+};
+
+//! GUI-facing mirror of DiagnoseLib::Diagnose::diagnoseResults. Values match the
+//! core enum; runDiagnostics() static_asserts them.
+enum class DiagnosticStatus {
+    PASS = 0,
+    WARNING,
+    FAIL,
+    NONE,
+};
+
+//! One diagnostic test's outcome as pointer-free value data. The node runs the
+//! test and resolves its result/tip templates (translated by _() with their %1
+//! arguments already substituted), so the GUI only maps test_id to the row label
+//! and renders the status colour and the two strings.
+struct DiagnosticResult
+{
+    int test_id = 0;            //!< DiagnosticTest raw value.
+    int status = 0;            //!< DiagnosticStatus raw value.
+    std::string result_string; //!< Final result text ("" when none).
+    std::string tip_string;    //!< Final tooltip text ("" when none).
+};
+
 //! Top-level node interface for the GUI: chain and network state queries plus
 //! notification registration. In the monolithic build the implementation
 //! wraps the existing globals directly (see src/node/interfaces.cpp); in the
@@ -183,6 +222,13 @@ public:
     //! GRC::Upgrade) and return the result as a value. Callers run this off the
     //! GUI thread -- it does a libcurl GET with up to a 10 s connect timeout.
     virtual LatestVersionInfo checkForLatestUpdate() = 0;
+
+    //! Run every wallet diagnostic and return the results as value rows, one per
+    //! DiagnosticTest in enum order. Runs synchronously and can take several
+    //! seconds -- it includes an NTP (UDP) clock probe and a TCP listen-port
+    //! probe -- so the GUI shows a pending state and lets the event loop paint
+    //! before calling it.
+    virtual std::vector<DiagnosticResult> runDiagnostics() = 0;
 
     //! Proof-of-stake difficulty corresponding to a compact target-bits
     //! value (pure conversion; no chain state read).

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -102,6 +102,17 @@ struct ScraperConvergenceSnapshot
     std::vector<std::string> scrapers_not_publishing;
 };
 
+//! Result of the GitHub "latest release" check the About dialog runs. Value
+//! snapshot so the GUI needs no gridcoin/upgrade.h. upgrade_type carries a
+//! GRC::Upgrade::UpgradeType value as int (0 Unknown / 1 Leisure / 2 Mandatory
+//! / 3 Unsupported); the implementation static_asserts that mapping.
+struct LatestVersionInfo
+{
+    std::string version;      //!< Human-readable latest-version message.
+    std::string details;      //!< Change log / details text.
+    int upgrade_type = 0;
+};
+
 //! Top-level node interface for the GUI: chain and network state queries plus
 //! notification registration. In the monolithic build the implementation
 //! wraps the existing globals directly (see src/node/interfaces.cpp); in the
@@ -162,6 +173,11 @@ public:
 
     //! Whether the node runs on testnet.
     virtual bool isTestNet() = 0;
+
+    //! Run the blocking GitHub "latest release" check (the read-only half of
+    //! GRC::Upgrade) and return the result as a value. Callers run this off the
+    //! GUI thread -- it does a libcurl GET with up to a 10 s connect timeout.
+    virtual LatestVersionInfo checkForLatestUpdate() = 0;
 
     //! Proof-of-stake difficulty corresponding to a compact target-bits
     //! value (pure conversion; no chain state read).

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -174,6 +174,11 @@ public:
     //! Whether the node runs on testnet.
     virtual bool isTestNet() = 0;
 
+    //! Request that the node begin shutting down (the GUI->core direction, e.g.
+    //! a Windows WM_QUERYENDSESSION). Wraps the core StartShutdown(); in the
+    //! monolith this brings the whole app down, matching the prior direct call.
+    virtual void startShutdown() = 0;
+
     //! Run the blocking GitHub "latest release" check (the read-only half of
     //! GRC::Upgrade) and return the result as a value. Callers run this off the
     //! GUI thread -- it does a libcurl GET with up to a 10 s connect timeout.

--- a/src/interfaces/voting.h
+++ b/src/interfaces/voting.h
@@ -19,6 +19,68 @@ namespace interfaces {
 
 class Handler;
 
+//! GUI-facing mirror of GRC::PollFilterFlag (gridcoin/voting/filter.h). A plain
+//! (unscoped) enum like the core one, because it is used as a bitmask
+//! (flags & ACTIVE). The values match; the VotingManager impl static_asserts
+//! them. Lets the voting widgets/models express a filter without the core header.
+enum PollFilterFlag {
+    NO_FILTER = 0,
+    ACTIVE = 1,
+    FINISHED = 2,
+};
+
+//! GUI-facing mirror of GRC::PollType (gridcoin/voting/fwd.h). Values match; the
+//! implementation static_asserts them.
+enum class PollType {
+    UNKNOWN = 0,
+    SURVEY,
+    PROJECT,
+    DEVELOPMENT,
+    GOVERNANCE,
+    MARKETING,
+    OUTREACH,
+    COMMUNITY,
+    OUT_OF_BOUND,
+};
+
+//! GUI-facing mirror of GRC::PollWeightType (gridcoin/voting/fwd.h), so the
+//! pollcard can classify PollTableItem::weight_type (the raw enum value) without
+//! the core header. Values match; the implementation static_asserts them.
+enum class PollWeightType {
+    UNKNOWN = 0,
+    MAGNITUDE,
+    BALANCE,
+    BALANCE_AND_MAGNITUDE,
+    CPID_COUNT,
+    PARTICIPANT_COUNT,
+    OUT_OF_BOUND,
+};
+
+//! Poll field-size limits, mirrored from GRC::Poll::MAX_* / MIN_DURATION_DAYS so
+//! the GUI's (static) input-validation helpers can read them without
+//! gridcoin/voting/poll.h. The VotingManager implementation static_asserts each
+//! value against the core constant, so drift is a compile error.
+namespace poll_limits {
+inline constexpr int MIN_DURATION_DAYS = 7;
+inline constexpr int MAX_TITLE_LENGTH = 80;
+inline constexpr int MAX_URL_LENGTH = 100;
+inline constexpr int MAX_QUESTION_LENGTH = 100;
+inline constexpr int MAX_CHOICE_LABEL_LENGTH = 100;
+inline constexpr int MAX_ADDITIONAL_FIELD_NAME_LENGTH = 100;
+inline constexpr int MAX_ADDITIONAL_FIELD_VALUE_LENGTH = 500;
+inline constexpr int MAX_CHOICES = 20;
+} // namespace poll_limits
+
+//! Metadata for one poll type (from the core POLL_TYPES / POLL_TYPE_RULES
+//! tables), as a value row for the GUI's poll-type picker.
+struct PollTypeMeta {
+    int type = 0;                       //!< PollType raw value.
+    std::string name;                   //!< Translated type name.
+    std::string description;            //!< Translated type description.
+    int min_duration_days = 0;
+    std::vector<std::string> required_fields;
+};
+
 //! One choice of a poll together with its tallied result, as pointer-free value
 //! data (Phase 1d-iii). The label is resolved on the node side; weight is
 //! already scaled to whole GRC (divided by COIN), matching what the GUI renders.
@@ -142,6 +204,14 @@ public:
     //! against a single pinned tip. Potentially slow (a large poll's tally), so
     //! callers must invoke it off the UI thread. Thread-safe.
     virtual std::vector<PollTableItem> buildPollTable(int filter_flags) = 0;
+
+    //! Poll-type metadata (name/description/min-duration/required fields) for
+    //! each valid poll type, in enum order, excluding OUT_OF_BOUND.
+    virtual std::vector<PollTypeMeta> getPollTypes() = 0;
+
+    //! Whether poll v3 is active at the current tip (replaces a GUI-side
+    //! IsPollV3Enabled(nBestHeight) read); gates the extra project poll fields.
+    virtual bool pollV3Enabled() = 0;
 
     //! Estimated fee to create a poll, in 1/COIN units.
     virtual CAmount estimatePollFee() = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -360,6 +360,12 @@ public:
     //! not touch the address book -- the caller labels the address separately.
     virtual bool getNewReceiveAddress(std::string& address_out) = 0;
 
+    //! Reserve a fresh (non-reused) key from the pool, set its address-book
+    //! label, and return its encoded destination -- the CPubKey stays node-side.
+    //! For the researcher pool page, which previously reserved the key and
+    //! encoded the address GUI-side. Returns false on key-generation failure.
+    virtual bool getNewReceiveAddress(const std::string& label, std::string& address_out) = 0;
+
     //! Owned addresses with a positive balance that are not yet in the address
     //! book (encoded), for the "add existing receive address" picker.
     virtual std::vector<std::string> getUnbookedReceiveAddresses() = 0;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -45,6 +45,12 @@ using namespace std;
 
 unsigned int nMinerSleep;
 
+// Development-build staking cripple; see miner.h. Extracted from the former
+// util.h global. Set from init (AppInit2 devbuild/testnet gating).
+static bool fDevbuildCripple = false;
+bool GetDevbuildCripple() { return fDevbuildCripple; }
+void SetDevbuildCripple(bool crippled) { fDevbuildCripple = crippled; }
+
 std::atomic<int> g_stakelimit_height{0};
 
 int32_t ComputeBlockVersion(int height)
@@ -1421,7 +1427,7 @@ bool IsMiningAllowed(CWallet *pwallet)
         g_miner_status.AddError(GRC::MinerStatus::WALLET_LOCKED);
     }
 
-    if (fDevbuildCripple) {
+    if (GetDevbuildCripple()) {
         g_miner_status.AddError(GRC::MinerStatus::TESTNET_ONLY);
     }
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -40,11 +40,6 @@ int32_t ComputeBlockVersion(int height);
 // (Particl-analog) and consumed in StakeMiner. Unused on testnet / mainnet.
 extern std::atomic<int> g_stakelimit_height;
 
-// Note the below constant controls the minimum value allowed for post
-// split UTXO size. It is int64_t but in GRC so that it matches the entry in the config file.
-// It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
-static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
-
 //! Whether the development-build staking cripple is active. When true,
 //! ThreadStakeMiner refuses to stake and CommitTransaction refuses
 //! reward-bearing sends: a development build disables all staking unless the

--- a/src/miner.h
+++ b/src/miner.h
@@ -45,6 +45,15 @@ extern std::atomic<int> g_stakelimit_height;
 // It will be converted to Halfords in GetNumberOfStakeOutputs by multiplying by COIN.
 static const int64_t MIN_STAKE_SPLIT_VALUE_GRC = 800;
 
+//! Whether the development-build staking cripple is active. When true,
+//! ThreadStakeMiner refuses to stake and CommitTransaction refuses
+//! reward-bearing sends: a development build disables all staking unless the
+//! hidden `devbuild=override` setting is passed. State lives in miner.cpp;
+//! extracted from the former util.h fDevbuildCripple global so util.h is
+//! stateless. Set from init.
+bool GetDevbuildCripple();
+void SetDevbuildCripple(bool crippled);
+
 void SplitCoinStakeOutput(CMutableTransaction& mtxCoinstake, CBlock &blocknew, int64_t &nReward,
                           bool &fEnableStakeSplit, bool &fEnableSideStaking,
                           int64_t &nMinStakeSplitValue, double &dEfficiency) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -55,6 +55,12 @@ void ThreadDNSAddressSeed2(void* parg);
 //
 // Global state variables
 //
+// -listen=0 disables inbound P2P. Extracted from the former util.h fNoListen
+// global (all readers are net / net_processing); set once from init.
+static bool fNoListen = false;
+bool IsListenDisabled() { return fNoListen; }
+void SetListenDisabled(bool disabled) { fNoListen = disabled; }
+
 bool fDiscover = true;
 ServiceFlags nLocalServices = NODE_NETWORK;
 CCriticalSection cs_mapLocalHost;
@@ -122,7 +128,7 @@ void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
 // find 'best' local address for a particular peer
 bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
 {
-    if (fNoListen)
+    if (IsListenDisabled())
         return false;
 
     int nBestScore = -1;
@@ -180,7 +186,7 @@ bool IsPeerAddrLocalGood(CNode *pnode)
 // pushes our own address to a peer
 void AdvertiseLocal(CNode *pnode)
 {
-    if (!fNoListen && pnode->fSuccessfullyConnected)
+    if (!IsListenDisabled() && pnode->fSuccessfullyConnected)
     {
         CAddress addrLocal = GetLocalAddress(&pnode->addr);
 
@@ -1644,7 +1650,7 @@ void CConnman::ThreadOpenAddedConnections2()
         LogPrint(BCLog::LogFlags::NET, "INFO: %s: addnode %s.", __func__, strAddNode);
 
         vector<CService> vservNode(0);
-        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
+        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), GetNameLookup(), 0))
         {
             vservAddressesToAdd.push_back(vservNode);
             {
@@ -1658,7 +1664,7 @@ void CConnman::ThreadOpenAddedConnections2()
     {
         vector<vector<CService> > vservConnectAddresses = vservAddressesToAdd;
         // Attempt to connect to each IP for each addnode entry until at least one is successful per addnode entry
-        // (keeping in mind that addnode entries can have many IPs if fNameLookup)
+        // (keeping in mind that addnode entries can have many IPs if GetNameLookup())
         {
             LOCK(m_nodes_mutex);
             for (auto const& pnode : m_nodes)

--- a/src/net.h
+++ b/src/net.h
@@ -53,6 +53,12 @@ unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));
 void StartNode(void* parg);
 bool StopNode();
+
+//! Whether inbound P2P listening is disabled (-listen=0). State lives in
+//! net.cpp; extracted from the former util.h fNoListen global so util.h is
+//! stateless. Set once from init.
+bool IsListenDisabled();
+void SetListenDisabled(bool disabled);
 // Declared below CNode (the EXCLUSIVE_LOCKS_REQUIRED annotation references
 // pnode->cs_vSend and needs the complete CNode type).
 void SocketSendData(CNode *pnode);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -537,7 +537,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (!pfrom->fInbound)
         {
             // Advertise our address
-            if (!fNoListen && !IsInitialBlockDownload())
+            if (!IsListenDisabled() && !IsInitialBlockDownload())
             {
                 AdvertiseLocal(pfrom);
             }
@@ -1454,7 +1454,7 @@ static bool SendMessages(CNode* pto, bool fSendTrickle)
             // Periodically clear setAddrKnown to allow refresh broadcasts
             //pnode->setAddrKnown.clear();
             // Rebroadcast our address
-            if (!fNoListen)
+            if (!IsListenDisabled())
             {
                 AdvertiseLocal(pto);
                 pto->nNextRebroadcastTime = GetAdjustedTime() + 12*60*60 + GetRand(12*60*60);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -23,8 +23,17 @@ using namespace std;
 static proxyType proxyInfo[NET_MAX];
 static CService nameProxy;
 static CCriticalSection cs_proxyInfos;
-int nConnectTimeout = 5000;
-bool fNameLookup = false;
+// Extracted from the former netbase.h externs so the header carries only
+// stateless declarations; set once from init (-timeout / -dns) and otherwise
+// read-only. Internal readers below use these directly; external callers go
+// through the accessors.
+static int nConnectTimeout = 5000;
+static bool fNameLookup = false;
+
+int GetConnectTimeout() { return nConnectTimeout; }
+void SetConnectTimeout(int timeout) { nConnectTimeout = timeout; }
+bool GetNameLookup() { return fNameLookup; }
+void SetNameLookup(bool enable) { fNameLookup = enable; }
 
 enum Network ParseNetwork(std::string net) {
     net = ToLower(net);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -11,8 +11,12 @@
 #include "netaddress.h"
 #include "serialize.h"
 
-extern int nConnectTimeout;
-extern bool fNameLookup;
+// Network base config, extracted from the former externs to keep this header
+// stateless (the state lives in netbase.cpp). Set once from init.
+int GetConnectTimeout();
+void SetConnectTimeout(int timeout);
+bool GetNameLookup();
+void SetNameLookup(bool enable);
 
 #ifdef WIN32
 // In MSVC, this is defined as a macro, undefine it to prevent a compile and link error
@@ -33,7 +37,7 @@ bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLoo
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
 CService LookupNumeric(const char *pszName, int portDefault = 0);
 bool LookupSubNet(const char *pszName, CSubNet& subnet);
-bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = nConnectTimeout);
-bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = nConnectTimeout);
+bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout = GetConnectTimeout());
+bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault = 0, int nTimeout = GetConnectTimeout());
 
 #endif

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -30,12 +30,15 @@
 #include "rpc/server.h"
 #include "sync.h"
 #include "util.h"
+#include "wallet/diagnose.h"
 
 #include <univalue.h>
 
+#include <cctype>
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 // The converged scraper stats cache has no header declaration; every consumer
 // declares the extern locally (quorum.cpp, scraper_net.cpp, rpc/blockchain.cpp).
@@ -44,6 +47,45 @@ extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 namespace interfaces {
 namespace {
+
+//! Substitute a diagnostic template's positional placeholders the same way the
+//! GUI formerly did with QString::arg(): each argument, in order, replaces the
+//! lowest-numbered "%N" marker still present in the string (all occurrences of
+//! that marker). The diagnostic templates only ever use "%1", but this mirrors
+//! QString::arg's lowest-marker-first rule so multi-arg templates behave
+//! identically if any are added. This matches QString::arg exactly for the
+//! diagnostic args, which are all numeric (no '%'); an argument that itself
+//! contained "%N" could be rescanned by a later argument (QString::arg tracks
+//! already-filled positions), but no diagnostic produces such an argument.
+std::string ArgSubstitute(std::string text, const std::vector<std::string>& args)
+{
+    for (const std::string& arg : args) {
+        // Find the lowest-numbered %N marker currently in the string.
+        int lowest = -1;
+        for (size_t i = 0; i + 1 < text.size(); ++i) {
+            if (text[i] != '%' || !std::isdigit(static_cast<unsigned char>(text[i + 1]))) continue;
+
+            size_t j = i + 1;
+            int value = 0;
+            while (j < text.size() && std::isdigit(static_cast<unsigned char>(text[j]))) {
+                value = value * 10 + (text[j] - '0');
+                ++j;
+            }
+
+            if (lowest == -1 || value < lowest) lowest = value;
+        }
+
+        if (lowest == -1) break; // No markers left; extra args are dropped (as QString::arg would).
+
+        const std::string marker = "%" + ToString(lowest);
+        for (size_t pos = text.find(marker); pos != std::string::npos; pos = text.find(marker, pos)) {
+            text.replace(pos, marker.size(), arg);
+            pos += arg.size();
+        }
+    }
+
+    return text;
+}
 
 //! In-process Node implementation: thin wrappers over the existing globals.
 //! Methods that read cs_main-guarded chain state take the lock themselves, so
@@ -125,6 +167,67 @@ public:
                       "LatestVersionInfo::upgrade_type int contract must match GRC::Upgrade::UpgradeType");
         info.upgrade_type = static_cast<int>(upgrade_type);
         return info;
+    }
+
+    std::vector<DiagnosticResult> runDiagnostics() override
+    {
+        // The GUI-facing test-id and status mirrors must match the core enums.
+        static_assert(static_cast<int>(DiagnosticTest::CheckConnectionCount) == DiagnoseLib::Diagnose::CheckConnectionCount
+                      && static_cast<int>(DiagnosticTest::CheckOutboundConnectionCount) == DiagnoseLib::Diagnose::CheckOutboundConnectionCount
+                      && static_cast<int>(DiagnosticTest::VerifyWalletIsSynced) == DiagnoseLib::Diagnose::VerifyWalletIsSynced
+                      && static_cast<int>(DiagnosticTest::CheckClientVersion) == DiagnoseLib::Diagnose::CheckClientVersion
+                      && static_cast<int>(DiagnosticTest::VerifyBoincPath) == DiagnoseLib::Diagnose::VerifyBoincPath
+                      && static_cast<int>(DiagnosticTest::VerifyCPIDHasRAC) == DiagnoseLib::Diagnose::VerifyCPIDHasRAC
+                      && static_cast<int>(DiagnosticTest::VerifyCPIDIsActive) == DiagnoseLib::Diagnose::VerifyCPIDIsActive
+                      && static_cast<int>(DiagnosticTest::VerifyCPIDValid) == DiagnoseLib::Diagnose::VerifyCPIDValid
+                      && static_cast<int>(DiagnosticTest::VerifyClock) == DiagnoseLib::Diagnose::VerifyClock
+                      && static_cast<int>(DiagnosticTest::VerifyTCPPort) == DiagnoseLib::Diagnose::VerifyTCPPort
+                      && static_cast<int>(DiagnosticTest::CheckDifficulty) == DiagnoseLib::Diagnose::CheckDifficulty
+                      && static_cast<int>(DiagnosticTest::CheckETTS) == DiagnoseLib::Diagnose::CheckETTS,
+                      "interfaces::DiagnosticTest must mirror DiagnoseLib::Diagnose::TestNames");
+        static_assert(static_cast<int>(DiagnosticStatus::PASS) == DiagnoseLib::Diagnose::PASS
+                      && static_cast<int>(DiagnosticStatus::WARNING) == DiagnoseLib::Diagnose::WARNING
+                      && static_cast<int>(DiagnosticStatus::FAIL) == DiagnoseLib::Diagnose::FAIL
+                      && static_cast<int>(DiagnosticStatus::NONE) == DiagnoseLib::Diagnose::NONE,
+                      "interfaces::DiagnosticStatus must mirror DiagnoseLib::Diagnose::diagnoseResults");
+
+        // Resolve the researcher mode the tests branch on (reads core researcher
+        // state, not the GUI model).
+        DiagnoseLib::Diagnose::setResearcherModel();
+
+        // Construct all tests up front so they are all registered before any
+        // runs: two tests (VerifyClock, VerifyTCPPort) read CheckConnectionCount's
+        // result through the shared test map, and CheckConnectionCount -- enum id
+        // 0 -- is run first below, so its result is available to them.
+        std::vector<std::unique_ptr<DiagnoseLib::Diagnose>> tests;
+        tests.push_back(std::make_unique<DiagnoseLib::CheckConnectionCount>());
+        tests.push_back(std::make_unique<DiagnoseLib::CheckOutboundConnectionCount>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyWalletIsSynced>());
+        tests.push_back(std::make_unique<DiagnoseLib::CheckClientVersion>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyBoincPath>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyCPIDHasRAC>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyCPIDIsActive>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyCPIDValid>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyClock>());
+        tests.push_back(std::make_unique<DiagnoseLib::VerifyTCPPort>());
+        tests.push_back(std::make_unique<DiagnoseLib::CheckDifficulty>());
+        tests.push_back(std::make_unique<DiagnoseLib::CheckETTS>());
+
+        std::vector<DiagnosticResult> results;
+        results.reserve(tests.size());
+
+        for (auto& test : tests) {
+            test->runCheck();
+
+            DiagnosticResult result;
+            result.test_id = static_cast<int>(test->getTestName());
+            result.status = static_cast<int>(test->getResults());
+            result.result_string = ArgSubstitute(test->getResultsString(), test->getStringArgs());
+            result.tip_string = ArgSubstitute(test->getResultsTip(), test->getTipArgs());
+            results.push_back(std::move(result));
+        }
+
+        return results;
     }
 
     double getBlockDifficulty(uint32_t target_bits) override

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -30,11 +30,11 @@
 #include "rpc/server.h"
 #include "sync.h"
 #include "util.h"
+#include "util/strencodings.h"
 #include "wallet/diagnose.h"
 
 #include <univalue.h>
 
-#include <cctype>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -60,14 +60,16 @@ namespace {
 std::string ArgSubstitute(std::string text, const std::vector<std::string>& args)
 {
     for (const std::string& arg : args) {
-        // Find the lowest-numbered %N marker currently in the string.
+        // Find the lowest-numbered %N marker currently in the string. IsDigit()
+        // (util/strencodings.h) is used rather than std::isdigit, which is
+        // locale-dependent (banned by lint-locale-dependence.sh).
         int lowest = -1;
         for (size_t i = 0; i + 1 < text.size(); ++i) {
-            if (text[i] != '%' || !std::isdigit(static_cast<unsigned char>(text[i + 1]))) continue;
+            if (text[i] != '%' || !IsDigit(text[i + 1])) continue;
 
             size_t j = i + 1;
             int value = 0;
-            while (j < text.size() && std::isdigit(static_cast<unsigned char>(text[j]))) {
+            while (j < text.size() && IsDigit(text[j])) {
                 value = value * 10 + (text[j] - '0');
                 ++j;
             }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -10,6 +10,7 @@
 #include "gridcoin/scraper/scraper.h"
 #include "gridcoin/staking/difficulty.h"
 #include "gridcoin/superblock.h"
+#include "gridcoin/upgrade.h"
 #include "init.h"
 #include "interfaces/handler.h"
 #include "interfaces/init.h"
@@ -107,6 +108,22 @@ public:
     std::string getClientVersion() override { return FormatFullVersion(); }
 
     bool isTestNet() override { return OnTestnet(); }
+
+    LatestVersionInfo checkForLatestUpdate() override
+    {
+        LatestVersionInfo info;
+        GRC::Upgrade::UpgradeType upgrade_type = GRC::Upgrade::UpgradeType::Unknown;
+        GRC::Upgrade::CheckForLatestUpdate(info.version, info.details, upgrade_type, false);
+        // Lock the int contract carried in LatestVersionInfo::upgrade_type (and
+        // mirrored GUI-side by UpdateDialog::UpdateType) to the core enum.
+        static_assert(static_cast<int>(GRC::Upgrade::UpgradeType::Unknown) == 0
+                      && static_cast<int>(GRC::Upgrade::UpgradeType::Leisure) == 1
+                      && static_cast<int>(GRC::Upgrade::UpgradeType::Mandatory) == 2
+                      && static_cast<int>(GRC::Upgrade::UpgradeType::Unsupported) == 3,
+                      "LatestVersionInfo::upgrade_type int contract must match GRC::Upgrade::UpgradeType");
+        info.upgrade_type = static_cast<int>(upgrade_type);
+        return info;
+    }
 
     double getBlockDifficulty(uint32_t target_bits) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -109,6 +109,8 @@ public:
 
     bool isTestNet() override { return OnTestnet(); }
 
+    void startShutdown() override { StartShutdown(); }
+
     LatestVersionInfo checkForLatestUpdate() override
     {
         LatestVersionInfo info;

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -28,7 +28,6 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::NewPollReceivedSig> NewPollReceived;
     boost::signals2::signal<CClientUIInterface::NewVoteReceivedSig> NewVoteReceived;
     boost::signals2::signal<CClientUIInterface::NotifyScraperEventSig> NotifyScraperEvent;
-    boost::signals2::signal<CClientUIInterface::ThreadSafeHandleURISig> ThreadSafeHandleURI;
     boost::signals2::signal<CClientUIInterface::QueueShutdownSig> QueueShutdown;
     boost::signals2::signal<CClientUIInterface::TranslateSig> Translate;
     boost::signals2::signal<CClientUIInterface::NotifyBlocksChangedSig> NotifyBlocksChanged;
@@ -58,7 +57,6 @@ ADD_SIGNALS_IMPL_WRAPPER(PSGTPoolChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NewPollReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NewVoteReceived);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyScraperEvent);
-ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeHandleURI);
 ADD_SIGNALS_IMPL_WRAPPER(QueueShutdown);
 ADD_SIGNALS_IMPL_WRAPPER(Translate);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlocksChanged);
@@ -68,7 +66,6 @@ ADD_SIGNALS_IMPL_WRAPPER(MandatorySideStakeChanged);
 
 void CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
 void CClientUIInterface::UpdateMessageBox(const std::string& version, const int& update_type, const std::string& message) { return g_ui_signals.UpdateMessageBox(version, update_type, message); }
-void CClientUIInterface::ThreadSafeHandleURI(const std::string& strURI) { return g_ui_signals.ThreadSafeHandleURI(strURI); }
 void CClientUIInterface::InitMessage(const std::string &message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::QueueShutdown() { return g_ui_signals.QueueShutdown(); }
 std::string CClientUIInterface::Translate(const char* psz) { return g_ui_signals.Translate(psz).value_or(std::string(psz)); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -91,9 +91,6 @@ public:
     /** Update notification message box. */
     ADD_SIGNALS_DECL_WRAPPER(UpdateMessageBox, void, const std::string& version, const int& update_type, const std::string& message);
 
-    /** Handle a URL passed at the command line. */
-    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeHandleURI, void, const std::string& strURI);
-
     /** Progress message during initialization. */
     ADD_SIGNALS_DECL_WRAPPER(InitMessage, void, const std::string &message);
 

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -39,9 +39,12 @@ AboutDialog::AboutDialog(QWidget *parent) :
 
 void AboutDialog::setModel(ClientModel *model)
 {
+    // Set unconditionally so a teardown setModel(nullptr) clears the pointer
+    // rather than leaving it dangling at the previous model's node.
+    m_node = model ? &model->node() : nullptr;
+
     if(model)
     {
-        m_node = &model->node();
         ui->versionLabel->setText(model->formatFullVersion());
 
         // Wire the version-info / update-check button. Testnet status is read
@@ -74,6 +77,12 @@ void AboutDialog::on_buttonBox_accepted()
 
 void AboutDialog::handlePressVersionInfoButton()
 {
+    // No node (dialog shown before setModel(), or cleared at teardown): nothing
+    // to query. The captured pointer below must be non-null off the GUI thread.
+    if (!m_node) {
+        return;
+    }
+
     // CheckForLatestUpdate does a blocking libcurl GET of the GitHub release
     // JSON (up to a 10 s connect timeout). Run it off the GUI thread so a click
     // never freezes the UI. Guard against overlapping checks: a second click

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -3,6 +3,7 @@
 #include "ui_aboutdialog.h"
 #include "clientmodel.h"
 #include "updatedialog.h"
+#include "interfaces/node.h"
 #include "util.h"
 
 #include <QtConcurrent>
@@ -40,6 +41,7 @@ void AboutDialog::setModel(ClientModel *model)
 {
     if(model)
     {
+        m_node = &model->node();
         ui->versionLabel->setText(model->formatFullVersion());
 
         // Wire the version-info / update-check button. Testnet status is read
@@ -83,12 +85,9 @@ void AboutDialog::handlePressVersionInfoButton()
 
     ui->versionInfoButton->setDisabled(true);
 
-    m_version_check_watcher.setFuture(QtConcurrent::run([]() {
-        AboutVersionInfo info;
-        GRC::Upgrade::UpgradeType upgrade_type = GRC::Upgrade::UpgradeType::Unknown;
-        GRC::Upgrade::CheckForLatestUpdate(info.version, info.details, upgrade_type, false);
-        info.upgrade_type = static_cast<int>(upgrade_type);
-        return info;
+    m_version_check_watcher.setFuture(QtConcurrent::run([node = m_node]() {
+        interfaces::LatestVersionInfo latest = node->checkForLatestUpdate();
+        return AboutVersionInfo{latest.version, latest.details, latest.upgrade_type};
     }));
 }
 
@@ -107,7 +106,10 @@ void AboutDialog::versionCheckFinished()
 
     update_dialog.setWindowTitle("Gridcoin Version Information");
     update_dialog.setVersion(QString::fromStdString(info.version));
-    update_dialog.setUpgradeType(static_cast<GRC::Upgrade::UpgradeType>(info.upgrade_type));
+    // info.upgrade_type is an int carrying a GRC::Upgrade::UpgradeType value
+    // (from interfaces::Node::checkForLatestUpdate, which static_asserts the
+    // mapping node-side); UpdateDialog consumes it as its own UpdateType mirror.
+    update_dialog.setUpgradeType(info.upgrade_type);
     update_dialog.setDetails(QString::fromStdString(info.details));
     update_dialog.setModal(false);
 

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -10,6 +10,7 @@ namespace Ui {
     class AboutDialog;
 }
 class ClientModel;
+namespace interfaces { class Node; }
 
 /** "About" dialog box */
 class AboutDialog : public QDialog
@@ -34,6 +35,10 @@ private:
     };
 
     Ui::AboutDialog *ui;
+    //! Node settings/query surface; set in setModel(). Used off the GUI thread
+    //! for checkForLatestUpdate() -- process-lifetime, so capturing it in the
+    //! background worker is safe.
+    interfaces::Node* m_node = nullptr;
     //! Watches the background version-check fetch so the blocking libcurl GET
     //! never runs on the GUI thread.
     QFutureWatcher<AboutVersionInfo> m_version_check_watcher;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -352,11 +352,6 @@ int main(int argc, char *argv[])
     // Install global event filter that suppresses help context question mark
     app.installEventFilter(new GUIUtil::WindowContextHelpButtonHintFilter(&app));
 
-#if defined(WIN32)
-    // Install global event filter for processing Windows session related Windows messages (WM_QUERYENDSESSION and WM_ENDSESSION)
-    app.installNativeEventFilter(new WinShutdownMonitor());
-#endif
-
     // The sidestake registry interface backs the OptionsModel's sidestake table
     // model (Phase 1d-ii). Created here, before optionsModel, so it outlives it
     // (reverse destruction order). It wraps the global registry, so it needs no
@@ -370,6 +365,14 @@ int main(int argc, char *argv[])
     // so it is safe to construct before core init -- OptionsModel only reads/writes
     // settings through it later (dialog open, migrateCoreSettings()).
     std::unique_ptr<interfaces::Node> gui_node = gui_init->makeNode();
+
+#if defined(WIN32)
+    // Install global event filter for processing Windows session related Windows
+    // messages (WM_QUERYENDSESSION and WM_ENDSESSION). Placed after gui_node so
+    // the monitor can request shutdown through the node interface; installing it
+    // here (still well before app.exec()) is soon enough to catch session-end.
+    app.installNativeEventFilter(new WinShutdownMonitor(*gui_node));
+#endif
 
     // Load the optionsModel. This has to be loaded before the translations, because the language selection is
     // a setting that can be stored in options.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -549,7 +549,6 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
 
     // Subscribe to global signals from core
     uiInterface.ThreadSafeMessageBox_connect(ThreadSafeMessageBox);
-    uiInterface.ThreadSafeHandleURI_connect(ThreadSafeHandleURI);
     uiInterface.InitMessage_connect(InitMessage);
     uiInterface.QueueShutdown_connect(QueueShutdown);
     uiInterface.Translate_connect(Translate);
@@ -711,7 +710,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 }
 
                 // Place this here as guiref has to be defined if we don't want to lose URIs
-                ipcInit(argc, argv);
+                ipcInit(argc, argv, ThreadSafeHandleURI);
 
 #if defined(WIN32) && defined(QT_GUI)
                 WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("%1 didn't yet exit safely...").arg(QObject::tr(PACKAGE_NAME)), (HWND)window.winId());

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -833,6 +833,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
         connect(m_mask_values_action, &QAction::toggled, this, &BitcoinGUI::setPrivacy);
 
         rpcConsole->setClientModel(clientModel);
+        diagnosticsDialog->setClientModel(clientModel);
         addressBookPage->setOptionsModel(clientModel->getOptionsModel());
         receiveCoinsPage->setOptionsModel(clientModel->getOptionsModel());
         votingPage->setOptionsModel(clientModel->getOptionsModel());
@@ -847,8 +848,9 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
     {
         // Shutdown teardown: propagate the cleared model so the RPC console
         // stops its executor thread before the interfaces::Node it references
-        // is destroyed.
+        // is destroyed. The diagnostics dialog likewise drops its node pointer.
         rpcConsole->setClientModel(nullptr);
+        diagnosticsDialog->setClientModel(nullptr);
     }
 }
 
@@ -1244,7 +1246,7 @@ void BitcoinGUI::update(const QString &title, const QString& version, const int&
 
     updateMessageDialog->setWindowTitle(title);
     updateMessageDialog->setVersion(version);
-    updateMessageDialog->setUpgradeType(static_cast<GRC::Upgrade::UpgradeType>(upgrade_type));
+    updateMessageDialog->setUpgradeType(upgrade_type);
     updateMessageDialog->setDetails(message);
     updateMessageDialog->setModal(false);
 

--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -7,7 +7,7 @@
 #include "qt/transactiontablemodel.h"
 #include "qt/walletmodel.h"
 #include "interfaces/wallet_tx_source.h"
-#include "util/system.h"
+#include "optionsmodel.h" // For getOptionsModel()->getShowOrphans().
 
 #include <QTimer>
 
@@ -55,7 +55,7 @@ DetailedTxModel::DetailedTxModel(WalletModel* walletModel, QObject* parent)
     // runtime input is -showorphans, read once here (a launch-time arg with no
     // runtime mutation path, behavior-identical to reading it repeatedly).
     GRC::FilterSpec spec;
-    spec.show_orphans = gArgs.GetBoolArg("-showorphans", false);
+    spec.show_orphans = m_walletModel->getOptionsModel()->getShowOrphans();
     interfaces::WalletTxSource& store = m_walletModel->txSource();
     store.registerView(GRC::VIEW_DETAILED, spec, GRC::TXCOL_DATE, GRC::TXSORT_DESC);
 

--- a/src/qt/diagnosticsdialog.cpp
+++ b/src/qt/diagnosticsdialog.cpp
@@ -3,13 +3,33 @@
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
 #include "diagnosticsdialog.h"
+#include "interfaces/node.h"
+#include "qt/clientmodel.h"
 #include "qt/guilog.h"
 #include "qt/forms/ui_diagnosticsdialog.h"
 #include "qt/decoration.h"
 #include "qt/researcher/researchermodel.h"
 
-#include <numeric>
-#include <type_traits>
+#include <QCoreApplication>
+
+#include <algorithm>
+
+namespace {
+//! Map a node-side diagnostic status (interfaces::DiagnosticStatus raw value) to
+//! the dialog's display result. The node runs the tests; the dialog only renders
+//! the outcome.
+DiagnosticsDialog::DiagnosticResult MapStatus(int status)
+{
+    switch (static_cast<interfaces::DiagnosticStatus>(status)) {
+    case interfaces::DiagnosticStatus::FAIL:    return DiagnosticsDialog::failed;
+    case interfaces::DiagnosticStatus::WARNING: return DiagnosticsDialog::warning;
+    case interfaces::DiagnosticStatus::PASS:    return DiagnosticsDialog::passed;
+    case interfaces::DiagnosticStatus::NONE:    return DiagnosticsDialog::NA;
+    }
+
+    return DiagnosticsDialog::NA;
+}
+} // anonymous namespace
 
 DiagnosticsDialog::DiagnosticsDialog(QWidget *parent, ResearcherModel* researcher_model) :
     QDialog(parent),
@@ -24,38 +44,45 @@ DiagnosticsDialog::DiagnosticsDialog(QWidget *parent, ResearcherModel* researche
     GRC::ScaleFontPointSize(ui->overallResultLabel, 12);
     GRC::ScaleFontPointSize(ui->overallResultResultLabel, 12);
 
-    // Construct the tests needed.
-    // If need to add a test m just add it to the below set.
-    // Check Diagnose.h for the base class to create tests.
-    diagnoseTestInsertInSet(ui->checkConnectionCountResultLabel,
-                            std::make_unique<DiagnoseLib::CheckConnectionCount>());
-    diagnoseTestInsertInSet(ui->checkOutboundConnectionCountResultLabel,
-                            std::make_unique<DiagnoseLib::CheckOutboundConnectionCount>());
-    diagnoseTestInsertInSet(ui->verifyWalletIsSyncedResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyWalletIsSynced>());
-    diagnoseTestInsertInSet(ui->verifyClockResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyClock>());
-    diagnoseTestInsertInSet(ui->checkClientVersionResultLabel,
-                            std::make_unique<DiagnoseLib::CheckClientVersion>());
-    diagnoseTestInsertInSet(ui->verifyBoincPathResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyBoincPath>());
-    diagnoseTestInsertInSet(ui->verifyCPIDValidResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyCPIDValid>());
-    diagnoseTestInsertInSet(ui->verifyCPIDHasRACResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyCPIDHasRAC>());
-    diagnoseTestInsertInSet(ui->verifyCPIDIsActiveResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyCPIDIsActive>());
-    diagnoseTestInsertInSet(ui->verifyTCPPortResultLabel,
-                            std::make_unique<DiagnoseLib::VerifyTCPPort>());
-    diagnoseTestInsertInSet(ui->checkDifficultyResultLabel,
-                            std::make_unique<DiagnoseLib::CheckDifficulty>());
-    diagnoseTestInsertInSet(ui->checkETTSResultLabel,
-                            std::make_unique<DiagnoseLib::CheckETTS>());
+    // Associate each result-row label with the test whose outcome it displays.
+    // The tests themselves run in the node (interfaces::Node::runDiagnostics);
+    // the dialog keys on the interfaces::DiagnosticTest id carried back in each
+    // interfaces::DiagnosticResult. If a test is added, add its row here and bump
+    // m_number_of_tests.
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::CheckConnectionCount)] =
+        ui->checkConnectionCountResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::CheckOutboundConnectionCount)] =
+        ui->checkOutboundConnectionCountResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyWalletIsSynced)] =
+        ui->verifyWalletIsSyncedResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyClock)] =
+        ui->verifyClockResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::CheckClientVersion)] =
+        ui->checkClientVersionResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyBoincPath)] =
+        ui->verifyBoincPathResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyCPIDValid)] =
+        ui->verifyCPIDValidResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyCPIDHasRAC)] =
+        ui->verifyCPIDHasRACResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyCPIDIsActive)] =
+        ui->verifyCPIDIsActiveResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::VerifyTCPPort)] =
+        ui->verifyTCPPortResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::CheckDifficulty)] =
+        ui->checkDifficultyResultLabel;
+    m_test_labels[static_cast<int>(interfaces::DiagnosticTest::CheckETTS)] =
+        ui->checkETTSResultLabel;
 }
 
 DiagnosticsDialog::~DiagnosticsDialog()
 {
     delete ui;
+}
+
+void DiagnosticsDialog::setClientModel(ClientModel* client_model)
+{
+    m_node = client_model ? &client_model->node() : nullptr;
 }
 
 void DiagnosticsDialog::SetResearcherModel(ResearcherModel *researcherModel)
@@ -105,8 +132,6 @@ void DiagnosticsDialog::SetResultLabel(QLabel *label, DiagnosticTestStatus test_
 
 unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
 {
-    LOCK(cs_diagnostictests);
-
     unsigned int pending_count = 0;
 
     for (const auto& entry : m_test_status_map)
@@ -117,11 +142,9 @@ unsigned int DiagnosticsDialog::GetNumberOfTestsPending()
     return pending_count;
 }
 
-DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(DiagnoseLib::Diagnose::TestNames test_name)
+DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(int test_id)
 {
-    LOCK(cs_diagnostictests);
-
-    auto entry = m_test_status_map.find(test_name);
+    auto entry = m_test_status_map.find(test_id);
 
     if (entry != m_test_status_map.end())
     {
@@ -133,37 +156,31 @@ DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetTestStatus(Diagnos
     }
 }
 
-unsigned int DiagnosticsDialog::UpdateTestStatus(DiagnoseLib::Diagnose::TestNames test_name, QLabel *label,
+unsigned int DiagnosticsDialog::UpdateTestStatus(int test_id, QLabel *label,
                                                  DiagnosticTestStatus test_status, DiagnosticResult test_result,
                                                  QString override_text, QString tooltip_text)
 {
-    LOCK(cs_diagnostictests);
-
-    m_test_status_map[test_name] = test_status;
+    m_test_status_map[test_id] = test_status;
 
     SetResultLabel(label, test_status, test_result, override_text, tooltip_text);
 
-    UpdateTestResult(test_name, test_result);
+    UpdateTestResult(test_id, test_result);
 
     UpdateOverallDiagnosticResult(test_result);
 
     return m_test_status_map.size();
 }
 
-void DiagnosticsDialog::UpdateTestResult(DiagnoseLib::Diagnose::TestNames test_name, DiagnosticResult test_result)
+void DiagnosticsDialog::UpdateTestResult(int test_id, DiagnosticResult test_result)
 {
-    LOCK(cs_diagnostictests);
-
-    m_test_result_map[test_name] = test_result;
+    m_test_result_map[test_id] = test_result;
 }
 
-DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetTestResult(DiagnoseLib::Diagnose::TestNames test_name)
+DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetTestResult(int test_id)
 {
-    LOCK(cs_diagnostictests);
-
     DiagnosticResult result;
 
-    auto iter = m_test_result_map.find(test_name);
+    auto iter = m_test_result_map.find(test_id);
 
     if (iter == m_test_result_map.end()) {
         result = NA;
@@ -176,8 +193,6 @@ DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetTestResult(DiagnoseLib
 
 void DiagnosticsDialog::ResetOverallDiagnosticResult()
 {
-    LOCK(cs_diagnostictests);
-
     m_test_status_map.clear();
     m_test_result_map.clear();
 
@@ -188,9 +203,7 @@ void DiagnosticsDialog::ResetOverallDiagnosticResult()
 
 void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in)
 {
-    LOCK(cs_diagnostictests);
-
-    // Set diagnostic_result_status to completed. This is under lock, so no one can snoop.
+    // Set diagnostic_result_status to completed.
     m_overall_diagnostic_result_status = completed;
 
     // If the total number of registered tests is less than the initialized number, then
@@ -218,13 +231,11 @@ void DiagnosticsDialog::UpdateOverallDiagnosticResult(DiagnosticResult diagnosti
     }
 }
 
-// Lock should be taken on cs_diagnostictests before calling this function.
 DiagnosticsDialog::DiagnosticResult DiagnosticsDialog::GetOverallDiagnosticResult()
 {
     return m_overall_diagnostic_result;
 }
 
-// Lock should be taken on cs_diagnostictests before calling this function.
 DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetOverallDiagnosticStatus()
 {
     return m_overall_diagnostic_result_status;
@@ -233,8 +244,6 @@ DiagnosticsDialog::DiagnosticTestStatus DiagnosticsDialog::GetOverallDiagnosticS
 
 void DiagnosticsDialog::DisplayOverallDiagnosticResult()
 {
-    LOCK(cs_diagnostictests);
-
     DiagnosticsDialog::DiagnosticTestStatus overall_diagnostic_status = GetOverallDiagnosticStatus();
     DiagnosticsDialog::DiagnosticResult overall_diagnostic_result = GetOverallDiagnosticResult();
 
@@ -276,37 +285,26 @@ void DiagnosticsDialog::on_testButton_clicked()
         return;
     }
 
+    if (!m_node) return;
+
     ResetOverallDiagnosticResult();
+
+    // Show every row as pending, then let the event loop paint before the
+    // blocking node call. runDiagnostics() runs all tests (including the NTP and
+    // TCP-port network probes) and can take several seconds.
+    for (const auto& [test_id, label] : m_test_labels) {
+        UpdateTestStatus(test_id, label, pending, NA);
+    }
     DisplayOverallDiagnosticResult();
+    QCoreApplication::processEvents();
 
-    DiagnoseLib::Diagnose::setResearcherModel();
+    for (const interfaces::DiagnosticResult& result : m_node->runDiagnostics()) {
+        auto entry = m_test_labels.find(result.test_id);
+        if (entry == m_test_labels.end()) continue;
 
-    for (auto& i : m_diagnostic_tests) {
-        auto& diagnose_test = i.second;
-        auto diagnoselabel = i.first;
-        UpdateTestStatus(i.second->getTestName(), diagnoselabel, pending, NA);
-        diagnose_test->runCheck();
-        QString tooltip = tr(diagnose_test->getResultsTip().c_str());
-        QString resultString = tr(diagnose_test->getResultsString().c_str());
-        for (auto& j : diagnose_test->getStringArgs()) {
-            resultString = resultString.arg(QString::fromStdString(j));
-        }
-        for (auto& j : diagnose_test->getTipArgs()) {
-            tooltip = tooltip.arg(QString::fromStdString(j));
-        }
-
-        if (diagnose_test->getResults() == DiagnoseLib::Diagnose::NONE) {
-            UpdateTestStatus(i.second->getTestName(), diagnoselabel, completed, NA);
-        } else if (diagnose_test->getResults() == DiagnoseLib::Diagnose::FAIL) {
-            UpdateTestStatus(i.second->getTestName(), diagnoselabel, completed, failed,
-                             resultString, tooltip);
-        } else if (diagnose_test->getResults() == DiagnoseLib::Diagnose::WARNING) {
-            UpdateTestStatus(i.second->getTestName(), diagnoselabel, completed, warning,
-                             resultString, tooltip);
-        } else {
-            UpdateTestStatus(i.second->getTestName(), diagnoselabel, completed, passed,
-                             resultString);
-        }
+        UpdateTestStatus(result.test_id, entry->second, completed, MapStatus(result.status),
+                         QString::fromStdString(result.result_string),
+                         QString::fromStdString(result.tip_string));
     }
 
     DisplayOverallDiagnosticResult();

--- a/src/qt/diagnosticsdialog.h
+++ b/src/qt/diagnosticsdialog.h
@@ -6,20 +6,17 @@
 #define BITCOIN_QT_DIAGNOSTICSDIALOG_H
 
 #include <QDialog>
-#include <QtNetwork/QTcpSocket>
-#include <QtNetwork/QUdpSocket>
 #include <QtWidgets/QLabel>
 
 #include <string>
 #include <unordered_map>
 
-#include "sync.h"
-#include <set>
-#include <vector>
-#include <memory>
-#include "wallet/diagnose.h"
-
+class ClientModel;
 class ResearcherModel;
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
 
 namespace Ui {
 class DiagnosticsDialog;
@@ -50,14 +47,12 @@ public:
 
 private:
     Ui::DiagnosticsDialog *ui;
-    void GetData();
 
-    typedef std::set<std::pair<QLabel*, std::unique_ptr<DiagnoseLib::Diagnose>>> DiagnoseLabelTestPtr_set;
-    //Set the contains a pair <Label of the diagnose, Pointer to TestClass>
-    DiagnoseLabelTestPtr_set m_diagnostic_tests;
-
-    // Because some of the tests are "spurs", this object is multithreaded
-    CCriticalSection cs_diagnostictests;
+    //! Maps each diagnostic test (interfaces::DiagnosticTest raw value, matching
+    //! the test_id carried in interfaces::DiagnosticResult) to its result row
+    //! label. Built once at construction; the node owns the tests now, so the
+    //! dialog holds only display state.
+    std::unordered_map<int, QLabel*> m_test_labels;
 
     // Holds the overall result of all diagnostic tests
     DiagnosticResult m_overall_diagnostic_result;
@@ -72,28 +67,30 @@ private:
     // Boolean to indicate researcher mode.
     bool m_researcher_mode = true;
 
-    // Holds the test status and result entries
-    typedef std::unordered_map<DiagnoseLib::Diagnose::TestNames, DiagnosticTestStatus> DiagnosticTestStatus_map;
-    typedef std::unordered_map<DiagnoseLib::Diagnose::TestNames, DiagnosticResult> DiagnosticTestResult_map;
+    // Holds the test status and result entries, keyed by test_id.
+    typedef std::unordered_map<int, DiagnosticTestStatus> DiagnosticTestStatus_map;
+    typedef std::unordered_map<int, DiagnosticResult> DiagnosticTestResult_map;
     DiagnosticTestStatus_map m_test_status_map;
     DiagnosticTestResult_map m_test_result_map;
 
     ResearcherModel *m_researcher_model;
 
-    QUdpSocket *m_udpSocket;
-    QTcpSocket *m_tcpSocket;
+    //! The node interface used to run the diagnostics. Set via setClientModel()
+    //! from the client model's node(); the tests execute in the node.
+    interfaces::Node* m_node = nullptr;
 
 public:
+    void setClientModel(ClientModel* client_model);
     void SetResearcherModel(ResearcherModel *researcherModel);
     unsigned int GetNumberOfTestsPending();
-    unsigned int UpdateTestStatus(DiagnoseLib::Diagnose::TestNames test_name, QLabel *label,
+    unsigned int UpdateTestStatus(int test_id, QLabel *label,
                                   DiagnosticTestStatus test_status, DiagnosticResult test_result,
                                   QString override_text = QString(), QString tooltip_text = QString());
-    DiagnosticTestStatus GetTestStatus(DiagnoseLib::Diagnose::TestNames test_name);
-    void UpdateTestResult(DiagnoseLib::Diagnose::TestNames test_name, DiagnosticResult test_result);
+    DiagnosticTestStatus GetTestStatus(int test_id);
+    void UpdateTestResult(int test_id, DiagnosticResult test_result);
     void ResetOverallDiagnosticResult();
     void UpdateOverallDiagnosticResult(DiagnosticResult diagnostic_result_in);
-    DiagnosticResult GetTestResult(DiagnoseLib::Diagnose::TestNames test_name);
+    DiagnosticResult GetTestResult(int test_id);
     DiagnosticResult GetOverallDiagnosticResult();
     DiagnosticTestStatus GetOverallDiagnosticStatus();
     void DisplayOverallDiagnosticResult();
@@ -102,11 +99,6 @@ private:
     void SetResultLabel(QLabel *label, DiagnosticTestStatus test_status,
                         DiagnosticResult test_result, QString override_text = QString(),
                         QString tooltip_text = QString());
-    void diagnoseTestInsertInSet(QLabel* label, std::unique_ptr<DiagnoseLib::Diagnose>&& test){
-        auto labeltestpair = std::make_pair(label , std::move(test));
-        m_diagnostic_tests.insert(std::move(labeltestpair));
-    }
-
 
 private slots:
     void on_testButton_clicked();

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -8,7 +8,7 @@
 #include "monitoreddatamapper.h"
 #include "optionsmodel.h"
 #include "qt/decoration.h"
-#include "miner.h"
+#include "amount.h" // For MIN_STAKE_SPLIT_VALUE_GRC.
 #include "sidestaketablemodel.h"
 #include "editsidestakedialog.h"
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -438,6 +438,14 @@ bool OptionsModel::getSuppressNetworkGraph()
     return gArgs.GetArg("-suppressnetworkgraph", "false") == "true";
 }
 
+bool OptionsModel::getShowOrphans()
+{
+    // Routed through the node settings surface (equivalent to the former
+    // gArgs.GetBoolArg("-showorphans", false)) so the transaction models can
+    // read it without a direct util/system.h include.
+    return m_node.getSettingBool("showorphans", false);
+}
+
 bool OptionsModel::getMaskValues()
 {
     return fMaskValues;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -8,7 +8,7 @@
 #include "interfaces/node.h"
 #include "util/strencodings.h" // For SplitHostPort (IPv6-aware host:port parsing).
 
-#include "miner.h"
+#include "amount.h" // For MIN_STAKE_SPLIT_VALUE_GRC.
 
 #include <utility>
 
@@ -403,11 +403,6 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
     emit dataChanged(index, index);
 
     return successful;
-}
-
-qint64 OptionsModel::getTransactionFee()
-{
-    return nTransactionFee;
 }
 
 qint64 OptionsModel::getReserveBalance()

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -93,6 +93,10 @@ public:
     bool getLimitTxnDisplay();
     bool getSuppressNetworkGraph();
     bool getMaskValues();
+    //! Whether stale (orphaned) coinstake txns are shown in the transaction
+    //! list (-showorphans). Read through the node settings interface so the tx
+    //! models need not include util/system.h to reach gArgs.
+    bool getShowOrphans();
     QDate getLimitTxnDate();
     int64_t getLimitTxnDateTime();
     double getPollExpireNotification();

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -75,7 +75,6 @@ public:
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
 
     /* Explicit getters */
-    qint64 getTransactionFee();
     qint64 getReserveBalance();
     //! Whether the node is on testnet, read through the node interface
     //! (interfaces::Node::isTestNet). Lets dialogs that hold an OptionsModel gate

--- a/src/qt/qtipcserver.cpp
+++ b/src/qt/qtipcserver.cpp
@@ -5,10 +5,11 @@
 #include "qtipcserver.h"
 #include "qt/guilog.h"
 #include "guiconstants.h"
-#include "node/ui_interface.h"
 #include "util.h"
 
 #include <atomic>
+#include <functional>
+#include <string>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -27,7 +28,7 @@ using namespace boost::posix_time;
 // URI handling not implemented on OSX yet
 
 void ipcScanRelay(int argc, char *argv[]) { }
-void ipcInit(int argc, char *argv[]) { }
+void ipcInit(int argc, char *argv[], std::function<void(const std::string&)> uri_handler) { }
 void ipcShutdown() { }
 
 #else
@@ -38,6 +39,13 @@ void ipcShutdown() { }
 //! -- the URI server is owned by this GUI process, so its exit is gated on the
 //! GUI quitting, never on core teardown state.
 static std::atomic<bool> g_ipc_shutdown{false};
+
+//! GUI-supplied handler invoked with each received "gridcoin:" URI. Set by
+//! ipcInit() before the listener thread starts and only read afterwards (the
+//! thread is joined via g_ipc_shutdown before the GUI tears down), so no
+//! additional synchronization is needed. Replaces the former
+//! uiInterface.ThreadSafeHandleURI signal dispatch.
+static std::function<void(const std::string&)> g_uri_handler;
 
 void ipcShutdown()
 {
@@ -113,7 +121,8 @@ static void ipcThread2(void* pArg)
         ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(100);
         if (mq->timed_receive(&buffer, sizeof(buffer), nSize, nPriority, d))
         {
-            uiInterface.ThreadSafeHandleURI(std::string(buffer, nSize));
+            if (g_uri_handler)
+                g_uri_handler(std::string(buffer, nSize));
             UninterruptibleSleep(std::chrono::seconds{1});
         }
 
@@ -127,8 +136,10 @@ static void ipcThread2(void* pArg)
     delete mq;
 }
 
-void ipcInit(int argc, char *argv[])
+void ipcInit(int argc, char *argv[], std::function<void(const std::string&)> uri_handler)
 {
+    g_uri_handler = std::move(uri_handler);
+
     message_queue* mq = nullptr;
     char buffer[MAX_URI_LENGTH + 1] = "";
     size_t nSize = 0;
@@ -143,7 +154,8 @@ void ipcInit(int argc, char *argv[])
             ptime d = boost::posix_time::microsec_clock::universal_time() + millisec(1);
             if (mq->timed_receive(&buffer, sizeof(buffer), nSize, nPriority, d))
             {
-                uiInterface.ThreadSafeHandleURI(std::string(buffer, nSize));
+                if (g_uri_handler)
+                    g_uri_handler(std::string(buffer, nSize));
             }
             else
                 break;

--- a/src/qt/qtipcserver.h
+++ b/src/qt/qtipcserver.h
@@ -1,11 +1,21 @@
 #ifndef BITCOIN_QT_QTIPCSERVER_H
 #define BITCOIN_QT_QTIPCSERVER_H
 
+#include <functional>
+#include <string>
+
 // Define Gridcoin-Qt message queue name
 #define BITCOINURI_QUEUE_NAME "GridcoinURI"
 
 void ipcScanRelay(int argc, char *argv[]);
-void ipcInit(int argc, char *argv[]);
+
+//! Start the URI-listener thread. \p uri_handler is invoked (on the listener
+//! thread) with each "gridcoin:" URI received from another instance; the GUI
+//! composition root supplies a handler that marshals the URI onto the GUI
+//! thread. Passing the handler in directly replaces the former core
+//! uiInterface.ThreadSafeHandleURI signal round-trip -- URI dispatch is entirely
+//! within this GUI process, so it needs no core boundary.
+void ipcInit(int argc, char *argv[], std::function<void(const std::string&)> uri_handler);
 
 //! Signal the URI-listener thread started by ipcInit() to exit. Called from the
 //! GUI composition root once the Qt event loop has returned. This is a

--- a/src/qt/researcher/researcherwizardpoolpage.cpp
+++ b/src/qt/researcher/researcherwizardpoolpage.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <key_io.h>
-#include "key.h"
 #include "qt/decoration.h"
 #include "qt/forms/ui_researcherwizardpoolpage.h"
 #include "qt/guiutil.h"
@@ -105,15 +103,14 @@ void ResearcherWizardPoolPage::getNewAddress()
         return;
     }
 
-    CPubKey public_key;
+    const QString address = m_wallet_model->getNewReceiveAddress(label);
 
-    if (!m_wallet_model->getKeyFromPool(public_key, label.toStdString())) {
+    if (address.isEmpty()) {
         ui->addressLabel->setText(tr("Error: failed to generate a new address."));
         return;
     }
 
-    ui->addressLabel->setText(
-        QString::fromStdString(EncodeDestination(public_key.GetID())));
+    ui->addressLabel->setText(address);
     ui->copyToClipboardButton->setVisible(true);
 }
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -14,7 +14,6 @@
 #include "optionsmodel.h"
 #include "guiutil.h"
 #include "qt/decoration.h"
-#include "util/system.h"
 
 #include <algorithm>
 #include <limits>
@@ -215,7 +214,7 @@ void TransactionView::setModel(WalletModel *model)
         // local filter spec's -showorphans gate to match the model's registered
         // spec so the first widget-driven applyFilter() does not drop it.
         m_filterSpec = GRC::FilterSpec();
-        m_filterSpec.show_orphans = gArgs.GetBoolArg("-showorphans", false);
+        m_filterSpec.show_orphans = model->getOptionsModel()->getShowOrphans();
 
         m_detailedModel = new DetailedTxModel(model, this);
 

--- a/src/qt/updatedialog.cpp
+++ b/src/qt/updatedialog.cpp
@@ -48,7 +48,11 @@ void UpdateDialog::setUpgradeType(int upgrade_type)
     case UpdateType::Leisure:
         ui->infoIcon->setPixmap(GRC::ScaleIcon(this, info_icon, 48));
         break;
-    case UpdateType::Unknown:
+    default:
+        // UpdateType::Unknown and any unexpected int (future enum value / corrupt
+        // input): show the unknown icon rather than leaving it unset. Unknown is
+        // handled here rather than as its own case so the switch keeps a default
+        // without tripping -Wcovered-switch-default.
         ui->infoIcon->setPixmap(GRC::ScaleIcon(this, unknown_icon, 48));
         break;
     }

--- a/src/qt/updatedialog.cpp
+++ b/src/qt/updatedialog.cpp
@@ -33,22 +33,22 @@ void UpdateDialog::setDetails(QString message)
     ui->versionDetails->setText(message);
 }
 
-void UpdateDialog::setUpgradeType(GRC::Upgrade::UpgradeType upgrade_type)
+void UpdateDialog::setUpgradeType(int upgrade_type)
 {
     QIcon info_icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation);
     QIcon warning_icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
     QIcon unknown_icon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxQuestion);
 
-    switch (upgrade_type) {
-    case GRC::Upgrade::UpgradeType::Mandatory:
+    switch (static_cast<UpdateType>(upgrade_type)) {
+    case UpdateType::Mandatory:
         [[fallthrough]];
-    case GRC::Upgrade::UpgradeType::Unsupported:
+    case UpdateType::Unsupported:
         ui->infoIcon->setPixmap(GRC::ScaleIcon(this, warning_icon, 48));
         break;
-    case GRC::Upgrade::UpgradeType::Leisure:
+    case UpdateType::Leisure:
         ui->infoIcon->setPixmap(GRC::ScaleIcon(this, info_icon, 48));
         break;
-    case GRC::Upgrade::Unknown:
+    case UpdateType::Unknown:
         ui->infoIcon->setPixmap(GRC::ScaleIcon(this, unknown_icon, 48));
         break;
     }

--- a/src/qt/updatedialog.h
+++ b/src/qt/updatedialog.h
@@ -5,12 +5,23 @@
 #ifndef BITCOIN_QT_UPDATEDIALOG_H
 #define BITCOIN_QT_UPDATEDIALOG_H
 
-#include "gridcoin/upgrade.h"
 #include <QDialog>
 
 namespace Ui {
 class UpdateDialog;
 }
+
+//! GUI-local mirror of GRC::Upgrade::UpgradeType. The value is transported as a
+//! plain int across the About dialog's QtConcurrent boundary (aboutdialog.cpp
+//! stamps static_cast<int>(GRC::Upgrade::UpgradeType)), so this dialog need not
+//! include gridcoin/upgrade.h. The enumerator values MUST stay in sync with
+//! GRC::Upgrade::UpgradeType; aboutdialog.cpp static_asserts that they do.
+enum class UpdateType {
+    Unknown = 0,
+    Leisure = 1,
+    Mandatory = 2,
+    Unsupported = 3,
+};
 
 class UpdateDialog : public QDialog
 {
@@ -22,7 +33,8 @@ public:
 
     void setVersion(QString version);
     void setDetails(QString message);
-    void setUpgradeType(GRC::Upgrade::UpgradeType upgrade_type);
+    //! \p upgrade_type is a UpdateType value passed as int (see the enum note).
+    void setUpgradeType(int upgrade_type);
 
 private:
     Ui::UpdateDialog *ui;

--- a/src/qt/updatedialog.h
+++ b/src/qt/updatedialog.h
@@ -11,11 +11,12 @@ namespace Ui {
 class UpdateDialog;
 }
 
-//! GUI-local mirror of GRC::Upgrade::UpgradeType. The value is transported as a
-//! plain int across the About dialog's QtConcurrent boundary (aboutdialog.cpp
-//! stamps static_cast<int>(GRC::Upgrade::UpgradeType)), so this dialog need not
-//! include gridcoin/upgrade.h. The enumerator values MUST stay in sync with
-//! GRC::Upgrade::UpgradeType; aboutdialog.cpp static_asserts that they do.
+//! GUI-local mirror of GRC::Upgrade::UpgradeType. The value is carried as a plain
+//! int in interfaces::LatestVersionInfo::upgrade_type, which the About dialog
+//! obtains from interfaces::Node::checkForLatestUpdate() and passes here, so this
+//! dialog need not include gridcoin/upgrade.h. The enumerator values MUST stay in
+//! sync with GRC::Upgrade::UpgradeType; src/node/interfaces.cpp static_asserts
+//! that they do.
 enum class UpdateType {
     Unknown = 0,
     Leisure = 1,

--- a/src/qt/voting/additionalfieldstablemodel.cpp
+++ b/src/qt/voting/additionalfieldstablemodel.cpp
@@ -8,8 +8,6 @@
 
 #include <QStringList>
 
-using namespace GRC;
-
 namespace {
 class AdditionalFieldsTableDataModel : public QAbstractTableModel
 {

--- a/src/qt/voting/poll_types.cpp
+++ b/src/qt/voting/poll_types.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "gridcoin/voting/poll.h"
+#include "interfaces/voting.h"
 #include "qt/voting/poll_types.h"
 
 #include <QCoreApplication>
@@ -11,26 +11,23 @@
 // Class: PollTypes
 // -----------------------------------------------------------------------------
 
-PollTypes::PollTypes()
+PollTypes::PollTypes(const std::vector<interfaces::PollTypeMeta>& types)
 {
-    // Load from core Poll class. Note we do not use PollPayload::GetValidPollTypes, because with poll v2 the UI supported
-    // the other poll types from a user perspective, but in fact only submitted the polls as "SURVEY" in the core.
-    // GetValidPollTypes will only return SURVEY for v2, so it is not appropriate to use here.
-    //
-    // I am not particularly fond of how this is crosswired into the GUI code here, but it will suffice for now.
-    // TODO: refactor poll types between core and UI.
-    for (const auto& type : GRC::Poll::POLL_TYPES) {
-        if (type == GRC::PollType::OUT_OF_BOUND) continue;
-
+    // The node resolves the poll-type metadata (name, description, minimum
+    // duration and required fields) from the core Poll tables and hands it over
+    // as value rows in enum order (OUT_OF_BOUND already dropped), so the GUI no
+    // longer reaches into gridcoin/voting/poll.h. Note that pre-v3 the UI still
+    // presents every type even though the core only submits SURVEY; the node
+    // side preserves that by returning the full type list here.
+    for (const interfaces::PollTypeMeta& type : types) {
         emplace_back();
-        // Note that these use the default value for the translated boolean, which is true.
-        back().m_name = QString::fromStdString(GRC::Poll::PollTypeToString(type));
-        back().m_description = QString::fromStdString(GRC::Poll::PollTypeToDescString(type));
-        back().m_min_duration_days = GRC::Poll::POLL_TYPE_RULES[(int) type].m_mininum_duration;
+        back().m_name = QString::fromStdString(type.name);
+        back().m_description = QString::fromStdString(type.description);
+        back().m_min_duration_days = type.min_duration_days;
 
         std::vector<QString> required_fields;
-        for (const auto& iter : GRC::Poll::POLL_TYPE_RULES[(int) type].m_required_fields) {
-            required_fields.push_back(QString::fromStdString(iter));
+        for (const auto& field : type.required_fields) {
+            required_fields.push_back(QString::fromStdString(field));
         }
 
         back().m_required_fields = required_fields;

--- a/src/qt/voting/poll_types.h
+++ b/src/qt/voting/poll_types.h
@@ -8,6 +8,10 @@
 #include <QString>
 #include <vector>
 
+namespace interfaces {
+struct PollTypeMeta;
+} // namespace interfaces
+
 class PollTypeItem
 {
 public:
@@ -20,7 +24,10 @@ public:
 class PollTypes : public std::vector<PollTypeItem>
 {
 public:
-    PollTypes();
+    //! Build the GUI poll-type rows from the node-side poll-type metadata
+    //! (interfaces::VotingManager::getPollTypes()), preserving enum order so the
+    //! wizard's button ids still index the PollType raw values.
+    explicit PollTypes(const std::vector<interfaces::PollTypeMeta>& types);
 };
 
 #endif // GRIDCOIN_QT_VOTING_POLL_TYPES_H

--- a/src/qt/voting/pollcard.cpp
+++ b/src/qt/voting/pollcard.cpp
@@ -73,13 +73,13 @@ PollCard::PollCard(const PollItem& poll_item, QWidget* parent)
                                                                                       * (double) 100.0, 'f', 4) + '\%');
     }
 
-    if (!(poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE ||
-          poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE_AND_MAGNITUDE)) {
+    if (!(poll_item.m_weight_type == (int)interfaces::PollWeightType::BALANCE ||
+          poll_item.m_weight_type == (int)interfaces::PollWeightType::BALANCE_AND_MAGNITUDE)) {
         ui->balanceLabel->hide();
     }
 
-    if (!(poll_item.m_weight_type == (int)GRC::PollWeightType::MAGNITUDE ||
-          poll_item.m_weight_type == (int)GRC::PollWeightType::BALANCE_AND_MAGNITUDE)) {
+    if (!(poll_item.m_weight_type == (int)interfaces::PollWeightType::MAGNITUDE ||
+          poll_item.m_weight_type == (int)interfaces::PollWeightType::BALANCE_AND_MAGNITUDE)) {
         ui->magnitudeLabel->hide();
     }
 

--- a/src/qt/voting/polltab.cpp
+++ b/src/qt/voting/polltab.cpp
@@ -17,8 +17,6 @@
 #include <QPropertyAnimation>
 #include <QResizeEvent>
 
-using namespace GRC;
-
 namespace {
 QString RefreshMessage()
 {
@@ -179,7 +177,7 @@ void PollTab::setVotingModel(VotingModel* model)
     ui->table->setAccessibleName(tr("Polls (table view)"));
 }
 
-void PollTab::setPollFilterFlags(PollFilterFlag flags)
+void PollTab::setPollFilterFlags(interfaces::PollFilterFlag flags)
 {
     m_polltable_model->setPollFilterFlags(flags);
 }

--- a/src/qt/voting/polltab.h
+++ b/src/qt/voting/polltab.h
@@ -5,7 +5,7 @@
 #ifndef GRIDCOIN_QT_VOTING_POLLTAB_H
 #define GRIDCOIN_QT_VOTING_POLLTAB_H
 
-#include "gridcoin/voting/filter.h"
+#include "interfaces/voting.h"
 
 #include <memory>
 #include <QDateTime>
@@ -48,7 +48,7 @@ public:
     ~PollTab();
 
     void setVotingModel(VotingModel* voting_model);
-    void setPollFilterFlags(GRC::PollFilterFlag flags);
+    void setPollFilterFlags(interfaces::PollFilterFlag flags);
 
 signals:
     void newVoteReceivedAndPollMarkedDirty();

--- a/src/qt/voting/polltablemodel.cpp
+++ b/src/qt/voting/polltablemodel.cpp
@@ -14,8 +14,6 @@
 #include <QSortFilterProxyModel>
 #include <QStringList>
 
-using namespace GRC;
-
 PollTableDataModel::PollTableDataModel()
 {
     qRegisterMetaType<QList<QPersistentModelIndex>>();
@@ -235,7 +233,7 @@ void PollTableDataModel::handlePollStaleFlag(QString poll_txid_string)
 PollTableModel::PollTableModel(QObject* parent)
     : QSortFilterProxyModel(parent)
     , m_data_model(new PollTableDataModel())
-    , m_filter_flags(GRC::PollFilterFlag::NO_FILTER)
+    , m_filter_flags(interfaces::NO_FILTER)
 {
     setSourceModel(m_data_model.get());
     setDynamicSortFilter(true);
@@ -288,14 +286,14 @@ void PollTableModel::setModel(VotingModel* model)
     }
 }
 
-void PollTableModel::setPollFilterFlags(PollFilterFlag flags)
+void PollTableModel::setPollFilterFlags(interfaces::PollFilterFlag flags)
 {
     m_filter_flags = flags;
 }
 
 bool PollTableModel::includesActivePolls() const
 {
-    return (m_filter_flags & PollFilterFlag::ACTIVE) != 0;
+    return (m_filter_flags & interfaces::ACTIVE) != 0;
 }
 
 int PollTableModel::size() const

--- a/src/qt/voting/polltablemodel.h
+++ b/src/qt/voting/polltablemodel.h
@@ -6,7 +6,7 @@
 #define GRIDCOIN_QT_VOTING_POLLTABLEMODEL_H
 
 #include "uint256.h"
-#include "gridcoin/voting/filter.h"
+#include "interfaces/voting.h"
 #include "qt/voting/votingmodel.h"
 
 #include <atomic>
@@ -65,7 +65,7 @@ public:
     ~PollTableModel();
 
     void setModel(VotingModel* model = nullptr);
-    void setPollFilterFlags(GRC::PollFilterFlag flags);
+    void setPollFilterFlags(interfaces::PollFilterFlag flags);
     bool includesActivePolls() const;
 
     int size() const;
@@ -92,7 +92,7 @@ private:
     // detach (setModel(nullptr)), which made the lack of init reachable.
     VotingModel* m_voting_model{nullptr};
     std::unique_ptr<PollTableDataModel> m_data_model;
-    GRC::PollFilterFlag m_filter_flags;
+    interfaces::PollFilterFlag m_filter_flags;
     // Debounce flag for refresh(). Set on the GUI thread when a refresh
     // worker is launched, cleared inside the GUI continuation lambda once
     // reload() has actually run. Covering the full build + queued reload

--- a/src/qt/voting/pollwizard.cpp
+++ b/src/qt/voting/pollwizard.cpp
@@ -14,7 +14,7 @@
 PollWizard::PollWizard(VotingModel& voting_model, QWidget* parent)
     : QWizard(parent)
     , ui(new Ui::PollWizard)
-    , m_poll_types(new PollTypes())
+    , m_poll_types(new PollTypes(voting_model.getPollTypes()))
 {
     ui->setupUi(this);
 

--- a/src/qt/voting/pollwizarddetailspage.cpp
+++ b/src/qt/voting/pollwizarddetailspage.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include "main.h"
 #include "qitemdelegate.h"
 #include "qt/bitcoinunits.h"
 #include "qt/decoration.h"
@@ -229,7 +228,7 @@ PollWizardDetailsPage::PollWizardDetailsPage(QWidget* parent)
             ui->removeChoiceButton->setVisible(!selected.isEmpty());
         });
     connect(ui->addChoiceButton, &QAbstractButton::clicked, this, [=]() {
-        if ((size_t) ui->choicesList->model()->rowCount() >= GRC::POLL_MAX_CHOICES_SIZE - 1) {
+        if (ui->choicesList->model()->rowCount() >= interfaces::poll_limits::MAX_CHOICES - 1) {
             ui->addChoiceButton->setDisabled(true);
             ui->addChoiceButton->setToolTip(tr("Cannot have more than 20 choices in a poll."));
         }
@@ -243,7 +242,7 @@ PollWizardDetailsPage::PollWizardDetailsPage(QWidget* parent)
     connect(ui->removeChoiceButton, &QAbstractButton::clicked, this, [=]() {
         m_choices_model->removeItem(ui->choicesList->selectionModel()->selectedIndexes().first());
 
-        if ((size_t) ui->choicesList->model()->rowCount() < GRC::POLL_MAX_CHOICES_SIZE) {
+        if (ui->choicesList->model()->rowCount() < interfaces::poll_limits::MAX_CHOICES) {
             ui->addChoiceButton->setEnabled(true);
             ui->addChoiceButton->setToolTip("");
         }
@@ -272,7 +271,7 @@ void PollWizardDetailsPage::setPollTypes(const PollTypes* const poll_types)
 
 void PollWizardDetailsPage::initializePage()
 {
-    if (!m_poll_types) {
+    if (!m_poll_types || !m_voting_model) {
         return;
     }
 
@@ -292,7 +291,7 @@ void PollWizardDetailsPage::initializePage()
     ui->durationField->setMinimum(poll_type.m_min_duration_days);
     ui->durationField->setValue(poll_type.m_min_duration_days);
 
-    if (type_id != (int) GRC::PollType::SURVEY) {
+    if (type_id != (int) interfaces::PollType::SURVEY) {
         ui->pollTypeAlert->show();
         ui->weightTypeList->setCurrentIndex(1); // Magnitude+Balance
         ui->weightTypeList->setDisabled(true);
@@ -301,7 +300,7 @@ void PollWizardDetailsPage::initializePage()
         ui->weightTypeList->setEnabled(true);
     }
 
-    if (type_id == (int) GRC::PollType::PROJECT) {
+    if (type_id == (int) interfaces::PollType::PROJECT) {
         ui->titleField->setText(QStringLiteral("[%1] %2 %3")
             .arg(poll_type.m_name,
                  field("projectPollAddRemoveState").toString(),
@@ -309,14 +308,10 @@ void PollWizardDetailsPage::initializePage()
         ui->responseTypeList->setCurrentIndex(0); // Yes/No/Abstain
         ui->responseTypeList->setDisabled(true);
 
-        // Only populate poll additional field entries if version >= 3.
-        bool v3_enabled = false;
-        {
-            LOCK(cs_main);
-            v3_enabled = IsPollV3Enabled(nBestHeight);
-        }
-
-        if (v3_enabled) {
+        // Only populate poll additional field entries if version >= 3. The node
+        // resolves the v3 activation against its own tip (the former GUI-side
+        // LOCK(cs_main) + IsPollV3Enabled(nBestHeight) read).
+        if (m_voting_model->pollV3Enabled()) {
             poll_item.m_additional_field_entries.push_back(
                         AdditionalFieldEntry("project_name", field("projectName").toString(), true));
             poll_item.m_additional_field_entries.push_back(
@@ -354,7 +349,7 @@ bool PollWizardDetailsPage::validatePage()
     }
 
     const int type_id = field("pollType").toInt();
-    const GRC::PollType& core_poll_type = GRC::Poll::POLL_TYPES[type_id];
+    const interfaces::PollType poll_type = static_cast<interfaces::PollType>(type_id);
 
     std::vector<AdditionalFieldEntry> additional_field_entries;
 
@@ -363,7 +358,7 @@ bool PollWizardDetailsPage::validatePage()
     }
 
     const VotingResult result = m_voting_model->sendPoll(
-        core_poll_type,
+        poll_type,
         field("title").toString(),
         field("durationDays").toInt(),
         field("question").toString(),

--- a/src/qt/voting/pollwizardtypepage.cpp
+++ b/src/qt/voting/pollwizardtypepage.cpp
@@ -32,7 +32,7 @@ PollWizardTypePage::PollWizardTypePage(QWidget* parent)
     type_proxy->setVisible(false);
 
     registerField("pollType*", type_proxy);
-    setField("pollType", (int) GRC::PollType::UNKNOWN);
+    setField("pollType", (int) interfaces::PollType::UNKNOWN);
 
     #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
         connect(
@@ -76,7 +76,7 @@ void PollWizardTypePage::setPollTypes(const PollTypes* const poll_types)
 int PollWizardTypePage::nextId() const
 {
     switch (field("pollType").toInt()) {
-        case (int) GRC:: PollType::PROJECT:
+        case (int) interfaces::PollType::PROJECT:
             return PollWizard::PageProject;
     }
 

--- a/src/qt/voting/votingmodel.cpp
+++ b/src/qt/voting/votingmodel.cpp
@@ -4,7 +4,6 @@
 
 #include "amount.h"
 #include "qt/guilog.h"
-#include "gridcoin/voting/poll.h"
 #include "interfaces/handler.h"
 #include "interfaces/researcher.h"
 #include "interfaces/voting.h"
@@ -16,8 +15,6 @@
 #include "util/time.h"
 
 #include <optional>
-
-using namespace GRC;
 
 namespace {
 //!
@@ -121,7 +118,7 @@ VotingModel::~VotingModel()
 
 int VotingModel::minPollDurationDays()
 {
-    return Poll::MIN_DURATION_DAYS;
+    return interfaces::poll_limits::MIN_DURATION_DAYS;
 }
 
 int VotingModel::maxPollDurationDays()
@@ -139,7 +136,7 @@ int VotingModel::maxPollTitleLength()
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Poll::MAX_TITLE_SIZE;
+    return interfaces::poll_limits::MAX_TITLE_LENGTH;
 }
 
 int VotingModel::maxPollUrlLength()
@@ -148,7 +145,7 @@ int VotingModel::maxPollUrlLength()
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Poll::MAX_URL_SIZE;
+    return interfaces::poll_limits::MAX_URL_LENGTH;
 }
 
 int VotingModel::maxPollQuestionLength()
@@ -157,7 +154,7 @@ int VotingModel::maxPollQuestionLength()
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Poll::MAX_QUESTION_SIZE;
+    return interfaces::poll_limits::MAX_QUESTION_LENGTH;
 }
 
 int VotingModel::maxPollChoiceLabelLength()
@@ -166,7 +163,7 @@ int VotingModel::maxPollChoiceLabelLength()
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Poll::Choice::MAX_LABEL_SIZE;
+    return interfaces::poll_limits::MAX_CHOICE_LABEL_LENGTH;
 }
 
 int VotingModel::maxPollAdditionalFieldNameLength()
@@ -175,7 +172,7 @@ int VotingModel::maxPollAdditionalFieldNameLength()
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Poll::AdditionalField::MAX_NAME_SIZE;
+    return interfaces::poll_limits::MAX_ADDITIONAL_FIELD_NAME_LENGTH;
 }
 
 int VotingModel::maxPollAdditionalFieldValueLength()
@@ -184,7 +181,7 @@ int VotingModel::maxPollAdditionalFieldValueLength()
     // Qt limits field lengths in UTF-8 characters which may be represented by
     // more than one byte.
     //
-    return Poll::AdditionalField::MAX_VALUE_SIZE;
+    return interfaces::poll_limits::MAX_ADDITIONAL_FIELD_VALUE_LENGTH;
 }
 
 int VotingModel::maxPollProjectNameLength() const
@@ -267,7 +264,7 @@ QStringList VotingModel::getExpiringPollsNotNotified()
     return expiring_polls;
 }
 
-std::vector<PollItem> VotingModel::buildPollTable(const PollFilterFlag flags)
+std::vector<PollItem> VotingModel::buildPollTable(const interfaces::PollFilterFlag flags)
 {
     // The tally, its cache, the reorg-retry and the registry walk all live in the
     // core now (interfaces::VotingManager over PollResultCache). This maps the
@@ -304,8 +301,18 @@ CAmount VotingModel::estimatePollFee() const
     return m_voting.estimatePollFee();
 }
 
+std::vector<interfaces::PollTypeMeta> VotingModel::getPollTypes() const
+{
+    return m_voting.getPollTypes();
+}
+
+bool VotingModel::pollV3Enabled() const
+{
+    return m_voting.pollV3Enabled();
+}
+
 VotingResult VotingModel::sendPoll(
-        const PollType& type,
+        const interfaces::PollType type,
         const QString& title,
         const int duration_days,
         const QString& question,

--- a/src/qt/voting/votingmodel.h
+++ b/src/qt/voting/votingmodel.h
@@ -6,9 +6,8 @@
 #define GRIDCOIN_QT_VOTING_VOTINGMODEL_H
 
 #include "amount.h"
-#include "gridcoin/voting/filter.h"
+#include "interfaces/voting.h"
 #include "qt/voting/poll_types.h"
-#include "gridcoin/voting/poll.h"
 
 #include <QDateTime>
 #include <QObject>
@@ -180,12 +179,20 @@ public:
     //! expiration), and which have not previously been included on the list (i.e. notified).
     //!
     QStringList getExpiringPollsNotNotified();
-    std::vector<PollItem> buildPollTable(const GRC::PollFilterFlag flags);
+    std::vector<PollItem> buildPollTable(const interfaces::PollFilterFlag flags);
+
+    //! Poll-type metadata rows (name/description/min-duration/required fields)
+    //! for the poll-creation wizard.
+    std::vector<interfaces::PollTypeMeta> getPollTypes() const;
+
+    //! Whether poll v3 is active at the current tip (gates the project poll's
+    //! additional fields).
+    bool pollV3Enabled() const;
 
     CAmount estimatePollFee() const;
 
     VotingResult sendPoll(
-            const GRC::PollType& type,
+            const interfaces::PollType type,
             const QString& title,
             const int duration_days,
             const QString& question,

--- a/src/qt/voting/votingpage.cpp
+++ b/src/qt/voting/votingpage.cpp
@@ -58,8 +58,8 @@ VotingPage::VotingPage(QWidget* parent)
         ui->finishedPollsTab
     };
 
-    ui->activePollsTab->setPollFilterFlags(PollFilterFlag::ACTIVE);
-    ui->finishedPollsTab->setPollFilterFlags(PollFilterFlag::FINISHED);
+    ui->activePollsTab->setPollFilterFlags(interfaces::ACTIVE);
+    ui->finishedPollsTab->setPollFilterFlags(interfaces::FINISHED);
 
     m_filter_action->setShortcut(Qt::CTRL | Qt::Key_F);
     ui->filterLineEdit->addAction(m_filter_action.get(), QLineEdit::LeadingPosition);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -5,7 +5,6 @@
 #include "addresstablemodel.h"
 #include "transactiontablemodel.h"
 
-#include "node/ui_interface.h" /* for ChangeType */
 #include <key_io.h>
 #include "util.h" /* for LogPrint / LogPrintf */
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -538,6 +538,15 @@ bool WalletModel::getKeyFromPool(CPubKey& out_public_key, const std::string& lab
     return m_wallet.getKeyFromPool(out_public_key, label);
 }
 
+QString WalletModel::getNewReceiveAddress(const QString& label)
+{
+    std::string address;
+    if (!m_wallet.getNewReceiveAddress(label.toStdString(), address)) {
+        return QString();
+    }
+    return QString::fromStdString(address);
+}
+
 // returns value snapshots of the given outpoints (unknown or conflicted
 // outpoints are skipped)
 std::vector<interfaces::WalletOutput> WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints) const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -169,6 +169,10 @@ public:
 
     bool getPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
     bool getKeyFromPool(CPubKey& out_public_key, const std::string& label);
+    //! Reserve a fresh receive key labeled \p label and return its encoded
+    //! address (empty on failure). The key stays node-side; used by the
+    //! researcher pool page so it needs no key.h / CPubKey.
+    QString getNewReceiveAddress(const QString& label);
     std::vector<interfaces::WalletOutput> getOutputs(const std::vector<COutPoint>& vOutpoints) const;
     std::map<std::string, std::vector<interfaces::WalletOutput>> listCoins() const;
 

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -5,7 +5,7 @@
 #include <qt/winshutdownmonitor.h>
 
 #if defined(WIN32)
-#include <init.h>
+#include "interfaces/node.h"
 #include <util.h>
 
 #include <windows.h>
@@ -30,7 +30,7 @@ bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pM
            {
                // Initiate a client shutdown after receiving a WM_QUERYENDSESSION and block
                // Windows session end until we have finished client shutdown.
-               StartShutdown();
+               m_node.startShutdown();
                *pnResult = FALSE;
                return true;
            }

--- a/src/qt/winshutdownmonitor.h
+++ b/src/qt/winshutdownmonitor.h
@@ -13,9 +13,15 @@
 
 #include <QAbstractNativeEventFilter>
 
+namespace interfaces { class Node; }
+
 class WinShutdownMonitor : public QAbstractNativeEventFilter
 {
 public:
+    //! \p node is used to request shutdown on WM_QUERYENDSESSION; it is
+    //! process-lifetime (main()'s gui_node), so holding a reference is safe.
+    explicit WinShutdownMonitor(interfaces::Node& node) : m_node(node) {}
+
     /** Implements QAbstractNativeEventFilter interface for processing Windows messages */
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     bool nativeEventFilter(const QByteArray &eventType, void *pMessage, qintptr *pnResult);
@@ -25,6 +31,9 @@ public:
 
     /** Register the reason for blocking shutdown on Windows to allow clean client exit */
     static void registerShutdownBlockReason(const QString& strReason, const HWND& mainWinId);
+
+private:
+    interfaces::Node& m_node;
 };
 #endif
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -226,7 +226,7 @@ UniValue getaddednodeinfo(const UniValue& params)
     for (auto const& strAddNode : laddedNodes)
     {
         vector<CService> vservNode(0);
-        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
+        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), GetNameLookup(), 0))
             laddedAddresses.push_back(make_pair(strAddNode, vservNode));
         else
         {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -88,6 +88,15 @@ LockData& GetLockData() {
     return lock_data;
 }
 
+namespace {
+// Lock-order debugging flags, extracted from the former sync.h externs so the
+// header carries only the (stateless) lock primitives and macros. Defined ahead
+// of their in-file readers below; toggled from unit tests through the
+// Get/Set accessors (defined at the bottom of the DEBUG_LOCKORDER block).
+bool g_debug_lockorder_abort = false;
+bool g_debug_lockorder_throw_exception = false;
+} // namespace
+
 static void potential_deadlock_detected(const LockPair& mismatch, const LockStack& s1, const LockStack& s2)
 {
     // Identify the two conflicting locks by name. Try s2 (current stack) first,
@@ -297,7 +306,9 @@ bool LockStackEmpty()
     return it->second.empty();
 }
 
-bool g_debug_lockorder_abort = false;
-bool g_debug_lockorder_throw_exception = false;
+bool GetLockOrderDebugAbort() { return g_debug_lockorder_abort; }
+void SetLockOrderDebugAbort(bool enable) { g_debug_lockorder_abort = enable; }
+bool GetLockOrderDebugThrowException() { return g_debug_lockorder_throw_exception; }
+void SetLockOrderDebugThrowException(bool enable) { g_debug_lockorder_throw_exception = enable; }
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/sync.h
+++ b/src/sync.h
@@ -66,8 +66,14 @@ bool LockStackEmpty();
  * just logging information and throwing a logic_error. Defaults to true, and
  * set to false in DEBUG_LOCKORDER unit tests.
  */
-extern bool g_debug_lockorder_abort;
-extern bool g_debug_lockorder_throw_exception;
+// Test-only hooks for the lock-order debugging flags. The state lives in
+// sync.cpp; DEBUG_LOCKORDER unit tests toggle these to exercise the deadlock
+// detector without aborting the process. Kept as functions (not externs) so
+// this header stays stateless.
+bool GetLockOrderDebugAbort();
+void SetLockOrderDebugAbort(bool enable);
+bool GetLockOrderDebugThrowException();
+void SetLockOrderDebugThrowException(bool enable);
 #else
 inline void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 inline void LeaveCritical() {}

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -14,11 +14,11 @@ BOOST_AUTO_TEST_SUITE(sync_tests)
 BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 {
     #ifdef DEBUG_LOCKORDER
-    bool prev_lockorder_abort = g_debug_lockorder_abort;
-    bool prev_lockorder_throw_exception = g_debug_lockorder_throw_exception;
+    bool prev_lockorder_abort = GetLockOrderDebugAbort();
+    bool prev_lockorder_throw_exception = GetLockOrderDebugThrowException();
 
-    g_debug_lockorder_abort = false;
-    g_debug_lockorder_throw_exception = true;
+    SetLockOrderDebugAbort(false);
+    SetLockOrderDebugThrowException(true);
 
     #endif
 
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
     #endif
 
     #ifdef DEBUG_LOCKORDER
-    g_debug_lockorder_abort = prev_lockorder_abort;
-    g_debug_lockorder_throw_exception = prev_lockorder_throw_exception;
+    SetLockOrderDebugAbort(prev_lockorder_abort);
+    SetLockOrderDebugThrowException(prev_lockorder_throw_exception);
     #endif
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,14 +27,7 @@
 
 using namespace std;
 
-bool fPrintToConsole = false;
-bool fCommandLine = false;
-bool fNoListen = false;
-bool fLogTimestamps = false;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
-bool fReopenDebugLog = false;
-
-bool fDevbuildCripple;
 
 /** A map that contains all the currently held directory locks. After
  * successful locking, these will be held here until the global destructor

--- a/src/util.h
+++ b/src/util.h
@@ -79,13 +79,6 @@
 
 extern int GetDayOfYear(int64_t timestamp);
 
-extern bool fPrintToConsole;
-extern bool fCommandLine;
-extern bool fNoListen;
-extern bool fLogTimestamps;
-extern bool fReopenDebugLog;
-extern bool fDevbuildCripple;
-
 void LogException(std::exception* pex, const char* pszThread);
 void PrintException(std::exception* pex, const char* pszThread);
 void PrintExceptionContinue(std::exception* pex, const char* pszThread);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -274,6 +274,23 @@ public:
         return true;
     }
 
+    bool getNewReceiveAddress(const std::string& label, std::string& address_out) override
+    {
+        // fAllowReuse=false to match the researcher pool page's former
+        // getKeyFromPool(..., false) call: a deliberately fresh receive key.
+        CPubKey new_key;
+        if (!m_wallet->GetKeyFromPool(new_key, false)) {
+            return false;
+        }
+
+        if (!label.empty()) {
+            m_wallet->SetAddressBookName(new_key.GetID(), label);
+        }
+
+        address_out = EncodeDestination(new_key.GetID());
+        return true;
+    }
+
     std::vector<std::string> getUnbookedReceiveAddresses() override
     {
         std::vector<std::string> result;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7,6 +7,7 @@
 #include <key_io.h>
 #include "txdb.h"
 #include "wallet/wallet.h"
+#include "miner.h" // For GetDevbuildCripple() (staking cripple gate).
 #include "wallet/walletdb.h"
 #include "crypter.h"
 #include "node/ui_interface.h"
@@ -3520,7 +3521,7 @@ bool CWallet::CreateTransaction(CScript scriptPubKey, int64_t nValue, CWalletTx&
 // Call after CreateTransaction unless you want to abort
 bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 {
-    if(fDevbuildCripple)
+    if(GetDevbuildCripple())
     {
         return error("CommitTransaction(): Development build restrictions in effect");
     }

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -42,8 +42,6 @@ src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
 src/qt/detailedtxmodel.cpp:util/system.h
 src/qt/diagnosticsdialog.h:wallet/diagnose.h
-src/qt/optionsdialog.cpp:miner.h
-src/qt/optionsmodel.cpp:miner.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
 src/qt/transactionview.cpp:util/system.h

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -42,7 +42,6 @@ src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
 src/qt/diagnosticsdialog.h:wallet/diagnose.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
-src/qt/researcher/researcherwizardpoolpage.cpp:key.h
 src/qt/upgradeqt.cpp:gridcoin/upgrade.h
 src/qt/voting/polltab.h:gridcoin/voting/filter.h
 src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
@@ -51,7 +50,6 @@ src/qt/voting/pollwizarddetailspage.cpp:main.h
 src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
 src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
 src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
-src/qt/winshutdownmonitor.cpp:init.h
 "
 
 EXIT_CODE=0

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -25,8 +25,15 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 # GUI may include them directly and they are no longer forbidden here.
 FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|psgt\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
 
-# file:header pairs present when the ratchet was introduced. DO NOT ADD
-# ENTRIES -- migrate the file onto src/interfaces/*.h instead. (Sole
+# Remaining file:header pairs. The Phase 1e burn-down has driven this down to
+# the composition-root floor: every entry now lives in one of the three process
+# entry points -- bitcoin.cpp (the app main / model wiring), bitcoingui.cpp, and
+# upgradeqt.cpp (the standalone updater) -- which legitimately drive core
+# start-up, shutdown and the updater and so are not themselves migrated onto
+# src/interfaces/*.h. Flipping the ratchet to a hard-fail against exactly this
+# floor is the Phase 1f gate.
+#
+# DO NOT ADD ENTRIES -- migrate the file onto src/interfaces/*.h instead. (Sole
 # exception: an entry may be added when a migration surfaces PRE-EXISTING
 # coupling that was previously hidden behind a transitive include, e.g.
 # rpcconsole.cpp:banman.h -- the coupling is old, only the include is new.)
@@ -40,16 +47,7 @@ src/qt/bitcoin.cpp:policy/fees.h
 src/qt/bitcoin.cpp:txdb.h
 src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
-src/qt/diagnosticsdialog.h:wallet/diagnose.h
-src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/upgradeqt.cpp:gridcoin/upgrade.h
-src/qt/voting/polltab.h:gridcoin/voting/filter.h
-src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
-src/qt/voting/poll_types.cpp:gridcoin/voting/poll.h
-src/qt/voting/pollwizarddetailspage.cpp:main.h
-src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
-src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
-src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
 "
 
 EXIT_CODE=0

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -40,12 +40,9 @@ src/qt/bitcoin.cpp:policy/fees.h
 src/qt/bitcoin.cpp:txdb.h
 src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
-src/qt/detailedtxmodel.cpp:util/system.h
 src/qt/diagnosticsdialog.h:wallet/diagnose.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
-src/qt/transactionview.cpp:util/system.h
-src/qt/updatedialog.h:gridcoin/upgrade.h
 src/qt/upgradeqt.cpp:gridcoin/upgrade.h
 src/qt/voting/polltab.h:gridcoin/voting/filter.h
 src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
@@ -54,7 +51,6 @@ src/qt/voting/pollwizarddetailspage.cpp:main.h
 src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
 src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
 src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
-src/qt/walletmodel.cpp:node/ui_interface.h
 src/qt/winshutdownmonitor.cpp:init.h
 "
 

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -19,25 +19,18 @@ export LC_ALL=C
 
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
-FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|netbase\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|chainparams\.h|chainparamsbase\.h|protocol\.h|psgt\.h|sync\.h|util\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
+# chainparams.h / chainparamsbase.h / protocol.h were made stateless by the
+# fTestNet extraction (#3204); netbase.h / sync.h / util.h by the remaining
+# core-global extraction. They expose only stateless declarations now, so the
+# GUI may include them directly and they are no longer forbidden here.
+FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|psgt\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
 
 # file:header pairs present when the ratchet was introduced. DO NOT ADD
 # ENTRIES -- migrate the file onto src/interfaces/*.h instead. (Sole
 # exception: an entry may be added when a migration surfaces PRE-EXISTING
 # coupling that was previously hidden behind a transitive include, e.g.
 # rpcconsole.cpp:banman.h -- the coupling is old, only the include is new.)
-#
-# PERMANENT exception (not a migrate-away target): guiutil.cpp:chainparams.h.
-# GetAutoStartupArguments() must resolve the network THIS GUI process was
-# launched with (its own -testnet/-chain arg) locally, via OnTestnet() over the
-# process's own SelectParams() result. It cannot route through
-# interfaces::Node::isTestNet() because in the separated build no core process
-# exists yet at that point -- the local resolution is what selects WHICH core
-# (mainnet vs testnet) the GUI then connects to. Bootstrap catch-22; keep.
 ALLOWLIST="\
-src/qt/aboutdialog.cpp:util.h
-src/qt/bitcoin.cpp:chainparamsbase.h
-src/qt/bitcoin.cpp:chainparams.h
 src/qt/bitcoin.cpp:gridcoin/gridcoin.h
 src/qt/bitcoin.cpp:gridcoin/upgrade.h
 src/qt/bitcoin.cpp:init.h
@@ -45,34 +38,18 @@ src/qt/bitcoin.cpp:node/shutdown.h
 src/qt/bitcoin.cpp:node/ui_interface.h
 src/qt/bitcoin.cpp:policy/fees.h
 src/qt/bitcoin.cpp:txdb.h
-src/qt/bitcoin.cpp:util.h
 src/qt/bitcoin.cpp:validation.h
 src/qt/bitcoingui.cpp:init.h
-src/qt/bitcoingui.cpp:util.h
-src/qt/consolidateunspentdialog.cpp:util.h
-src/qt/consolidateunspentwizard.cpp:util.h
-src/qt/consolidateunspentwizardselectdestinationpage.cpp:util.h
-src/qt/consolidateunspentwizardsendpage.cpp:util.h
 src/qt/detailedtxmodel.cpp:util/system.h
-src/qt/diagnosticsdialog.h:sync.h
 src/qt/diagnosticsdialog.h:wallet/diagnose.h
-src/qt/guiutil.cpp:chainparams.h
-src/qt/guiutil.cpp:util.h
-src/qt/intro.cpp:chainparams.h
-src/qt/intro.cpp:util.h
 src/qt/optionsdialog.cpp:miner.h
-src/qt/optionsdialog.cpp:netbase.h
 src/qt/optionsmodel.cpp:miner.h
 src/qt/qtipcserver.cpp:node/ui_interface.h
-src/qt/qtipcserver.cpp:util.h
 src/qt/researcher/researcherwizardpoolpage.cpp:key.h
-src/qt/transactiontablemodel.cpp:util.h
 src/qt/transactionview.cpp:util/system.h
 src/qt/updatedialog.h:gridcoin/upgrade.h
 src/qt/upgradeqt.cpp:gridcoin/upgrade.h
-src/qt/upgradeqt.cpp:util.h
 src/qt/voting/polltab.h:gridcoin/voting/filter.h
-src/qt/voting/polltablemodel.cpp:util.h
 src/qt/voting/polltablemodel.h:gridcoin/voting/filter.h
 src/qt/voting/poll_types.cpp:gridcoin/voting/poll.h
 src/qt/voting/pollwizarddetailspage.cpp:main.h
@@ -80,9 +57,7 @@ src/qt/voting/votingmodel.cpp:gridcoin/voting/poll.h
 src/qt/voting/votingmodel.h:gridcoin/voting/filter.h
 src/qt/voting/votingmodel.h:gridcoin/voting/poll.h
 src/qt/walletmodel.cpp:node/ui_interface.h
-src/qt/walletmodel.cpp:util.h
 src/qt/winshutdownmonitor.cpp:init.h
-src/qt/winshutdownmonitor.cpp:util.h
 "
 
 EXIT_CODE=0


### PR DESCRIPTION
> **Stacked on #3210** (the remaining-globals extraction). Its commit is the base of this branch; once #3210 merges, this PR's delta shrinks to its own four commits. Reviewable now.

Completes the Phase 1e `lint-qt-includes.sh` ratchet burn-down: migrates the remaining GUI files off forbidden core-header includes onto `interfaces::` abstractions, driving the allowlist down to the **composition-root floor** — the 10 remaining entries all live in the three process entry points (`bitcoin.cpp`, `bitcoingui.cpp`, `upgradeqt.cpp`), which legitimately drive core start-up/shutdown and the standalone updater. Flipping the ratchet to hard-fail *against* that floor is the Phase 1f gate and is **not** part of this PR.

## Commits

**1. `MIN_STAKE_SPLIT_VALUE_GRC` → `amount.h`** — relocates the constant so `optionsdialog`/`optionsmodel` drop `miner.h`; removes a dead `getTransactionFee()`.

**2. showorphans / update-check migrations** — `OptionsModel::getShowOrphans()` via the settings interface; `aboutdialog`/`updatedialog` off `gridcoin/upgrade.h` via `interfaces::Node::checkForLatestUpdate()` + a `LatestVersionInfo` value row and an `UpdateType` enum mirror; `walletmodel` drops `node/ui_interface.h`.

**3. researcher key + winshutdown migrations** — new-receive-address via `interfaces::Wallet::getNewReceiveAddress()` (researcher widgets drop `key.h`/`key_io.h`); `WinShutdownMonitor` takes `interfaces::Node&` and calls `startShutdown()`.

**4. voting / URI dispatch / diagnostics** (final tranche, reaches the floor):

- *Voting widgets* — GUI-facing `PollFilterFlag` / `PollType` / `PollWeightType` enum mirrors, a `poll_limits` constant namespace and a `PollTypeMeta` value row in `interfaces/voting.h`; `VotingManager` gains `getPollTypes()` and `pollV3Enabled()`. `VotingManagerImpl` `static_assert`s every mirror against the core `GRC::` definitions, so drift is a compile error. The widgets drop `gridcoin/voting/{poll,filter,fwd}.h` and `main.h`; the GUI-side `IsPollV3Enabled(nBestHeight)` (which took `cs_main`) becomes `VotingManager::pollV3Enabled()`.
- *URI dispatch* — `qtipcserver` no longer includes `node/ui_interface.h`; `ipcInit()` takes a `std::function` URI handler from the composition root, replacing the `uiInterface.ThreadSafeHandleURI` signal round-trip (a GUI-process-internal indirection whose only connector was `bitcoin.cpp`). The now-dead signal is removed from `CClientUIInterface`.
- *Diagnostics* — `Node::runDiagnostics()` runs the 12 `DiagnoseLib` tests node-side and returns `std::vector<DiagnosticResult>` value rows (`test_id`, `status`, and the resolved/translated result & tip strings with `%1` args substituted node-side); `DiagnosticTest`/`DiagnosticStatus` mirrors are `static_assert`ed against the core enums. `diagnosticsdialog` drops `wallet/diagnose.h` (and its transitively-pulled `main.h`/`net.h`/`gridcoin/*`), keeping a `test_id → QLabel` map and rendering the rows; its now-pointless `cs_diagnostictests` lock and dead `QTcpSocket`/`QUdpSocket` members are removed and the node is wired in via `setClientModel()`. Test execution is now deterministic (enum order), fixing a latent ordering bug where the original ran tests in `QLabel*`-address order despite `CheckConnectionCount` needing to be first.

## Testing

- `build_targets.sh TARGET=native BUILD_TYPE=RelWithDebInfo USE_QT6=true WITH_GUI=true` — clean build.
- Full ctest suite: `functional_tests`, `gridcoin_qt_tests`, `gridcoin_tests` all pass.
- `test/lint/lint-qt-includes.sh` (now at the composition-root floor) and `lint-whitespace.sh` pass.
- Independent adversarial reviews of the voting and diagnostics clusters found no correctness defects; their notes (static_assert completeness, a doc-comment fix, an `initializePage` null-guard) are folded in.

## Note on transitive coupling

The ratchet only inspects *direct* `#include` lines, so removing a header can surface pre-existing coupling that was hidden behind it. This PR fixes three such cases exposed by the header removals: `bitcoingui.cpp` (`GRC::Upgrade` via a stale cast — dropped), `pollcard.cpp` (`GRC::PollWeightType` → the new mirror), and three voting TUs carrying a now-vestigial `using namespace GRC;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)