### PR TITLE
wallet: fix listtransactions ordering for incoming transactions (missing nOrderPos)

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -418,6 +418,171 @@ BOOST_AUTO_TEST_CASE(sync_legacy_from_state_unrecognized)
     BOOST_CHECK_EQUAL(wtx.nIndex, -1);
 }
 
+BOOST_AUTO_TEST_CASE(seed_phrase_record_roundtrip)
+{
+    CWallet test_wallet; // in-memory, not file-backed
+
+    // Build a record from a freshly generated phrase.
+    CKey master_key;
+    const SecureString password; // empty phrase password
+    const SecureString phrase = GRC::Mnemonics::GenerateSeedPhrase(password, master_key);
+    BOOST_REQUIRE(master_key.IsValid());
+
+    CSeedPhraseData data;
+    data.vchBlob.resize(GRC::Mnemonics::ENCIPHERED_LENGTH);
+    BOOST_REQUIRE(GRC::Mnemonics::DecodeSeedPhrase(phrase, MakeWritableByteSpan(data.vchBlob)));
+
+    CKey parsed_key;
+    BOOST_REQUIRE(GRC::Mnemonics::ParseSeedPhrase(phrase, password, parsed_key, &data.nBirthday));
+    data.masterKeyID = master_key.GetPubKey().GetID();
+
+    // The record's serialization round-trips (wallet.dat record shape).
+    CDataStream ss(SER_DISK, CLIENT_VERSION);
+    ss << data;
+    CSeedPhraseData data2;
+    ss >> data2;
+    BOOST_CHECK(data2.vchBlob == data.vchBlob);
+    BOOST_CHECK(data2.masterKeyID == data.masterKeyID);
+    BOOST_CHECK_EQUAL(data2.nBirthday, data.nBirthday);
+
+    // Set/get on an unencrypted wallet stores the plaintext blob.
+    LOCK(test_wallet.cs_wallet);
+    BOOST_CHECK(!test_wallet.HasSeedPhrase());
+    BOOST_REQUIRE(test_wallet.SetSeedPhraseData(data));
+    BOOST_CHECK(test_wallet.HasSeedPhrase());
+    BOOST_CHECK(!test_wallet.SeedPhraseBlobCrypted());
+
+    CKeyingMaterial blob;
+    BOOST_REQUIRE(test_wallet.GetSeedPhraseBlob(blob));
+    BOOST_REQUIRE_EQUAL(blob.size(), data.vchBlob.size());
+    BOOST_CHECK(std::equal(blob.begin(), blob.end(), data.vchBlob.begin()));
+
+    // Re-encoding the stored blob reproduces the phrase verbatim.
+    BOOST_CHECK(GRC::Mnemonics::EncodeSeedPhrase(MakeByteSpan(blob)) == phrase);
+
+    // The phrase birthday clamps the scanner's first-key bound.
+    BOOST_CHECK_EQUAL(test_wallet.nTimeFirstKey, data.nBirthday);
+}
+
+BOOST_AUTO_TEST_CASE(seed_phrase_crypted_blob_requires_unlock)
+{
+    CWallet test_wallet;
+
+    CSeedPhraseData data;
+    data.vchBlob.assign(GRC::Mnemonics::ENCIPHERED_LENGTH, 0x42);
+    data.nBirthday = GRC::Mnemonics::BIRTHDAY_EPOCH;
+
+    // A blob loaded from a "cseedphrase" record must be unrecoverable while
+    // the wallet's keying material is unavailable, not returned as raw
+    // ciphertext.
+    LOCK(test_wallet.cs_wallet);
+    BOOST_REQUIRE(test_wallet.LoadSeedPhraseData(data, /*crypted=*/true));
+    BOOST_CHECK(test_wallet.HasSeedPhrase());
+    BOOST_CHECK(test_wallet.SeedPhraseBlobCrypted());
+
+    CKeyingMaterial blob;
+    BOOST_CHECK(!test_wallet.GetSeedPhraseBlob(blob));
+
+    // Defense in depth: a stale plaintext record must not shadow an already
+    // loaded crypted record, whatever order the db cursor yields them in.
+    CSeedPhraseData plaintext_data;
+    plaintext_data.vchBlob.assign(GRC::Mnemonics::ENCIPHERED_LENGTH, 0x24);
+    plaintext_data.nBirthday = GRC::Mnemonics::BIRTHDAY_EPOCH;
+
+    BOOST_REQUIRE(test_wallet.LoadSeedPhraseData(plaintext_data, /*crypted=*/false));
+    BOOST_CHECK(test_wallet.SeedPhraseBlobCrypted());
+    BOOST_CHECK(test_wallet.GetSeedPhraseData().vchBlob == data.vchBlob);
+}
+
+BOOST_AUTO_TEST_CASE(seed_phrase_key_classification)
+{
+    CWallet test_wallet;
+    LOCK(test_wallet.cs_wallet);
+
+    CKey master_key;
+    master_key.MakeNewKey(true);
+    const CKeyID master_id = master_key.GetPubKey().GetID();
+
+    CSeedPhraseData data;
+    data.vchBlob.assign(GRC::Mnemonics::ENCIPHERED_LENGTH, 0x11);
+    data.masterKeyID = master_id;
+    data.nBirthday = GRC::Mnemonics::BIRTHDAY_EPOCH;
+    BOOST_REQUIRE(test_wallet.SetSeedPhraseData(data));
+
+    // The phrase master itself is covered.
+    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(master_id)
+                == CWallet::SeedPhraseKeyClass::COVERED);
+
+    // A key whose metadata descends from the phrase master is covered.
+    CKey child;
+    child.MakeNewKey(true);
+    const CKeyID child_id = child.GetPubKey().GetID();
+    CKeyMetadata child_meta(1);
+    child_meta.hdKeypath = "m/0'/0'/0'";
+    child_meta.hdMasterKeyID = master_id;
+    test_wallet.mapKeyMetadata[child_id] = child_meta;
+    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(child_id)
+                == CWallet::SeedPhraseKeyClass::COVERED);
+
+    // A key derived from a different (retired) master is prior-HD.
+    CKey other_master;
+    other_master.MakeNewKey(true);
+    CKey prior;
+    prior.MakeNewKey(true);
+    const CKeyID prior_id = prior.GetPubKey().GetID();
+    CKeyMetadata prior_meta(1);
+    prior_meta.hdKeypath = "m/0'/0'/1'";
+    prior_meta.hdMasterKeyID = other_master.GetPubKey().GetID();
+    test_wallet.mapKeyMetadata[prior_id] = prior_meta;
+    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(prior_id)
+                == CWallet::SeedPhraseKeyClass::PRIOR_HD);
+
+    // No metadata at all is legacy.
+    CKey legacy;
+    legacy.MakeNewKey(true);
+    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(legacy.GetPubKey().GetID())
+                == CWallet::SeedPhraseKeyClass::LEGACY);
+
+    // Metadata with an empty keypath (a pre-HD key) is also legacy.
+    CKey legacy_meta_key;
+    legacy_meta_key.MakeNewKey(true);
+    const CKeyID legacy_meta_id = legacy_meta_key.GetPubKey().GetID();
+    test_wallet.mapKeyMetadata[legacy_meta_id] = CKeyMetadata(1);
+    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(legacy_meta_id)
+                == CWallet::SeedPhraseKeyClass::LEGACY);
+}
+
+BOOST_AUTO_TEST_CASE(sweep_swap_count_selection_math)
+{
+    // Values sorted ascending, as SweepSwapCount requires.
+
+    // Plenty of value in the smallest-first batch: no swaps.
+    BOOST_CHECK_EQUAL(SweepSwapCount({100, 200, 300, 400}, 2, 250), 0U);
+
+    // The dust-wedge case: the two smallest cannot pay the fee, but swapping
+    // the largest candidate in for the smallest selected one can.
+    BOOST_CHECK_EQUAL(SweepSwapCount({1, 2, 3, 1000}, 2, 10), 1U);
+
+    // Two swaps needed.
+    BOOST_CHECK_EQUAL(SweepSwapCount({1, 1, 1, 500, 600}, 3, 700), 2U);
+
+    // All candidates selected: swapping is meaningless, zero swaps even
+    // though the batch cannot pay the fee (caller reports dust-only).
+    BOOST_CHECK_EQUAL(SweepSwapCount({1, 2, 3}, 3, 100), 0U);
+
+    // Swaps exhaust the unselected pool without reaching the ceiling: the
+    // loop stops at the overlap bound.
+    BOOST_CHECK_EQUAL(SweepSwapCount({1, 1, 1, 2}, 3, 100), 1U);
+
+    // Degenerate inputs.
+    BOOST_CHECK_EQUAL(SweepSwapCount({}, 5, 100), 0U);
+    BOOST_CHECK_EQUAL(SweepSwapCount({50}, 1, 10), 0U);
+
+    // select_count larger than the candidate list clamps.
+    BOOST_CHECK_EQUAL(SweepSwapCount({1, 2}, 10, 100), 0U);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(wallet_integration_tests)
@@ -2252,168 +2417,9 @@ BOOST_AUTO_TEST_CASE(txstate_variant_index_stability_extended)
     BOOST_CHECK_EQUAL(s3.index(), 3u);
 }
 
