### PR TITLE
qt: Phase 1f — flip the interfaces:: ratchet to the hard-fail gate (+ marshalability pins, mock harness)

### DIFF
--- a/src/interfaces/marshal.h
+++ b/src/interfaces/marshal.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_MARSHAL_H
+#define GRIDCOIN_INTERFACES_MARSHAL_H
+
+#include <type_traits>
+
+//! Compile-time pin (multiprocess design §4.1) that a value type crossing the
+//! interfaces:: boundary stays freely copyable, so a node-side implementation can
+//! fill one and ship it across the boundary. It trips on a regression that adds a
+//! move-only / non-copyable member -- a std::unique_ptr, a std::mutex/atomic, or
+//! a reference. It does NOT (and cannot, via a copy-constructibility trait) catch
+//! a raw pointer into core state or a Qt type, both of which are still copyable:
+//! keeping DTOs pointer-free and Qt-free remains a review-owned discipline (and
+//! the doc comment on each DTO). Placed next to each DTO group in the interface
+//! headers; see wallet_tx_record.h for the additional fixed-width field pins.
+#define INTERFACES_ASSERT_MARSHALABLE(T)                            \
+    static_assert(std::is_copy_constructible_v<T>                   \
+                      && std::is_copy_assignable_v<T>               \
+                      && std::is_move_constructible_v<T>,           \
+                  #T " must remain a copyable value type for the "  \
+                     "interfaces:: boundary")
+
+#endif // GRIDCOIN_INTERFACES_MARSHAL_H

--- a/src/interfaces/mrc.h
+++ b/src/interfaces/mrc.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_MRC_H
 #define GRIDCOIN_INTERFACES_MRC_H
 
+#include "interfaces/marshal.h"
+
 #include "amount.h"
 
 #include <functional>
@@ -144,6 +146,11 @@ public:
 //! outlive the returned object.
 std::unique_ptr<MRC> MakeMRC(CWallet* wallet);
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(MRCSnapshot);
+INTERFACES_ASSERT_MARSHALABLE(MRCSubmitResult);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_MRC_H

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_NODE_H
 #define GRIDCOIN_INTERFACES_NODE_H
 
+#include "interfaces/marshal.h"
+
 #include "interfaces/handler.h"
 // For scrapereventtypes' enumerators, which consumers of the scraper-event
 // handler discriminate on. TODO(Stage 2): extract the enum into a standalone
@@ -349,6 +351,16 @@ public:
 //! Return an in-process Node interface implementation.
 std::unique_ptr<Node> MakeNode();
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(BannedNode);
+INTERFACES_ASSERT_MARSHALABLE(PeerInfo);
+INTERFACES_ASSERT_MARSHALABLE(RpcConsoleResult);
+INTERFACES_ASSERT_MARSHALABLE(SettingChangeResult);
+INTERFACES_ASSERT_MARSHALABLE(ScraperConvergenceSnapshot);
+INTERFACES_ASSERT_MARSHALABLE(LatestVersionInfo);
+INTERFACES_ASSERT_MARSHALABLE(DiagnosticResult);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_NODE_H

--- a/src/interfaces/psgt.h
+++ b/src/interfaces/psgt.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_PSGT_H
 #define GRIDCOIN_INTERFACES_PSGT_H
 
+#include "interfaces/marshal.h"
+
 #include "amount.h"
 
 #include <cstdint>
@@ -302,6 +304,19 @@ public:
 //! single wallet. \p wallet must outlive the object.
 std::unique_ptr<PSGTPoolContext> MakePSGTPoolContext(CWallet* wallet);
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(PSGTPoolStatus);
+INTERFACES_ASSERT_MARSHALABLE(PSGTPoolRow);
+INTERFACES_ASSERT_MARSHALABLE(PSGTInputInfo);
+INTERFACES_ASSERT_MARSHALABLE(PSGTOutputInfo);
+INTERFACES_ASSERT_MARSHALABLE(PSGTDescription);
+INTERFACES_ASSERT_MARSHALABLE(PSGTSignResult);
+INTERFACES_ASSERT_MARSHALABLE(PSGTCombineResult);
+INTERFACES_ASSERT_MARSHALABLE(PSGTSubmitResult);
+INTERFACES_ASSERT_MARSHALABLE(PSGTFinalizeResult);
+INTERFACES_ASSERT_MARSHALABLE(PSGTDecodeResult);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_PSGT_H

