### PR TITLE
ipc: Cap'n Proto schemas for Init/Handler/Node/StakingStatus (Phase 2a)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,15 +17,9 @@ add_compile_definitions(
     __STDC_FORMAT_MACROS
 )
 
-# Multiprocess (IPC) build, RFC #2937. In the default (vendored) mode, build the
-# libmultiprocess runtime and its mpgen code generator from the in-tree subtree at
-# src/ipc/libmultiprocess. Cap'n Proto was already located in the top-level
-# CMakeLists.txt. This only defines the build targets; no Gridcoin target consumes
-# them yet (the .capnp schemas and proxy wiring come in a later Phase 2 step).
-if(ENABLE_MULTIPROCESS AND NOT WITH_EXTERNAL_LIBMULTIPROCESS)
-    include(${CMAKE_SOURCE_DIR}/cmake/libmultiprocess.cmake)
-    add_libmultiprocess(ipc/libmultiprocess)
-endif()
+# Multiprocess (IPC) build, RFC #2937: src/ipc is add_subdirectory'd later in this
+# file (after gridcoin_util is defined, since the generated proxy layer links it
+# for the core interface headers). See the ENABLE_MULTIPROCESS block near the end.
 
 if(WIN32)
     # _WIN32_WINNT is already defined by the toolchain/CMake.
@@ -299,6 +293,18 @@ if(UNIX)
 endif()
 
 target_link_libraries(gridcoin_util PUBLIC ${LIBGRIDCOIN_CRYPTO})
