### PR TITLE
gui: namespace QSettings per node (datadir)

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -477,6 +477,12 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    // The datadir is now finalized (network selected, -datadir resolved), so the
+    // per-node QSettings group is known: read the GUI preferences that are keyed
+    // per node. OptionsModel's constructor (Init) ran earlier -- before the
+    // datadir was chosen -- so it deliberately deferred these until now.
+    optionsModel.readNodeSettings();
+
     // Now that the config file, network selection and read-write settings file
     // are loaded, migrate any proxy / UPnP / reservebalance / update-check values
     // the user had in Gridcoin-Qt.conf into the core read-write settings (one-time).

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -109,11 +109,7 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
 {
     QSettings settings;
 
-    QString window_geometry_key = "MainWindowGeometry";
-
-    if (GetDataDir() != GetDefaultDataDir()) {
-        window_geometry_key += "_" + QString().fromStdString(SanitizeString(GetDataDir().string()));
-    }
+    const QString window_geometry_key = GUIUtil::nodeSettingsKey("MainWindowGeometry");
 
     if (!restoreGeometry(settings.value(window_geometry_key).toByteArray())) {
         // Restore failed (perhaps missing setting), center the window
@@ -255,11 +251,7 @@ BitcoinGUI::~BitcoinGUI()
 {
     QSettings settings;
 
-    QString window_geometry_key = "MainWindowGeometry";
-
-    if (GetDataDir() != GetDefaultDataDir()) {
-        window_geometry_key += "_" + QString().fromStdString(SanitizeString(GetDataDir().string()));
-    }
+    const QString window_geometry_key = GUIUtil::nodeSettingsKey("MainWindowGeometry");
 
     settings.setValue(window_geometry_key, saveGeometry());
     if(trayIcon) // Hide tray icon, as deleting will let it linger until quit (on Ubuntu)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -13,6 +13,8 @@
 // test/lint/lint-qt-includes.sh.
 #include "chainparams.h"
 #include "clientversion.h"
+#include "util/strencodings.h" // For SanitizeString (per-node QSettings key).
+#include <algorithm>           // For std::replace.
 #include <codecvt>
 
 #include <QString>
@@ -334,6 +336,29 @@ QString boostPathToQString(const fs::path &path)
 QString getDefaultDataDirectory()
 {
     return boostPathToQString(GetDefaultDataDir());
+}
+
+namespace {
+//! The per-node QSettings group: "" for the default datadir (keep the existing
+//! flat keys), "node_<sanitized datadir>" otherwise. Path separators are
+//! flattened so the datadir becomes one group level rather than nested QSettings
+//! groups.
+QString NodeSettingsGroup()
+{
+    if (GetDataDir() == GetDefaultDataDir()) {
+        return QString();
+    }
+    std::string dd = SanitizeString(GetDataDir().string());
+    std::replace(dd.begin(), dd.end(), '/', '_');
+    std::replace(dd.begin(), dd.end(), '\\', '_');
+    return "node_" + QString::fromStdString(dd);
+}
+} // namespace
+
+QString nodeSettingsKey(const QString& key)
+{
+    const QString group = NodeSettingsGroup();
+    return group.isEmpty() ? key : group + "/" + key;
 }
 
 QString getSaveFileName(QWidget *parent, const QString &caption,

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -345,10 +345,19 @@ namespace {
 //! groups.
 QString NodeSettingsGroup()
 {
-    if (GetDataDir() == GetDefaultDataDir()) {
+    // Compare the NON-net-specific datadir against the default. The network is
+    // already separated by the QSettings ApplicationName, so the group only needs
+    // to distinguish datadirs. GetDataDir() (net-specific) includes the
+    // "testnet"/"regtest" subdir, which would make even the default datadir look
+    // non-default on those networks -- breaking the "primary node keeps flat keys"
+    // goal. GetDataDir(false) answers "did the user override -datadir?" regardless
+    // of network.
+    if (GetDataDir(false) == GetDefaultDataDir()) {
         return QString();
     }
-    std::string dd = SanitizeString(GetDataDir().string());
+    // Convert via boostPathToQString(), not fs::path::string(): a raw narrowing
+    // can corrupt non-codepage path characters on Windows (see boostPathToQString).
+    std::string dd = SanitizeString(boostPathToQString(GetDataDir(false)).toStdString());
     std::replace(dd.begin(), dd.end(), '/', '_');
     std::replace(dd.begin(), dd.end(), '\\', '_');
     return "node_" + QString::fromStdString(dd);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -73,6 +73,16 @@ namespace GUIUtil
 
     QString getDefaultDataDirectory();
 
+    //! Namespace a QSettings key per node (datadir) so multiple wallet instances
+    //! on one machine don't overwrite each other's GUI preferences. Returns \p key
+    //! unchanged for the default datadir (preserving the existing flat keys, so the
+    //! primary node needs no migration), and prefixes a per-datadir group
+    //! ("node_<sanitized datadir>/") otherwise. Combined with the network-scoped
+    //! application name, this isolates each (network, datadir) node. MUST be called
+    //! only after the datadir is finalized (GetDataDir() valid) -- see
+    //! OptionsModel::readNodeSettings and the note in bitcoin.cpp.
+    QString nodeSettingsKey(const QString& key);
+
     /** Get save filename, mimics QFileDialog::getSaveFileName, except that it appends a default suffix
         when no suffix is provided by the user.
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -132,8 +132,15 @@ void OptionsModel::readNodeSettings()
     // finalized there; the composition root calls this once it is.
     QSettings settings;
     nDisplayUnit = settings.value(GUIUtil::nodeSettingsKey("nDisplayUnit"), BitcoinUnits::BTC).toInt();
-    fStartAtStartup = settings.value(GUIUtil::nodeSettingsKey("fStartAtStartup"), false).toBool();
-    fStartMin = settings.value(GUIUtil::nodeSettingsKey("fStartMin"), true).toBool();
+    // fStartAtStartup / fStartMin are deliberately NOT per-node: the OS autostart
+    // entry they mirror (GUIUtil::SetStartOnSystemStartup) is keyed only by network
+    // ("gridcoin-mainnet.desktop" / "gridcoin-testnet.desktop"), not by datadir, so
+    // all same-network nodes share one entry. Per-node QSettings state would let the
+    // UI show an autostart status that disagrees with the single OS entry. Use flat
+    // (network-scoped, via ApplicationName) keys so the stored state matches the
+    // actual per-network behavior. Keep this in sync with the setData() cases.
+    fStartAtStartup = settings.value("fStartAtStartup", false).toBool();
+    fStartMin = settings.value("fStartMin", true).toBool();
     fMinimizeToTray = settings.value(GUIUtil::nodeSettingsKey("fMinimizeToTray"), false).toBool();
     fDisableTrxNotifications = settings.value(GUIUtil::nodeSettingsKey("fDisableTrxNotifications"), false).toBool();
     fDisablePollNotifications = settings.value(GUIUtil::nodeSettingsKey("fDisablePollNotifications"), false).toBool();
@@ -288,7 +295,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (fStartAtStartup != value.toBool())
             {
                 fStartAtStartup = value.toBool();
-                settings.setValue(GUIUtil::nodeSettingsKey("fStartAtStartup"), fStartAtStartup);
+                // Flat (network-scoped) key, not per-node: the OS autostart entry is
+                // per-network, not per-datadir. See readNodeSettings().
+                settings.setValue("fStartAtStartup", fStartAtStartup);
                 successful = GUIUtil::SetStartOnSystemStartup(fStartAtStartup, fStartMin);
             }
             break;
@@ -296,7 +305,8 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (fStartMin != value.toBool())
             {
                 fStartMin = value.toBool();
-                settings.setValue(GUIUtil::nodeSettingsKey("fStartMin"), fStartMin);
+                // Flat (network-scoped) key, not per-node: see readNodeSettings().
+                settings.setValue("fStartMin", fStartMin);
                 successful = GUIUtil::SetStartOnSystemStartup(fStartAtStartup, fStartMin);
             }
             break;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -36,9 +36,10 @@ std::string FormatReserveBalanceSetting(qint64 sat)
 //! from the previous behavior).
 bool PushEffectiveProxy(interfaces::Node& node, QSettings& settings)
 {
-    const bool use_proxy = settings.value("fUseProxy", false).toBool();
+    const bool use_proxy = settings.value(GUIUtil::nodeSettingsKey("fUseProxy"), false).toBool();
     const std::string addr =
-        use_proxy ? settings.value("addrProxy", "127.0.0.1:9050").toString().toStdString() : std::string();
+        use_proxy ? settings.value(GUIUtil::nodeSettingsKey("addrProxy"), "127.0.0.1:9050").toString().toStdString()
+                  : std::string();
     return node.changeSettings({{"proxy", addr}}).ok;
 }
 
@@ -76,23 +77,11 @@ void OptionsModel::Init()
 {
     QSettings settings;
 
-    // These are Qt-only settings:
-    nDisplayUnit = settings.value("nDisplayUnit", BitcoinUnits::BTC).toInt();
-    fStartAtStartup = settings.value("fStartAtStartup", false).toBool();
-    fStartMin = settings.value("fStartMin", true).toBool();
-    fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
-    fDisableTrxNotifications = settings.value("fDisableTrxNotifications", false).toBool();
-    fDisablePollNotifications = settings.value("fDisablePollNotifications", false).toBool();
-    bDisplayAddresses = settings.value("bDisplayAddresses", false).toBool();
-    fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
-    fConfirmOnClose = settings.value("fConfirmOnClose", false).toBool();
-    fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
-    fLimitTxnDisplay = settings.value("fLimitTxnDisplay", false).toBool();
-    fMaskValues = settings.value("fMaskValues", false).toBool();
-    limitTxnDate = settings.value("limitTxnDate", QDate()).toDate();
-    pollExpireNotification = settings.value("pollExpireNotification", 8.0).toDouble();
+    // language is read HERE (not in readNodeSettings) because it feeds -lang for
+    // the Qt translator, which is installed before the datadir is finalized -- so
+    // it stays a global (not per-node) setting. Every other Qt-only preference is
+    // per-node and read later, in readNodeSettings(), once GetDataDir() is known.
     language = settings.value("language", "").toString();
-    walletStylesheet = settings.value("walletStylesheet", "dark").toString();
 
     // Language stays GUI-local (the core does not read -lang): apply it into this
     // process's own args for the Qt translator.
@@ -112,6 +101,30 @@ void OptionsModel::Init()
     }
 
     m_sidestake_model = new SideStakeTableModel(m_sidestake_manager, this);
+}
+
+void OptionsModel::readNodeSettings()
+{
+    // The per-node GUI preferences, read under the datadir-keyed QSettings group
+    // (GUIUtil::nodeSettingsKey) so multiple wallet instances on one machine do
+    // not overwrite each other. Deferred out of Init() because the datadir is not
+    // finalized there; the composition root calls this once it is.
+    QSettings settings;
+    nDisplayUnit = settings.value(GUIUtil::nodeSettingsKey("nDisplayUnit"), BitcoinUnits::BTC).toInt();
+    fStartAtStartup = settings.value(GUIUtil::nodeSettingsKey("fStartAtStartup"), false).toBool();
+    fStartMin = settings.value(GUIUtil::nodeSettingsKey("fStartMin"), true).toBool();
+    fMinimizeToTray = settings.value(GUIUtil::nodeSettingsKey("fMinimizeToTray"), false).toBool();
+    fDisableTrxNotifications = settings.value(GUIUtil::nodeSettingsKey("fDisableTrxNotifications"), false).toBool();
+    fDisablePollNotifications = settings.value(GUIUtil::nodeSettingsKey("fDisablePollNotifications"), false).toBool();
+    bDisplayAddresses = settings.value(GUIUtil::nodeSettingsKey("bDisplayAddresses"), false).toBool();
+    fMinimizeOnClose = settings.value(GUIUtil::nodeSettingsKey("fMinimizeOnClose"), false).toBool();
+    fConfirmOnClose = settings.value(GUIUtil::nodeSettingsKey("fConfirmOnClose"), false).toBool();
+    fCoinControlFeatures = settings.value(GUIUtil::nodeSettingsKey("fCoinControlFeatures"), false).toBool();
+    fLimitTxnDisplay = settings.value(GUIUtil::nodeSettingsKey("fLimitTxnDisplay"), false).toBool();
+    fMaskValues = settings.value(GUIUtil::nodeSettingsKey("fMaskValues"), false).toBool();
+    limitTxnDate = settings.value(GUIUtil::nodeSettingsKey("limitTxnDate"), QDate()).toDate();
+    pollExpireNotification = settings.value(GUIUtil::nodeSettingsKey("pollExpireNotification"), 8.0).toDouble();
+    walletStylesheet = settings.value(GUIUtil::nodeSettingsKey("walletStylesheet"), "dark").toString();
 }
 
 void OptionsModel::migrateCoreSettings()
@@ -188,11 +201,11 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case ProxyUse:
             // GUI editing state: whether the user enabled the proxy. The effective
             // proxy address is mirrored to the core -proxy setting on change.
-            return settings.value("fUseProxy", false);
+            return settings.value(GUIUtil::nodeSettingsKey("fUseProxy"), false);
         case ProxyIP:
-            return QVariant(SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).first);
+            return QVariant(SplitProxy(settings.value(GUIUtil::nodeSettingsKey("addrProxy"), "127.0.0.1:9050").toString()).first);
         case ProxyPort:
-            return QVariant(SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).second);
+            return QVariant(SplitProxy(settings.value(GUIUtil::nodeSettingsKey("addrProxy"), "127.0.0.1:9050").toString()).second);
         case ReserveBalance: {
             qint64 sat = 0;
             BitcoinUnits::parse(BitcoinUnits::BTC,
@@ -206,7 +219,7 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case Language:
             return settings.value("language", "");
         case WalletStylesheet:
-            return settings.value("walletStylesheet", "dark");
+            return settings.value(GUIUtil::nodeSettingsKey("walletStylesheet"), "dark");
         case CoinControlFeatures:
             return QVariant(fCoinControlFeatures);
         case LimitTxnDisplay:
@@ -254,7 +267,7 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (fStartAtStartup != value.toBool())
             {
                 fStartAtStartup = value.toBool();
-                settings.setValue("fStartAtStartup", fStartAtStartup);
+                settings.setValue(GUIUtil::nodeSettingsKey("fStartAtStartup"), fStartAtStartup);
                 successful = GUIUtil::SetStartOnSystemStartup(fStartAtStartup, fStartMin);
             }
             break;
@@ -262,25 +275,25 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (fStartMin != value.toBool())
             {
                 fStartMin = value.toBool();
-                settings.setValue("fStartMin", fStartMin);
+                settings.setValue(GUIUtil::nodeSettingsKey("fStartMin"), fStartMin);
                 successful = GUIUtil::SetStartOnSystemStartup(fStartAtStartup, fStartMin);
             }
             break;
         case MinimizeToTray:
             fMinimizeToTray = value.toBool();
-            settings.setValue("fMinimizeToTray", fMinimizeToTray);
+            settings.setValue(GUIUtil::nodeSettingsKey("fMinimizeToTray"), fMinimizeToTray);
             break;
         case ConfirmOnClose:
             fConfirmOnClose = value.toBool();
-            settings.setValue("fConfirmOnClose", fConfirmOnClose);
+            settings.setValue(GUIUtil::nodeSettingsKey("fConfirmOnClose"), fConfirmOnClose);
             break;
         case DisableTrxNotifications:
             fDisableTrxNotifications = value.toBool();
-            settings.setValue("fDisableTrxNotifications", fDisableTrxNotifications);
+            settings.setValue(GUIUtil::nodeSettingsKey("fDisableTrxNotifications"), fDisableTrxNotifications);
             break;
         case DisablePollNotifications:
             fDisablePollNotifications = value.toBool();
-            settings.setValue("fDisablePollNotifications", fDisablePollNotifications);
+            settings.setValue(GUIUtil::nodeSettingsKey("fDisablePollNotifications"), fDisablePollNotifications);
             break;
         case MapPortUPnP:
             // Core setting: the node applies it (SetUseUPnP + MapPort start/stop
@@ -289,24 +302,24 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
         case MinimizeOnClose:
             fMinimizeOnClose = value.toBool();
-            settings.setValue("fMinimizeOnClose", fMinimizeOnClose);
+            settings.setValue(GUIUtil::nodeSettingsKey("fMinimizeOnClose"), fMinimizeOnClose);
             break;
         case ProxyUse:
-            settings.setValue("fUseProxy", value.toBool());
+            settings.setValue(GUIUtil::nodeSettingsKey("fUseProxy"), value.toBool());
             successful = PushEffectiveProxy(m_node, settings);
             break;
         case ProxyIP: {
             // Replace the host part of the stored address; port is kept. IPv6-aware
             // via SplitProxy/FormatProxy (brackets round-trip correctly).
-            const int port = SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).second;
-            settings.setValue("addrProxy", FormatProxy(value.toString(), port));
+            const int port = SplitProxy(settings.value(GUIUtil::nodeSettingsKey("addrProxy"), "127.0.0.1:9050").toString()).second;
+            settings.setValue(GUIUtil::nodeSettingsKey("addrProxy"), FormatProxy(value.toString(), port));
             successful = PushEffectiveProxy(m_node, settings);
         }
         break;
         case ProxyPort: {
             // Replace the port part of the stored address; host is kept.
-            const QString host = SplitProxy(settings.value("addrProxy", "127.0.0.1:9050").toString()).first;
-            settings.setValue("addrProxy", FormatProxy(host, value.toInt()));
+            const QString host = SplitProxy(settings.value(GUIUtil::nodeSettingsKey("addrProxy"), "127.0.0.1:9050").toString()).first;
+            settings.setValue(GUIUtil::nodeSettingsKey("addrProxy"), FormatProxy(host, value.toInt()));
             successful = PushEffectiveProxy(m_node, settings);
         }
         break;
@@ -324,44 +337,44 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         break;
         case DisplayUnit:
             nDisplayUnit = value.toInt();
-            settings.setValue("nDisplayUnit", nDisplayUnit);
+            settings.setValue(GUIUtil::nodeSettingsKey("nDisplayUnit"), nDisplayUnit);
             emit displayUnitChanged(nDisplayUnit);
             break;
 		case DisplayAddresses:
              bDisplayAddresses = value.toBool();
-             settings.setValue("bDisplayAddresses", bDisplayAddresses);
+             settings.setValue(GUIUtil::nodeSettingsKey("bDisplayAddresses"), bDisplayAddresses);
              break;
         case Language:
             settings.setValue("language", value);
             break;
         case WalletStylesheet:
             walletStylesheet = value.toString();
-            settings.setValue("walletStylesheet", walletStylesheet);
+            settings.setValue(GUIUtil::nodeSettingsKey("walletStylesheet"), walletStylesheet);
             emit walletStylesheetChanged(walletStylesheet);
             break;
         case CoinControlFeatures: {
             fCoinControlFeatures = value.toBool();
-            settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
+            settings.setValue(GUIUtil::nodeSettingsKey("fCoinControlFeatures"), fCoinControlFeatures);
             emit coinControlFeaturesChanged(fCoinControlFeatures);
             }
             break;
         case LimitTxnDisplay:
             fLimitTxnDisplay = value.toBool();
-            settings.setValue("fLimitTxnDisplay", fLimitTxnDisplay);
+            settings.setValue(GUIUtil::nodeSettingsKey("fLimitTxnDisplay"), fLimitTxnDisplay);
             emit LimitTxnDisplayChanged(fLimitTxnDisplay);
             break;
         case MaskValues:
             fMaskValues = value.toBool();
-            settings.setValue("fMaskValues", fMaskValues);
+            settings.setValue(GUIUtil::nodeSettingsKey("fMaskValues"), fMaskValues);
             emit MaskValuesChanged(fMaskValues);
             break;
         case LimitTxnDate:
             limitTxnDate = value.toDate();
-            settings.setValue("limitTxnDate", limitTxnDate);
+            settings.setValue(GUIUtil::nodeSettingsKey("limitTxnDate"), limitTxnDate);
             break;
         case PollExpireNotification:
             pollExpireNotification = value.toDouble();
-            settings.setValue("pollExpireNotification", pollExpireNotification);
+            settings.setValue(GUIUtil::nodeSettingsKey("pollExpireNotification"), pollExpireNotification);
             break;
         case DisableUpdateCheck:
             // Core read-write setting (the core scheduler and the GUI both read

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -77,6 +77,27 @@ void OptionsModel::Init()
 {
     QSettings settings;
 
+    // Give the per-node preference members determinate values up front. They are
+    // re-read from the per-node QSettings group in readNodeSettings() once the
+    // datadir is finalized, but Init() runs from the constructor (before that), so
+    // without this any access in the interim would read an uninitialized member.
+    // Keep these defaults in sync with readNodeSettings().
+    nDisplayUnit = BitcoinUnits::BTC;
+    fStartAtStartup = false;
+    fStartMin = true;
+    fMinimizeToTray = false;
+    fDisableTrxNotifications = false;
+    fDisablePollNotifications = false;
+    bDisplayAddresses = false;
+    fMinimizeOnClose = false;
+    fConfirmOnClose = false;
+    fCoinControlFeatures = false;
+    fLimitTxnDisplay = false;
+    fMaskValues = false;
+    limitTxnDate = QDate();
+    pollExpireNotification = 8.0;
+    walletStylesheet = "dark";
+
     // language is read HERE (not in readNodeSettings) because it feeds -lang for
     // the Qt translator, which is installed before the datadir is finalized -- so
     // it stays a global (not per-node) setting. Every other Qt-only preference is

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -63,6 +63,15 @@ public:
 
     void Init();
 
+    //! Read the per-node GUI preferences into the model's members. Split out of
+    //! Init() because those settings live under a per-node QSettings group keyed
+    //! on the datadir (GUIUtil::nodeSettingsKey), which is only known once the
+    //! datadir is finalized. Init() runs from the constructor -- before the
+    //! datadir is chosen (it seeds -datadir from the stored value) -- so it cannot
+    //! read them; the composition root calls this afterwards. See the ordering
+    //! note in bitcoin.cpp.
+    void readNodeSettings();
+
     //! One-time migration of the settings that moved from Gridcoin-Qt.conf into
     //! the core read-write settings file (proxy / UPnP / reservebalance /
     //! update-check). Must be called from the composition root AFTER the config


### PR DESCRIPTION
## Summary

Multiple wallet instances on one machine share a single QSettings store, scoped only by `OrganizationName` (`Gridcoin`) and a network-separated `ApplicationName` (`Gridcoin-Qt` / `Gridcoin-Qt-testnet`). Two nodes on the **same network but different datadirs** therefore overwrite each other's GUI preferences (display unit, minimize-to-tray, proxy, wallet stylesheet, ...). Only the main-window geometry was previously isolated per datadir, via an ad-hoc `_<sanitized datadir>` key suffix.

This PR introduces `GUIUtil::nodeSettingsKey()`, which prefixes a per-node group `node_<sanitized datadir>/` to a key for a non-default datadir and leaves the key unchanged for the default datadir (so the **primary node keeps its existing flat keys and needs no migration**). Every per-node GUI preference read/write is routed through it, and the bespoke window-geometry suffix logic in `bitcoingui.cpp` is folded onto the same helper.

## Init split (timing)

The datadir is not finalized when `OptionsModel` is constructed — `Init()` seeds `-datadir` from the stored value *before* the network is selected. So the per-node preference reads are split out of `Init()` into a new `OptionsModel::readNodeSettings()`, which the composition root (`bitcoin.cpp`) calls once the datadir is known (right before `migrateCoreSettings()`).

### What deliberately stays global
- **`language`** — feeds `-lang` for the Qt translator, which is installed *before* the datadir is finalized. Read in `Init()`, kept a global key.
- **`migrateCoreSettings()` source keys** (`fUseProxy` / `addrProxy` / `fUseUPnP` / `nReserveBalance` / `fDisableUpdateCheck`, and the `coreSettingsMigrated` flag) — these are the pre-upgrade global values the one-time migration must import; they must read the OLD global scope.
- **`dataDir`** — applies only to the *default* data dir bootstrap; multinode setups are expected to provide `-datadir` overrides for non-default nodes.

## Upgrade behavior

Non-default-datadir nodes see their GUI preferences (and window geometry) reset to defaults **once** on upgrade. They were colliding before, so this is a strict improvement and needs no migration. The default (primary) node is unaffected — its keys are unchanged.

## Testing
- Native GUI build (Qt6, `RelWithDebInfo`): clean.
- Full test suite: 100% passed (3/3 suites, including `test_gridcoin-qt`).
- `test/lint/lint-all.sh`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (review):** two adjustments from Copilot review —
1. `fStartAtStartup` / `fStartMin` are kept **global** (flat, network-scoped) rather than per-node: the OS autostart entry they mirror is keyed by network only (`gridcoin-<network>.desktop`), not by datadir, so per-node state could disagree with the single shared OS entry.
2. Precise upgrade note: the only *default*-datadir node that resets on upgrade is a **testnet/regtest** node's **window geometry** (it previously used a net-specific suffixed key; it now uses the flat key). Mainnet default nodes are unaffected. This is a one-time, cosmetic reposition; a legacy-key fallback was intentionally not added (it would reintroduce the net-specific path logic this PR removes).