--- a/src/interfaces/researcher.h
+++ b/src/interfaces/researcher.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_RESEARCHER_H
 #define GRIDCOIN_INTERFACES_RESEARCHER_H
 
+#include "interfaces/marshal.h"
+
 #include "amount.h"
 
 #include <cstdint>
@@ -258,6 +260,13 @@ public:
 //! registries and the node's single wallet. \p wallet must outlive the object.
 std::unique_ptr<ResearcherContext> MakeResearcherContext(CWallet* wallet);
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(ResearcherSnapshot);
+INTERFACES_ASSERT_MARSHALABLE(ResearcherProjectRow);
+INTERFACES_ASSERT_MARSHALABLE(BeaconAdvertiseResult);
+INTERFACES_ASSERT_MARSHALABLE(WhitelistProject);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_RESEARCHER_H

--- a/src/interfaces/sidestake.h
+++ b/src/interfaces/sidestake.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_SIDESTAKE_H
 #define GRIDCOIN_INTERFACES_SIDESTAKE_H
 
+#include "interfaces/marshal.h"
+
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -143,6 +145,12 @@ public:
 //! Return an in-process SideStakeManager over the global sidestake registry.
 std::unique_ptr<SideStakeManager> MakeSideStakeManager();
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(SideStakeEntry);
+INTERFACES_ASSERT_MARSHALABLE(SideStakeSnapshot);
+INTERFACES_ASSERT_MARSHALABLE(SideStakeEditResult);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_SIDESTAKE_H

--- a/src/interfaces/voting.h
+++ b/src/interfaces/voting.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_VOTING_H
 #define GRIDCOIN_INTERFACES_VOTING_H
 
+#include "interfaces/marshal.h"
+
 #include "amount.h"
 
 #include <cstdint>
@@ -247,6 +249,16 @@ public:
 //! result cache and the node's single wallet.
 std::unique_ptr<VotingManager> MakeVotingManager();
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(PollTypeMeta);
+INTERFACES_ASSERT_MARSHALABLE(PollChoiceResult);
+INTERFACES_ASSERT_MARSHALABLE(PollAdditionalField);
+INTERFACES_ASSERT_MARSHALABLE(PollSelfVoteResponse);
+INTERFACES_ASSERT_MARSHALABLE(PollTableItem);
+INTERFACES_ASSERT_MARSHALABLE(PollSubmission);
+INTERFACES_ASSERT_MARSHALABLE(VotingSubmitResult);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_VOTING_H

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_WALLET_H
 #define GRIDCOIN_INTERFACES_WALLET_H
 
+#include "interfaces/marshal.h"
+
 #include "interfaces/handler.h"
 #include "node/ui_interface.h" // For ChangeType.
 #include "primitives/transaction.h" // For COutPoint.
@@ -407,6 +409,17 @@ public:
 //! wallet, which must outlive the returned object.
 std::unique_ptr<Wallet> MakeWallet(CWallet* wallet);
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(WalletBalances);
+INTERFACES_ASSERT_MARSHALABLE(WalletLockState);
+INTERFACES_ASSERT_MARSHALABLE(WalletOutput);
+INTERFACES_ASSERT_MARSHALABLE(WalletAddress);
+INTERFACES_ASSERT_MARSHALABLE(WalletCoinControl);
+INTERFACES_ASSERT_MARSHALABLE(CoinControlSummary);
+INTERFACES_ASSERT_MARSHALABLE(WalletSendRecipient);
+INTERFACES_ASSERT_MARSHALABLE(SendCoinsResult);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_WALLET_H

--- a/src/interfaces/wallet_tx_channel.h
+++ b/src/interfaces/wallet_tx_channel.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_WALLET_TX_CHANNEL_H
 #define GRIDCOIN_INTERFACES_WALLET_TX_CHANNEL_H
 
+#include "interfaces/marshal.h"
+
 #include "interfaces/wallet_tx_filter.h"
 #include "interfaces/wallet_tx_record.h"
 #include "uint256.h"
@@ -308,5 +310,17 @@ struct WalletTxDetail
     std::vector<InputInfo> inputs;
 };
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(RowsInsertedPayload);
+INTERFACES_ASSERT_MARSHALABLE(RowsRemovedPayload);
+INTERFACES_ASSERT_MARSHALABLE(RowsResetPayload);
+INTERFACES_ASSERT_MARSHALABLE(RowCountChangedPayload);
+INTERFACES_ASSERT_MARSHALABLE(RowsChangedPayload);
+INTERFACES_ASSERT_MARSHALABLE(ChainTipChangedPayload);
+INTERFACES_ASSERT_MARSHALABLE(WalletEvent);
+INTERFACES_ASSERT_MARSHALABLE(RowsResult);
+INTERFACES_ASSERT_MARSHALABLE(WalletTxDetail);
 } // namespace GRC
 #endif // GRIDCOIN_INTERFACES_WALLET_TX_CHANNEL_H