-BOOST_AUTO_TEST_CASE(seed_phrase_record_roundtrip)
-{
-    CWallet test_wallet; // in-memory, not file-backed
 
-    // Build a record from a freshly generated phrase.
-    CKey master_key;
-    const SecureString password; // empty phrase password
-    const SecureString phrase = GRC::Mnemonics::GenerateSeedPhrase(password, master_key);
-    BOOST_REQUIRE(master_key.IsValid());
 
-    CSeedPhraseData data;
-    data.vchBlob.resize(GRC::Mnemonics::ENCIPHERED_LENGTH);
-    BOOST_REQUIRE(GRC::Mnemonics::DecodeSeedPhrase(phrase, MakeWritableByteSpan(data.vchBlob)));
 
-    CKey parsed_key;
-    BOOST_REQUIRE(GRC::Mnemonics::ParseSeedPhrase(phrase, password, parsed_key, &data.nBirthday));
-    data.masterKeyID = master_key.GetPubKey().GetID();
 
-    // The record's serialization round-trips (wallet.dat record shape).
-    CDataStream ss(SER_DISK, CLIENT_VERSION);
-    ss << data;
-    CSeedPhraseData data2;
-    ss >> data2;
-    BOOST_CHECK(data2.vchBlob == data.vchBlob);
-    BOOST_CHECK(data2.masterKeyID == data.masterKeyID);
-    BOOST_CHECK_EQUAL(data2.nBirthday, data.nBirthday);
-
-    // Set/get on an unencrypted wallet stores the plaintext blob.
-    LOCK(test_wallet.cs_wallet);
-    BOOST_CHECK(!test_wallet.HasSeedPhrase());
-    BOOST_REQUIRE(test_wallet.SetSeedPhraseData(data));
-    BOOST_CHECK(test_wallet.HasSeedPhrase());
-    BOOST_CHECK(!test_wallet.SeedPhraseBlobCrypted());
-
-    CKeyingMaterial blob;
-    BOOST_REQUIRE(test_wallet.GetSeedPhraseBlob(blob));
-    BOOST_REQUIRE_EQUAL(blob.size(), data.vchBlob.size());
-    BOOST_CHECK(std::equal(blob.begin(), blob.end(), data.vchBlob.begin()));
-
-    // Re-encoding the stored blob reproduces the phrase verbatim.
-    BOOST_CHECK(GRC::Mnemonics::EncodeSeedPhrase(MakeByteSpan(blob)) == phrase);
-
-    // The phrase birthday clamps the scanner's first-key bound.
-    BOOST_CHECK_EQUAL(test_wallet.nTimeFirstKey, data.nBirthday);
-}
-
-BOOST_AUTO_TEST_CASE(seed_phrase_crypted_blob_requires_unlock)
-{
-    CWallet test_wallet;
-
-    CSeedPhraseData data;
-    data.vchBlob.assign(GRC::Mnemonics::ENCIPHERED_LENGTH, 0x42);
-    data.nBirthday = GRC::Mnemonics::BIRTHDAY_EPOCH;
-
-    // A blob loaded from a "cseedphrase" record must be unrecoverable while
-    // the wallet's keying material is unavailable, not returned as raw
-    // ciphertext.
-    LOCK(test_wallet.cs_wallet);
-    BOOST_REQUIRE(test_wallet.LoadSeedPhraseData(data, /*crypted=*/true));
-    BOOST_CHECK(test_wallet.HasSeedPhrase());
-    BOOST_CHECK(test_wallet.SeedPhraseBlobCrypted());
-
-    CKeyingMaterial blob;
-    BOOST_CHECK(!test_wallet.GetSeedPhraseBlob(blob));
-
-    // Defense in depth: a stale plaintext record must not shadow an already
-    // loaded crypted record, whatever order the db cursor yields them in.
-    CSeedPhraseData plaintext_data;
-    plaintext_data.vchBlob.assign(GRC::Mnemonics::ENCIPHERED_LENGTH, 0x24);
-    plaintext_data.nBirthday = GRC::Mnemonics::BIRTHDAY_EPOCH;
-
-    BOOST_REQUIRE(test_wallet.LoadSeedPhraseData(plaintext_data, /*crypted=*/false));
-    BOOST_CHECK(test_wallet.SeedPhraseBlobCrypted());
-    BOOST_CHECK(test_wallet.GetSeedPhraseData().vchBlob == data.vchBlob);
-}
-
-BOOST_AUTO_TEST_CASE(seed_phrase_key_classification)
-{
-    CWallet test_wallet;
-    LOCK(test_wallet.cs_wallet);
-
-    CKey master_key;
-    master_key.MakeNewKey(true);
-    const CKeyID master_id = master_key.GetPubKey().GetID();
-
-    CSeedPhraseData data;
-    data.vchBlob.assign(GRC::Mnemonics::ENCIPHERED_LENGTH, 0x11);
-    data.masterKeyID = master_id;
-    data.nBirthday = GRC::Mnemonics::BIRTHDAY_EPOCH;
-    BOOST_REQUIRE(test_wallet.SetSeedPhraseData(data));
-
-    // The phrase master itself is covered.
-    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(master_id)
-                == CWallet::SeedPhraseKeyClass::COVERED);
-
-    // A key whose metadata descends from the phrase master is covered.
-    CKey child;
-    child.MakeNewKey(true);
-    const CKeyID child_id = child.GetPubKey().GetID();
-    CKeyMetadata child_meta(1);
-    child_meta.hdKeypath = "m/0'/0'/0'";
-    child_meta.hdMasterKeyID = master_id;
-    test_wallet.mapKeyMetadata[child_id] = child_meta;
-    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(child_id)
-                == CWallet::SeedPhraseKeyClass::COVERED);
-
-    // A key derived from a different (retired) master is prior-HD.
-    CKey other_master;
-    other_master.MakeNewKey(true);
-    CKey prior;
-    prior.MakeNewKey(true);
-    const CKeyID prior_id = prior.GetPubKey().GetID();
-    CKeyMetadata prior_meta(1);
-    prior_meta.hdKeypath = "m/0'/0'/1'";
-    prior_meta.hdMasterKeyID = other_master.GetPubKey().GetID();
-    test_wallet.mapKeyMetadata[prior_id] = prior_meta;
-    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(prior_id)
-                == CWallet::SeedPhraseKeyClass::PRIOR_HD);
-
-    // No metadata at all is legacy.
-    CKey legacy;
-    legacy.MakeNewKey(true);
-    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(legacy.GetPubKey().GetID())
-                == CWallet::SeedPhraseKeyClass::LEGACY);
-
-    // Metadata with an empty keypath (a pre-HD key) is also legacy.
-    CKey legacy_meta_key;
-    legacy_meta_key.MakeNewKey(true);
-    const CKeyID legacy_meta_id = legacy_meta_key.GetPubKey().GetID();
-    test_wallet.mapKeyMetadata[legacy_meta_id] = CKeyMetadata(1);
-    BOOST_CHECK(test_wallet.ClassifySeedPhraseKey(legacy_meta_id)
-                == CWallet::SeedPhraseKeyClass::LEGACY);
-}
-
-BOOST_AUTO_TEST_CASE(sweep_swap_count_selection_math)
-{
-    // Values sorted ascending, as SweepSwapCount requires.
-
-    // Plenty of value in the smallest-first batch: no swaps.
-    BOOST_CHECK_EQUAL(SweepSwapCount({100, 200, 300, 400}, 2, 250), 0U);
-
-    // The dust-wedge case: the two smallest cannot pay the fee, but swapping
-    // the largest candidate in for the smallest selected one can.
-    BOOST_CHECK_EQUAL(SweepSwapCount({1, 2, 3, 1000}, 2, 10), 1U);
-
-    // Two swaps needed.
-    BOOST_CHECK_EQUAL(SweepSwapCount({1, 1, 1, 500, 600}, 3, 700), 2U);
-
-    // All candidates selected: swapping is meaningless, zero swaps even
-    // though the batch cannot pay the fee (caller reports dust-only).
-    BOOST_CHECK_EQUAL(SweepSwapCount({1, 2, 3}, 3, 100), 0U);
-
-    // Swaps exhaust the unselected pool without reaching the ceiling: the
-    // loop stops at the overlap bound.
-    BOOST_CHECK_EQUAL(SweepSwapCount({1, 1, 1, 2}, 3, 100), 1U);
-
-    // Degenerate inputs.
-    BOOST_CHECK_EQUAL(SweepSwapCount({}, 5, 100), 0U);
-    BOOST_CHECK_EQUAL(SweepSwapCount({50}, 1, 10), 0U);
-
-    // select_count larger than the candidate list clamps.
-    BOOST_CHECK_EQUAL(SweepSwapCount({1, 2}, 10, 100), 0U);
-}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -2276,6 +2276,82 @@ BOOST_AUTO_TEST_CASE(incoming_tx_gets_order_position)
     pwalletMain->EraseFromWallet(tx2.GetHash());
 }
 