+
+# Multiprocess (IPC) build, RFC #2937. src/ipc owns the libmultiprocess runtime +
+# mpgen (built from the in-tree subtree in the default vendored mode) and the
+# generated Cap'n Proto proxy layer (gridcoin_ipc). Added here, after gridcoin_util
+# is defined, because the generated proxy code includes the interfaces:: headers,
+# which transitively pull core headers (univalue, etc.); gridcoin_ipc links
+# gridcoin_util for that include environment. The proxy targets are
+# EXCLUDE_FROM_ALL; no Gridcoin binary links them yet (transport + client wiring
+# are later Phase 2 steps).
+if(ENABLE_MULTIPROCESS)
+    add_subdirectory(ipc)
+endif()
 
 if(WIN32)
     target_link_libraries(gridcoin_util PUBLIC

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+# Multiprocess (IPC) layer for the interfaces:: boundary (RFC #2937, Phase 2).
+# Reached only when ENABLE_MULTIPROCESS is ON (this directory is add_subdirectory'd
+# from src/CMakeLists.txt under that guard).
+
+# Build the vendored libmultiprocess runtime + mpgen from the in-tree subtree,
+# unless an external libmultiprocess was requested (then the top-level
+# CMakeLists.txt found it via find_package).
+if(NOT WITH_EXTERNAL_LIBMULTIPROCESS)
+    include(${CMAKE_SOURCE_DIR}/cmake/libmultiprocess.cmake)
+    add_libmultiprocess(libmultiprocess)
+endif()
+
+# The generated Cap'n Proto proxy layer. target_capnp_sources runs mpgen on each
+# .capnp, generating the raw capnp types (.capnp.h/.c++) and the ProxyClient/
+# ProxyServer marshalling code (.proxy-*), and adds them as sources of this
+# library. The include prefix (this dir) reproduces the ipc/capnp/... include
+# spelling the schemas' $Proxy.includeTypes and consumers use.
+add_library(gridcoin_ipc STATIC EXCLUDE_FROM_ALL)
+
+target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
+    capnp/handler.capnp
+    capnp/staking.capnp
+    capnp/node.capnp
+    capnp/init.capnp
+)
+
+# ${CMAKE_SOURCE_DIR}/src resolves the interfaces/*.h the generated code wraps;
+# ${CMAKE_BINARY_DIR}/src resolves the generated ipc/capnp/*.capnp.h headers
+# (matching the project-wide convention in this file's parent).
+target_include_directories(gridcoin_ipc PUBLIC
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src
+)
+
+# The generated proxy code includes libmultiprocess's mp/ headers, which use C++20
+# concepts; the rest of Gridcoin is C++17. Compile this target (and propagate to
+# anything linking it, since the proxy headers are C++20) as C++20.
+set_target_properties(gridcoin_ipc PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+target_compile_features(gridcoin_ipc PUBLIC cxx_std_20)
+
+# Link gridcoin_util for the core interface headers' include environment (the
+# interfaces:: headers the generated proxies wrap transitively include core
+# headers such as univalue). Static-lib linkage here only propagates include
+# dirs / compile definitions; no objects are pulled into libgridcoin_ipc.a.
+target_link_libraries(gridcoin_ipc PUBLIC
+    gridcoin_util
+)

--- a/src/ipc/capnp/common-types.h
+++ b/src/ipc/capnp/common-types.h
@@ -11,6 +11,7 @@
 #include <mp/util.h>
 
 #include <cstring>
+#include <stdexcept>
 #include <vector>
 
 //! Custom marshalling for Gridcoin value types that cross the IPC boundary but
@@ -34,6 +35,13 @@ template <typename Input, typename ReadDest>
 decltype(auto) CustomReadField(TypeList<uint256>, Priority<1>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
 {
     auto data = input.get();
+    // The Data field comes off the wire (untrusted in the separated build). The
+    // uint256(vector) constructor asserts the length and then memcpy's a fixed
+    // 32 bytes, so a short buffer would read out of bounds once asserts are
+    // compiled out (NDEBUG). Validate the length here and fail fast on mismatch.
+    if (data.size() != uint256::size()) {
+        throw std::runtime_error("uint256 IPC field has wrong length");
+    }
     return read_dest.construct(std::vector<unsigned char>(data.begin(), data.end()));
 }
 

--- a/src/ipc/capnp/common-types.h
+++ b/src/ipc/capnp/common-types.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_COMMON_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_COMMON_TYPES_H
+
+#include <uint256.h>
+
+#include <mp/proxy-types.h>
+#include <mp/util.h>
+
+#include <cstring>
+#include <vector>
+
+//! Custom marshalling for Gridcoin value types that cross the IPC boundary but
+//! are not plain capnp structs. Included (via each schema's
+//! $Proxy.includeTypes -> *-types.h) so the generated proxy code can build/read
+//! them. Lives in namespace mp so ADL finds these next to the library's own
+//! CustomBuildField/CustomReadField overloads.
+namespace mp {
+
+//! uint256 is marshalled as its 32 raw bytes in a capnp Data field. (A blob
+//! rather than a $Proxy.wrap struct: it is an opaque fixed-width hash, not a
+//! record of named fields.)
+template <typename Value, typename Output>
+void CustomBuildField(TypeList<uint256>, Priority<1>, InvokeContext& invoke_context, Value&& value, Output&& output)
+{
+    auto result = output.init(value.size());
+    std::memcpy(result.begin(), value.begin(), value.size());
+}
+
+template <typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<uint256>, Priority<1>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
+{
+    auto data = input.get();
+    return read_dest.construct(std::vector<unsigned char>(data.begin(), data.end()));
+}
+
+} // namespace mp
+
+#endif // GRIDCOIN_IPC_CAPNP_COMMON_TYPES_H

--- a/src/ipc/capnp/handler-types.h
+++ b/src/ipc/capnp/handler-types.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_HANDLER_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_HANDLER_TYPES_H
+
+#include <interfaces/handler.h>
+#include <ipc/capnp/handler.capnp.proxy.h>
+
+// Type-marshalling support headers for the capnp types this schema uses.
+// Handler only takes the framework-supplied Proxy.Context.
+#include <mp/type-context.h>
+#include <mp/type-decay.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_HANDLER_TYPES_H

--- a/src/ipc/capnp/handler.capnp
+++ b/src/ipc/capnp/handler.capnp
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xdd5d967b6b9f5e26;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/handler.h");
+$Proxy.includeTypes("ipc/capnp/handler-types.h");
+
+interface Handler $Proxy.wrap("interfaces::Handler") {
+    destroy @0 (context :Proxy.Context) -> ();
+    disconnect @1 (context :Proxy.Context) -> ();
+}

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_INIT_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_INIT_TYPES_H
+
+#include <interfaces/init.h>
+
+// Init hands out other interface capabilities, so it needs their proxy-types in
+// scope to build/read the returned capabilities.
+#include <ipc/capnp/node.capnp.proxy-types.h>
+#include <ipc/capnp/staking.capnp.proxy-types.h>
+
+#include <ipc/capnp/init.capnp.proxy.h>
+
+#include <mp/proxy-types.h>
+
+// Type-marshalling support: the construct() ThreadMap exchange (type-threadmap),
+// returned interface capabilities (type-interface), the Bool result of
+// isCoreReady (type-number), and the framework Context.
+#include <mp/type-context.h>
+#include <mp/type-decay.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-threadmap.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_INIT_TYPES_H

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xe079c305988de2da;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/init.h");
+$Proxy.includeTypes("ipc/capnp/init-types.h");
+
+using Node = import "node.capnp";
+using Staking = import "staking.capnp";
+
+# Per-process bootstrap interface (interfaces::Init). construct @0 is the
+# libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
+# hand out the other interface capabilities. Only the subset whose return types
+# are schema'd so far is exposed (grow-per-migration): the remaining factories
+# (makeWallet / makeMRC / ...) are added as their interfaces get schemas.
+interface Init $Proxy.wrap("interfaces::Init") {
+    construct @0 (threadMap :Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
+    isCoreReady @1 (context :Proxy.Context) -> (result :Bool);
+    makeNode @2 (context :Proxy.Context) -> (result :Node.Node);
+    makeStakingStatus @3 (context :Proxy.Context) -> (result :Staking.StakingStatus);
+}

--- a/src/ipc/capnp/node-types.h
+++ b/src/ipc/capnp/node-types.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_NODE_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_NODE_TYPES_H
+
+#include <interfaces/node.h>
+
+// uint256 <-> Data marshalling, and the Handler capability the handleX methods
+// return.
+#include <ipc/capnp/common-types.h>
+#include <ipc/capnp/handler.capnp.proxy-types.h>
+
+#include <ipc/capnp/node.capnp.proxy.h>
+
+// proxy-types.h (ReadDestUpdate/ReadDestEmplace) must precede the container type
+// headers (optional/struct/pair/vector) that use it via CTAD.
+#include <mp/proxy-types.h>
+
+// Type-marshalling support for the capnp types this schema uses.
+#include <mp/type-context.h>
+#include <mp/type-data.h>
+#include <mp/type-decay.h>
+#include <mp/type-function.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-optional.h>
+#include <mp/type-pair.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+#include <mp/type-vector.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_NODE_TYPES_H

--- a/src/ipc/capnp/node.capnp
+++ b/src/ipc/capnp/node.capnp
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xe6826a6267f49ab4;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/node.h");
+$Proxy.includeTypes("ipc/capnp/node-types.h");
+
+using Handler = import "handler.capnp";
+
+# Mirrors interfaces::Node (src/interfaces/node.h). uint256 crosses as Data
+# (32 raw bytes, see common-types.h); std::optional<int> returns as a
+# (result, hasResult) pair; the core enums ChangeType / scrapereventtypes and the
+# GUI enums (DiagnosticTest/DiagnosticStatus, carried as ints in the DTOs) cross
+# as their integer values.
+interface Node $Proxy.wrap("interfaces::Node") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    getNodeCount @1 (context :Proxy.Context) -> (result :Int32);
+    getTotalBytesRecv @2 (context :Proxy.Context) -> (result :UInt64);
+    getTotalBytesSent @3 (context :Proxy.Context) -> (result :UInt64);
+    getNumBlocks @4 (context :Proxy.Context) -> (result :Int32);
+    getBestBlockHash @5 (context :Proxy.Context) -> (result :Data);
+    getLastBlockTime @6 (context :Proxy.Context) -> (result :Int64);
+    getNumBlocksOfPeers @7 (context :Proxy.Context) -> (result :Int32);
+    tryGetNumBlocksOfPeers @8 (context :Proxy.Context) -> (result :Int32, hasResult :Bool);
+    getDifficulty @9 (context :Proxy.Context) -> (result :Float64);
+    isInitialBlockDownload @10 (context :Proxy.Context) -> (result :Bool);
+    isOutOfSyncByAge @11 (context :Proxy.Context) -> (result :Bool);
+    getWarnings @12 (context :Proxy.Context) -> (result :Text);
+    getClientVersion @13 (context :Proxy.Context) -> (result :Text);
+    isTestNet @14 (context :Proxy.Context) -> (result :Bool);
+    startShutdown @15 (context :Proxy.Context) -> ();
+    checkForLatestUpdate @16 (context :Proxy.Context) -> (result :LatestVersionInfo);
+    runDiagnostics @17 (context :Proxy.Context) -> (result :List(DiagnosticResult));
+    getBlockDifficulty @18 (context :Proxy.Context, targetBits :UInt32) -> (result :Float64);
+    getAlertStatusBarMessage @19 (context :Proxy.Context, hash :Data) -> (result :Text);
+    getBanned @20 (context :Proxy.Context) -> (result :List(BannedNode));
+    getPeers @21 (context :Proxy.Context) -> (result :List(PeerInfo));
+    banNode @22 (context :Proxy.Context, nodeId :Int64, banTimeSeconds :Int64) -> ();
+    unban @23 (context :Proxy.Context, subnet :Text) -> (result :Bool);
+    disconnectNode @24 (context :Proxy.Context, nodeId :Int64) -> (result :Bool);
+    executeRpcConsoleCommand @25 (context :Proxy.Context, method :Text, args :List(Text)) -> (result :RpcConsoleResult);
+    listRpcCommands @26 (context :Proxy.Context) -> (result :List(Text));
+    getSettingBool @27 (context :Proxy.Context, name :Text, defaultVal :Bool) -> (result :Bool);
+    getSettingInt @28 (context :Proxy.Context, name :Text, defaultVal :Int64) -> (result :Int64);
+    getSettingStr @29 (context :Proxy.Context, name :Text, defaultVal :Text) -> (result :Text);
+    isSettingSet @30 (context :Proxy.Context, name :Text) -> (result :Bool);
+    changeSettings @31 (context :Proxy.Context, settings :List(Pair(Text, Text))) -> (result :SettingChangeResult);
+    handleRwSettingsUpdated @32 (context :Proxy.Context, callback :VoidCallback) -> (result :Handler.Handler);
+    handleInitShutdown @33 (context :Proxy.Context, callback :VoidCallback) -> (result :Handler.Handler);
+    getScraperConvergenceSnapshot @34 (context :Proxy.Context) -> (result :ScraperConvergenceSnapshot);
+    handleNotifyBlocksChanged @35 (context :Proxy.Context, callback :NotifyBlocksChangedCallback) -> (result :Handler.Handler);
+    handleNotifyNumConnectionsChanged @36 (context :Proxy.Context, callback :NotifyNumConnectionsChangedCallback) -> (result :Handler.Handler);
+    handleBannedListChanged @37 (context :Proxy.Context, callback :VoidCallback) -> (result :Handler.Handler);
+    handleNotifyAlertChanged @38 (context :Proxy.Context, callback :NotifyAlertChangedCallback) -> (result :Handler.Handler);
+    handleMinerStatusChanged @39 (context :Proxy.Context, callback :MinerStatusChangedCallback) -> (result :Handler.Handler);
+    handlePSGTPoolChanged @40 (context :Proxy.Context, callback :PSGTPoolChangedCallback) -> (result :Handler.Handler);
+    handleNotifyScraperEvent @41 (context :Proxy.Context, callback :NotifyScraperEventCallback) -> (result :Handler.Handler);
+}
+
+# --- Notification callbacks (interfaces::Node::*Fn std::function types) ---
+# Each wraps mp::ProxyCallback<the std::function type>; call() carries the
+# callback's arguments. Several handlers share the void() signature.
+
+interface VoidCallback $Proxy.wrap("ProxyCallback<std::function<void()>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context) -> ();
+}
+
+interface NotifyBlocksChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(bool, int, int64_t, uint32_t)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, syncing :Bool, height :Int32, bestTime :Int64, targetBits :UInt32) -> ();
+}
+
+interface NotifyNumConnectionsChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(int)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, numConnections :Int32) -> ();
+}
+
+interface NotifyAlertChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(const uint256&, ChangeType)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, hash :Data, status :Int32) -> ();
+}
+
+interface MinerStatusChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(bool, double)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, staking :Bool, coinWeight :Float64) -> ();
+}
+
+interface PSGTPoolChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(const uint256&, ChangeType, int)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, revisionHash :Data, status :Int32, reason :Int32) -> ();
+}
+
+interface NotifyScraperEventCallback $Proxy.wrap("ProxyCallback<std::function<void(const scrapereventtypes&, ChangeType, const std::string&)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, eventType :Int32, status :Int32, message :Text) -> ();
+}
+
+# --- Value DTOs (interfaces:: structs in node.h) ---
+
+struct BannedNode $Proxy.wrap("interfaces::BannedNode") {
+    address @0 :Text;
+    banUntil @1 :Int64 $Proxy.name("ban_until");
+}
+
+struct PeerInfo $Proxy.wrap("interfaces::PeerInfo") {
+    id @0 :Int64;
+    addrName @1 :Text $Proxy.name("addr_name");
+    addrLocal @2 :Text $Proxy.name("addr_local");
+    subversion @3 :Text;
+    services @4 :UInt64;
+    version @5 :Int32;
+    startingHeight @6 :Int32 $Proxy.name("starting_height");
+    misbehavior @7 :Int32;
+    inbound @8 :Bool;
+    lastSend @9 :Int64 $Proxy.name("last_send");
+    lastRecv @10 :Int64 $Proxy.name("last_recv");
+    sendBytes @11 :UInt64 $Proxy.name("send_bytes");
+    recvBytes @12 :UInt64 $Proxy.name("recv_bytes");
+    timeConnected @13 :Int64 $Proxy.name("time_connected");
+    timeOffset @14 :Int64 $Proxy.name("time_offset");
+    pingTime @15 :Float64 $Proxy.name("ping_time");
+    pingWait @16 :Float64 $Proxy.name("ping_wait");
+    minPing @17 :Float64 $Proxy.name("min_ping");
+}
+
+struct RpcConsoleResult $Proxy.wrap("interfaces::RpcConsoleResult") {
+    ok @0 :Bool;
+    output @1 :Text;
+}
+
+struct SettingChangeResult $Proxy.wrap("interfaces::SettingChangeResult") {
+    ok @0 :Bool;
+    invalidInput @1 :Bool $Proxy.name("invalid_input");
+    error @2 :Text;
+    requiresRestart @3 :Bool $Proxy.name("requires_restart");
+    noChange @4 :List(Text) $Proxy.name("no_change");
+    immediate @5 :List(Text);
+    requiresRestartSettings @6 :List(Text) $Proxy.name("requires_restart_settings");
+}
+
+struct ScraperConvergenceSnapshot $Proxy.wrap("interfaces::ScraperConvergenceSnapshot") {
+    time @0 :Int64;
+    excludedProjects @1 :List(Text) $Proxy.name("excluded_projects");
+    includedScrapers @2 :List(Text) $Proxy.name("included_scrapers");
+    excludedScrapers @3 :List(Text) $Proxy.name("excluded_scrapers");
+    scrapersNotPublishing @4 :List(Text) $Proxy.name("scrapers_not_publishing");
+}
+
+struct LatestVersionInfo $Proxy.wrap("interfaces::LatestVersionInfo") {
+    version @0 :Text;
+    details @1 :Text;
+    upgradeType @2 :Int32 $Proxy.name("upgrade_type");
+}
+
+struct DiagnosticResult $Proxy.wrap("interfaces::DiagnosticResult") {
+    testId @0 :Int32 $Proxy.name("test_id");
+    status @1 :Int32;
+    resultString @2 :Text $Proxy.name("result_string");
+    tipString @3 :Text $Proxy.name("tip_string");
+}
+
+# Generic key/value pair, for changeSettings' vector<pair<string,string>>.
+struct Pair(T1, T2) {
+    first @0 :T1;
+    second @1 :T2;
+}