--- a/src/interfaces/wallet_tx_filter.h
+++ b/src/interfaces/wallet_tx_filter.h
@@ -5,6 +5,8 @@
 #ifndef GRIDCOIN_INTERFACES_WALLET_TX_FILTER_H
 #define GRIDCOIN_INTERFACES_WALLET_TX_FILTER_H
 
+#include "interfaces/marshal.h"
+
 #include <cstdint>
 #include <string>
 
@@ -182,6 +184,12 @@ int CompareKeys(const SortKey& a, const SortKey& b, int column, int order);
 //!
 bool Less(const SortKey& a, const SortKey& b, int column, int order);
 
+
+// Marshalability pins (interfaces/marshal.h): each DTO above must stay a
+// copyable value type the node side can fill and ship across the boundary.
+INTERFACES_ASSERT_MARSHALABLE(FilterSpec);
+INTERFACES_ASSERT_MARSHALABLE(TxFilterFields);
+INTERFACES_ASSERT_MARSHALABLE(SortKey);
 } // namespace GRC
 
 #endif // GRIDCOIN_INTERFACES_WALLET_TX_FILTER_H

--- a/src/interfaces/wallet_tx_record.h
+++ b/src/interfaces/wallet_tx_record.h
@@ -1,6 +1,7 @@
 #ifndef GRIDCOIN_INTERFACES_WALLET_TX_RECORD_H
 #define GRIDCOIN_INTERFACES_WALLET_TX_RECORD_H
 
+#include "interfaces/marshal.h"
 #include "uint256.h"
 #include "wallet/generated_type.h"
 #include "wallet/ismine.h"
@@ -173,18 +174,14 @@ public:
     std::string label;
 };
 
-//! Marshalability pin (multiprocess design §4.1, windowed-model design): these
+//! Marshalability pins (multiprocess design §4.1, windowed-model design): these
 //! records are the wallet-transaction-channel DTOs and must stay value types a
 //! node-side source can fill and ship across the interfaces:: boundary — no Qt
 //! types, no pointers into core state, freely copyable. The translated type
 //! rendering lives GUI-side (transactionview/transactiontablemodel), not here.