+BOOST_AUTO_TEST_CASE(mempool_spend_marks_parent_output_spent)
+{
+    // Legacy WalletUpdateSpent parity restored on the SyncTransaction path:
+    // a spend of our output observed in the MEMPOOL already marks the parent
+    // output spent; before the fix only a confirmed sighting did.
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CKey key;
+    key.MakeNewKey(true);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = COutPoint(uint256S("0x3333333333333333333333333333333333333333333333333333333333333333"), 0);
+    parent.vout.resize(1);
+    parent.vout[0].nValue = 2 * COIN;
+    parent.vout[0].scriptPubKey.SetDestination(CTxDestination(key.GetPubKey().GetID()));
+    const CTransaction parent_tx(parent);
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(parent_tx), TxStateInMempool{}));
+
+    // Child spends our parent output, paying a key we do not own (from-me).
+    CKey external_key;
+    external_key.MakeNewKey(true);
+    CMutableTransaction child;
+    child.vin.resize(1);
+    child.vin[0].prevout = COutPoint(parent_tx.GetHash(), 0);
+    child.vout.resize(1);
+    child.vout[0].nValue = 1 * COIN;
+    child.vout[0].scriptPubKey.SetDestination(CTxDestination(external_key.GetPubKey().GetID()));
+    const CTransaction child_tx(child);
+
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(child_tx), TxStateInMempool{}));
+
+    const auto it = pwalletMain->mapWallet.find(parent_tx.GetHash());
+    BOOST_REQUIRE(it != pwalletMain->mapWallet.end());
+    BOOST_CHECK(it->second.IsSpent(0));
+
+    pwalletMain->EraseFromWallet(child_tx.GetHash());
+    pwalletMain->EraseFromWallet(parent_tx.GetHash());
+}
+
+BOOST_AUTO_TEST_CASE(incoming_payment_rotates_default_key)
+{
+    // Legacy AddToWallet parity restored on the SyncTransaction path: a
+    // payment to the default receiving address rotates it to a fresh key
+    // (daemon mode; the Qt GUI manages its own receiving addresses).
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    if (!pwalletMain->vchDefaultKey.IsValid()) {
+        CPubKey bootstrap_default;
+        BOOST_REQUIRE(pwalletMain->GetKeyFromPool(bootstrap_default, false));
+        BOOST_REQUIRE(pwalletMain->SetDefaultKey(bootstrap_default));
+    }
+
+    const CPubKey old_default = pwalletMain->vchDefaultKey;
+
+    CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(uint256S("0x4444444444444444444444444444444444444444444444444444444444444444"), 0);
+    mtx.vout.resize(1);
+    mtx.vout[0].nValue = 1 * COIN;
+    mtx.vout[0].scriptPubKey.SetDestination(CTxDestination(old_default.GetID()));
+    const CTransaction tx(mtx);
+
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(tx), TxStateInMempool{}));
+
+    // Rotated away from the paid key; the fresh default is booked with the
+    // empty label so it surfaces as a receiving address.
+    BOOST_CHECK(pwalletMain->vchDefaultKey.IsValid());
+    BOOST_CHECK(pwalletMain->vchDefaultKey != old_default);
+    BOOST_CHECK(pwalletMain->mapAddressBook.count(
+        CTxDestination(pwalletMain->vchDefaultKey.GetID())));
+
+    pwalletMain->EraseFromWallet(tx.GetHash());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 // ===========================================================================

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "gridcoin/mnemonics.h"
 #include "gridcoin/sidestake.h"