--- a/src/ipc/capnp/staking-types.h
+++ b/src/ipc/capnp/staking-types.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_STAKING_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_STAKING_TYPES_H
+
+#include <interfaces/staking.h>
+#include <ipc/capnp/staking.capnp.proxy.h>
+
+// proxy-types.h defines ReadDestUpdate/ReadDestEmplace, which the container type
+// headers below (type-optional here) use via CTAD; it must precede them.
+#include <mp/proxy-types.h>
+
+// Type-marshalling support: Bool/Float64 scalars (type-number), Text<->std::string
+// (type-string), std::optional<double> results (type-optional), and the
+// framework Context.
+#include <mp/type-context.h>
+#include <mp/type-decay.h>
+#include <mp/type-number.h>
+#include <mp/type-optional.h>
+#include <mp/type-string.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_STAKING_TYPES_H

--- a/src/ipc/capnp/staking.capnp
+++ b/src/ipc/capnp/staking.capnp
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xd973814d231e38d7;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/staking.h");
+$Proxy.includeTypes("ipc/capnp/staking-types.h");
+
+# Mirrors interfaces::StakingStatus (src/interfaces/staking.h). The try* methods
+# return std::optional<double>, expressed here as a (result, hasResult) pair.
+interface StakingStatus $Proxy.wrap("interfaces::StakingStatus") {
+    destroy @0 (context :Proxy.Context) -> ();
+    isStaking @1 (context :Proxy.Context) -> (result :Bool);
+    getErrors @2 (context :Proxy.Context) -> (result :Text);
+    getCoinWeight @3 (context :Proxy.Context) -> (result :Float64);
+    getNetworkWeight @4 (context :Proxy.Context) -> (result :Float64);
+    tryGetNetworkWeight @5 (context :Proxy.Context) -> (result :Float64, hasResult :Bool);
+    tryGetEstimatedTimeToStake @6 (context :Proxy.Context) -> (result :Float64, hasResult :Bool);
+}

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -21,10 +21,15 @@ struct secure_allocator : public std::allocator<T> {
     typedef std::allocator<T> base;
     typedef typename base::size_type size_type;
     typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
+    // std::allocator dropped the pointer/const_pointer/reference/const_reference
+    // member typedefs in C++20 (they were deprecated in C++17). Define them
+    // directly so this allocator compiles under both C++17 and C++20 -- the latter
+    // is required by the multiprocess (Cap'n Proto) proxy translation units, which
+    // transitively include this header.
+    typedef T* pointer;
+    typedef const T* const_pointer;
+    typedef T& reference;
+    typedef const T& const_reference;
     typedef typename base::value_type value_type;
     secure_allocator() noexcept {}
     secure_allocator(const secure_allocator& a) noexcept : base(a) {}

--- a/test/lint/lint-capnp-schema-compat.py
+++ b/test/lint/lint-capnp-schema-compat.py
@@ -5,13 +5,21 @@
 
 """Cap'n Proto schema backward-compatibility lint (multiprocess, design section 4.2).
 
-The IPC wire format is defined by the src/ipc/capnp/*.capnp schemas. Cap'n Proto
-compatibility depends on ordinals (@N) and the file id (@0x...) being *stable*:
-an ordinal may never be renumbered, reused, or removed, and a field/method's
-ordinal must keep its name -- otherwise an old client and a new node disagree on
-the wire. This lint diffs each schema against its version at the most recent
-mainnet release tag and fails if any released ordinal was removed or renamed, or
-if a file's id changed.
+The IPC wire format is defined by the src/ipc/capnp/*.capnp schemas. Two distinct
+kinds of stability matter, and this lint guards both:
+
+  * Wire compatibility depends on the file id (@0x...) and the ordinals (@N)
+    with their types: renumbering, reusing, removing, or changing the type of a
+    released ordinal makes an old peer and a new one disagree on the wire.
+  * Member *names* do NOT affect the wire -- renaming a field/method while
+    keeping its ordinal is wire-compatible. But the name IS the generated C++
+    proxy API (and the $Proxy.name mapping to the C++ member), so a rename is a
+    source-level break for everything that uses the proxies.
+
+This lint diffs each schema against its version at the most recent mainnet
+release tag and fails if a released ordinal was removed or renamed, or if a
+file's id changed. (It does not yet diff field types; type changes on an existing
+ordinal are a wire break it would miss -- a future enhancement.)
 
 Schemas that did not exist at the baseline release are new: there is nothing to
 compare, so they pass (their ordinals become the baseline at the next release).
@@ -120,11 +128,12 @@ def main():
             head_members = head_scopes.get(scope, {})
             for ordinal, name in members.items():
                 if ordinal not in head_members:
-                    problems.append(f"{path}: {scope} @{ordinal} ('{name}') removed since {tag} (ordinals are append-only)")
+                    problems.append(f"{path}: {scope} @{ordinal} ('{name}') removed since {tag} "
+                                    "(removing/renumbering a released ordinal breaks the wire)")
                 elif head_members[ordinal] != name:
                     problems.append(
                         f"{path}: {scope} @{ordinal} renamed '{name}' -> '{head_members[ordinal]}' since {tag} "
-                        "(ordinal reuse breaks the wire format)")
+                        "(wire-safe, but breaks the generated proxy API and $Proxy.name mapping)")
 
     if problems:
         print(f"Cap'n Proto schema compatibility regressions vs release {tag}:")

--- a/test/lint/lint-capnp-schema-compat.py
+++ b/test/lint/lint-capnp-schema-compat.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+"""Cap'n Proto schema backward-compatibility lint (multiprocess, design section 4.2).
+
+The IPC wire format is defined by the src/ipc/capnp/*.capnp schemas. Cap'n Proto
+compatibility depends on ordinals (@N) and the file id (@0x...) being *stable*:
+an ordinal may never be renumbered, reused, or removed, and a field/method's
+ordinal must keep its name -- otherwise an old client and a new node disagree on
+the wire. This lint diffs each schema against its version at the most recent
+mainnet release tag and fails if any released ordinal was removed or renamed, or
+if a file's id changed.
+
+Schemas that did not exist at the baseline release are new: there is nothing to
+compare, so they pass (their ordinals become the baseline at the next release).
+If no baseline release tag is found, the lint passes (nothing to compare against).
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+CAPNP_DIR = "src/ipc/capnp"
+# Match a pure mainnet release tag: N.N.N.N (no -testnet / -macos / other suffix).
+RELEASE_TAG_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+FILE_ID_RE = re.compile(r"^\s*@(0x[0-9a-fA-F]+)\s*;")
+SCOPE_RE = re.compile(r"^\s*(?:interface|struct)\s+(\w+)")
+# A member with an ordinal: "name @N ..." (methods and fields both).
+MEMBER_RE = re.compile(r"^\s*(\w+)\s*@(\d+)\b")
+
+
+def sh(args):
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def repo_root():
+    r = sh(["git", "rev-parse", "--show-toplevel"])
+    return r.stdout.strip() if r.returncode == 0 else "."
+
+
+def latest_release_tag():
+    r = sh(["git", "tag"])
+    if r.returncode != 0:
+        return None
+    tags = [t for t in r.stdout.split() if RELEASE_TAG_RE.match(t)]
+    if not tags:
+        return None
+    # Sort by numeric version components.
+    tags.sort(key=lambda t: [int(x) for x in t.split(".")])
+    return tags[-1]
+
+
+def parse_schema(text):
+    """Return (file_id, {scope_name: {ordinal: member_name}}). Brace-tracked so
+    ordinals are attributed to their enclosing interface/struct."""
+    file_id = None
+    scopes = {}
+    stack = []  # (scope_name,) tracked by brace depth
+    depth = 0
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0]  # strip capnp comments
+        if file_id is None:
+            m = FILE_ID_RE.match(line)
+            if m:
+                file_id = m.group(1).lower()
+        m = SCOPE_RE.match(line)
+        if m:
+            # Scope opens on this line (its "{" may be same or next line).
+            pending_scope = m.group(1)
+        else:
+            pending_scope = None
+        opens = line.count("{")
+        closes = line.count("}")
+        if pending_scope and opens:
+            stack.append((depth, pending_scope))
+            scopes.setdefault(pending_scope, {})
+        elif pending_scope:
+            # "{" on a later line; remember to push when we see it.
+            stack.append((depth, pending_scope))
+            scopes.setdefault(pending_scope, {})
+        depth += opens - closes
+        # Attribute member ordinals to the innermost open scope.
+        mm = MEMBER_RE.match(line)
+        if mm and stack:
+            name, ordinal = mm.group(1), int(mm.group(2))
+            scope = stack[-1][1]
+            scopes[scope][ordinal] = name
+        # Pop scopes whose brace depth we've fallen back below.
+        while stack and depth <= stack[-1][0]:
+            stack.pop()
+    return file_id, scopes
+
+
+def main():
+    os.chdir(repo_root())
+    tag = latest_release_tag()
+    if not tag:
+        print("lint-capnp-schema-compat: no mainnet release tag found; nothing to compare.")
+        return 0
+
+    files = sh(["git", "ls-files", f"{CAPNP_DIR}/*.capnp"]).stdout.split()
+    problems = []
+    checked = new = 0
+    for path in files:
+        base = sh(["git", "show", f"{tag}:{path}"])
+        if base.returncode != 0:
+            new += 1
+            continue  # new schema since the baseline release
+        checked += 1
+        with open(path, encoding="utf-8") as fh:
+            head_text = fh.read()
+        base_id, base_scopes = parse_schema(base.stdout)
+        head_id, head_scopes = parse_schema(head_text)
+        if base_id and head_id and base_id != head_id:
+            problems.append(f"{path}: file id changed {base_id} -> {head_id} (breaks all compatibility)")
+        for scope, members in base_scopes.items():
+            head_members = head_scopes.get(scope, {})
+            for ordinal, name in members.items():
+                if ordinal not in head_members:
+                    problems.append(f"{path}: {scope} @{ordinal} ('{name}') removed since {tag} (ordinals are append-only)")
+                elif head_members[ordinal] != name:
+                    problems.append(
+                        f"{path}: {scope} @{ordinal} renamed '{name}' -> '{head_members[ordinal]}' since {tag} "
+                        "(ordinal reuse breaks the wire format)")
+
+    if problems:
+        print(f"Cap'n Proto schema compatibility regressions vs release {tag}:")
+        for p in problems:
+            print(f"  {p}")
+        print("\nAppend new ordinals; never renumber, reuse, or remove a released one.")
+        return 1
+
+    print(f"lint-capnp-schema-compat: OK ({checked} schema(s) checked vs {tag}, {new} new).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/lint/lint-capnp-schema-compat.sh
+++ b/test/lint/lint-capnp-schema-compat.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+#
+# Cap'n Proto IPC schema backward-compatibility lint (multiprocess design
+# section 4.2): the src/ipc/capnp/*.capnp ordinals and file ids define the IPC
+# wire format and must stay append-only across releases. This diffs each schema
+# against the most recent mainnet release tag and fails on a removed/renamed
+# ordinal or a changed file id. New schemas (absent at the baseline release) pass.
+
+export LC_ALL=C
+exec python3 "$(dirname "$0")/lint-capnp-schema-compat.py"

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -17,10 +17,10 @@ for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_W
 do
     if [[ $HEADER_FILE == src/gridcoin/* ]]; then
         # Gridcoin: allow src/gridcoin to be accessed with just GRIDCOIN_ prefix.
-        HEADER_ID_BASE=$(cut -f3- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr -- '-/' _ | tr "[:lower:]" "[:upper:]")
+        HEADER_ID_BASE=$(cut -f3- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr '/-' _ | tr "[:lower:]" "[:upper:]")
         HEADER_ID="GRIDCOIN_${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
     else
-        HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr -- '-/' _ | tr "[:lower:]" "[:upper:]")
+        HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr '/-' _ | tr "[:lower:]" "[:upper:]")
         HEADER_ID="${HEADER_ID_PREFIX}${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
     fi
 

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -17,10 +17,10 @@ for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_W
 do
     if [[ $HEADER_FILE == src/gridcoin/* ]]; then
         # Gridcoin: allow src/gridcoin to be accessed with just GRIDCOIN_ prefix.
-        HEADER_ID_BASE=$(cut -f3- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr / _ | tr "[:lower:]" "[:upper:]")
+        HEADER_ID_BASE=$(cut -f3- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr -- '-/' _ | tr "[:lower:]" "[:upper:]")
         HEADER_ID="GRIDCOIN_${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
     else
-        HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr / _ | tr "[:lower:]" "[:upper:]")
+        HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr -- '-/' _ | tr "[:lower:]" "[:upper:]")
         HEADER_ID="${HEADER_ID_PREFIX}${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
     fi
 


### PR DESCRIPTION
## Summary

The **schema half of Phase 2a** (RFC #2937): the Cap'n Proto `.capnp` schemas that mirror the `interfaces::` boundary 1:1, the `mpgen` codegen wiring, and a schema-compatibility lint. The build-toolchain half (`ENABLE_MULTIPROCESS`, Cap'n Proto + vendored libmultiprocess) landed in #3215.

**No runtime behavior changes yet** — no Gridcoin binary links the generated proxies (`gridcoin_ipc` is `EXCLUDE_FROM_ALL`); the transport + client wiring is 2b. This PR proves the schema→`mpgen`→proxy→compile→link pipeline works for the full interface surface.

## Schemas (`src/ipc/capnp/`, namespace `ipc::capnp::messages`)

- **`handler` / `staking` / `init` / `node`** mirror `interfaces::{Handler, StakingStatus, Init, Node}` — `$Proxy.wrap` interfaces, `$Proxy.wrap` value structs for the 7 Node DTOs (with `$Proxy.name` for snake_case members).
- **Init** exposes only the factories whose return types are schema'd so far (`makeNode`/`makeStakingStatus`); the rest grow per migration (2c/2d).
- **Node's 9 `std::function` notification callbacks** → capnp callback interfaces (`$Proxy.wrap("ProxyCallback<std::function<...>>")` with `destroy` + `call`), the `handleX` methods returning a `Handler` capability.
- Type mapping: `uint256`→32-byte `Data` (`common-types.h` custom marshalling); `std::optional<T>`→`(result, hasResult)`; core enums (`ChangeType`, `scrapereventtypes`) and DTO-carried GUI enums→their int values; `vector<pair<string,string>>`→`List(Pair(Text,Text))`.

## Build

- `src/ipc/CMakeLists.txt` defines `gridcoin_ipc` (`STATIC`, `EXCLUDE_FROM_ALL`) via `target_capnp_sources`. It compiles as **C++20** (the generated proxy code uses libmultiprocess's concepts headers; Gridcoin is otherwise C++17) and links `gridcoin_util` for the interface headers' transitive include environment. `add_subdirectory(ipc)` moved after `gridcoin_util`; the libmultiprocess `add_subdirectory` moved into `src/ipc/CMakeLists.txt`.

## Two changes beyond the schemas (flagged for review)

1. **`secure_allocator` C++20 fix** (`src/support/allocators/secure.h`) — `std::allocator` dropped the `pointer`/`const_pointer`/`reference`/`const_reference` typedefs in C++20; `secure_allocator` inherited them, and the C++20 proxy TUs transitively include this header via `SecureString`. Define the four directly. Semantically identical in C++17; a general C++20-readiness fix.
2. **`gridcoin_ipc` links `gridcoin_util`** — `node.h` transitively pulls the full core header stack (the `fwd.h`→`scraper_net.h`→`univalue` chain its own TODO flags). Static-lib linkage → include propagation only, no objects pulled in. (A future cleanup could slim `node.h`'s transitive includes per that TODO.)

## Lint

- **`lint-capnp-schema-compat.{py,sh}`** — diffs each schema against the most recent mainnet release tag; fails on a removed/renamed ordinal or changed file id (Cap'n Proto append-only wire-compat, design §4.2). New schemas pass; teeth engage at the next release.
- **`lint-include-guards.sh`** — translate `-`→`_` when deriving the expected guard (matching Bitcoin Core) so the new `*-types.h` headers use valid guards. No existing header has a hyphen in its name.

## Validation

- `cmake --build --target gridcoin_ipc` with `ENABLE_MULTIPROCESS=ON`: **links cleanly** — `mpgen` generates all four schemas and the C++20 proxies compile against the real `interfaces::` implementations. (Because the codegen references `&interfaces::X::member` and the exact `std::function` signatures, a clean compile validates the schema-to-C++ fidelity.)
- `ENABLE_MULTIPROCESS=OFF` (the CI default): unaffected — the `ipc` subdirectory is gated on the flag and `secure.h` is C++17-equivalent.
- `test/lint/lint-all.sh`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)