-static_assert(std::is_copy_constructible_v<TransactionRecord>
-                  && std::is_copy_assignable_v<TransactionRecord>
-                  && std::is_move_constructible_v<TransactionRecord>,
-              "TransactionRecord must remain a copyable value type");
-static_assert(std::is_copy_constructible_v<TransactionStatus>
-                  && std::is_copy_assignable_v<TransactionStatus>,
-              "TransactionStatus must remain a copyable value type");
+//! The fixed-width pin additionally locks the amount/time wire representation.
+INTERFACES_ASSERT_MARSHALABLE(TransactionRecord);
+INTERFACES_ASSERT_MARSHALABLE(TransactionStatus);
 static_assert(std::is_same_v<decltype(TransactionRecord::time), int64_t>
                   && std::is_same_v<decltype(TransactionRecord::debit), int64_t>
                   && std::is_same_v<decltype(TransactionRecord::credit), int64_t>,

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(test_gridcoin-qt
     test_main.cpp
     bitcoinunitstests.cpp
     uritests.cpp
+    sidestakemodeltests.cpp
 )
 
 set_target_properties(test_gridcoin-qt PROPERTIES

--- a/src/qt/test/interfacefakes.h
+++ b/src/qt/test/interfacefakes.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_INTERFACEFAKES_H
+#define BITCOIN_QT_TEST_INTERFACEFAKES_H
+
+#include "interfaces/handler.h"
+#include "interfaces/sidestake.h"
+
+#include <memory>
+#include <string>
+
+//! Hand-rolled test doubles for the interfaces:: boundary (Phase 1f). A model
+//! test constructs a GUI model against one of these fakes -- with no wallet,
+//! registry, or core global in sight -- and asserts the model reads and maps
+//! only interface value data. That is the decoupling proof: the model compiles
+//! and behaves correctly against a pure in-memory interface, so it holds no
+//! hidden core coupling. Each fake serves canned value structs and records the
+//! commands the model issued, so a test can also assert the model delegated the
+//! right arguments back across the boundary.
+//!
+//! These are deliberately hand-rolled (not gMock): the project's test stack is
+//! Qt Test / Boost.Test with no gmock dependency, and the interfaces are small
+//! enough that a plain override-and-record fake is clearer than a mock DSL.
+namespace qt_test {
+
+//! Fake interfaces::SideStakeManager: serves a canned entries() snapshot, returns
+//! a canned result from every mutating command, and records the last add/delete
+//! so a test can assert the model delegated to the interface with the right args.
+class FakeSideStakeManager : public interfaces::SideStakeManager
+{
+public:
+    // Canned responses (set by the test before use).
+    interfaces::SideStakeSnapshot m_snapshot;
+    interfaces::SideStakeEditResult m_edit_result;
+
+    // Recorded calls.
+    int m_entries_calls = 0;
+    std::string m_last_add_address;
+    double m_last_add_allocation = 0.0;
+    std::string m_last_add_description;
+    std::string m_last_deleted_address;
+
+    interfaces::SideStakeSnapshot entries() override
+    {
+        ++m_entries_calls;
+        return m_snapshot;
+    }
+
+    uint64_t localRevision() override { return m_snapshot.local_revision; }
+
+    interfaces::SideStakeEditResult addLocal(const std::string& address,
+                                             double allocation_percent,
+                                             const std::string& description) override
+    {
+        m_last_add_address = address;
+        m_last_add_allocation = allocation_percent;
+        m_last_add_description = description;
+        return m_edit_result;
+    }
+
+    interfaces::SideStakeEditResult setAllocation(const std::string& /*address*/,
+                                                  double /*allocation_percent*/) override
+    {
+        return m_edit_result;
+    }
+
+    interfaces::SideStakeEditResult setDescription(const std::string& /*address*/,
+                                                   const std::string& /*description*/) override
+    {
+        return m_edit_result;
+    }
+
+    interfaces::SideStakeEditResult deleteLocal(const std::string& address) override
+    {
+        m_last_deleted_address = address;
+        return m_edit_result;
+    }
+
+    // The subscription callbacks are dropped: these tests exercise the query and
+    // command paths, not notification delivery. A model's notification slots
+    // marshal onto the GUI thread via a queued QMetaObject::invokeMethod, so a
+    // future notification-path test must run a QCoreApplication event loop (or
+    // pump it) for the queued call to dispatch -- store and invoke the fn here
+    // once that harness exists.
+    std::unique_ptr<interfaces::Handler> handleRwSettingsUpdated(interfaces::RwSettingsUpdatedFn /*fn*/) override
+    {
+        return interfaces::MakeCleanupHandler([] {});
+    }
+
+    std::unique_ptr<interfaces::Handler> handleMandatorySideStakeChanged(
+        interfaces::MandatorySideStakeChangedFn /*fn*/) override
+    {
+        return interfaces::MakeCleanupHandler([] {});
+    }
+};
+
+} // namespace qt_test
+
+#endif // BITCOIN_QT_TEST_INTERFACEFAKES_H

--- a/src/qt/test/sidestakemodeltests.cpp
+++ b/src/qt/test/sidestakemodeltests.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "qt/test/sidestakemodeltests.h"
+
+#include "interfaces/sidestake.h"
+#include "qt/sidestaketablemodel.h"
+#include "qt/test/interfacefakes.h"
+
+#include <QModelIndex>
+#include <QString>
+
+#include <string>
+
+namespace {
+//! Build a value row the fake serves as if it came from the node side.
+interfaces::SideStakeEntry MakeEntry(const std::string& address,
+                                     double allocation_percent,
+                                     const std::string& description,
+                                     const std::string& status,
+                                     bool mandatory)
+{
+    interfaces::SideStakeEntry entry;
+    entry.address = address;
+    entry.allocation_percent = allocation_percent;
+    entry.description = description;
+    entry.status = status;
+    entry.is_mandatory = mandatory;
+    return entry;
+}
+
+QVariant CellDisplay(const SideStakeTableModel& model, int row, SideStakeTableModel::ColumnIndex column)
+{
+    return model.data(model.index(row, column, QModelIndex()), Qt::DisplayRole);
+}
+} // anonymous namespace
+
+void SideStakeModelTests::emptyUntilRefresh()
+{
+    qt_test::FakeSideStakeManager fake;
+    fake.m_snapshot.entries.push_back(MakeEntry("addr1", 10.0, "d", "Active", false));
+
+    SideStakeTableModel model(fake);
+
+    // The model defers its first fetch until refresh() (the sidestake registry
+    // and final chain params are not ready at construction), so it starts empty
+    // and has not touched the interface.
+    QCOMPARE(model.rowCount(QModelIndex()), 0);
+    QCOMPARE(model.columnCount(QModelIndex()), 4);
+    QCOMPARE(fake.m_entries_calls, 0);
+}
+
+void SideStakeModelTests::mapsSnapshotToTable()
+{
+    qt_test::FakeSideStakeManager fake;
+    fake.m_snapshot.entries.push_back(MakeEntry("mandAddr", 25.0, "mand desc", "Mandatory", true));
+    fake.m_snapshot.entries.push_back(MakeEntry("localAddr", 50.5, "local desc", "Active", false));
+
+    SideStakeTableModel model(fake);
+    model.refresh();
+
+    QCOMPARE(model.rowCount(QModelIndex()), 2);
+
+    // Row 0 (mandatory): every column maps from the interface value row.
+    QCOMPARE(CellDisplay(model, 0, SideStakeTableModel::Address).toString(), QString("mandAddr"));
+    QCOMPARE(CellDisplay(model, 0, SideStakeTableModel::Allocation).toString(), QString("25.00%"));
+    QCOMPARE(CellDisplay(model, 0, SideStakeTableModel::Description).toString(), QString("mand desc"));
+    QCOMPARE(CellDisplay(model, 0, SideStakeTableModel::Status).toString(), QString("Mandatory"));
+    QVERIFY(model.isMandatory(0));
+
+    // Row 1 (local): allocation is formatted to two decimals; not mandatory.
+    QCOMPARE(CellDisplay(model, 1, SideStakeTableModel::Allocation).toString(), QString("50.50%"));
+    QVERIFY(!model.isMandatory(1));
+
+    // Out-of-range row is not mandatory (defensive path).
+    QVERIFY(!model.isMandatory(5));
+}
+
+void SideStakeModelTests::addRowDelegatesToInterface()
+{
+    qt_test::FakeSideStakeManager fake;
+    fake.m_edit_result.status = interfaces::SideStakeEditStatus::OK;
+    fake.m_edit_result.address = "encodedAddr";
+    fake.m_edit_result.local_revision = 7;
+
+    SideStakeTableModel model(fake);
+    const QString added = model.addRow("rawAddr", "42.50", "the description");
+
+    // The model parses the allocation GUI-side and delegates to the interface
+    // with the parsed value; the encoded address comes back from the interface.
+    QCOMPARE(QString::fromStdString(fake.m_last_add_address), QString("rawAddr"));
+    QCOMPARE(fake.m_last_add_allocation, 42.5);
+    QCOMPARE(QString::fromStdString(fake.m_last_add_description), QString("the description"));
+    QCOMPARE(added, QString("encodedAddr"));
+    QCOMPARE(model.getEditStatus(), SideStakeTableModel::OK);
+}
+
+void SideStakeModelTests::addRowInvalidAllocationSkipsInterface()
+{
+    qt_test::FakeSideStakeManager fake;
+
+    SideStakeTableModel model(fake);
+    const QString added = model.addRow("rawAddr", "not-a-number", "d");
+
+    // An unparseable allocation is rejected GUI-side; the interface is not called.
+    QVERIFY(added.isEmpty());
+    QCOMPARE(model.getEditStatus(), SideStakeTableModel::INVALID_ALLOCATION);
+    QVERIFY(fake.m_last_add_address.empty());
+}
+
+void SideStakeModelTests::removeRowDelegatesToInterface()
+{
+    qt_test::FakeSideStakeManager fake;
+    fake.m_snapshot.entries.push_back(MakeEntry("delAddr", 10.0, "d", "Active", false));
+    fake.m_edit_result.status = interfaces::SideStakeEditStatus::OK;
+
+    SideStakeTableModel model(fake);
+    model.refresh();
+
+    QVERIFY(model.removeRows(0, 1, QModelIndex()));
+    QCOMPARE(QString::fromStdString(fake.m_last_deleted_address), QString("delAddr"));
+}
+
+void SideStakeModelTests::removeRowRefusesMandatory()
+{
+    qt_test::FakeSideStakeManager fake;
+    fake.m_snapshot.entries.push_back(MakeEntry("mandAddr", 25.0, "d", "Mandatory", true));
+    fake.m_edit_result.status = interfaces::SideStakeEditStatus::OK;
+
+    SideStakeTableModel model(fake);
+    model.refresh();
+
+    // A mandatory (contract) entry cannot be deleted: removeRows refuses it and
+    // never reaches the interface, so no deleteLocal command is issued.
+    QVERIFY(!model.removeRows(0, 1, QModelIndex()));
+    QVERIFY(fake.m_last_deleted_address.empty());
+}

--- a/src/qt/test/sidestakemodeltests.h
+++ b/src/qt/test/sidestakemodeltests.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_SIDESTAKEMODELTESTS_H
+#define BITCOIN_QT_TEST_SIDESTAKEMODELTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+//! Phase 1f decoupling proof for SideStakeTableModel: the model is driven
+//! entirely by a fake interfaces::SideStakeManager (qt_test::FakeSideStakeManager)
+//! with no wallet, sidestake registry, or core global involved. The tests assert
+//! the model (a) maps interface value rows onto the table and (b) delegates every
+//! add/delete command back across the interface with the arguments it parsed.
+class SideStakeModelTests : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void emptyUntilRefresh();
+    void mapsSnapshotToTable();
+    void addRowDelegatesToInterface();
+    void addRowInvalidAllocationSkipsInterface();
+    void removeRowDelegatesToInterface();
+    void removeRowRefusesMandatory();
+};
+
+#endif // BITCOIN_QT_TEST_SIDESTAKEMODELTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -2,6 +2,7 @@
 #include <QObject>
 
 #include "bitcoinunitstests.h"
+#include "sidestakemodeltests.h"
 #include "uritests.h"
 
 #if defined(QT_STATICPLUGIN)
@@ -30,6 +31,10 @@ int main(int argc, char *argv[])
 
     URITests test2;
     if (QTest::qExec(&test2) != 0)
+        fInvalid = true;
+
+    SideStakeModelTests test3;
+    if (QTest::qExec(&test3) != 0)
         fInvalid = true;
 
     return fInvalid;

--- a/test/lint/lint-qt-includes.sh
+++ b/test/lint/lint-qt-includes.sh
@@ -4,13 +4,25 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/licenses/mit-license.php.
 #
-# Ratchet for the interfaces:: migration (doc/multiprocess_design.md §7):
-# src/qt must not grow NEW direct includes of core headers -- new GUI code
-# goes through src/interfaces/*.h instead. The allowlist below records the
-# offenders that existed when the ratchet was introduced; entries may only
-# ever be REMOVED (the lint fails on stale entries so the list shrinks as
-# Phase 1 migrates each file). Flipping this from ratchet to empty-allowlist
-# hard-fail is the gate to Phase 2.
+# Phase 1f GATE for the interfaces:: migration (doc/multiprocess_design.md §7).
+# The Phase 1e burn-down drove the old shrinking allowlist to the
+# composition-root floor; this is the flip to the terminal hard-fail gate:
+#
+#   Every src/qt file EXCEPT the composition root must reach core state only
+#   through src/interfaces/*.h. A direct include of a core header is a hard
+#   failure -- there is NO allowlist to grow.
+#
+# The composition root (below) is the ONE documented exemption: the GUI-process
+# entry points that legitimately wire core start-up/shutdown and the updater.
+# They are excluded from the scan, not allowlisted, so no per-header bookkeeping
+# survives here.
+#
+# Surface-area policy (jco): keep the forbidden set BROAD. Even where a core
+# header is stateless, minimizing the core-header surface the GUI links against
+# directly is the goal -- so a header is NOT released from the forbidden set just
+# because it carries no state. Only the genuinely-needed stateless value/utility
+# headers the GUI already includes (amount.h, uint256.h, chainparams.h, sync.h,
+# netbase.h, protocol.h, util.h, ...) stay outside FORBIDDEN_RE.
 #
 # Known non-goals: relative-path evasions (../main.h) are not chased; code
 # review owns those.
@@ -21,40 +33,25 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 
 # chainparams.h / chainparamsbase.h / protocol.h were made stateless by the
 # fTestNet extraction (#3204); netbase.h / sync.h / util.h by the remaining
-# core-global extraction. They expose only stateless declarations now, so the
-# GUI may include them directly and they are no longer forbidden here.
+# core-global extraction. They expose only stateless declarations the GUI
+# already relies on directly, so they stay out of the forbidden set. Everything
+# else core-side (including nominally-stateless key.h / util/system.h) stays
+# forbidden per the surface-area policy above.
 FORBIDDEN_RE='^[[:space:]]*#[[:space:]]*include[[:space:]]*["<](main\.h|validation\.h|init\.h|net\.h|net_processing\.h|miner\.h|txdb\.h|txdb-leveldb\.h|txmempool\.h|banman\.h|alert\.h|keystore\.h|key\.h|chain\.h|psgt\.h|node/[^">]+|util/system\.h|wallet/[^">]+|gridcoin/[^">]+|rpc/[^">]+|policy/[^">]+|script/[^">]+)[">]'
 
-# Remaining file:header pairs. The Phase 1e burn-down has driven this down to
-# the composition-root floor: every entry now lives in one of the three process
-# entry points -- bitcoin.cpp (the app main / model wiring), bitcoingui.cpp, and
-# upgradeqt.cpp (the standalone updater) -- which legitimately drive core
-# start-up, shutdown and the updater and so are not themselves migrated onto
-# src/interfaces/*.h. Flipping the ratchet to a hard-fail against exactly this
-# floor is the Phase 1f gate.
-#
-# DO NOT ADD ENTRIES -- migrate the file onto src/interfaces/*.h instead. (Sole
-# exception: an entry may be added when a migration surfaces PRE-EXISTING
-# coupling that was previously hidden behind a transitive include, e.g.
-# rpcconsole.cpp:banman.h -- the coupling is old, only the include is new.)
-ALLOWLIST="\
-src/qt/bitcoin.cpp:gridcoin/gridcoin.h
-src/qt/bitcoin.cpp:gridcoin/upgrade.h
-src/qt/bitcoin.cpp:init.h
-src/qt/bitcoin.cpp:node/shutdown.h
-src/qt/bitcoin.cpp:node/ui_interface.h
-src/qt/bitcoin.cpp:policy/fees.h
-src/qt/bitcoin.cpp:txdb.h
-src/qt/bitcoin.cpp:validation.h
-src/qt/bitcoingui.cpp:init.h
-src/qt/upgradeqt.cpp:gridcoin/upgrade.h
-"
-
-EXIT_CODE=0
+# The composition root: the three GUI-process entry points (app main / model
+# wiring, the main window, the standalone updater). They own the process wiring
+# -- choosing MakeGridcoinInit()/the IPC Init proxy and driving start-up,
+# shutdown and the updater -- so they legitimately see core headers and are the
+# ONE documented exemption. Excluded from the scan below. This is NOT an
+# allowlist: it is a fixed set of files, not file:header pairs, and it does not
+# grow as the GUI evolves.
+COMPOSITION_ROOT_RE='^src/qt/(bitcoin|bitcoingui|upgradeqt)\.cpp$'
 
 # git wildmatch '*' crosses '/' in ls-files pathspecs, so these two patterns
-# also cover the researcher/, voting/ and test/ subdirectories.
-CURRENT=$(git ls-files 'src/qt/*.cpp' 'src/qt/*.h' | sort -u | while read -r f; do
+# also cover the researcher/, voting/ and test/ subdirectories. The composition
+# root is filtered out; every other file is scanned.
+VIOLATIONS=$(git ls-files 'src/qt/*.cpp' 'src/qt/*.h' | grep -vE "$COMPOSITION_ROOT_RE" | sort -u | while read -r f; do
     grep -E "$FORBIDDEN_RE" "$f" 2>/dev/null \
         | sed -E 's/^[[:space:]]*#[[:space:]]*include[[:space:]]*["<]([^">]+)[">].*/\1/' \
         | while read -r h; do
@@ -62,23 +59,16 @@ CURRENT=$(git ls-files 'src/qt/*.cpp' 'src/qt/*.h' | sort -u | while read -r f; 
         done
 done | sort -u)
 
-NEW_VIOLATIONS=$(comm -13 <(echo "$ALLOWLIST" | grep -v '^$' | sort -u) <(echo "$CURRENT" | grep -v '^$'))
-STALE_ENTRIES=$(comm -23 <(echo "$ALLOWLIST" | grep -v '^$' | sort -u) <(echo "$CURRENT" | grep -v '^$'))
-
-if [ -n "$NEW_VIOLATIONS" ]; then
-    echo "New direct core include(s) in src/qt (file:header):"
-    echo "$NEW_VIOLATIONS"
+if [ -n "$VIOLATIONS" ]; then
+    echo "Direct core header include(s) in src/qt outside the composition root (file:header):"
+    echo "$VIOLATIONS"
     echo
-    echo "GUI code must consume core state through src/interfaces/*.h (see"
-    echo "src/interfaces/README.md and doc/multiprocess_design.md). Do not add"
-    echo "these includes to the allowlist in $(basename "${BASH_SOURCE[0]}")."
-    EXIT_CODE=1
+    echo "This is the Phase 1f gate: GUI code must consume core state through"
+    echo "src/interfaces/*.h (see src/interfaces/README.md and"
+    echo "doc/multiprocess_design.md). There is no allowlist -- migrate the file"
+    echo "onto an interface, or (only for the process entry points) add it to the"
+    echo "composition-root exemption in $(basename "${BASH_SOURCE[0]}")."
+    exit 1
 fi
 
-if [ -n "$STALE_ENTRIES" ]; then
-    echo "Stale allowlist entr(y/ies) in $(basename "${BASH_SOURCE[0]}") -- the include is gone; remove the entry so the ratchet tightens:"
-    echo "$STALE_ENTRIES"
-    EXIT_CODE=1
-fi
-
-exit $EXIT_CODE
+exit 0


### PR DESCRIPTION
> **Draft — holding for maintainer review before merge.** This is the Phase 1f gate; it should not land without a deliberate sign-off on the gate policy.

Phase 1f of the multiprocess GUI/node separation (RFC #2937): the gate to Phase 2. Three deliverables.

## 1. Flip the ratchet to the hard-fail gate

The Phase 1e burn-down (#3211) drove `lint-qt-includes.sh`'s shrinking allowlist down to the composition-root floor. This flips it to the terminal gate:

- Every `src/qt` file **except the three GUI-process entry points** (`bitcoin.cpp` / `bitcoingui.cpp` / `upgradeqt.cpp`) must reach core state only through `src/interfaces/*.h`. A direct core-header include is now a **hard failure** — there is no allowlist to grow.
- The composition root is a fixed **scan-exclusion** (a set of files, not `file:header` pairs), the one documented exemption. No per-header bookkeeping survives.
- **Surface-area policy:** `FORBIDDEN_RE` stays broad. A core header is *not* released just because it is stateless — minimizing the core-header surface the GUI links against directly is the goal — so only the genuinely-needed stateless value headers the GUI already includes stay outside the forbidden set.

Verified: passes on the current tree, and hard-fails when a forbidden include is added to any non-root file.

## 2. Marshalability pins on every boundary DTO

`src/interfaces/marshal.h` adds `INTERFACES_ASSERT_MARSHALABLE(T)` — a compile-time pin that a value type crossing the `interfaces::` boundary stays freely copyable, so a node-side impl can fill one and ship it across. It trips on a move-only / non-copyable regression (a `std::unique_ptr`, `std::mutex`/atomic, or reference member). It does not catch a raw pointer or Qt type (both stay copyable) — that discipline remains review-owned, and the comment says so.

Applied to all ~54 boundary DTOs across the interface headers; the existing longhand asserts in `wallet_tx_record.h` are refactored onto the macro (keeping its fixed-width `decltype` pin on the amount/time fields).

## 3. Interface-fake model-test harness

The decoupling *proof*: exercise a GUI model against a hand-rolled fake of its `interfaces::` boundary — no wallet, registry, or core global — so the model demonstrably holds no hidden core coupling.

- `src/qt/test/interfacefakes.h` — reusable test doubles (starting with `FakeSideStakeManager`: canned `entries()`/edit results, records the add/delete arguments the model issued).
- `src/qt/test/sidestakemodeltests.{h,cpp}` — a Qt Test suite driving `SideStakeTableModel` against the fake: starts empty until `refresh()`, maps interface value rows onto the table, delegates add/delete back across the interface with the GUI-parsed allocation, rejects an unparseable allocation without calling the interface, and refuses to delete a mandatory entry.
- Hand-rolled rather than gMock: the test stack has no gmock dependency and the interfaces are small enough that override-and-record fakes read more clearly.

This establishes the harness; `interfacefakes.h` is built to grow more fakes (ClientModel + Node/StakingStatus next) as further models get decoupling tests.

## Testing
- `build_targets.sh TARGET=native BUILD_TYPE=RelWithDebInfo USE_QT6=true WITH_GUI=true` — clean build.
- Full ctest incl. the new `SideStakeModelTests` (Qt Test) — all pass.
- `lint-qt-includes.sh` (the new gate) + `lint-all.sh` pass.
- Independent adversarial review of all three deliverables — no correctness defects; its notes (marshal.h comment accuracy, a mandatory-refusal test case, a no-event-loop note for future notification tests) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)