+#include "init.h"
 #include "main.h"
 #include "wallet/wallet.h"
 
@@ -2061,6 +2062,53 @@ BOOST_AUTO_TEST_CASE(maptxspends_cleanup_preserves_other_conflicts)
         BOOST_CHECK(range.first != range.second);
         BOOST_CHECK_EQUAL(range.first->second, hash2);
     }
+}
+
+BOOST_AUTO_TEST_CASE(incoming_tx_gets_order_position)
+{
+    // Regression test for the #2839 state-machine rewrite: incoming
+    // transactions inserted through SyncTransaction/AddToWalletIfInvolvingMe
+    // kept the default nOrderPos of -1, so OrderedTxItems (and therefore
+    // listtransactions) sorted every new receive/stake as the OLDEST entry
+    // until ReorderTransactions repaired the sentinel at the next wallet
+    // load. Locally created sends were unaffected (CommitTransaction goes
+    // through AddToWallet, which assigns the position).
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CKey key;
+    key.MakeNewKey(true);
+    BOOST_REQUIRE(pwalletMain->AddKey(key));
+
+    // A payment to an owned key funded by an outpoint this wallet does not
+    // know: the shape of an external receive. GetDebit finds no prevout in
+    // mapWallet, so IsFromMe is false, and the non-null prevout keeps the
+    // transaction structurally valid (and distinct from a coinbase).
+    CMutableTransaction mtx;
+    mtx.vin.resize(1);
+    mtx.vin[0].prevout = COutPoint(uint256S("0x1111111111111111111111111111111111111111111111111111111111111111"), 0);
+    mtx.vout.resize(1);
+    mtx.vout[0].nValue = 5 * COIN;
+    mtx.vout[0].scriptPubKey.SetDestination(CTxDestination(key.GetPubKey().GetID()));
+    const CTransaction tx1(mtx);
+
+    mtx.vout[0].nValue = 6 * COIN; // distinct hash
+    const CTransaction tx2(mtx);
+
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(tx1), TxStateInMempool{}));
+    BOOST_REQUIRE(pwalletMain->SyncTransaction(MakeTransactionRef(tx2), TxStateInMempool{}));
+
+    const auto it1 = pwalletMain->mapWallet.find(tx1.GetHash());
+    const auto it2 = pwalletMain->mapWallet.find(tx2.GetHash());
+    BOOST_REQUIRE(it1 != pwalletMain->mapWallet.end());
+    BOOST_REQUIRE(it2 != pwalletMain->mapWallet.end());
+
+    // Both entries carry real, strictly increasing order positions.
+    BOOST_CHECK(it1->second.nOrderPos >= 0);
+    BOOST_CHECK(it2->second.nOrderPos > it1->second.nOrderPos);
+
+    // Clean up so later cases see the wallet they expect.
+    pwalletMain->EraseFromWallet(tx1.GetHash());
+    pwalletMain->EraseFromWallet(tx2.GetHash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1003,8 +1003,14 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx,
 
     std::vector<CWalletTx*> txns_to_write;
 
-    // Mark consumed inputs as spent when confirming
-    if (std::holds_alternative<TxStateConfirmed>(state)) {
+    // Mark consumed inputs as spent. Legacy parity: WalletUpdateSpent ran on
+    // every AddToWallet sighting, so a spend already observed in the mempool
+    // marks our parent outputs (repairing stale flags from wallet copies and
+    // keeping unconfirmed balances honest). blockDisconnected reverses the
+    // marks on reorg; inactive/unrecognized states do not mark.
+    if (std::holds_alternative<TxStateConfirmed>(state)
+        || std::holds_alternative<TxStateInMempool>(state))
+    {
         for (const auto& txin : ptx->vin) {
             auto mi = mapWallet.find(txin.prevout.hash);
             if (mi != mapWallet.end()) {
@@ -1026,14 +1032,44 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx,
                     parent_wtx.MarkSpent(txin.prevout.n);
                     parent_wtx.MarkDirty();
                     txns_to_write.push_back(&parent_wtx);
+
+                    // Legacy WalletUpdateSpent parity: surface the parent's
+                    // changed spent state to the UI.
+                    NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
                 }
             }
         }
+    }
 
+    if (std::holds_alternative<TxStateConfirmed>(state)) {
         // Ensure legacy fields are in sync after state update
         auto it = mapWallet.find(hash);
         if (it != mapWallet.end()) {
             it->second.SyncLegacyFromState();
+        }
+    }
+
+    // If the default receiving address was paid, rotate it to a fresh key
+    // (legacy AddToWallet parity; the Qt GUI manages its own receiving
+    // addresses). The rotation is naturally idempotent across the
+    // mempool-then-confirmed resync of the same transaction: after the first
+    // rotation the transaction no longer pays the current default key.
+    if (!fQtActive && vchDefaultKey.IsValid()) {
+        CScript scriptDefaultKey;
+        scriptDefaultKey.SetDestination(vchDefaultKey.GetID());
+
+        for (auto const& txout : ptx->vout) {
+            if (txout.scriptPubKey == scriptDefaultKey) {
+                // Book the fresh default only if it was fully activated;
+                // one rotation retires the paid key, so further outputs to
+                // it need no additional rotations (unlike the legacy loop,
+                // which drew one pool key per matching output).
+                CPubKey newDefaultKey;
+                if (GetKeyFromPool(newDefaultKey, false) && SetDefaultKey(newDefaultKey)) {
+                    SetAddressBookName(vchDefaultKey.GetID(), "");
+                }
+                break;
+            }
         }
     }
 
@@ -1060,6 +1096,24 @@ bool CWallet::SyncTransaction(const CTransactionRef& ptx,
 
     // Notify UI of transaction change
     NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
+
+    // Notify an external script of network-observed transactions, which the
+    // state machine rewrite had dropped. Fire on the wallet's first sighting
+    // and on confirmation, not on every state resync: for sends this matches
+    // the legacy cadence (commit via AddToWallet, then confirm); for
+    // receives it matches upstream Core (legacy Gridcoin never synced
+    // wallets on mempool accept, so it only fired at confirmation).
+#if HAVE_SYSTEM
+    if (fInsertedNew || std::holds_alternative<TxStateConfirmed>(state)) {
+        std::string strCmd = gArgs.GetArg("-walletnotify", "");
+        if (!strCmd.empty())
+        {
+            ReplaceAll(strCmd, "%s", hash.GetHex());
+            boost::thread t(runCommand, strCmd);
+            t.detach(); // run free; never let t's destructor join/terminate
+        }
+    }
+#endif
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -696,7 +696,13 @@ int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb) EXCLUSIVE_LOCKS_REQUIRED(
     if (pwalletdb) {
         pwalletdb->WriteOrderPosNext(nOrderPosNext);
     } else {
-        CWalletDB(strWalletFile).WriteOrderPosNext(nOrderPosNext);
+        // flush_on_close=false: the default would run a full Berkeley DB
+        // checkpoint per call, which is prohibitive when this is reached per
+        // new transaction during a rescan. A crash loses the counter bump
+        // together with the same-session transaction writes; the load-time
+        // ReorderTransactions repair covers that, matching the legacy
+        // AddToWalletIfInvolvingMe flush-off contract.
+        CWalletDB(strWalletFile, "r+", /*flush_on_close=*/false).WriteOrderPosNext(nOrderPosNext);
     }
     return nRet;
 }
@@ -1141,6 +1147,14 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx,
         wtx.SetTxState(state);
         wtx.nTimeReceived = GetTime();
         wtx.fFromMe = fIsFromMe;
+
+        // Assign the wallet ordering position. Without this the entry keeps
+        // the -1 sentinel, sorts before every existing transaction in
+        // OrderedTxItems (listtransactions shows it as the oldest entry),
+        // and is only repaired by ReorderTransactions at the next wallet
+        // load. The pre-state-machine path went through AddToWallet, which
+        // assigns it; this insert path must do the same.
+        wtx.nOrderPos = IncOrderPosNext();
 
         wtx.nTimeSmart = wtx.nTimeReceived;
         if (const auto* conf = std::get_if<TxStateConfirmed>(&state)) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -191,6 +191,13 @@ CWalletDB::ReorderTransactions(CWallet* pwallet)
 
             if (pwtx != nullptr) {
                 pwtx->nOrderPos = nOrderPos;
+
+                // Persist the repair (upstream parity): without this the
+                // record keeps -1 on disk, ReorderTransactions re-runs on
+                // every load, and every valid-position transaction sorting
+                // after this one is shifted and rewritten at each restart.
+                if (!WriteTx(pwtx->GetHash(), *pwtx))
+                    return DB_LOAD_FAIL;
             } else if (pacentry_opt.has_value()) {
                 // Have to write accounting regardless, since we don't keep it in memory
                 CAccountingEntry entry_copy = pacentry_opt.value();


### PR DESCRIPTION
## Problem

Reported by QuaXeros (Discord #testnet, July 2026), reliably reproduced: every transaction the wallet learns about from the network — receives, stakes, sidestake payouts — appears as the **oldest** entry in `listtransactions` (CLI and GUI debug console) until the wallet is restarted. Locally created sends sort correctly. Testnet builds only; no mainnet release is affected.

Root cause: the wallet transaction state machine rewrite (#2839) replaced the legacy `AddToWalletIfInvolvingMe` path — which routed new transactions through `AddToWallet` — with a direct `mapWallet` emplace that sets the received time, smart time, state and `vfSpent` but never assigns `nOrderPos`. The entry keeps the `-1` sentinel and sorts before every real position in `OrderedTxItems`. On restart, `LoadWallet`'s `ReorderTransactions` repairs the sentinels, which is why the order "fixes itself".

## Fix (4 commits)

1. **Assign the position at insertion** (`wtx.nOrderPos = IncOrderPosNext()`), matching `AddToWallet`. `SyncTransaction`'s existing batch write persists it; the counter is written before the transaction record, so a crash between the two leaves a harmless gap, never a duplicate. The `IncOrderPosNext` no-handle fallback now opens its `CWalletDB` with `flush_on_close=false` — the default would run a full Berkeley DB checkpoint **per new transaction**, which is prohibitive during rescans; flush-off is the legacy `AddToWalletIfInvolvingMe` durability contract, and the load-time repair covers the crash window. Regression test in `wallet_state_tests` pins strictly increasing non-negative positions for externally received transactions.

2. **Suite-placement hygiene**: `wallet_tests.cpp` holds four Boost suites, and the seed phrase / sweep-selection cases from #3195/#3198 had been appended before the file's final `SUITE_END`, registering them under `psgt_readiness_tests`. They always ran in the full binary (no coverage was lost), but suite-scoped runs skipped them. Moved to `wallet_tests` where they belong; no content changes.

3. **Persist `ReorderTransactions`' repairs** (upstream v0.13.2 parity): the `-1` repair branch assigned the recomputed position only in memory, so bug-era wallets re-ran the repair on *every* load and inflated the positions of later transactions at each restart. Affected testnet wallets now converge in one restart.

## Verification

- **Two-node regtest, unfixed build**: `listtransactions` confirmations scrambled (9, 3, 37, 22, 45, 39, 12) with the send correctly last — the reported split exactly.
- **Fixed build, same harness**: fully monotonic in arrival order — send(6), generate(6), generate(5), generate(4), send(3), generate(3), generate(2), generate(1).
- Regression unit test fails on unfixed code by construction (`nOrderPos` stays `-1`).
- Restoration commit: regression tests for the default-key rotation and mempool spent-marking in `wallet_state_tests`; `-walletnotify` validated on a two-node regtest (`walletnotify=echo %s >> file`): exactly one notification at the mempool sighting of an incoming payment and a second at confirmation.
- Full `test_gridcoin` suite, Qt6 GUI build, Clang thread-safety analysis, and `lint-all.sh` green.
- Two independent adversarial review passes: all call paths verified to hold `cs_wallet`/`cs_main` at the assignment; no new lock-order edges (`cs_wallet → bitdb.cs_db` is pre-established, and the flush thread uses `TRY_LOCK` without touching `cs_wallet`); non-file-backed wallets safe (`CDB` no-ops on an empty filename); mempool-sighting → block-confirm takes the update branch, so no double assignment.

## The other dropped behaviors (4th commit)

Review of the #2839 rewrite surfaced three more legacy `AddToWallet` behaviors dropped on the network-observed path, now restored in the same place (`SyncTransaction`):

- **`-walletnotify` fires again for receives/stakes/sidestake payouts** — on the wallet's first sighting and on confirmation, the cadence the legacy path produced for both sends and receives (sends still notify from `CommitTransaction`; the mempool resync of an own send is not a first sighting, so no duplicate).
- **Default receiving key rotation (daemon mode)** — a payment to the default address draws a fresh key from the pool, makes it the default, and books it with the empty label, exactly as the legacy block did. Idempotent across the mempool-then-confirmed resync of the same transaction.
- **Mempool sightings mark parent outputs spent** — restored, keeping unconfirmed balances honest and closing the reorg window where a disconnected spender sitting in the mempool left parents unmarked. The parent's `CT_UPDATED` UI notification from legacy `WalletUpdateSpent` is restored with it. `blockDisconnected` reverses marks on reorg; inactive/unrecognized states do not mark.

Two behavior notes for the record, from the adversarial review's archaeology: (1) the receive-side `-walletnotify` cadence (first sighting + confirmation) is **upstream Core parity** — legacy Gridcoin never synced wallets on mempool accept at all, so it fired only at confirmation; sends keep the exact legacy cadence. Rescan-found transactions do not notify (`ScanForWalletTransactions` bypasses `SyncTransaction`), unlike legacy which spawned one notify thread per found transaction. (2) A wallet-copy's spend seen only in the mempool that never confirms now leaves parents marked spent (balance understated) until `repairwallet` — an exposure no era had only because legacy was blind to mempool transactions entirely; the marking is the correct accounting and `repairwallet` remains the recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
