### PR TITLE
ipc: multiprocess GUI/node split — transport, handshake, all interfaces + GUI seam (Phase 2b–2d)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,9 @@ if(ENABLE_MULTIPROCESS)
         message(STATUS "Multiprocess (IPC) build: ENABLED (vendored subtree)")
     endif()
     message(STATUS "  Cap'n Proto: ${CapnProto_VERSION}")
+    # Compile definition so the -multiprocess seam code (in gridcoinresearchd and
+    # the GUI) is gated: OFF builds neither reference nor link gridcoin_ipc.
+    add_compile_definitions(ENABLE_MULTIPROCESS)
 else()
     message(STATUS "Multiprocess (IPC) build: disabled (monolithic, direct calls)")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,13 @@ if(ENABLE_UPNP)
 endif()
 
 if(ENABLE_MULTIPROCESS)
+    # The IPC transport is pathname AF_UNIX sockets with POSIX close-on-exec /
+    # umask semantics (src/ipc/); it is a Unix-only feature. Fail with a clear
+    # message rather than a confusing compile error if it is enabled on Windows.
+    if(WIN32)
+        message(FATAL_ERROR "ENABLE_MULTIPROCESS is not supported on Windows (it requires POSIX AF_UNIX sockets).")
+    endif()
+
     # Cap'n Proto provides the serialization runtime and the capnp / capnpc-c++
     # code generators; libmultiprocess provides the proxy runtime and the mpgen
     # generator that turns an interfaces .capnp schema into client/server proxies.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,7 +354,7 @@ if(ENABLE_DAEMON)
     # serve the GUI over the socket. gridcoin_ipc is EXCLUDE_FROM_ALL, so listing it
     # here is what pulls it into the build for this configuration.
     if(ENABLE_MULTIPROCESS)
-        target_link_libraries(gridcoinresearchd PUBLIC gridcoin_ipc)
+        target_link_libraries(gridcoinresearchd PRIVATE gridcoin_ipc)
     endif()
 
     # Link gridcoinresearchd to gridcoin_util AND all of gridcoin_util's

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -350,6 +350,13 @@ if(ENABLE_DAEMON)
     target_include_directories(gridcoinresearchd PRIVATE ${CMAKE_BINARY_DIR})
     target_compile_definitions(gridcoinresearchd PRIVATE CURL_STATICLIB) # <--- ADDED
 
+    # Multiprocess (RFC #2937): the daemon links the IPC layer so -multiprocess can
+    # serve the GUI over the socket. gridcoin_ipc is EXCLUDE_FROM_ALL, so listing it
+    # here is what pulls it into the build for this configuration.
+    if(ENABLE_MULTIPROCESS)
+        target_link_libraries(gridcoinresearchd PUBLIC gridcoin_ipc)
+    endif()
+
     # Link gridcoinresearchd to gridcoin_util AND all of gridcoin_util's
     # dependencies, because it is a static library.
     target_link_libraries(gridcoinresearchd PUBLIC

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -28,6 +28,7 @@
 #include "interfaces/ipc.h"
 #include "ipc/handshake.h"
 #include "ipc/serve_init.h"
+#include <atomic>
 #include <memory>
 #endif
 
@@ -37,6 +38,11 @@
 #include <stdexcept>
 
 extern bool fQtActive;
+// Set true at the end of core init. The GUI sets it via ThreadAppInit2; the
+// daemon runs AppInit2 directly, so it sets it here (below) -- otherwise a
+// multiprocess GUI's isCoreReady() poll, served from this process, never
+// returns true and the GUI hangs on the splash.
+extern std::atomic<bool> bGridcoinCoreInitComplete;
 
 #if HAVE_DECL_FORK
 
@@ -299,6 +305,11 @@ bool AppInit(int argc, char* argv[])
     }
 
     if (fRet) {
+        // Core init succeeded. ThreadAppInit2 (the GUI's init wrapper) sets this
+        // for the monolith; the daemon calls AppInit2 directly, so set it here so
+        // a multiprocess GUI's isCoreReady() (served from this process) returns
+        // true once the core is up.
+        bGridcoinCoreInitComplete = true;
 #ifdef ENABLE_MULTIPROCESS
         // Multiprocess (RFC #2937): after core init, optionally listen on the
         // AF_UNIX socket and serve the interfaces::Init to an attached GUI. The

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -23,6 +23,14 @@
 #include "node/ui_interface.h"
 #include "gridcoin/upgrade.h"
 
+#ifdef ENABLE_MULTIPROCESS
+#include "interfaces/init.h"
+#include "interfaces/ipc.h"
+#include "ipc/handshake.h"
+#include "ipc/serve_init.h"
+#include <memory>
+#endif
+
 #include <boost/thread.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <stdio.h>
@@ -291,9 +299,33 @@ bool AppInit(int argc, char* argv[])
     }
 
     if (fRet) {
+#ifdef ENABLE_MULTIPROCESS
+        // Multiprocess (RFC #2937): after core init, optionally listen on the
+        // AF_UNIX socket and serve the interfaces::Init to an attached GUI. The
+        // serving Init + Ipc live for the run, torn down after the wait loop.
+        std::unique_ptr<interfaces::Init> serve_init;
+        std::unique_ptr<interfaces::Ipc> ipc;
+        if (gArgs.GetBoolArg("-multiprocess", false)) {
+            try {
+                std::string cookie = ipc::WriteCookie(GetDataDir());
+                interfaces::NodeIdentity identity = ipc::WriteIdentity(GetDataDir());
+                serve_init = ipc::MakeServeInit(interfaces::MakeGridcoinInit(),
+                                                std::move(cookie), std::move(identity));
+                ipc = interfaces::MakeIpc("gridcoinresearchd", *serve_init);
+                std::string address = "unix";
+                ipc->listenAddress(address);
+                LogPrintf("IPC: serving GUI connections on %s\n", address);
+            } catch (const std::exception& e) {
+                LogPrintf("IPC: failed to start the multiprocess listener: %s\n", e.what());
+            }
+        }
+#endif
         while (!ShutdownRequested()) {
             UninterruptibleSleep(std::chrono::milliseconds{500});
         }
+#ifdef ENABLE_MULTIPROCESS
+        if (ipc) ipc->disconnectIncoming();
+#endif
     }
 
     Shutdown(nullptr);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -729,6 +729,12 @@ void SetupServerArgs()
     // RPC
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    argsman.AddArg("-multiprocess",
+                   "Run in multiprocess mode (RFC #2937): the daemon also listens on an AF_UNIX "
+                   "socket in the data directory and serves the GUI over IPC; the GUI (started "
+                   "separately with -multiprocess) connects to it instead of running core in-process. "
+                   "Default: off (monolithic).",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections",
                    ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::RPC);
     argsman.AddArg("-rpcwait", "Wait for RPC server to start.",

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -20,6 +20,15 @@ Init::~Init() = default;
 
 bool Init::isCoreReady() { return true; }
 
+// Handshake surface (doc/multiprocess_design.md section 4.3). The monolithic
+// build has no IPC peer, so authenticate() reports success and the build/identity
+// snapshots are empty; the node's serving Init (Stage 2) overrides these.
+bool Init::authenticate(const std::string& /*cookie*/) { return true; }
+
+BuildInfo Init::getBuildInfo() { return BuildInfo{}; }
+
+NodeIdentity Init::getIdentity() { return NodeIdentity{}; }
+
 std::unique_ptr<Node> Init::makeNode() { return nullptr; }
 
 std::unique_ptr<StakingStatus> Init::makeStakingStatus() { return nullptr; }

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -20,10 +20,14 @@ Init::~Init() = default;
 
 bool Init::isCoreReady() { return true; }
 
-// Handshake surface (doc/multiprocess_design.md section 4.3). The monolithic
-// build has no IPC peer, so authenticate() reports success and the build/identity
-// snapshots are empty; the node's serving Init (Stage 2) overrides these.
-bool Init::authenticate(const std::string& /*cookie*/) { return true; }
+// Handshake surface (doc/multiprocess_design.md section 4.3). The base default
+// denies: authentication is only meaningful for an Init served over IPC, and the
+// serving wrapper (ipc::MakeServeInit) overrides this to grant on a valid cookie.
+// Denying by default means a base Init accidentally served directly never grants
+// unauthenticated access. (The monolithic build never calls authenticate() -- it
+// uses the in-process Init without a handshake.) The build/identity snapshots are
+// empty for the same reason; the serving Init overrides them.
+bool Init::authenticate(const std::string& /*cookie*/) { return false; }
 
 BuildInfo Init::getBuildInfo() { return BuildInfo{}; }
 

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -37,18 +37,18 @@ std::unique_ptr<Node> Init::makeNode() { return nullptr; }
 
 std::unique_ptr<StakingStatus> Init::makeStakingStatus() { return nullptr; }
 
-std::unique_ptr<MRC> Init::makeMRC(CWallet* /*wallet*/) { return nullptr; }
+std::unique_ptr<MRC> Init::makeMRC() { return nullptr; }
 
 std::unique_ptr<SideStakeManager> Init::makeSideStakeManager() { return nullptr; }
 
 std::unique_ptr<VotingManager> Init::makeVotingManager() { return nullptr; }
 
-std::unique_ptr<ResearcherContext> Init::makeResearcherContext(CWallet* /*wallet*/) { return nullptr; }
+std::unique_ptr<ResearcherContext> Init::makeResearcherContext() { return nullptr; }
 
-std::unique_ptr<PSGTPoolContext> Init::makePSGTPoolContext(CWallet* /*wallet*/) { return nullptr; }
+std::unique_ptr<PSGTPoolContext> Init::makePSGTPoolContext() { return nullptr; }
 
 std::unique_ptr<Wallet> Init::makeWallet() { return nullptr; }
 
-std::shared_ptr<WalletTxSource> Init::makeWalletTxSource(CWallet* /*wallet*/) { return nullptr; }
+std::shared_ptr<WalletTxSource> Init::makeWalletTxSource() { return nullptr; }
 
 } // namespace interfaces

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -32,7 +32,7 @@ class WalletTxSource;
 //! snapshot; crosses the IPC boundary.
 struct BuildInfo
 {
-    std::string git_commit;      //!< BUILD_GIT_COMMIT (may carry a -dirty suffix).
+    std::string git_commit;      //!< FormatFullVersion(): client version + git commit (with a -dirty suffix when the tree is modified).
     std::string built_at;        //!< Build timestamp (informational, About dialog).
     uint32_t schema_major = 0;   //!< Cap'n Proto schema major (wire compatibility).
     uint32_t schema_minor = 0;

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -5,7 +5,11 @@
 #ifndef GRIDCOIN_INTERFACES_INIT_H
 #define GRIDCOIN_INTERFACES_INIT_H
 
+#include "interfaces/marshal.h"
+
+#include <cstdint>
 #include <memory>
+#include <string>
 
 class CWallet;
 
@@ -20,6 +24,33 @@ class StakingStatus;
 class VotingManager;
 class Wallet;
 class WalletTxSource;
+
+//! The node's compile-time build fingerprint. After authentication the GUI
+//! compares its own embedded fingerprint against the node's, per the matching
+//! policy in doc/multiprocess_design.md section 4.2 (schema_major mismatch is a
+//! hard fail, git_commit mismatch a dismissible soft-warn banner, etc.). Value
+//! snapshot; crosses the IPC boundary.
+struct BuildInfo
+{
+    std::string git_commit;      //!< BUILD_GIT_COMMIT (may carry a -dirty suffix).
+    std::string built_at;        //!< Build timestamp (informational, About dialog).
+    uint32_t schema_major = 0;   //!< Cap'n Proto schema major (wire compatibility).
+    uint32_t schema_minor = 0;
+    uint32_t protocol_version = 0;
+};
+
+//! The node's per-datadir identity. The GUI persists the expected node_id +
+//! network on first successful connect and hard-fails on every later launch when
+//! a different node_id answers at the same socket path (a moved datadir, a
+//! -reindex rotation, or a foreign node squatting the socket). See
+//! doc/multiprocess_design.md section 4.2. Value snapshot; crosses IPC.
+struct NodeIdentity
+{
+    std::string node_id;      //!< Random per-datadir UUID (from node_identity.json).
+    std::string network;      //!< Chain name ("main" / "test" / "regtest").
+    std::string datadir;      //!< Canonical datadir path.
+    std::string genesis_hash; //!< Genesis block hash, hex.
+};
 
 //! Per-process bootstrap interface: hands out the other interfaces. In the
 //! monolithic build MakeGridcoinInit() returns an implementation whose
@@ -40,6 +71,26 @@ public:
     //! bGridcoinCoreInitComplete global; a Stage-2 IPC readiness handshake later
     //! replaces the poll. The default (no core to wait on) reports ready.
     virtual bool isCoreReady();
+
+    //! First IPC call of the connect handshake (doc/multiprocess_design.md
+    //! section 4.3, step 5): the GUI presents the 256-bit cookie it read from
+    //! <datadir>/<network>/ipc.cookie; the node compares it constant-time against
+    //! the cookie it wrote at startup and returns whether it matches. Build and
+    //! identity information are never served to an unauthenticated peer, so the
+    //! GUI hard-fails and disconnects on a false result. Authentication precedes
+    //! every other exchange. The monolithic default (no IPC peer) returns true.
+    virtual bool authenticate(const std::string& cookie);
+
+    //! The node's build fingerprint, for the schema/protocol/commit comparison in
+    //! the handshake (section 4.2). Only meaningful after a successful
+    //! authenticate(). The base default returns an empty snapshot; the node's
+    //! serving Init populates it from the process's embedded build constants.
+    virtual BuildInfo getBuildInfo();
+
+    //! The node's per-datadir identity, compared against the GUI's stored
+    //! expectation (section 4.2). Only meaningful after authenticate(). The base
+    //! default returns an empty snapshot; the node's serving Init populates it.
+    virtual NodeIdentity getIdentity();
 
     //! The defaults return nullptr and are defined out of line (init.cpp):
     //! inline definitions would require every includer to see the complete
@@ -89,6 +140,11 @@ public:
 
 //! Return the monolithic-build Init implementation.
 std::unique_ptr<Init> MakeGridcoinInit();
+
+// Marshalability pins (interfaces/marshal.h): the handshake DTOs cross the IPC
+// boundary and must stay copyable value types.
+INTERFACES_ASSERT_MARSHALABLE(BuildInfo);
+INTERFACES_ASSERT_MARSHALABLE(NodeIdentity);
 
 } // namespace interfaces
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -101,10 +101,11 @@ public:
 
     virtual std::unique_ptr<StakingStatus> makeStakingStatus();
 
-    //! Returns the Manual Research Claim interface over the node's single
-    //! wallet. Returns nullptr for a null wallet; \p wallet must outlive the
-    //! returned object.
-    virtual std::unique_ptr<MRC> makeMRC(CWallet* wallet);
+    //! Returns the Manual Research Claim interface over the node's single wallet.
+    //! Takes no wallet argument: the implementation uses the node's single wallet
+    //! (a node-internal CWallet* cannot cross the IPC boundary in the split build).
+    //! Returns nullptr before wallet startup completes.
+    virtual std::unique_ptr<MRC> makeMRC();
 
     //! Returns the sidestake registry interface (the unified mandatory + local
     //! sidestake table and local add/edit/delete commands). Over the global
@@ -118,26 +119,26 @@ public:
 
     //! Returns the researcher/beacon interface (identity/magnitude/accrual/beacon
     //! snapshot, the fused project table, and beacon/mode commands) over the
-    //! global researcher registries and the node's single wallet. Returns nullptr
-    //! for a null wallet; \p wallet must outlive the returned object.
-    virtual std::unique_ptr<ResearcherContext> makeResearcherContext(CWallet* wallet);
+    //! global researcher registries and the node's single wallet. Takes no wallet
+    //! argument (see makeMRC). Returns nullptr before wallet startup completes.
+    virtual std::unique_ptr<ResearcherContext> makeResearcherContext();
 
     //! Returns the PSGT pool + multisig-workbench interface (pool table reads/
     //! commands and the PSGT sign/combine/submit/finalize operations) over the
-    //! global PSGT pool and the node's single wallet. Returns nullptr for a null
-    //! wallet; \p wallet must outlive the returned object.
-    virtual std::unique_ptr<PSGTPoolContext> makePSGTPoolContext(CWallet* wallet);
+    //! global PSGT pool and the node's single wallet. Takes no wallet argument
+    //! (see makeMRC). Returns nullptr before wallet startup completes.
+    virtual std::unique_ptr<PSGTPoolContext> makePSGTPoolContext();
 
     //! Returns the interface for the node's single wallet. May return nullptr
     //! before wallet startup completes.
     virtual std::unique_ptr<Wallet> makeWallet();
 
-    //! Returns a transaction-table source over \p wallet (the windowed
-    //! tx-table store, its worker, and the producer subscriptions). The
-    //! returned object owns the node-side machinery, so a headless process
-    //! that never calls this pays nothing. Returns nullptr for a null wallet.
-    //! \p wallet must outlive the returned object.
-    virtual std::shared_ptr<WalletTxSource> makeWalletTxSource(CWallet* wallet);
+    //! Returns a transaction-table source over the node's single wallet (the
+    //! windowed tx-table store, its worker, and the producer subscriptions). The
+    //! returned object owns the node-side machinery, so a headless process that
+    //! never calls this pays nothing. Takes no wallet argument (see makeMRC).
+    //! Returns nullptr before wallet startup completes.
+    virtual std::shared_ptr<WalletTxSource> makeWalletTxSource();
 };
 
 //! Return the monolithic-build Init implementation.

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -78,7 +78,9 @@ public:
     //! the cookie it wrote at startup and returns whether it matches. Build and
     //! identity information are never served to an unauthenticated peer, so the
     //! GUI hard-fails and disconnects on a false result. Authentication precedes
-    //! every other exchange. The monolithic default (no IPC peer) returns true.
+    //! every other exchange. The base default denies (returns false); only the
+    //! serving Init wrapper grants on a valid cookie, so a base Init served
+    //! directly never leaks access. The monolithic build never calls this.
     virtual bool authenticate(const std::string& cookie);
 
     //! The node's build fingerprint, for the schema/protocol/commit comparison in

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_INTERFACES_IPC_H
+#define GRIDCOIN_INTERFACES_IPC_H
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <typeindex>
+
+namespace ipc {
+struct Context;
+} // namespace ipc
+
+namespace interfaces {
+class Init;
+
+//! Interprocess-communication (IPC) helper. Establishes a connection between a
+//! controlling process (the GUI) and a controlled process (the node). When a
+//! connection is established the controlled process exposes its interfaces::Init,
+//! which the controlling process uses to reach the other interfaces.
+//!
+//! Gridcoin's Stage-2 split uses two independently-started binaries and a named
+//! AF_UNIX socket -- the node listenAddress()es, the GUI connectAddress()es. The
+//! GUI does not spawn the node (see doc/multiprocess_design.md), so this helper
+//! is deliberately narrower than Bitcoin Core's Ipc (no spawnProcess /
+//! startSpawnedProcess).
+class Ipc
+{
+public:
+    virtual ~Ipc() = default;
+
+    //! Connect to a socket address and return a pointer to the remote process's
+    //! Init interface. Returns null if \p address is empty ("") or disabled
+    //! ("0"), or if a connection was refused/absent but not required ("auto");
+    //! throws on an unexpected error.
+    virtual std::unique_ptr<Init> connectAddress(std::string& address) = 0;
+
+    //! Listen on a socket address, exposing this process's Init interface to
+    //! clients. Throws on error (including a live listener already on the path).
+    virtual void listenAddress(std::string& address) = 0;
+
+    //! Disconnect any incoming connections that are still connected.
+    virtual void disconnectIncoming() = 0;
+
+    //! Add a cleanup callback to a remote interface, run when it is deleted.
+    template <typename Interface>
+    void addCleanup(Interface& iface, std::function<void()> cleanup)
+    {
+        addCleanup(typeid(Interface), &iface, std::move(cleanup));
+    }
+
+    //! IPC context struct accessor.
+    virtual ipc::Context& context() = 0;
+
+protected:
+    //! Type-erased implementation of the public addCleanup template (template
+    //! methods cannot be virtual).
+    virtual void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) = 0;
+};
+
+//! Return an implementation of the Ipc interface. \p exe_name is this process's
+//! role name (used for the socket filename and thread names); \p init is the
+//! Init this process serves when listening.
+std::unique_ptr<Ipc> MakeIpc(const char* exe_name, Init& init);
+} // namespace interfaces
+
+#endif // GRIDCOIN_INTERFACES_IPC_H

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -286,8 +286,10 @@ public:
     virtual bool getPubKey(const CKeyID& address, CPubKey& pub_key_out) = 0;
 
     //! Fetch a fresh public key from the key pool, labeling its address in
-    //! the address book when label is non-empty.
-    virtual bool getKeyFromPool(CPubKey& pub_key_out, const std::string& label) = 0;
+    //! the address book when label is non-empty. Input (label) precedes the
+    //! output (pub_key_out) so the IPC proxy maps request/response fields to
+    //! these arguments in order.
+    virtual bool getKeyFromPool(const std::string& label, CPubKey& pub_key_out) = 0;
 
     //! Value snapshots of the given outpoints; unknown or conflicted
     //! (negative-depth) outpoints are skipped.
@@ -382,7 +384,10 @@ public:
     //! label, and return its encoded destination -- the CPubKey stays node-side.
     //! For the researcher pool page, which previously reserved the key and
     //! encoded the address GUI-side. Returns false on key-generation failure.
-    virtual bool getNewReceiveAddress(const std::string& label, std::string& address_out) = 0;
+    //! Distinct name (not an overload of getNewReceiveAddress) because the IPC
+    //! proxy generator takes a member-function pointer and cannot disambiguate
+    //! overloaded names.
+    virtual bool getNewReceiveAddressWithLabel(const std::string& label, std::string& address_out) = 0;
 
     //! Owned addresses with a positive balance that are not yet in the address
     //! book (encoded), for the "add existing receive address" picker.

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 add_library(gridcoin_ipc STATIC EXCLUDE_FROM_ALL
     process.cpp
     interfaces.cpp
+    handshake.cpp
+    serve_init.cpp
     capnp/protocol.cpp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -37,6 +37,7 @@ target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/wallet_tx_source.capnp
     capnp/mrc.capnp
     capnp/voting.capnp
+    capnp/researcher.capnp
     capnp/init.capnp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(gridcoin_ipc STATIC EXCLUDE_FROM_ALL
     interfaces.cpp
     handshake.cpp
     serve_init.cpp
+    connect.cpp
     capnp/protocol.cpp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -35,6 +35,7 @@ target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/node.capnp
     capnp/wallet.capnp
     capnp/wallet_tx_source.capnp
+    capnp/mrc.capnp
     capnp/init.capnp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -36,6 +36,7 @@ target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/wallet.capnp
     capnp/wallet_tx_source.capnp
     capnp/mrc.capnp
+    capnp/voting.capnp
     capnp/init.capnp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -38,6 +38,7 @@ target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/mrc.capnp
     capnp/voting.capnp
     capnp/researcher.capnp
+    capnp/psgt.capnp
     capnp/init.capnp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -14,12 +14,17 @@ if(NOT WITH_EXTERNAL_LIBMULTIPROCESS)
     add_libmultiprocess(libmultiprocess)
 endif()
 
-# The generated Cap'n Proto proxy layer. target_capnp_sources runs mpgen on each
+# The IPC layer: the hand-written transport (process/protocol/interfaces) plus the
+# generated Cap'n Proto proxy layer. target_capnp_sources runs mpgen on each
 # .capnp, generating the raw capnp types (.capnp.h/.c++) and the ProxyClient/
 # ProxyServer marshalling code (.proxy-*), and adds them as sources of this
 # library. The include prefix (this dir) reproduces the ipc/capnp/... include
 # spelling the schemas' $Proxy.includeTypes and consumers use.
-add_library(gridcoin_ipc STATIC EXCLUDE_FROM_ALL)
+add_library(gridcoin_ipc STATIC EXCLUDE_FROM_ALL
+    process.cpp
+    interfaces.cpp
+    capnp/protocol.cpp
+)
 
 target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/handler.capnp

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -33,6 +33,7 @@ target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/staking.capnp
     capnp/node.capnp
     capnp/wallet.capnp
+    capnp/wallet_tx_source.capnp
     capnp/init.capnp
 )
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -32,6 +32,7 @@ target_capnp_sources(gridcoin_ipc ${CMAKE_CURRENT_SOURCE_DIR}
     capnp/handler.capnp
     capnp/staking.capnp
     capnp/node.capnp
+    capnp/wallet.capnp
     capnp/init.capnp
 )
 

--- a/src/ipc/capnp/common-types.h
+++ b/src/ipc/capnp/common-types.h
@@ -5,6 +5,9 @@
 #ifndef GRIDCOIN_IPC_CAPNP_COMMON_TYPES_H
 #define GRIDCOIN_IPC_CAPNP_COMMON_TYPES_H
 
+#include <pubkey.h>
+#include <support/allocators/secure.h>
+#include <support/cleanse.h>
 #include <uint256.h>
 
 #include <mp/proxy-types.h>
@@ -43,6 +46,69 @@ decltype(auto) CustomReadField(TypeList<uint256>, Priority<1>, InvokeContext& in
         throw std::runtime_error("uint256 IPC field has wrong length");
     }
     return read_dest.construct(std::vector<unsigned char>(data.begin(), data.end()));
+}
+
+//! CKeyID is a uint160 (20 raw bytes), marshalled as its bytes in a Data field
+//! like uint256. Only key *identifiers* and public keys cross the boundary --
+//! private key material never does (see interfaces::Wallet).
+template <typename Value, typename Output>
+void CustomBuildField(TypeList<CKeyID>, Priority<1>, InvokeContext& invoke_context, Value&& value, Output&& output)
+{
+    auto result = output.init(value.size());
+    std::memcpy(result.begin(), value.begin(), value.size());
+}
+
+template <typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<CKeyID>, Priority<1>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
+{
+    auto data = input.get();
+    if (data.size() != CKeyID::size()) {
+        throw std::runtime_error("CKeyID IPC field has wrong length");
+    }
+    return read_dest.construct(uint160(std::vector<unsigned char>(data.begin(), data.end())));
+}
+
+//! CPubKey is a variable-length (33- or 65-byte) public key, marshalled as its
+//! serialized bytes in a Data field. The read side reconstructs via the
+//! two-iterator constructor, which self-validates the length and marks the key
+//! invalid on a malformed (untrusted) buffer.
+template <typename Value, typename Output>
+void CustomBuildField(TypeList<CPubKey>, Priority<1>, InvokeContext& invoke_context, Value&& value, Output&& output)
+{
+    auto result = output.init(value.size());
+    std::memcpy(result.begin(), value.begin(), value.size());
+}
+
+template <typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<CPubKey>, Priority<1>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
+{
+    auto data = input.get();
+    return read_dest.construct(data.begin(), data.end());
+}
+
+//! SecureString (the wallet passphrase) is marshalled as raw bytes in a Data
+//! field. Bespoke rather than reusing the std::string hook so the plaintext
+//! copies are explicitly scrubbed: the read side constructs the SecureString
+//! (whose secure_allocator zeroes on destruction) and then memory_cleanse()s the
+//! received wire buffer, so no plaintext lingers in the node's message arena.
+//! (The send-side capnp segment is not scrubbed here -- libmultiprocess exposes
+//! no post-send per-message hook -- but it lives only in the short-lived request
+//! arena of the calling process, which already holds the passphrase the user
+//! just typed.)
+template <typename Value, typename Output>
+void CustomBuildField(TypeList<SecureString>, Priority<1>, InvokeContext& invoke_context, Value&& value, Output&& output)
+{
+    auto result = output.init(value.size());
+    std::memcpy(result.begin(), value.data(), value.size());
+}
+
+template <typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<SecureString>, Priority<1>, InvokeContext& invoke_context, Input&& input, ReadDest&& read_dest)
+{
+    auto data = input.get();
+    decltype(auto) result = read_dest.construct(CharCast(data.begin()), data.size());
+    memory_cleanse(const_cast<char*>(CharCast(data.begin())), data.size());
+    return result;
 }
 
 } // namespace mp

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -13,6 +13,7 @@
 #include <ipc/capnp/staking.capnp.proxy-types.h>
 #include <ipc/capnp/wallet.capnp.proxy-types.h>
 #include <ipc/capnp/wallet_tx_source.capnp.proxy-types.h>
+#include <ipc/capnp/mrc.capnp.proxy-types.h>
 
 #include <ipc/capnp/init.capnp.proxy.h>
 

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -14,6 +14,7 @@
 #include <ipc/capnp/wallet.capnp.proxy-types.h>
 #include <ipc/capnp/wallet_tx_source.capnp.proxy-types.h>
 #include <ipc/capnp/mrc.capnp.proxy-types.h>
+#include <ipc/capnp/voting.capnp.proxy-types.h>
 
 #include <ipc/capnp/init.capnp.proxy.h>
 

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -16,6 +16,7 @@
 #include <ipc/capnp/mrc.capnp.proxy-types.h>
 #include <ipc/capnp/voting.capnp.proxy-types.h>
 #include <ipc/capnp/researcher.capnp.proxy-types.h>
+#include <ipc/capnp/psgt.capnp.proxy-types.h>
 
 #include <ipc/capnp/init.capnp.proxy.h>
 

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -15,6 +15,7 @@
 #include <ipc/capnp/wallet_tx_source.capnp.proxy-types.h>
 #include <ipc/capnp/mrc.capnp.proxy-types.h>
 #include <ipc/capnp/voting.capnp.proxy-types.h>
+#include <ipc/capnp/researcher.capnp.proxy-types.h>
 
 #include <ipc/capnp/init.capnp.proxy.h>
 

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -12,6 +12,7 @@
 #include <ipc/capnp/node.capnp.proxy-types.h>
 #include <ipc/capnp/staking.capnp.proxy-types.h>
 #include <ipc/capnp/wallet.capnp.proxy-types.h>
+#include <ipc/capnp/wallet_tx_source.capnp.proxy-types.h>
 
 #include <ipc/capnp/init.capnp.proxy.h>
 
@@ -25,6 +26,8 @@
 #include <mp/type-decay.h>
 #include <mp/type-interface.h>
 #include <mp/type-number.h>
+// makeWalletTxSource returns a std::shared_ptr<WalletTxSource> capability.
+#include <mp/type-pointer.h>
 #include <mp/type-string.h>
 #include <mp/type-struct.h>
 #include <mp/type-threadmap.h>

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -17,12 +17,15 @@
 #include <mp/proxy-types.h>
 
 // Type-marshalling support: the construct() ThreadMap exchange (type-threadmap),
-// returned interface capabilities (type-interface), the Bool result of
-// isCoreReady (type-number), and the framework Context.
+// returned interface capabilities (type-interface), Bool/UInt32 scalars
+// (type-number), Text (type-string), the BuildInfo/NodeIdentity value structs
+// (type-struct), and the framework Context.
 #include <mp/type-context.h>
 #include <mp/type-decay.h>
 #include <mp/type-interface.h>
 #include <mp/type-number.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
 #include <mp/type-threadmap.h>
 
 #endif // GRIDCOIN_IPC_CAPNP_INIT_TYPES_H

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -11,6 +11,7 @@
 // scope to build/read the returned capabilities.
 #include <ipc/capnp/node.capnp.proxy-types.h>
 #include <ipc/capnp/staking.capnp.proxy-types.h>
+#include <ipc/capnp/wallet.capnp.proxy-types.h>
 
 #include <ipc/capnp/init.capnp.proxy.h>
 

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -15,6 +15,7 @@ using Node = import "node.capnp";
 using Staking = import "staking.capnp";
 using Wallet = import "wallet.capnp";
 using WalletTxSource = import "wallet_tx_source.capnp";
+using MRC = import "mrc.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
@@ -35,6 +36,7 @@ interface Init $Proxy.wrap("interfaces::Init") {
     getIdentity @6 (context :Proxy.Context) -> (result :NodeIdentity);
     makeWallet @7 (context :Proxy.Context) -> (result :Wallet.Wallet);
     makeWalletTxSource @8 (context :Proxy.Context) -> (result :WalletTxSource.WalletTxSource);
+    makeMRC @9 (context :Proxy.Context) -> (result :MRC.MRC);
 }
 
 struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -13,6 +13,7 @@ $Proxy.includeTypes("ipc/capnp/init-types.h");
 
 using Node = import "node.capnp";
 using Staking = import "staking.capnp";
+using Wallet = import "wallet.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
@@ -31,6 +32,7 @@ interface Init $Proxy.wrap("interfaces::Init") {
     authenticate @4 (context :Proxy.Context, cookie :Text) -> (result :Bool);
     getBuildInfo @5 (context :Proxy.Context) -> (result :BuildInfo);
     getIdentity @6 (context :Proxy.Context) -> (result :NodeIdentity);
+    makeWallet @7 (context :Proxy.Context) -> (result :Wallet.Wallet);
 }
 
 struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -14,6 +14,7 @@ $Proxy.includeTypes("ipc/capnp/init-types.h");
 using Node = import "node.capnp";
 using Staking = import "staking.capnp";
 using Wallet = import "wallet.capnp";
+using WalletTxSource = import "wallet_tx_source.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
@@ -33,6 +34,7 @@ interface Init $Proxy.wrap("interfaces::Init") {
     getBuildInfo @5 (context :Proxy.Context) -> (result :BuildInfo);
     getIdentity @6 (context :Proxy.Context) -> (result :NodeIdentity);
     makeWallet @7 (context :Proxy.Context) -> (result :Wallet.Wallet);
+    makeWalletTxSource @8 (context :Proxy.Context) -> (result :WalletTxSource.WalletTxSource);
 }
 
 struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -16,6 +16,7 @@ using Staking = import "staking.capnp";
 using Wallet = import "wallet.capnp";
 using WalletTxSource = import "wallet_tx_source.capnp";
 using MRC = import "mrc.capnp";
+using Voting = import "voting.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
@@ -37,6 +38,7 @@ interface Init $Proxy.wrap("interfaces::Init") {
     makeWallet @7 (context :Proxy.Context) -> (result :Wallet.Wallet);
     makeWalletTxSource @8 (context :Proxy.Context) -> (result :WalletTxSource.WalletTxSource);
     makeMRC @9 (context :Proxy.Context) -> (result :MRC.MRC);
+    makeVotingManager @10 (context :Proxy.Context) -> (result :Voting.VotingManager);
 }
 
 struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -18,6 +18,7 @@ using WalletTxSource = import "wallet_tx_source.capnp";
 using MRC = import "mrc.capnp";
 using Voting = import "voting.capnp";
 using Researcher = import "researcher.capnp";
+using PSGT = import "psgt.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
@@ -41,6 +42,7 @@ interface Init $Proxy.wrap("interfaces::Init") {
     makeMRC @9 (context :Proxy.Context) -> (result :MRC.MRC);
     makeVotingManager @10 (context :Proxy.Context) -> (result :Voting.VotingManager);
     makeResearcherContext @11 (context :Proxy.Context) -> (result :Researcher.ResearcherContext);
+    makePSGTPoolContext @12 (context :Proxy.Context) -> (result :PSGT.PSGTPoolContext);
 }
 
 struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -24,4 +24,26 @@ interface Init $Proxy.wrap("interfaces::Init") {
     isCoreReady @1 (context :Proxy.Context) -> (result :Bool);
     makeNode @2 (context :Proxy.Context) -> (result :Node.Node);
     makeStakingStatus @3 (context :Proxy.Context) -> (result :Staking.StakingStatus);
+
+    # Connect handshake (doc/multiprocess_design.md section 4.3). authenticate is
+    # the first call; the node serves build/identity info (and the makeX
+    # capabilities) only to an authenticated peer.
+    authenticate @4 (context :Proxy.Context, cookie :Text) -> (result :Bool);
+    getBuildInfo @5 (context :Proxy.Context) -> (result :BuildInfo);
+    getIdentity @6 (context :Proxy.Context) -> (result :NodeIdentity);
+}
+
+struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {
+    gitCommit @0 :Text $Proxy.name("git_commit");
+    builtAt @1 :Text $Proxy.name("built_at");
+    schemaMajor @2 :UInt32 $Proxy.name("schema_major");
+    schemaMinor @3 :UInt32 $Proxy.name("schema_minor");
+    protocolVersion @4 :UInt32 $Proxy.name("protocol_version");
+}
+
+struct NodeIdentity $Proxy.wrap("interfaces::NodeIdentity") {
+    nodeId @0 :Text $Proxy.name("node_id");
+    network @1 :Text;
+    datadir @2 :Text;
+    genesisHash @3 :Text $Proxy.name("genesis_hash");
 }

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -17,6 +17,7 @@ using Wallet = import "wallet.capnp";
 using WalletTxSource = import "wallet_tx_source.capnp";
 using MRC = import "mrc.capnp";
 using Voting = import "voting.capnp";
+using Researcher = import "researcher.capnp";
 
 # Per-process bootstrap interface (interfaces::Init). construct @0 is the
 # libmultiprocess lifecycle entry point (ThreadMap exchange); the makeX methods
@@ -39,6 +40,7 @@ interface Init $Proxy.wrap("interfaces::Init") {
     makeWalletTxSource @8 (context :Proxy.Context) -> (result :WalletTxSource.WalletTxSource);
     makeMRC @9 (context :Proxy.Context) -> (result :MRC.MRC);
     makeVotingManager @10 (context :Proxy.Context) -> (result :Voting.VotingManager);
+    makeResearcherContext @11 (context :Proxy.Context) -> (result :Researcher.ResearcherContext);
 }
 
 struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {

--- a/src/ipc/capnp/mrc-types.h
+++ b/src/ipc/capnp/mrc-types.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_MRC_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_MRC_TYPES_H
+
+#include <interfaces/mrc.h>
+
+// The MRC schema imports handler.capnp (handleMRCChanged returns Handler) and
+// node.capnp (the callback reuses Node.VoidCallback); their proxy types must be
+// in scope to marshal those.
+#include <ipc/capnp/handler.capnp.proxy-types.h>
+#include <ipc/capnp/node.capnp.proxy-types.h>
+
+#include <ipc/capnp/mrc.capnp.proxy.h>
+
+#include <mp/proxy-types.h>
+
+#include <mp/type-context.h>
+#include <mp/type-decay.h>
+#include <mp/type-function.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_MRC_TYPES_H

--- a/src/ipc/capnp/mrc.capnp
+++ b/src/ipc/capnp/mrc.capnp
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xc1d2e3f405162738;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/mrc.h");
+$Proxy.includeTypes("ipc/capnp/mrc-types.h");
+
+using Handler = import "handler.capnp";
+using Node = import "node.capnp";
+
+# Mirrors interfaces::MRC (src/interfaces/mrc.h), the Manual Research Claim
+# boundary. CAmount is int64_t and crosses as Int64. handleMRCChanged reuses
+# Node.VoidCallback (also ProxyCallback<std::function<void()>>) so the two
+# schemas do not register two capnp interfaces for the same C++ type.
+interface MRC $Proxy.wrap("interfaces::MRC") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    snapshot @1 (context :Proxy.Context, feeBoost :Int64, walletLocked :Bool, researcherEligible :Bool) -> (result :MRCSnapshot);
+    submit @2 (context :Proxy.Context, feeBoost :Int64, walletLocked :Bool) -> (result :MRCSubmitResult);
+    isOutOfSync @3 (context :Proxy.Context) -> (result :Bool);
+    handleMRCChanged @4 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
+}
+
+struct MRCSnapshot $Proxy.wrap("interfaces::MRCSnapshot") {
+    outOfSync @0 :Bool $Proxy.name("out_of_sync");
+    blockHeight @1 :Int32 $Proxy.name("block_height");
+    blockVersionValid @2 :Bool $Proxy.name("block_version_valid");
+    outputLimit @3 :Int32 $Proxy.name("output_limit");
+    createError @4 :Bool $Proxy.name("create_error");
+    createErrorMsg @5 :Text $Proxy.name("create_error_msg");
+    boostedFeeError @6 :Bool $Proxy.name("boosted_fee_error");
+    boostedFeeErrorMsg @7 :Text $Proxy.name("boosted_fee_error_msg");
+    reward @8 :Int64;
+    minFee @9 :Int64 $Proxy.name("min_fee");
+    fee @10 :Int64;
+    queueLength @11 :Int32 $Proxy.name("queue_length");
+    pos @12 :Int32;
+    foundInQueue @13 :Bool $Proxy.name("found_in_queue");
+    queueHeadFee @14 :Int64 $Proxy.name("queue_head_fee");
+    queueTailFee @15 :Int64 $Proxy.name("queue_tail_fee");
+    queuePayLimitFee @16 :Int64 $Proxy.name("queue_pay_limit_fee");
+}
+
+struct MRCSubmitResult $Proxy.wrap("interfaces::MRCSubmitResult") {
+    success @0 :Bool;
+    error @1 :Text;
+    submittedHeight @2 :Int32 $Proxy.name("submitted_height");
+    researchSubsidy @3 :Int64 $Proxy.name("research_subsidy");
+}

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/capnp/protocol.h"
+
+#include "interfaces/init.h"
+#include "ipc/capnp/init.capnp.h"
+#include "ipc/capnp/init.capnp.proxy.h"
+#include "ipc/context.h"
+#include "ipc/protocol.h"
+#include "util.h"
+
+#include <mp/proxy-io.h>
+#include <mp/proxy-types.h>
+
+#include <cassert>
+#include <functional>
+#include <future>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <system_error>
+#include <thread>
+#include <typeindex>
+
+namespace ipc {
+namespace capnp {
+namespace {
+
+//! Route libmultiprocess log messages into the Gridcoin log. Raise-level
+//! messages are turned into exceptions (mp's convention for fatal protocol
+//! errors), matching Bitcoin Core's IpcLogFn.
+void IpcLogFn(mp::LogMessage message)
+{
+    if (message.level == mp::Log::Raise) {
+        LogPrintf("ipc: %s\n", message.message);
+        throw std::runtime_error(message.message);
+    }
+    LogPrintf("ipc: %s\n", message.message);
+}
+
+class CapnpProtocol : public Protocol
+{
+public:
+    ~CapnpProtocol() noexcept override
+    {
+        m_loop_ref.reset();
+        if (m_loop_thread.joinable()) m_loop_thread.join();
+        assert(!m_loop);
+    }
+
+    std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name) override
+    {
+        startLoop(exe_name);
+        return mp::ConnectStream<messages::Init>(*m_loop, mp::MakeStream(*m_loop, fd));
+    }
+
+    void listen(int listen_fd, const char* exe_name, interfaces::Init& init) override
+    {
+        startLoop(exe_name);
+        if (::listen(listen_fd, /*backlog=*/5) != 0) {
+            throw std::system_error(errno, std::system_category());
+        }
+        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init);
+    }
+
+    void disconnectIncoming() override
+    {
+        if (!m_loop) return;
+        m_loop->sync([&] {
+            m_loop->m_incoming_connections.remove_if(
+                [this](mp::Connection& c) { return &c != m_parent_connection; });
+        });
+    }
+
+    void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) override
+    {
+        mp::ProxyTypeRegister::types().at(type)(iface).cleanup_fns.emplace_back(std::move(cleanup));
+    }
+
+    Context& context() override { return m_context; }
+
+    //! Start the background event-loop thread (idempotent). The loop is
+    //! constructed on that thread; a promise makes startLoop() block until it
+    //! exists, and an EventLoopRef keeps it alive until the last reference drops.
+    void startLoop(const char* exe_name)
+    {
+        if (m_loop) return;
+        std::promise<void> promise;
+        m_loop_thread = std::thread([&] {
+            RenameThread("capnp-loop");
+            m_loop.emplace(exe_name, mp::LogFn{IpcLogFn}, &m_context);
+            m_loop_ref.emplace(*m_loop);
+            promise.set_value();
+            m_loop->loop();
+            m_loop.reset();
+        });
+        promise.get_future().wait();
+    }
+
+    Context m_context;
+    std::thread m_loop_thread;
+    std::optional<mp::EventLoop> m_loop;
+    std::optional<mp::EventLoopRef> m_loop_ref;
+    //! Connection to a controlling parent process, if any. Gridcoin never spawns,
+    //! so this stays null; kept so disconnectIncoming() reads cleanly.
+    mp::Connection* m_parent_connection{nullptr};
+};
+} // namespace
+
+std::unique_ptr<Protocol> MakeCapnpProtocol() { return std::make_unique<CapnpProtocol>(); }
+} // namespace capnp
+} // namespace ipc

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -64,7 +64,11 @@ public:
         if (::listen(listen_fd, /*backlog=*/5) != 0) {
             throw std::system_error(errno, std::system_category());
         }
-        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init);
+        // Cap at a single simultaneous connection: the served Init (and its
+        // authentication state) is shared, and the v1 model is exactly one GUI.
+        // This prevents a second peer from riding an already-authenticated session
+        // (see ServeInit). Per-connection auth would lift this cap later.
+        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init, /*max_connections=*/1);
     }
 
     void disconnectIncoming() override
@@ -91,14 +95,23 @@ public:
         if (m_loop) return;
         std::promise<void> promise;
         m_loop_thread = std::thread([&] {
-            RenameThread("capnp-loop");
-            m_loop.emplace(exe_name, mp::LogFn{IpcLogFn}, &m_context);
-            m_loop_ref.emplace(*m_loop);
+            try {
+                RenameThread("capnp-loop");
+                m_loop.emplace(exe_name, mp::LogFn{IpcLogFn}, &m_context);
+                m_loop_ref.emplace(*m_loop);
+            } catch (...) {
+                // Surface a construction failure to the waiting thread instead of
+                // escaping std::thread (which would call std::terminate).
+                promise.set_exception(std::current_exception());
+                return;
+            }
             promise.set_value();
             m_loop->loop();
             m_loop.reset();
         });
-        promise.get_future().wait();
+        // Rethrows here if the loop thread failed to construct the EventLoop, so
+        // the caller (IpcImpl / AppInit) can log and continue instead of crashing.
+        promise.get_future().get();
     }
 
     Context m_context;

--- a/src/ipc/capnp/protocol.h
+++ b/src/ipc/capnp/protocol.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_PROTOCOL_H
+#define GRIDCOIN_IPC_CAPNP_PROTOCOL_H
+
+#include "ipc/protocol.h"
+
+#include <memory>
+
+namespace ipc {
+namespace capnp {
+//! Construct the Cap'n Proto IPC protocol implementation.
+std::unique_ptr<Protocol> MakeCapnpProtocol();
+} // namespace capnp
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_CAPNP_PROTOCOL_H

--- a/src/ipc/capnp/psgt-types.h
+++ b/src/ipc/capnp/psgt-types.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_PSGT_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_PSGT_TYPES_H
+
+#include <interfaces/psgt.h>
+
+#include <ipc/capnp/psgt.capnp.proxy.h>
+
+#include <mp/proxy-types.h>
+
+#include <mp/type-context.h>
+#include <mp/type-data.h>
+#include <mp/type-decay.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+#include <mp/type-vector.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_PSGT_TYPES_H

--- a/src/ipc/capnp/psgt.capnp
+++ b/src/ipc/capnp/psgt.capnp
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0x9a8b7c6d5e4f3021;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/psgt.h");
+$Proxy.includeTypes("ipc/capnp/psgt-types.h");
+
+# Mirrors interfaces::PSGTPoolContext (src/interfaces/psgt.h), the PSGT pool +
+# multisig-workbench boundary. PSGTBytes (std::vector<unsigned char>, the
+# serialized PSGT) crosses as Data; enum members (PSGTSignStatus, PSGTRelevance,
+# PSGTInput{Amount,Sig}State, PSGTPoolAddStatus, PSGTPoolRejectReason) cross as
+# their integer values; CAmount as Int64. signPoolEntry declares its input
+# (image_hex) before its outputs (error, txid), so the params-then-results
+# fields bind to the C++ arguments in order.
+interface PSGTPoolContext $Proxy.wrap("interfaces::PSGTPoolContext") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    entries @1 (context :Proxy.Context) -> (result :List(PSGTPoolRow));
+    signPoolEntry @2 (context :Proxy.Context, imageHex :Text) -> (error :Text, txid :Text, result :Int32);
+    removePoolEntry @3 (context :Proxy.Context, imageHex :Text) -> (result :Bool);
+    poolStatus @4 (context :Proxy.Context) -> (result :PSGTPoolStatus);
+    poolEntryPsgt @5 (context :Proxy.Context, imageHex :Text) -> (result :Data);
+    describePSGT @6 (context :Proxy.Context, psgt :Data) -> (result :PSGTDescription);
+    signPSGT @7 (context :Proxy.Context, psgt :Data) -> (result :PSGTSignResult);
+    combinePSGTs @8 (context :Proxy.Context, psgts :List(Data)) -> (result :PSGTCombineResult);
+    submitPSGTToPool @9 (context :Proxy.Context, psgt :Data) -> (result :PSGTSubmitResult);
+    finalizeToRawTxHex @10 (context :Proxy.Context, psgt :Data) -> (result :PSGTFinalizeResult);
+    decodePSGT @11 (context :Proxy.Context, bytes :Data) -> (result :PSGTDecodeResult);
+    walletHasSignature @12 (context :Proxy.Context, psgt :Data) -> (result :Bool);
+    walletMustSignRevision @13 (context :Proxy.Context, revisionHex :Text) -> (result :Bool);
+}
+
+struct PSGTPoolStatus $Proxy.wrap("interfaces::PSGTPoolStatus") {
+    active @0 :Bool;
+    v15Enabled @1 :Bool $Proxy.name("v15_enabled");
+    outOfSync @2 :Bool $Proxy.name("out_of_sync");
+}
+
+struct PSGTPoolRow $Proxy.wrap("interfaces::PSGTPoolRow") {
+    imageHex @0 :Text $Proxy.name("image_hex");
+    imageAddress @1 :Text $Proxy.name("image_address");
+    revisionHex @2 :Text $Proxy.name("revision_hex");
+    destination @3 :Text;
+    amount @4 :Int64;
+    validSigs @5 :Int32 $Proxy.name("valid_sigs");
+    sigsRequired @6 :Int32 $Proxy.name("sigs_required");
+    sigsTotal @7 :Int32 $Proxy.name("sigs_total");
+    timeReceived @8 :Int64 $Proxy.name("time_received");
+    inPool @9 :Bool $Proxy.name("in_pool");
+    relevance @10 :Int32;
+}
+
+struct PSGTInputInfo $Proxy.wrap("interfaces::PSGTInputInfo") {
+    prevoutHash @0 :Text $Proxy.name("prevout_hash");
+    prevoutN @1 :UInt32 $Proxy.name("prevout_n");
+    hasMetadata @2 :Bool $Proxy.name("has_metadata");
+    amountState @3 :Int32 $Proxy.name("amount_state");
+    amount @4 :Int64;
+    sigState @5 :Int32 $Proxy.name("sig_state");
+    partialSigCount @6 :Int32 $Proxy.name("partial_sig_count");
+    hasRedeem @7 :Bool $Proxy.name("has_redeem");
+    p2shAddress @8 :Text $Proxy.name("p2sh_address");
+    p2shHashHex @9 :Text $Proxy.name("p2sh_hash_hex");
+    isMultisig @10 :Bool $Proxy.name("is_multisig");
+    multisigM @11 :Int32 $Proxy.name("multisig_m");
+    multisigN @12 :Int32 $Proxy.name("multisig_n");
+}
+
+struct PSGTOutputInfo $Proxy.wrap("interfaces::PSGTOutputInfo") {
+    isStandard @0 :Bool $Proxy.name("is_standard");
+    destinations @1 :List(Text);
+    nRequired @2 :Int32 $Proxy.name("n_required");
+    amount @3 :Int64;
+}
+
+struct PSGTDescription $Proxy.wrap("interfaces::PSGTDescription") {
+    valid @0 :Bool;
+    error @1 :Text;
+    txid @2 :Text;
+    version @3 :Int32;
+    time @4 :UInt32;
+    lockTime @5 :UInt32 $Proxy.name("lock_time");
+    inputs @6 :List(PSGTInputInfo);
+    outputs @7 :List(PSGTOutputInfo);
+    signedInputCount @8 :Int32 $Proxy.name("signed_input_count");
+    inputCount @9 :Int32 $Proxy.name("input_count");
+    complete @10 :Bool;
+}
+
+struct PSGTSignResult $Proxy.wrap("interfaces::PSGTSignResult") {
+    psgt @0 :Data;
+    ok @1 :Bool;
+    complete @2 :Bool;
+    signedNow @3 :Int32 $Proxy.name("signed_now");
+    needsData @4 :Int32 $Proxy.name("needs_data");
+    couldNotSign @5 :Int32 $Proxy.name("could_not_sign");
+    error @6 :Text;
+}
+
+struct PSGTCombineResult $Proxy.wrap("interfaces::PSGTCombineResult") {
+    psgt @0 :Data;
+    ok @1 :Bool;
+    error @2 :Text;
+}
+
+struct PSGTSubmitResult $Proxy.wrap("interfaces::PSGTSubmitResult") {
+    decoded @0 :Bool;
+    validated @1 :Bool;
+    addStatus @2 :Int32 $Proxy.name("add_status");
+    rejectReason @3 :Int32 $Proxy.name("reject_reason");
+    rejectText @4 :Text $Proxy.name("reject_text");
+    revisionHex @5 :Text $Proxy.name("revision_hex");
+    error @6 :Text;
+    accepted @7 :Bool;
+}
+
+struct PSGTFinalizeResult $Proxy.wrap("interfaces::PSGTFinalizeResult") {
+    rawTxHex @0 :Text $Proxy.name("raw_tx_hex");
+    complete @1 :Bool;
+    error @2 :Text;
+}
+
+struct PSGTDecodeResult $Proxy.wrap("interfaces::PSGTDecodeResult") {
+    psgt @0 :Data;
+    ok @1 :Bool;
+    error @2 :Text;
+}

--- a/src/ipc/capnp/researcher-types.h
+++ b/src/ipc/capnp/researcher-types.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_RESEARCHER_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_RESEARCHER_TYPES_H
+
+#include <interfaces/researcher.h>
+
+// The researcher schema imports handler.capnp (the handleX methods return
+// Handler) and node.capnp (the four callbacks reuse Node's callback interfaces);
+// their proxy types must be in scope to marshal those.
+#include <ipc/capnp/handler.capnp.proxy-types.h>
+#include <ipc/capnp/node.capnp.proxy-types.h>
+
+#include <ipc/capnp/researcher.capnp.proxy.h>
+
+#include <mp/proxy-types.h>
+
+#include <mp/type-context.h>
+#include <mp/type-decay.h>
+#include <mp/type-function.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-optional.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+#include <mp/type-vector.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_RESEARCHER_TYPES_H

--- a/src/ipc/capnp/researcher.capnp
+++ b/src/ipc/capnp/researcher.capnp
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xa3b4c5d6e7f80912;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/researcher.h");
+$Proxy.includeTypes("ipc/capnp/researcher-types.h");
+
+using Handler = import "handler.capnp";
+using Node = import "node.capnp";
+
+# Mirrors interfaces::ResearcherContext (src/interfaces/researcher.h). Enum
+# members (BeaconStatus, ResearcherProjectRow::WhitelistStatus/ErrorKind,
+# ResearcherMode) cross as their integer values; CAmount as Int64. trySnapshot's
+# std::optional<ResearcherSnapshot> return uses the boxed struct's own
+# nullability (as wallet.capnp's optional coin-control param does). The two
+# field-level optionals (accrual_near_limit, gdpr_controls) are primitives, so
+# they use the presence-companion convention (a hasX field mpgen skips as a
+# member). The four notification callbacks reuse node.capnp's callback interfaces
+# so the shared C++ ProxyCallback types are registered once.
+interface ResearcherContext $Proxy.wrap("interfaces::ResearcherContext") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    snapshot @1 (context :Proxy.Context) -> (result :ResearcherSnapshot);
+    trySnapshot @2 (context :Proxy.Context) -> (result :ResearcherSnapshot);
+    outOfSync @3 (context :Proxy.Context) -> (result :Bool);
+    hasV3CapableProjects @4 (context :Proxy.Context) -> (result :Bool);
+    projects @5 (context :Proxy.Context, extended :Bool) -> (result :List(ResearcherProjectRow));
+    whitelistProjects @6 (context :Proxy.Context) -> (result :List(WhitelistProject));
+    maxProjectNameLength @7 (context :Proxy.Context) -> (result :Int32);
+    maxProjectUrlLength @8 (context :Proxy.Context) -> (result :Int32);
+    v3CapableProjects @9 (context :Proxy.Context) -> (result :List(WhitelistProject));
+    switchMode @10 (context :Proxy.Context, mode :Int32, email :Text) -> (result :Bool);
+    advertiseBeacon @11 (context :Proxy.Context) -> (result :BeaconAdvertiseResult);
+    generateBeaconKeyForV3 @12 (context :Proxy.Context) -> (result :Text);
+    advertiseBeaconV3 @13 (context :Proxy.Context, ownershipProofXml :Text) -> (result :BeaconAdvertiseResult);
+    reload @14 (context :Proxy.Context) -> ();
+    handleResearcherChanged @15 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
+    handleBeaconChanged @16 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
+    handleAccrualChanged @17 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
+    handleBlocksChanged @18 (context :Proxy.Context, callback :Node.NotifyBlocksChangedCallback) -> (result :Handler.Handler);
+}
+
+struct ResearcherSnapshot $Proxy.wrap("interfaces::ResearcherSnapshot") {
+    cpid @0 :Text;
+    hasCpid @1 :Bool $Proxy.name("has_cpid");
+    hasSplitCpid @2 :Bool $Proxy.name("has_split_cpid");
+    hasRac @3 :Bool $Proxy.name("has_rac");
+    email @4 :Text;
+    magnitude @5 :Float64;
+    magnitudeText @6 :Text $Proxy.name("magnitude_text");
+    hasMagnitude @7 :Bool $Proxy.name("has_magnitude");
+    accrual @8 :Int64;
+    accrualNearLimit @9 :Int64 $Proxy.name("accrual_near_limit");
+    hasAccrualNearLimit @10 :Bool;
+    configuredForNoncruncherMode @11 :Bool $Proxy.name("configured_for_noncruncher_mode");
+    detectedPoolMode @12 :Bool $Proxy.name("detected_pool_mode");
+    outOfSync @13 :Bool $Proxy.name("out_of_sync");
+    miningStatus @14 :Text $Proxy.name("mining_status");
+    hasEligibleProjects @15 :Bool $Proxy.name("has_eligible_projects");
+    hasPoolProjects @16 :Bool $Proxy.name("has_pool_projects");
+    actionNeeded @17 :Bool $Proxy.name("action_needed");
+    beaconStatus @18 :Int32 $Proxy.name("beacon_status");
+    beaconPresent @19 :Bool $Proxy.name("beacon_present");
+    pendingBeaconPresent @20 :Bool $Proxy.name("pending_beacon_present");
+    hasActiveBeacon @21 :Bool $Proxy.name("has_active_beacon");
+    hasPendingBeacon @22 :Bool $Proxy.name("has_pending_beacon");
+    hasRenewableBeacon @23 :Bool $Proxy.name("has_renewable_beacon");
+    beaconExpired @24 :Bool $Proxy.name("beacon_expired");
+    needsBeaconAuth @25 :Bool $Proxy.name("needs_beacon_auth");
+    beaconAddress @26 :Text $Proxy.name("beacon_address");
+    beaconVerificationCode @27 :Text $Proxy.name("beacon_verification_code");
+    beaconError @28 :Text $Proxy.name("beacon_error");
+    cachedBeaconPubkeyHex @29 :Text $Proxy.name("cached_beacon_pubkey_hex");
+    beaconTimestamp @30 :Int64 $Proxy.name("beacon_timestamp");
+    beaconAge @31 :Int64 $Proxy.name("beacon_age");
+    timeToBeaconExpiration @32 :Int64 $Proxy.name("time_to_beacon_expiration");
+    timeToPendingBeaconExpiration @33 :Int64 $Proxy.name("time_to_pending_beacon_expiration");
+    boincDataDir @34 :Text $Proxy.name("boinc_data_dir");
+    isV14Enabled @35 :Bool $Proxy.name("is_v14_enabled");
+}
+
+struct ResearcherProjectRow $Proxy.wrap("interfaces::ResearcherProjectRow") {
+    whitelisted @0 :Int32;
+    errorKind @1 :Int32 $Proxy.name("error_kind");
+    gdprControls @2 :Bool $Proxy.name("gdpr_controls");
+    hasGdprControls @3 :Bool;
+    name @4 :Text;
+    cpid @5 :Text;
+    magnitude @6 :Float64;
+    rac @7 :Float64;
+    errorMessage @8 :Text $Proxy.name("error_message");
+}
+
+struct BeaconAdvertiseResult $Proxy.wrap("interfaces::BeaconAdvertiseResult") {
+    status @0 :Int32;
+}
+
+struct WhitelistProject $Proxy.wrap("interfaces::WhitelistProject") {
+    name @0 :Text;
+    url @1 :Text;
+}

--- a/src/ipc/capnp/type-variant.h
+++ b/src/ipc/capnp/type-variant.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <variant>
@@ -94,6 +95,11 @@ decltype(auto) CustomReadField(TypeList<std::variant<Alts...>>,
     std::uint16_t which = 0;
     ReadField(TypeList<std::uint16_t>(), invoke_context,
         Make<StructField, std::tuple_element_t<0, Accessors>>(wire), ReadDestUpdate(which));
+    // The discriminant is untrusted in the separated build; reject an
+    // out-of-range value rather than silently leaving the variant default.
+    if (which >= std::variant_size_v<Variant>) {
+        throw std::runtime_error("variant discriminant out of range in IPC message");
+    }
     return read_dest.update([&](Variant& value) {
         ReadVariantAlt<0, Variant, Accessors>(invoke_context, wire, which,
             [&](auto index_tag, auto&&... args) -> auto& {

--- a/src/ipc/capnp/type-variant.h
+++ b/src/ipc/capnp/type-variant.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_TYPE_VARIANT_H
+#define GRIDCOIN_IPC_CAPNP_TYPE_VARIANT_H
+
+#include <mp/proxy-types.h>
+#include <mp/util.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+#include <utility>
+#include <variant>
+
+//! Marshalling for std::variant<Ts...>. libmultiprocess has no Cap'n Proto
+//! union support (its Accessor machinery drives plain struct fields only), so a
+//! variant crosses as a "discriminated struct": a UInt16 `which` field holding
+//! the active alternative's zero-based index, followed by one field per
+//! alternative in declaration order, of which only the active one is populated.
+//!
+//! The paired Cap'n Proto struct MUST be declared as
+//!
+//!   struct FooWire { which @0 :UInt16; alt0 @1 :T0; alt1 @2 :T1; ... }
+//!
+//! with `which` first and the alternatives in the SAME order as the C++
+//! std::variant. It is a synthetic wire type, so it carries no $Proxy.wrap.
+//!
+//! This is the variant analogue of mp/type-pair.h and reaches into the
+//! generated ProxyStruct Accessors exactly as that header does.
+namespace mp {
+
+//! Build the active alternative into wire field (index + 1). Walks the
+//! alternatives at compile time and stops at the runtime-active one.
+template <std::size_t I, typename Accessors, typename Wire, typename Variant>
+void BuildVariantAlt(InvokeContext& invoke_context, Wire& wire, const Variant& value)
+{
+    if constexpr (I < std::variant_size_v<Variant>) {
+        if (value.index() == I) {
+            BuildField(TypeList<std::variant_alternative_t<I, Variant>>(), invoke_context,
+                Make<StructField, std::tuple_element_t<I + 1, Accessors>>(wire), std::get<I>(value));
+        } else {
+            BuildVariantAlt<I + 1, Accessors>(invoke_context, wire, value);
+        }
+    }
+}
+
+template <typename... Alts, typename Value, typename Output>
+void CustomBuildField(TypeList<std::variant<Alts...>>,
+    Priority<1>,
+    InvokeContext& invoke_context,
+    Value&& value,
+    Output&& output)
+{
+    auto wire = output.init();
+    using Accessors = typename ProxyStruct<typename decltype(wire)::Builds>::Accessors;
+    BuildField(TypeList<std::uint16_t>(), invoke_context,
+        Make<StructField, std::tuple_element_t<0, Accessors>>(wire),
+        static_cast<std::uint16_t>(value.index()));
+    BuildVariantAlt<0, Accessors>(invoke_context, wire, value);
+}
+
+//! Read wire field (which + 1) into the variant, emplacing the matching
+//! alternative. `emplace` takes an std::integral_constant<size_t, I> tag plus
+//! the read-constructed arguments and installs alternative I.
+template <std::size_t I, typename Variant, typename Accessors, typename Wire, typename EmplaceFn>
+void ReadVariantAlt(InvokeContext& invoke_context, const Wire& wire, std::uint16_t which, EmplaceFn&& emplace)
+{
+    if constexpr (I < std::variant_size_v<Variant>) {
+        if (which == I) {
+            using Alt = std::variant_alternative_t<I, Variant>;
+            ReadField(TypeList<Alt>(), invoke_context,
+                Make<StructField, std::tuple_element_t<I + 1, Accessors>>(wire),
+                ReadDestEmplace(TypeList<Alt>(), [&](auto&&... args) -> auto& {
+                    return emplace(std::integral_constant<std::size_t, I>{}, std::forward<decltype(args)>(args)...);
+                }));
+        } else {
+            ReadVariantAlt<I + 1, Variant, Accessors>(invoke_context, wire, which, std::forward<EmplaceFn>(emplace));
+        }
+    }
+}
+
+template <typename... Alts, typename Input, typename ReadDest>
+decltype(auto) CustomReadField(TypeList<std::variant<Alts...>>,
+    Priority<1>,
+    InvokeContext& invoke_context,
+    Input&& input,
+    ReadDest&& read_dest)
+{
+    using Variant = std::variant<Alts...>;
+    const auto& wire = input.get();
+    using Accessors = typename ProxyStruct<typename Decay<decltype(wire)>::Reads>::Accessors;
+    std::uint16_t which = 0;
+    ReadField(TypeList<std::uint16_t>(), invoke_context,
+        Make<StructField, std::tuple_element_t<0, Accessors>>(wire), ReadDestUpdate(which));
+    return read_dest.update([&](Variant& value) {
+        ReadVariantAlt<0, Variant, Accessors>(invoke_context, wire, which,
+            [&](auto index_tag, auto&&... args) -> auto& {
+                constexpr std::size_t Idx = decltype(index_tag)::value;
+                value.template emplace<Idx>(std::forward<decltype(args)>(args)...);
+                return std::get<Idx>(value);
+            });
+    });
+}
+
+} // namespace mp
+
+#endif // GRIDCOIN_IPC_CAPNP_TYPE_VARIANT_H

--- a/src/ipc/capnp/voting-types.h
+++ b/src/ipc/capnp/voting-types.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_VOTING_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_VOTING_TYPES_H
+
+#include <interfaces/voting.h>
+
+// The voting schema imports handler.capnp (the handleX methods return Handler).
+#include <ipc/capnp/handler.capnp.proxy-types.h>
+
+#include <ipc/capnp/voting.capnp.proxy.h>
+
+#include <mp/proxy-types.h>
+
+#include <mp/type-context.h>
+#include <mp/type-data.h>
+#include <mp/type-decay.h>
+#include <mp/type-function.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-optional.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+#include <mp/type-vector.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_VOTING_TYPES_H

--- a/src/ipc/capnp/voting.capnp
+++ b/src/ipc/capnp/voting.capnp
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xb2c3d4e5f6071829;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/voting.h");
+$Proxy.includeTypes("ipc/capnp/voting-types.h");
+
+using Handler = import "handler.capnp";
+
+# Mirrors interfaces::VotingManager (src/interfaces/voting.h), the voting
+# boundary. The DTOs carry enum values as their raw ints (the C++ members are
+# already int, not the enum types); CAmount crosses as Int64. PollTableItem's
+# std::optional<bool> validated is a `validated` field paired with `hasValidated`
+# (the libmultiprocess presence-companion convention -- the has field is skipped
+# as a member and marks validated FIELD_OPTIONAL).
+interface VotingManager $Proxy.wrap("interfaces::VotingManager") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    buildPollTable @1 (context :Proxy.Context, filterFlags :Int32) -> (result :List(PollTableItem));
+    getPollTypes @2 (context :Proxy.Context) -> (result :List(PollTypeMeta));
+    pollV3Enabled @3 (context :Proxy.Context) -> (result :Bool);
+    estimatePollFee @4 (context :Proxy.Context) -> (result :Int64);
+    currentPollTitle @5 (context :Proxy.Context) -> (result :Text);
+    latestActivePollTime @6 (context :Proxy.Context) -> (result :Int64);
+    submitPoll @7 (context :Proxy.Context, poll :PollSubmission) -> (result :VotingSubmitResult);
+    submitVote @8 (context :Proxy.Context, pollTxid :Text, choiceOffsets :Data) -> (result :VotingSubmitResult);
+    handleNewPollReceived @9 (context :Proxy.Context, callback :NewPollReceivedCallback) -> (result :Handler.Handler);
+    handleNewVoteReceived @10 (context :Proxy.Context, callback :NewVoteReceivedCallback) -> (result :Handler.Handler);
+}
+
+# --- Notification callbacks (interfaces::VotingManager::*Fn) ---
+
+interface NewPollReceivedCallback $Proxy.wrap("ProxyCallback<std::function<void(int64_t)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, pollTime :Int64) -> ();
+}
+
+interface NewVoteReceivedCallback $Proxy.wrap("ProxyCallback<std::function<void(std::string)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, pollTxid :Text) -> ();
+}
+
+# --- Value DTOs (interfaces:: structs in voting.h) ---
+
+struct PollTypeMeta $Proxy.wrap("interfaces::PollTypeMeta") {
+    type @0 :Int32;
+    name @1 :Text;
+    description @2 :Text;
+    minDurationDays @3 :Int32 $Proxy.name("min_duration_days");
+    requiredFields @4 :List(Text) $Proxy.name("required_fields");
+}
+
+struct PollChoiceResult $Proxy.wrap("interfaces::PollChoiceResult") {
+    label @0 :Text;
+    votes @1 :Float64;
+    weight @2 :UInt64;
+}
+
+struct PollAdditionalField $Proxy.wrap("interfaces::PollAdditionalField") {
+    name @0 :Text;
+    value @1 :Text;
+    required @2 :Bool;
+}
+
+struct PollSelfVoteResponse $Proxy.wrap("interfaces::PollSelfVoteResponse") {
+    choiceOffset @0 :UInt8 $Proxy.name("choice_offset");
+    weight @1 :UInt64;
+}
+
+struct PollTableItem $Proxy.wrap("interfaces::PollTableItem") {
+    txid @0 :Text;
+    payloadVersion @1 :UInt32 $Proxy.name("payload_version");
+    typeStr @2 :Text $Proxy.name("type_str");
+    title @3 :Text;
+    question @4 :Text;
+    url @5 :Text;
+    startTime @6 :Int64 $Proxy.name("start_time");
+    expiration @7 :Int64;
+    durationDays @8 :UInt32 $Proxy.name("duration_days");
+    weightType @9 :Int32 $Proxy.name("weight_type");
+    weightTypeStr @10 :Text $Proxy.name("weight_type_str");
+    responseType @11 :Text $Proxy.name("response_type");
+    topAnswer @12 :Text $Proxy.name("top_answer");
+    totalVotes @13 :UInt32 $Proxy.name("total_votes");
+    totalWeight @14 :UInt64 $Proxy.name("total_weight");
+    activeWeight @15 :UInt64 $Proxy.name("active_weight");
+    votePercentAvw @16 :Float64 $Proxy.name("vote_percent_avw");
+    validated @17 :Bool;
+    hasValidated @18 :Bool;
+    finished @19 :Bool;
+    multipleChoice @20 :Bool $Proxy.name("multiple_choice");
+    additionalFields @21 :List(PollAdditionalField) $Proxy.name("additional_fields");
+    choices @22 :List(PollChoiceResult);
+    selfVoted @23 :Bool $Proxy.name("self_voted");
+    selfVoteResponses @24 :List(PollSelfVoteResponse) $Proxy.name("self_vote_responses");
+}
+
+struct PollSubmission $Proxy.wrap("interfaces::PollSubmission") {
+    type @0 :Int32;
+    title @1 :Text;
+    durationDays @2 :Int32 $Proxy.name("duration_days");
+    question @3 :Text;
+    url @4 :Text;
+    weightType @5 :Int32 $Proxy.name("weight_type");
+    responseType @6 :Int32 $Proxy.name("response_type");
+    choices @7 :List(Text);
+    additionalFields @8 :List(PollAdditionalField) $Proxy.name("additional_fields");
+}
+
+struct VotingSubmitResult $Proxy.wrap("interfaces::VotingSubmitResult") {
+    status @0 :Int32;
+    txid @1 :Text;
+    error @2 :Text;
+}

--- a/src/ipc/capnp/wallet-types.h
+++ b/src/ipc/capnp/wallet-types.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_WALLET_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_WALLET_TYPES_H
+
+#include <interfaces/wallet.h>
+
+// uint256/CKeyID/CPubKey/SecureString <-> Data marshalling.
+#include <ipc/capnp/common-types.h>
+
+// The Wallet schema imports handler.capnp (handleX returns Handler) and
+// node.capnp (handleStatusChanged reuses Node.VoidCallback; listCoins uses
+// Node.Pair); their proxy types must be in scope to marshal those.
+#include <ipc/capnp/handler.capnp.proxy-types.h>
+#include <ipc/capnp/node.capnp.proxy-types.h>
+
+#include <ipc/capnp/wallet.capnp.proxy.h>
+
+// proxy-types.h (ReadDestUpdate/ReadDestEmplace) precedes the container type
+// headers that use it.
+#include <mp/proxy-types.h>
+
+#include <mp/type-context.h>
+#include <mp/type-data.h>
+#include <mp/type-decay.h>
+#include <mp/type-function.h>
+#include <mp/type-interface.h>
+#include <mp/type-map.h>
+#include <mp/type-number.h>
+#include <mp/type-optional.h>
+#include <mp/type-pair.h>
+#include <mp/type-set.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+#include <mp/type-vector.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_WALLET_TYPES_H

--- a/src/ipc/capnp/wallet.capnp
+++ b/src/ipc/capnp/wallet.capnp
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xd46631119dfcd074;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/wallet.h");
+$Proxy.includeTypes("ipc/capnp/wallet-types.h");
+
+using Handler = import "handler.capnp";
+using Node = import "node.capnp";
+
+# Mirrors interfaces::Wallet (src/interfaces/wallet.h). interfaces::Wallet is a
+# pure-abstract interface, so every one of its methods must appear here: the
+# generated ProxyClient<Wallet> overrides them one-for-one and would remain
+# abstract (uninstantiable) if any were omitted.
+#
+# Conventions: methods with C++ out-parameters map each out-param to a leading
+# result field (in argument order) and the return value to a trailing `result`
+# field. Enums (MessageSignStatus/MessageVerifyStatus/SendCoinsStatus,
+# ChangeType) cross as their integer values. SecureString passphrases, CKeyID,
+# CPubKey, and uint256 cross as Data via the custom hooks in common-types.h.
+interface Wallet $Proxy.wrap("interfaces::Wallet") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    getBalance @1 (context :Proxy.Context) -> (result :Int64);
+    getStake @2 (context :Proxy.Context) -> (result :Int64);
+    getUnconfirmedBalance @3 (context :Proxy.Context) -> (result :Int64);
+    getImmatureBalance @4 (context :Proxy.Context) -> (result :Int64);
+    tryGetBalances @5 (context :Proxy.Context) -> (balances :WalletBalances, result :Bool);
+    getNumTransactions @6 (context :Proxy.Context) -> (result :Int32);
+    getLockState @7 (context :Proxy.Context) -> (result :WalletLockState);
+    isUnlockedForStakingOnly @8 (context :Proxy.Context) -> (result :Bool);
+    getUnlockStakingOnlyFlag @9 (context :Proxy.Context) -> (result :Bool);
+    encryptWallet @10 (context :Proxy.Context, passphrase :Data) -> (result :Bool);
+    lockWallet @11 (context :Proxy.Context) -> (result :Bool);
+    unlockWallet @12 (context :Proxy.Context, passphrase :Data, stakingOnly :Bool) -> (result :Bool);
+    changeWalletPassphrase @13 (context :Proxy.Context, oldPassphrase :Data, newPassphrase :Data) -> (result :Bool);
+    getPubKey @14 (context :Proxy.Context, address :Data) -> (pubKeyOut :Data, result :Bool);
+    getKeyFromPool @15 (context :Proxy.Context, label :Text) -> (pubKeyOut :Data, result :Bool);
+    getOutputs @16 (context :Proxy.Context, outpoints :List(OutPoint)) -> (result :List(WalletOutput));
+    listCoins @17 (context :Proxy.Context) -> (result :List(Node.Pair(Text, List(WalletOutput))));
+    computeCoinControlSummary @18 (context :Proxy.Context, selection :WalletCoinControl, recipientAmounts :List(Int64), subtractFeeFromAmount :Bool) -> (result :CoinControlSummary);
+    getMaxConsolidationInputs @19 (context :Proxy.Context) -> (result :UInt32);
+    sendCoins @20 (context :Proxy.Context, recipients :List(WalletSendRecipient), coinControl :WalletCoinControl, acceptedFee :Int64) -> (result :SendCoinsResult);
+    backupWallet @21 (context :Proxy.Context, dest :Text) -> (result :Bool);
+    backupConfigFile @22 (context :Proxy.Context, dest :Text) -> (result :Bool);
+    signMessage @23 (context :Proxy.Context, address :Text, message :Text) -> (signatureOut :Text, result :Int32);
+    verifyMessage @24 (context :Proxy.Context, address :Text, message :Text, signature :Data) -> (result :Int32);
+    getAddresses @25 (context :Proxy.Context) -> (result :List(WalletAddress));
+    getAddressLabel @26 (context :Proxy.Context, address :Text) -> (labelOut :Text, result :Bool);
+    isMine @27 (context :Proxy.Context, address :Text) -> (result :Bool);
+    setAddressBook @28 (context :Proxy.Context, address :Text, label :Text) -> ();
+    delAddressBook @29 (context :Proxy.Context, address :Text) -> (result :Bool);
+    getNewReceiveAddress @30 (context :Proxy.Context) -> (addressOut :Text, result :Bool);
+    getNewReceiveAddressWithLabel @31 (context :Proxy.Context, label :Text) -> (addressOut :Text, result :Bool);
+    getUnbookedReceiveAddresses @32 (context :Proxy.Context) -> (result :List(Text));
+    handleStatusChanged @33 (context :Proxy.Context, callback :Node.VoidCallback) -> (result :Handler.Handler);
+    handleAddressBookChanged @34 (context :Proxy.Context, callback :AddressBookChangedCallback) -> (result :Handler.Handler);
+    handleTransactionChanged @35 (context :Proxy.Context, callback :TransactionChangedCallback) -> (result :Handler.Handler);
+}
+
+# --- Notification callbacks (interfaces::Wallet::*Fn std::function types) ---
+# handleStatusChanged reuses Node.VoidCallback (also ProxyCallback<void()>) so
+# the two schemas do not register two capnp interfaces for the same C++ type.
+
+interface AddressBookChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(const std::string&, const std::string&, bool, const std::string&, ChangeType)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, address :Text, label :Text, isMine :Bool, purpose :Text, status :Int32) -> ();
+}
+
+interface TransactionChangedCallback $Proxy.wrap("ProxyCallback<std::function<void(const uint256&, ChangeType)>>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, txHash :Data, status :Int32) -> ();
+}
+
+# --- Value DTOs (interfaces:: structs in wallet.h) ---
+
+# COutPoint (primitives/transaction.h): a hash + output index.
+struct OutPoint $Proxy.wrap("COutPoint") {
+    hash @0 :Data;
+    n @1 :UInt32;
+}
+
+struct WalletBalances $Proxy.wrap("interfaces::WalletBalances") {
+    balance @0 :Int64;
+    stake @1 :Int64;
+    unconfirmedBalance @2 :Int64 $Proxy.name("unconfirmed_balance");
+    immatureBalance @3 :Int64 $Proxy.name("immature_balance");
+}
+
+struct WalletLockState $Proxy.wrap("interfaces::WalletLockState") {
+    crypted @0 :Bool;
+    locked @1 :Bool;
+    unlockedForStakingOnly @2 :Bool $Proxy.name("unlocked_for_staking_only");
+    stakingOnlyFlag @3 :Bool $Proxy.name("staking_only_flag");
+}
+
+struct WalletOutput $Proxy.wrap("interfaces::WalletOutput") {
+    outpoint @0 :OutPoint;
+    amount @1 :Int64;
+    address @2 :Text;
+    depth @3 :Int32;
+    time @4 :Int64;
+    immature @5 :Bool;
+}
+
+struct WalletAddress $Proxy.wrap("interfaces::WalletAddress") {
+    address @0 :Text;
+    label @1 :Text;
+    isMine @2 :Bool $Proxy.name("is_mine");
+}
+
+# The GUI's coin-selection value. `selected` is a std::set<COutPoint>, marshalled
+# as a List(OutPoint) via the type-set hook.
+struct WalletCoinControl $Proxy.wrap("interfaces::WalletCoinControl") {
+    destChange @0 :Text $Proxy.name("dest_change");
+    allowWatchOnly @1 :Bool $Proxy.name("allow_watch_only");
+    selected @2 :List(OutPoint);
+}
+
+struct CoinControlSummary $Proxy.wrap("interfaces::CoinControlSummary") {
+    quantity @0 :Int32;
+    amount @1 :Int64;
+    fee @2 :Int64;
+    afterFee @3 :Int64 $Proxy.name("after_fee");
+    bytes @4 :UInt32;
+    change @5 :Int64;
+    lowOutput @6 :Bool $Proxy.name("low_output");
+    dust @7 :Bool;
+}
+
+struct WalletSendRecipient $Proxy.wrap("interfaces::WalletSendRecipient") {
+    address @0 :Text;
+    label @1 :Text;
+    amount @2 :Int64;
+    message @3 :Text;
+    subtractFeeFromAmount @4 :Bool $Proxy.name("subtract_fee_from_amount");
+}
+
+struct SendCoinsResult $Proxy.wrap("interfaces::SendCoinsResult") {
+    status @0 :Int32;
+    fee @1 :Int64;
+    txidHex @2 :Text $Proxy.name("txid_hex");
+}

--- a/src/ipc/capnp/wallet_tx_source-types.h
+++ b/src/ipc/capnp/wallet_tx_source-types.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CAPNP_WALLET_TX_SOURCE_TYPES_H
+#define GRIDCOIN_IPC_CAPNP_WALLET_TX_SOURCE_TYPES_H
+
+// Pulls in interfaces::WalletTxSource plus the GRC:: channel/filter/record
+// value types (wallet_tx_channel.h -> wallet_tx_filter.h + wallet_tx_record.h).
+#include <interfaces/wallet_tx_source.h>
+
+// uint256 <-> Data marshalling (TransactionRecord.hash, the rowForKey/
+// getRowDetail hash params).
+#include <ipc/capnp/common-types.h>
+
+#include <ipc/capnp/wallet_tx_source.capnp.proxy.h>
+
+// proxy-types.h (ReadDestUpdate/ReadDestEmplace/ProxyStruct) precedes the
+// container/variant type headers that use it.
+#include <mp/proxy-types.h>
+
+// WalletEventPayload (std::variant) <-> WalletEventPayloadWire discriminated
+// struct. Uses the mp field machinery, so it follows proxy-types.h.
+#include <ipc/capnp/type-variant.h>
+
+#include <mp/type-context.h>
+#include <mp/type-data.h>
+#include <mp/type-decay.h>
+#include <mp/type-interface.h>
+#include <mp/type-number.h>
+#include <mp/type-pair.h>
+#include <mp/type-string.h>
+#include <mp/type-struct.h>
+#include <mp/type-vector.h>
+
+#endif // GRIDCOIN_IPC_CAPNP_WALLET_TX_SOURCE_TYPES_H

--- a/src/ipc/capnp/wallet_tx_source.capnp
+++ b/src/ipc/capnp/wallet_tx_source.capnp
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 The Gridcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/licenses/mit-license.php.
+
+@0xf1e2d3c4b5a69788;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/wallet_tx_source.h");
+$Proxy.includeTypes("ipc/capnp/wallet_tx_source-types.h");
+
+# Mirrors interfaces::WalletTxSource (src/interfaces/wallet_tx_source.h), the
+# windowed transaction-table event channel. Pure-abstract, so every method is
+# schema'd (else ProxyClient<WalletTxSource> stays abstract). Only value types
+# cross: uint256 as Data (common-types.h); enums (TransactionRecord::Type,
+# TransactionStatus::Status, MinedType, WalletTxDetail::Finality/Source/
+# AmountForm) as their integer values; and the WalletEventPayload std::variant
+# as a discriminated struct (WalletEventPayloadWire + type-variant.h).
+interface WalletTxSource $Proxy.wrap("interfaces::WalletTxSource") {
+    destroy @0 (context :Proxy.Context) -> ();
+
+    registerView @1 (context :Proxy.Context, viewId :Int32, filter :FilterSpec, sortColumn :Int32, sortOrder :Int32) -> ();
+    unregisterView @2 (context :Proxy.Context, viewId :Int32) -> ();
+    setViewSort @3 (context :Proxy.Context, viewId :Int32, sortColumn :Int32, sortOrder :Int32) -> ();
+    setViewFilter @4 (context :Proxy.Context, viewId :Int32, filter :FilterSpec) -> ();
+    setViewLimit @5 (context :Proxy.Context, viewId :Int32, limit :Int32) -> ();
+    getRows @6 (context :Proxy.Context, viewId :Int32, first :Int32, count :Int32) -> (result :RowsResult);
+    getAllRows @7 (context :Proxy.Context, viewId :Int32) -> (result :RowsResult);
+    rowForKey @8 (context :Proxy.Context, viewId :Int32, hash :Data, idx :Int32) -> (result :Int32);
+    getRowDetail @9 (context :Proxy.Context, hash :Data, idx :Int32) -> (result :WalletTxDetail);
+    reloadAndSnapshot @10 (context :Proxy.Context, limitEnabled :Bool, limitTime :Int64) -> (result :List(TransactionRecord));
+    drainEvents @11 (context :Proxy.Context, maxBatch :UInt64) -> (result :List(WalletEvent));
+    noteAddressBookChanged @12 (context :Proxy.Context, address :Text, label :Text) -> ();
+}
+
+# --- Filter / sort parameter (GRC::FilterSpec) ---
+
+struct FilterSpec $Proxy.wrap("GRC::FilterSpec") {
+    dateFrom @0 :Int64 $Proxy.name("date_from");
+    dateTo @1 :Int64 $Proxy.name("date_to");
+    typeMask @2 :UInt32 $Proxy.name("type_mask");
+    addressSubstr @3 :Text $Proxy.name("address_substr");
+    minAmount @4 :Int64 $Proxy.name("min_amount");
+    limitRows @5 :Int32 $Proxy.name("limit_rows");
+    showInactive @6 :Bool $Proxy.name("show_inactive");
+    showOrphans @7 :Bool $Proxy.name("show_orphans");
+}
+
+# --- Transaction record (TransactionRecord + nested TransactionStatus) ---
+
+struct TransactionStatus $Proxy.wrap("TransactionStatus") {
+    countsForBalance @0 :Bool;
+    sortKey @1 :Text;
+    maturesIn @2 :Int32 $Proxy.name("matures_in");
+    status @3 :Int32;
+    generatedType @4 :Int32 $Proxy.name("generated_type");
+    depth @5 :Int64;
+    openFor @6 :Int64 $Proxy.name("open_for");
+    curNumBlocks @7 :Int32 $Proxy.name("cur_num_blocks");
+}
+
+struct TransactionRecord $Proxy.wrap("TransactionRecord") {
+    hash @0 :Data;
+    time @1 :Int64;
+    type @2 :Int32;
+    address @3 :Text;
+    debit @4 :Int64;
+    credit @5 :Int64;
+    vout @6 :UInt32;
+    idx @7 :Int32;
+    status @8 :TransactionStatus;
+    label @9 :Text;
+}
+
+# --- Windowed read result (GRC::RowsResult) ---
+
+struct RowsResult $Proxy.wrap("GRC::RowsResult") {
+    records @0 :List(TransactionRecord);
+    totalAccepted @1 :Int32 $Proxy.name("total_accepted");
+    epoch @2 :UInt64;
+    highWater @3 :UInt64 $Proxy.name("high_water");
+}
+
+# --- Event payloads (GRC::*Payload) ---
+
+struct RowsInsertedPayload $Proxy.wrap("GRC::RowsInsertedPayload") {
+    position @0 :Int32;
+    records @1 :List(TransactionRecord);
+    viewId @2 :Int32;
+    epoch @3 :UInt64;
+}
+
+struct RowsRemovedPayload $Proxy.wrap("GRC::RowsRemovedPayload") {
+    position @0 :Int32;
+    count @1 :Int32;
+    viewId @2 :Int32;
+    epoch @3 :UInt64;
+}
+
+struct ChainTipChangedPayload $Proxy.wrap("GRC::ChainTipChangedPayload") {
+    height @0 :Int32;
+    bestTime @1 :Int64 $Proxy.name("best_time");
+}
+
+struct RowsResetPayload $Proxy.wrap("GRC::RowsResetPayload") {
+    viewId @0 :Int32;
+    epoch @1 :UInt64;
+    total @2 :Int32;
+}
+
+struct RowCountChangedPayload $Proxy.wrap("GRC::RowCountChangedPayload") {
+    viewId @0 :Int32;
+    epoch @1 :UInt64;
+    totalAccepted @2 :Int32 $Proxy.name("total_accepted");
+}
+
+struct RowsChangedPayload $Proxy.wrap("GRC::RowsChangedPayload") {
+    viewId @0 :Int32;
+    epoch @1 :UInt64;
+    first @2 :Int32;
+    count @3 :Int32;
+}
+
+# WalletEventPayload = std::variant<the six payloads>, marshalled by type-variant.h
+# as a discriminated struct: `which` (the active alternative index) plus one
+# field per alternative, in the SAME order as the C++ std::variant. Synthetic
+# wire type -- no $Proxy.wrap.
+struct WalletEventPayloadWire {
+    which @0 :UInt16;
+    rowsInserted @1 :RowsInsertedPayload;
+    rowsRemoved @2 :RowsRemovedPayload;
+    chainTipChanged @3 :ChainTipChangedPayload;
+    rowsReset @4 :RowsResetPayload;
+    rowCountChanged @5 :RowCountChangedPayload;
+    rowsChanged @6 :RowsChangedPayload;
+}
+
+struct WalletEvent $Proxy.wrap("GRC::WalletEvent") {
+    seqno @0 :UInt64;
+    emitTimeUs @1 :Int64 $Proxy.name("emit_time_us");
+    payload @2 :WalletEventPayloadWire;
+}
+
+# --- Transaction detail (GRC::WalletTxDetail + nested DebitOut / InputInfo) ---
+
+# Generic string pair for WalletTxDetail.stake_info (vector<pair<string,string>>).
+struct StrPair {
+    first @0 :Text;
+    second @1 :Text;
+}
+
+struct DebitOut $Proxy.wrap("GRC::WalletTxDetail::DebitOut") {
+    hasAddress @0 :Bool $Proxy.name("has_address");
+    address @1 :Text;
+    label @2 :Text;
+    amount @3 :Int64;
+}
+
+struct InputInfo $Proxy.wrap("GRC::WalletTxDetail::InputInfo") {
+    hasAddress @0 :Bool $Proxy.name("has_address");
+    address @1 :Text;
+    amount @2 :Int64;
+    isMine @3 :Bool $Proxy.name("is_mine");
+}
+
+struct WalletTxDetail $Proxy.wrap("GRC::WalletTxDetail") {
+    found @0 :Bool;
+    finality @1 :Int32;
+    finalityValue @2 :Int64 $Proxy.name("finality_value");
+    depth @3 :Int32;
+    requests @4 :Int32;
+    time @5 :Int64;
+    source @6 :Int32;
+    generatedType @7 :Int32 $Proxy.name("generated_type");
+    fromValue @8 :Text $Proxy.name("from_value");
+    hasOwnCreditLine @9 :Bool $Proxy.name("has_own_credit_line");
+    ownCreditAddress @10 :Text $Proxy.name("own_credit_address");
+    ownCreditLabel @11 :Text $Proxy.name("own_credit_label");
+    hasTo @12 :Bool $Proxy.name("has_to");
+    toValue @13 :Text $Proxy.name("to_value");
+    toLabel @14 :Text $Proxy.name("to_label");
+    amountForm @15 :Int32 $Proxy.name("amount_form");
+    unmatured @16 :Int64;
+    inMainChain @17 :Bool $Proxy.name("in_main_chain");
+    maturesIn @18 :Int32 $Proxy.name("matures_in");
+    debits @19 :List(DebitOut);
+    toSelf @20 :Bool $Proxy.name("to_self");
+    selfValue @21 :Int64 $Proxy.name("self_value");
+    hasFee @22 :Bool $Proxy.name("has_fee");
+    fee @23 :Int64;
+    mixedDebits @24 :List(Int64) $Proxy.name("mixed_debits");
+    mixedCredits @25 :List(Int64) $Proxy.name("mixed_credits");
+    net @26 :Int64;
+    mapMessage @27 :Text $Proxy.name("map_message");
+    mapComment @28 :Text $Proxy.name("map_comment");
+    txid @29 :Text;
+    hasBlockHash @30 :Bool $Proxy.name("has_block_hash");
+    blockHash @31 :Text $Proxy.name("block_hash");
+    contractMessage @32 :Text $Proxy.name("contract_message");
+    isGenerated @33 :Bool $Proxy.name("is_generated");
+    stakeInfo @34 :List(StrPair) $Proxy.name("stake_info");
+    verboseDebits @35 :List(Int64) $Proxy.name("verbose_debits");
+    verboseCredits @36 :List(Int64) $Proxy.name("verbose_credits");
+    txDump @37 :Text $Proxy.name("tx_dump");
+    inputs @38 :List(InputInfo);
+}

--- a/src/ipc/connect.cpp
+++ b/src/ipc/connect.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/connect.h"
+
+#include "ipc/handshake.h"
+#include "interfaces/init.h"
+#include "interfaces/ipc.h"
+#include "tinyformat.h"
+
+#include <exception>
+#include <string>
+
+namespace ipc {
+
+std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
+                                           interfaces::Init& local_init,
+                                           std::string& error_out)
+{
+    // 1. The node writes a fresh cookie on every startup; its absence means no
+    //    node is running on this datadir, so there is nothing to dial.
+    std::optional<std::string> cookie = ReadCookie(data_dir);
+    if (!cookie) {
+        error_out = strprintf("no IPC cookie in %s -- is the Gridcoin daemon running with -multiprocess?",
+                              data_dir.string());
+        return std::nullopt;
+    }
+
+    GuiConnection conn;
+    // MakeIpc requires the Init this process would serve when listening; a
+    // connect-only GUI never listens, but the reference must stay valid for the
+    // Ipc's lifetime -- local_init (owned by the caller) provides it.
+    conn.ipc = interfaces::MakeIpc("gridcoinresearch", local_init);
+
+    // 2. Connect to the node's default socket (<data_dir>/<network>/node.sock,
+    //    resolved from GetDataDir() inside connectAddress).
+    std::string address = "unix";
+    try {
+        conn.init = conn.ipc->connectAddress(address);
+    } catch (const std::exception& e) {
+        error_out = strprintf("could not connect to the daemon on %s: %s", address, e.what());
+        return std::nullopt;
+    }
+    if (!conn.init) {
+        error_out = strprintf("no daemon is listening on %s", address);
+        return std::nullopt;
+    }
+
+    // 3. Authenticate with the cookie and verify schema/protocol compatibility.
+    //    (Identity binding and the git-commit soft-warn are layered on GUI-side.)
+    std::string auth_error;
+    if (!ClientAuthenticateAndCheck(*conn.init, *cookie, auth_error)) {
+        error_out = auth_error;
+        return std::nullopt;
+    }
+
+    return conn;
+}
+
+} // namespace ipc

--- a/src/ipc/connect.h
+++ b/src/ipc/connect.h
@@ -30,8 +30,11 @@ struct GuiConnection {
 //! GUI side: perform the connect handshake against a node listening on
 //! <data_dir>/<network>/node.sock (doc/multiprocess_design.md section 4.3):
 //!
-//!   1. read the node's ipc.cookie -- absent means no node is running on this
-//!      datadir, so there is nothing to dial;
+//!   1. read the node's ipc.cookie -- its absence means the node has never run
+//!      on this datadir (the cookie is written at startup), so there is no
+//!      credential to authenticate with and nothing to dial. The cookie is not
+//!      removed at shutdown, so a stale one may outlive a stopped node; that is
+//!      harmless -- connectAddress in step 2 then simply fails with no listener;
 //!   2. MakeIpc + connectAddress("unix") to obtain the remote Init;
 //!   3. ClientAuthenticateAndCheck -- authenticate with the cookie and verify
 //!      schema/protocol compatibility.

--- a/src/ipc/connect.h
+++ b/src/ipc/connect.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CONNECT_H
+#define GRIDCOIN_IPC_CONNECT_H
+
+#include "fs.h"
+#include "interfaces/ipc.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace interfaces {
+class Init;
+} // namespace interfaces
+
+namespace ipc {
+
+//! A live connection to a node process: the remote Init capability plus the Ipc
+//! that owns the underlying socket and event loop. The Init is a proxy valid
+//! only while the Ipc lives, so a caller keeps the whole struct alive for as
+//! long as it uses any interface reached through init.
+struct GuiConnection {
+    std::unique_ptr<interfaces::Ipc> ipc;
+    std::unique_ptr<interfaces::Init> init;
+};
+
+//! GUI side: perform the connect handshake against a node listening on
+//! <data_dir>/<network>/node.sock (doc/multiprocess_design.md section 4.3):
+//!
+//!   1. read the node's ipc.cookie -- absent means no node is running on this
+//!      datadir, so there is nothing to dial;
+//!   2. MakeIpc + connectAddress("unix") to obtain the remote Init;
+//!   3. ClientAuthenticateAndCheck -- authenticate with the cookie and verify
+//!      schema/protocol compatibility.
+//!
+//! On success returns the connection. On any failure returns std::nullopt and
+//! sets \p error_out to a human-readable reason. \p local_init is the GUI's own
+//! Init, which MakeIpc requires (the Init this process would serve if it
+//! listened; a connect-only GUI never does) and which must outlive the returned
+//! connection.
+std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
+                                           interfaces::Init& local_init,
+                                           std::string& error_out);
+
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_CONNECT_H

--- a/src/ipc/context.h
+++ b/src/ipc/context.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_CONTEXT_H
+#define GRIDCOIN_IPC_CONTEXT_H
+
+namespace ipc {
+//! Context struct giving IPC protocol implementations access to application
+//! state, in case a hook needs to run extra code that is not needed within a
+//! single process. Empty for now; a place to hang shared state later.
+struct Context
+{
+};
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_CONTEXT_H

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -15,8 +15,11 @@
 
 #include <array>
 #include <cstddef>
+#include <fcntl.h>
 #include <fstream>
 #include <sys/stat.h>
+#include <system_error>
+#include <unistd.h>
 
 namespace ipc {
 namespace {
@@ -32,17 +35,39 @@ std::optional<std::string> ReadFile(const fs::path& path)
     return contents;
 }
 
-//! Write \p contents to \p path atomically (temp file + rename) with mode 0600.
+//! Write \p contents to \p path atomically (temp file + rename). The temp file is
+//! created with mode 0600 from the start (no umask window that could expose the
+//! secret cookie), the write is verified, and any failure throws so the caller
+//! knows the file does not hold what it expects.
 void WriteFileAtomic(const fs::path& path, const std::string& contents)
 {
     fs::path tmp = path;
     tmp += ".tmp";
-    {
-        std::ofstream out(tmp.string(), std::ios::binary | std::ios::trunc);
-        out << contents;
+    const std::string tmp_str = tmp.string();
+
+    int fd = ::open(tmp_str.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd == -1) {
+        throw std::system_error(errno, std::system_category(), "open " + tmp_str);
     }
-    ::chmod(tmp.string().c_str(), 0600);
-    fs::rename(tmp, path);
+    size_t written = 0;
+    while (written < contents.size()) {
+        ssize_t n = ::write(fd, contents.data() + written, contents.size() - written);
+        if (n < 0) {
+            int e = errno;
+            ::close(fd);
+            throw std::system_error(e, std::system_category(), "write " + tmp_str);
+        }
+        written += static_cast<size_t>(n);
+    }
+    if (::fsync(fd) != 0) {
+        int e = errno;
+        ::close(fd);
+        throw std::system_error(e, std::system_category(), "fsync " + tmp_str);
+    }
+    if (::close(fd) != 0) {
+        throw std::system_error(errno, std::system_category(), "close " + tmp_str);
+    }
+    fs::rename(tmp, path); // throws (boost::filesystem) on failure
 }
 
 //! 16 strong random bytes as hex -- a per-datadir node identifier.
@@ -104,9 +129,10 @@ interfaces::NodeIdentity WriteIdentity(const fs::path& dir)
     std::string node_id;
     if (auto existing = ReadFile(path)) {
         UniValue obj;
-        if (obj.read(*existing) && obj.isObject() && obj.exists("node_id")) {
+        if (obj.read(*existing) && obj.isObject() && obj.exists("node_id") && obj["node_id"].isStr()) {
             node_id = obj["node_id"].get_str();
         }
+        // A malformed/non-string node_id falls through to a freshly generated one.
     }
     if (node_id.empty()) node_id = GenerateNodeId();
 
@@ -132,11 +158,14 @@ std::optional<interfaces::NodeIdentity> ReadIdentity(const fs::path& dir)
     UniValue obj;
     if (!obj.read(*contents) || !obj.isObject()) return std::nullopt;
 
+    // Guard each field with isStr(): UniValue::get_str() throws on a non-string,
+    // but a malformed file must yield nullopt (the documented contract), not an
+    // exception the GUI caller may not catch.
     interfaces::NodeIdentity id;
-    if (obj.exists("node_id")) id.node_id = obj["node_id"].get_str();
-    if (obj.exists("network")) id.network = obj["network"].get_str();
-    if (obj.exists("datadir")) id.datadir = obj["datadir"].get_str();
-    if (obj.exists("genesis_hash")) id.genesis_hash = obj["genesis_hash"].get_str();
+    if (obj.exists("node_id") && obj["node_id"].isStr()) id.node_id = obj["node_id"].get_str();
+    if (obj.exists("network") && obj["network"].isStr()) id.network = obj["network"].get_str();
+    if (obj.exists("datadir") && obj["datadir"].isStr()) id.datadir = obj["datadir"].get_str();
+    if (obj.exists("genesis_hash") && obj["genesis_hash"].isStr()) id.genesis_hash = obj["genesis_hash"].get_str();
     if (id.node_id.empty()) return std::nullopt;
     return id;
 }

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/handshake.h"
+
+#include "chainparams.h"
+#include "clientversion.h"
+#include "random.h"
+#include "tinyformat.h"
+#include "util.h"
+#include "util/strencodings.h"
+
+#include <univalue.h>
+
+#include <array>
+#include <cstddef>
+#include <fstream>
+#include <sys/stat.h>
+
+namespace ipc {
+namespace {
+const char* const COOKIE_FILE = "ipc.cookie";
+const char* const IDENTITY_FILE = "node_identity.json";
+
+//! Read an entire file into a string; nullopt if it cannot be opened.
+std::optional<std::string> ReadFile(const fs::path& path)
+{
+    std::ifstream in(path.string(), std::ios::binary);
+    if (!in.good()) return std::nullopt;
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    return contents;
+}
+
+//! Write \p contents to \p path atomically (temp file + rename) with mode 0600.
+void WriteFileAtomic(const fs::path& path, const std::string& contents)
+{
+    fs::path tmp = path;
+    tmp += ".tmp";
+    {
+        std::ofstream out(tmp.string(), std::ios::binary | std::ios::trunc);
+        out << contents;
+    }
+    ::chmod(tmp.string().c_str(), 0600);
+    fs::rename(tmp, path);
+}
+
+//! 16 strong random bytes as hex -- a per-datadir node identifier.
+std::string GenerateNodeId()
+{
+    std::array<unsigned char, 16> buf{};
+    GetStrongRandBytes(buf);
+    return HexStr(buf);
+}
+} // namespace
+
+interfaces::BuildInfo GetLocalBuildInfo()
+{
+    interfaces::BuildInfo info;
+    info.git_commit = FormatFullVersion();
+    info.built_at = __DATE__ " " __TIME__;
+    info.schema_major = IPC_SCHEMA_MAJOR;
+    info.schema_minor = IPC_SCHEMA_MINOR;
+    info.protocol_version = IPC_PROTOCOL_VERSION;
+    return info;
+}
+
+bool ConstantTimeEqual(const std::string& a, const std::string& b)
+{
+    if (a.size() != b.size()) return false;
+    unsigned char diff = 0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        diff |= static_cast<unsigned char>(a[i]) ^ static_cast<unsigned char>(b[i]);
+    }
+    return diff == 0;
+}
+
+std::string WriteCookie(const fs::path& dir)
+{
+    std::array<unsigned char, 32> buf{};
+    GetStrongRandBytes(buf);
+    const std::string cookie = HexStr(buf);
+    WriteFileAtomic(dir / COOKIE_FILE, cookie);
+    return cookie;
+}
+
+std::optional<std::string> ReadCookie(const fs::path& dir)
+{
+    auto contents = ReadFile(dir / COOKIE_FILE);
+    if (!contents) return std::nullopt;
+    // Trim trailing whitespace/newline defensively.
+    while (!contents->empty() && (contents->back() == '\n' || contents->back() == '\r' || contents->back() == ' ')) {
+        contents->pop_back();
+    }
+    return contents;
+}
+
+interfaces::NodeIdentity WriteIdentity(const fs::path& dir)
+{
+    const fs::path path = dir / IDENTITY_FILE;
+
+    // Preserve the existing per-datadir node_id across restarts (the GUI binds to
+    // it); generate one only on first run.
+    std::string node_id;
+    if (auto existing = ReadFile(path)) {
+        UniValue obj;
+        if (obj.read(*existing) && obj.isObject() && obj.exists("node_id")) {
+            node_id = obj["node_id"].get_str();
+        }
+    }
+    if (node_id.empty()) node_id = GenerateNodeId();
+
+    interfaces::NodeIdentity id;
+    id.node_id = node_id;
+    id.network = Params().NetworkIDString();
+    id.datadir = GetDataDir().string();
+    id.genesis_hash = Params().GetConsensus().hashGenesisBlock.ToString();
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("node_id", id.node_id);
+    obj.pushKV("network", id.network);
+    obj.pushKV("datadir", id.datadir);
+    obj.pushKV("genesis_hash", id.genesis_hash);
+    WriteFileAtomic(path, obj.write(2) + "\n");
+    return id;
+}
+
+std::optional<interfaces::NodeIdentity> ReadIdentity(const fs::path& dir)
+{
+    auto contents = ReadFile(dir / IDENTITY_FILE);
+    if (!contents) return std::nullopt;
+    UniValue obj;
+    if (!obj.read(*contents) || !obj.isObject()) return std::nullopt;
+
+    interfaces::NodeIdentity id;
+    if (obj.exists("node_id")) id.node_id = obj["node_id"].get_str();
+    if (obj.exists("network")) id.network = obj["network"].get_str();
+    if (obj.exists("datadir")) id.datadir = obj["datadir"].get_str();
+    if (obj.exists("genesis_hash")) id.genesis_hash = obj["genesis_hash"].get_str();
+    if (id.node_id.empty()) return std::nullopt;
+    return id;
+}
+
+bool ClientAuthenticateAndCheck(interfaces::Init& init, const std::string& cookie, std::string& error_out)
+{
+    if (!init.authenticate(cookie)) {
+        error_out = "The node rejected the authentication cookie. It may have restarted since the "
+                    "cookie was written; try reconnecting.";
+        return false;
+    }
+
+    const interfaces::BuildInfo remote = init.getBuildInfo();
+    const interfaces::BuildInfo local = GetLocalBuildInfo();
+
+    if (remote.schema_major != local.schema_major) {
+        error_out = strprintf("Incompatible IPC schema: this GUI speaks schema major %u but the node "
+                              "speaks %u. Use matching builds of gridcoinresearch and "
+                              "gridcoinresearchd.",
+                              local.schema_major, remote.schema_major);
+        return false;
+    }
+    if (remote.protocol_version != local.protocol_version) {
+        error_out = strprintf("Incompatible IPC protocol version: GUI %u, node %u.",
+                              local.protocol_version, remote.protocol_version);
+        return false;
+    }
+    if (local.schema_minor > remote.schema_minor) {
+        error_out = strprintf("This GUI is newer than the node (IPC schema minor GUI %u > node %u). "
+                              "Update the node.",
+                              local.schema_minor, remote.schema_minor);
+        return false;
+    }
+    // GUI schema_minor < node: forward-compatible, accepted. A git_commit
+    // mismatch is a dismissible soft-warn handled GUI-side, not a failure here.
+    return true;
+}
+
+} // namespace ipc

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -141,7 +141,9 @@ interfaces::NodeIdentity WriteIdentity(const fs::path& dir)
     interfaces::NodeIdentity id;
     id.node_id = node_id;
     id.network = Params().NetworkIDString();
-    id.datadir = GetDataDir().string();
+    // Record the directory this identity file actually lives in (the caller's
+    // dir), not the process-global GetDataDir(), so the two cannot diverge.
+    id.datadir = dir.string();
     id.genesis_hash = Params().GetConsensus().hashGenesisBlock.ToString();
 
     UniValue obj(UniValue::VOBJ);

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -45,7 +45,9 @@ void WriteFileAtomic(const fs::path& path, const std::string& contents)
     tmp += ".tmp";
     const std::string tmp_str = tmp.string();
 
-    int fd = ::open(tmp_str.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    // O_CLOEXEC: don't leak this fd into any exec'd child. O_NOFOLLOW: the temp
+    // path must not be a pre-planted symlink (this holds secrets: the cookie).
+    int fd = ::open(tmp_str.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0600);
     if (fd == -1) {
         throw std::system_error(errno, std::system_category(), "open " + tmp_str);
     }

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_HANDSHAKE_H
+#define GRIDCOIN_IPC_HANDSHAKE_H
+
+#include "fs.h"
+#include "interfaces/init.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace ipc {
+
+//! IPC schema/protocol versions embedded in both binaries and compared during
+//! the connect handshake (doc/multiprocess_design.md section 4.2). Bump the minor
+//! for additive schema changes, the major for breaking ones (which also require a
+//! transition release); bump protocol for transport/handshake changes.
+constexpr uint32_t IPC_SCHEMA_MAJOR = 1;
+constexpr uint32_t IPC_SCHEMA_MINOR = 0;
+constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
+
+//! This process's build fingerprint (git commit, build time, schema/protocol
+//! versions) for the handshake build-info exchange.
+interfaces::BuildInfo GetLocalBuildInfo();
+
+//! Constant-time byte comparison of two strings (equal length required for a
+//! match). Used for the cookie compare so a timing side-channel can't leak it.
+bool ConstantTimeEqual(const std::string& a, const std::string& b);
+
+//! Node side: write a fresh 256-bit cookie to <dir>/ipc.cookie (0600, atomic
+//! rename) and return its hex. Called once per node startup.
+std::string WriteCookie(const fs::path& dir);
+
+//! GUI side: read the hex cookie from <dir>/ipc.cookie. Returns nullopt when the
+//! file is absent (the node is not running -- do not dial).
+std::optional<std::string> ReadCookie(const fs::path& dir);
+
+//! Node side: load the persistent per-datadir node_id from
+//! <dir>/node_identity.json (generating a new UUID on first run), then rewrite
+//! the file with the current network / datadir / genesis and return the identity.
+interfaces::NodeIdentity WriteIdentity(const fs::path& dir);
+
+//! GUI side: read <dir>/node_identity.json. Returns nullopt when absent or
+//! malformed.
+std::optional<interfaces::NodeIdentity> ReadIdentity(const fs::path& dir);
+
+//! GUI side: run the authentication + build-info compatibility half of the
+//! connect handshake (design section 4.3 steps 5-6) against a freshly-connected
+//! remote Init. Calls authenticate(\p cookie) then getBuildInfo() and compares
+//! versions against this build. Returns true on success; on failure returns false
+//! and sets \p error_out to a human-readable reason. Hard-fail conditions: wrong
+//! cookie, schema_major mismatch (incompatible wire format), protocol_version
+//! mismatch, and the GUI's schema_minor being newer than the node's. (The
+//! identity binding and the git_commit soft-warn are handled GUI-side.)
+bool ClientAuthenticateAndCheck(interfaces::Init& init, const std::string& cookie, std::string& error_out);
+
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_HANDSHAKE_H

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -14,10 +14,21 @@
 #include <string>
 #include <system_error>
 #include <typeindex>
+#include <unistd.h>
 #include <utility>
 
 namespace ipc {
 namespace {
+
+//! Closes a socket fd on scope exit unless release()d. Protects the window
+//! between acquiring the fd (Process::connect/bind) and the protocol layer taking
+//! ownership of it -- if the protocol call throws, the fd is not leaked.
+struct FdGuard
+{
+    int fd;
+    ~FdGuard() { if (fd != -1) ::close(fd); }
+    void release() { fd = -1; }
+};
 
 class IpcImpl : public interfaces::Ipc
 {
@@ -50,13 +61,18 @@ public:
         } else {
             fd = m_process->connect(GetDataDir(), address);
         }
-        return m_protocol->connect(fd, m_exe_name);
+        FdGuard guard{fd};
+        auto init = m_protocol->connect(fd, m_exe_name);
+        guard.release(); // the protocol/stream now owns the fd
+        return init;
     }
 
     void listenAddress(std::string& address) override
     {
         int fd = m_process->bind(GetDataDir(), address);
+        FdGuard guard{fd};
         m_protocol->listen(fd, m_exe_name, m_init);
+        guard.release(); // the protocol/listener now owns the fd
     }
 
     void disconnectIncoming() override { m_protocol->disconnectIncoming(); }

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/init.h"
+#include "interfaces/ipc.h"
+#include "ipc/capnp/protocol.h"
+#include "ipc/process.h"
+#include "ipc/protocol.h"
+#include "util.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <typeindex>
+#include <utility>
+
+namespace ipc {
+namespace {
+
+class IpcImpl : public interfaces::Ipc
+{
+public:
+    IpcImpl(const char* exe_name, interfaces::Init& init)
+        : m_exe_name(exe_name), m_init(init),
+          m_protocol(ipc::capnp::MakeCapnpProtocol()), m_process(ipc::MakeProcess())
+    {
+    }
+
+    std::unique_ptr<interfaces::Init> connectAddress(std::string& address) override
+    {
+        if (address.empty() || address == "0") return nullptr;
+        int fd;
+        if (address == "auto") {
+            // "auto": connect if a node is listening, otherwise return null so
+            // the caller can report "no daemon" cleanly (Gridcoin does not spawn).
+            try {
+                fd = m_process->connect(GetDataDir(), address);
+            } catch (const std::system_error& e) {
+                if (e.code() == std::errc::connection_refused ||
+                    e.code() == std::errc::no_such_file_or_directory ||
+                    e.code() == std::errc::not_a_directory) {
+                    return nullptr;
+                }
+                throw;
+            } catch (const std::invalid_argument&) {
+                return nullptr;
+            }
+        } else {
+            fd = m_process->connect(GetDataDir(), address);
+        }
+        return m_protocol->connect(fd, m_exe_name);
+    }
+
+    void listenAddress(std::string& address) override
+    {
+        int fd = m_process->bind(GetDataDir(), address);
+        m_protocol->listen(fd, m_exe_name, m_init);
+    }
+
+    void disconnectIncoming() override { m_protocol->disconnectIncoming(); }
+
+    void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) override
+    {
+        m_protocol->addCleanup(type, iface, std::move(cleanup));
+    }
+
+    Context& context() override { return m_protocol->context(); }
+
+    const char* m_exe_name;
+    interfaces::Init& m_init;
+    std::unique_ptr<Protocol> m_protocol;
+    std::unique_ptr<Process> m_process;
+};
+} // namespace
+} // namespace ipc
+
+namespace interfaces {
+std::unique_ptr<Ipc> MakeIpc(const char* exe_name, Init& init)
+{
+    return std::make_unique<ipc::IpcImpl>(exe_name, init);
+}
+} // namespace interfaces

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -11,6 +11,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <fcntl.h>
 #include <stdexcept>
 #include <string>
 #include <sys/socket.h>
@@ -55,11 +56,33 @@ fs::path ParseAddress(std::string& address, const fs::path& data_dir, struct soc
     return path;
 }
 
+//! Create an AF_UNIX SOCK_STREAM socket with close-on-exec set, so the IPC fd
+//! cannot leak into an exec'd child. Uses SOCK_CLOEXEC atomically where the
+//! platform provides it (Linux, the BSDs); falls back to fcntl(FD_CLOEXEC) on
+//! platforms that lack it (notably macOS). Returns -1 with errno set on failure.
+int MakeCloexecStreamSocket()
+{
+#ifdef SOCK_CLOEXEC
+    return ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+#else
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) return -1;
+    const int flags = ::fcntl(fd, F_GETFD);
+    if (flags == -1 || ::fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
+        const int saved = errno;
+        ::close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+#endif
+}
+
 //! Connect a fresh AF_UNIX SOCK_STREAM socket to \p addr. Returns the connected
 //! fd, or -1 with \p out_errno set on failure (caller decides how to react).
 int TryConnect(const struct sockaddr_un& addr, int& out_errno)
 {
-    int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    int fd = MakeCloexecStreamSocket();
     if (fd == -1) {
         out_errno = errno;
         return -1;
@@ -111,7 +134,7 @@ public:
         // node just bound. (A residual race with a live-but-backlog-full listener
         // remains; a lock file is the future hardening.)
         for (int attempt = 0; attempt < 2; ++attempt) {
-            int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+            int fd = MakeCloexecStreamSocket();
             if (fd == -1) {
                 throw std::system_error(errno, std::system_category());
             }

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/process.h"
+
+#include "fs.h"
+#include "tinyformat.h"
+#include "util.h"
+#include "util/syserror.h"
+
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <system_error>
+#include <unistd.h>
+
+namespace ipc {
+namespace {
+
+//! Default socket filename inside the (network-specific) data directory:
+//! <datadir>/<network>/node.sock (doc/multiprocess_design.md section 4.3).
+const char* const DEFAULT_SOCKET_FILE = "node.sock";
+
+//! Resolve \p address ("unix" -> <data_dir>/node.sock, "unix:<path>" -> a custom
+//! path) into a sockaddr_un. Rewrites \p address to its canonical "unix:<path>"
+//! form. Throws std::invalid_argument on an unrecognized address or an
+//! over-length path.
+fs::path ParseAddress(std::string& address, const fs::path& data_dir, struct sockaddr_un& addr)
+{
+    fs::path path;
+    if (address == "unix" || address == "auto") {
+        path = data_dir / DEFAULT_SOCKET_FILE;
+    } else if (address.rfind("unix:", 0) == 0 && address.size() > 5) {
+        path = fs::path(address.substr(5));
+        if (!path.is_absolute()) path = data_dir / path;
+    } else {
+        throw std::invalid_argument(strprintf("Unrecognized IPC address '%s'", address));
+    }
+
+    const std::string path_str = path.string();
+    if (path_str.size() >= sizeof(addr.sun_path)) {
+        throw std::invalid_argument(
+            strprintf("Unix socket path '%s' exceeds the maximum socket path length", path_str));
+    }
+    address = strprintf("unix:%s", path_str);
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path_str.c_str(), sizeof(addr.sun_path) - 1);
+    return path;
+}
+
+//! Connect a fresh AF_UNIX SOCK_STREAM socket to \p addr. Returns the connected
+//! fd, or -1 with \p out_errno set on failure (caller decides how to react).
+int TryConnect(const struct sockaddr_un& addr, int& out_errno)
+{
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) {
+        out_errno = errno;
+        return -1;
+    }
+    if (::connect(fd, (const struct sockaddr*)&addr, sizeof(addr)) == 0) {
+        out_errno = 0;
+        return fd;
+    }
+    out_errno = errno;
+    ::close(fd);
+    return -1;
+}
+
+class ProcessImpl : public Process
+{
+public:
+    int connect(const fs::path& data_dir, std::string& address) override
+    {
+        struct sockaddr_un addr;
+        ParseAddress(address, data_dir, addr);
+        int connect_errno = 0;
+        int fd = TryConnect(addr, connect_errno);
+        if (fd == -1) {
+            throw std::system_error(connect_errno, std::system_category());
+        }
+        return fd;
+    }
+
+    int bind(const fs::path& data_dir, std::string& address) override
+    {
+        struct sockaddr_un addr;
+        const fs::path path = ParseAddress(address, data_dir, addr);
+
+        // Socket directory 0700 (design section 4.3).
+        if (path.has_parent_path()) {
+            fs::create_directories(path.parent_path());
+            ::chmod(path.parent_path().string().c_str(), 0700);
+        }
+
+        // Anti-hijack (design section 4.3): if the socket path already exists,
+        // connect-probe it. A live listener means the node is already running --
+        // refuse to start rather than displace it. A refused/absent connection
+        // means a stale path left by a crash -- unlink and rebind. Never unlink a
+        // live socket.
+        if (fs::symlink_status(path).type() == fs::socket_file) {
+            int probe_errno = 0;
+            int probe_fd = TryConnect(addr, probe_errno);
+            if (probe_fd != -1) {
+                ::close(probe_fd);
+                throw std::runtime_error(strprintf(
+                    "Another process is already listening on the IPC socket '%s'; refusing to start.",
+                    path.string()));
+            }
+            // Stale socket (connection refused / gone): safe to remove.
+            fs::remove(path);
+        }
+
+        int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        if (fd == -1) {
+            throw std::system_error(errno, std::system_category());
+        }
+        if (::bind(fd, (const struct sockaddr*)&addr, sizeof(addr)) != 0) {
+            int bind_error = errno;
+            ::close(fd);
+            throw std::system_error(bind_error, std::system_category());
+        }
+        // Socket 0600 (design section 4.3).
+        ::chmod(path.string().c_str(), 0600);
+        return fd;
+    }
+};
+} // namespace
+
+std::unique_ptr<Process> MakeProcess() { return std::make_unique<ProcessImpl>(); }
+} // namespace ipc

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -59,7 +59,7 @@ fs::path ParseAddress(std::string& address, const fs::path& data_dir, struct soc
 //! fd, or -1 with \p out_errno set on failure (caller decides how to react).
 int TryConnect(const struct sockaddr_un& addr, int& out_errno)
 {
-    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (fd == -1) {
         out_errno = errno;
         return -1;
@@ -93,10 +93,14 @@ public:
         struct sockaddr_un addr;
         const fs::path path = ParseAddress(address, data_dir, addr);
 
-        // Socket directory 0700 (design section 4.3).
+        // Socket directory 0700 (design section 4.3). Fail closed: if we cannot
+        // restrict the directory, refuse to listen rather than expose the socket
+        // in a world-accessible directory.
         if (path.has_parent_path()) {
             fs::create_directories(path.parent_path());
-            ::chmod(path.parent_path().string().c_str(), 0700);
+            if (::chmod(path.parent_path().string().c_str(), 0700) != 0) {
+                throw std::system_error(errno, std::system_category());
+            }
         }
 
         // Try to bind; only if the path already exists (EADDRINUSE) do we probe it.
@@ -107,7 +111,7 @@ public:
         // node just bound. (A residual race with a live-but-backlog-full listener
         // remains; a lock file is the future hardening.)
         for (int attempt = 0; attempt < 2; ++attempt) {
-            int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+            int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
             if (fd == -1) {
                 throw std::system_error(errno, std::system_category());
             }

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -123,7 +123,14 @@ public:
             const int bind_errno = errno;
             ::umask(old_umask);
             if (rc == 0) {
-                ::chmod(path.string().c_str(), 0600); // belt-and-suspenders
+                // Belt-and-suspenders after the umask above. Fail closed: if the
+                // socket cannot be confirmed 0600, refuse to serve rather than
+                // leave the wallet IPC socket potentially accessible.
+                if (::chmod(path.string().c_str(), 0600) != 0) {
+                    const int chmod_errno = errno;
+                    ::close(fd);
+                    throw std::system_error(chmod_errno, std::system_category());
+                }
                 return fd;
             }
             ::close(fd);

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -99,12 +99,33 @@ public:
             ::chmod(path.parent_path().string().c_str(), 0700);
         }
 
-        // Anti-hijack (design section 4.3): if the socket path already exists,
-        // connect-probe it. A live listener means the node is already running --
-        // refuse to start rather than displace it. A refused/absent connection
-        // means a stale path left by a crash -- unlink and rebind. Never unlink a
-        // live socket.
-        if (fs::symlink_status(path).type() == fs::socket_file) {
+        // Try to bind; only if the path already exists (EADDRINUSE) do we probe it.
+        // A live listener means the node is already running (refuse to start rather
+        // than displace it); a refused/absent connection means a stale path from a
+        // crash (unlink and retry once). Binding first -- rather than pre-emptively
+        // unlinking -- avoids a window where we remove a socket another starting
+        // node just bound. (A residual race with a live-but-backlog-full listener
+        // remains; a lock file is the future hardening.)
+        for (int attempt = 0; attempt < 2; ++attempt) {
+            int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+            if (fd == -1) {
+                throw std::system_error(errno, std::system_category());
+            }
+            // Create the socket node with 0600 from the start: bind() honors the
+            // umask, so a permissive umask would otherwise leave a world-accessible
+            // window before an after-the-fact chmod.
+            const mode_t old_umask = ::umask(0177);
+            const int rc = ::bind(fd, (const struct sockaddr*)&addr, sizeof(addr));
+            const int bind_errno = errno;
+            ::umask(old_umask);
+            if (rc == 0) {
+                ::chmod(path.string().c_str(), 0600); // belt-and-suspenders
+                return fd;
+            }
+            ::close(fd);
+            if (bind_errno != EADDRINUSE || attempt == 1) {
+                throw std::system_error(bind_errno, std::system_category());
+            }
             int probe_errno = 0;
             int probe_fd = TryConnect(addr, probe_errno);
             if (probe_fd != -1) {
@@ -113,22 +134,11 @@ public:
                     "Another process is already listening on the IPC socket '%s'; refusing to start.",
                     path.string()));
             }
-            // Stale socket (connection refused / gone): safe to remove.
-            fs::remove(path);
+            if (fs::symlink_status(path).type() == fs::socket_file) {
+                fs::remove(path); // stale: safe to remove, then retry the bind
+            }
         }
-
-        int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
-        if (fd == -1) {
-            throw std::system_error(errno, std::system_category());
-        }
-        if (::bind(fd, (const struct sockaddr*)&addr, sizeof(addr)) != 0) {
-            int bind_error = errno;
-            ::close(fd);
-            throw std::system_error(bind_error, std::system_category());
-        }
-        // Socket 0600 (design section 4.3).
-        ::chmod(path.string().c_str(), 0600);
-        return fd;
+        throw std::runtime_error("Failed to bind the IPC socket"); // unreachable
     }
 };
 } // namespace

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_PROCESS_H
+#define GRIDCOIN_IPC_PROCESS_H
+
+#include "fs.h"
+
+#include <memory>
+#include <string>
+
+namespace ipc {
+
+//! Platform IPC process helper: acquires an AF_UNIX socket descriptor by
+//! connecting to, or binding+listening on, a named socket. (Gridcoin does not
+//! spawn child processes, so unlike Bitcoin Core's Process there is no
+//! spawn/checkSpawned here.)
+class Process
+{
+public:
+    virtual ~Process() = default;
+
+    //! Canonicalize and connect to \p address under \p data_dir, returning the
+    //! connected socket descriptor.
+    virtual int connect(const fs::path& data_dir, std::string& address) = 0;
+
+    //! Canonicalize \p address under \p data_dir, create + bind a listening
+    //! socket, and return its descriptor. Removes a stale socket file left by a
+    //! crash; throws if the path is already bound by a live listener.
+    virtual int bind(const fs::path& data_dir, std::string& address) = 0;
+};
+
+//! Constructor for the Process interface.
+std::unique_ptr<Process> MakeProcess();
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_PROCESS_H

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_PROTOCOL_H
+#define GRIDCOIN_IPC_PROTOCOL_H
+
+#include "interfaces/init.h"
+
+#include <functional>
+#include <memory>
+#include <typeindex>
+
+namespace ipc {
+struct Context;
+
+//! IPC protocol interface for calling interface methods over a socket. A single
+//! implementation (Cap'n Proto) backs it; the abstraction keeps the transport
+//! seam narrow. Gridcoin only needs the connect (client) and listen (server)
+//! directions -- there is no foreground serve() because the node listens on a
+//! background event loop rather than being spawned.
+class Protocol
+{
+public:
+    virtual ~Protocol() = default;
+
+    //! Return an Init interface that forwards calls over \p fd. I/O runs on a
+    //! background thread.
+    virtual std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name) = 0;
+
+    //! Listen for connections on \p listen_fd, accept them, and serve \p init on
+    //! each. Non-blocking; I/O runs on a background thread.
+    virtual void listen(int listen_fd, const char* exe_name, interfaces::Init& init) = 0;
+
+    //! Disconnect any incoming connections that are still connected.
+    virtual void disconnectIncoming() = 0;
+
+    //! Add a cleanup callback to an interface, run when it is deleted.
+    virtual void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) = 0;
+
+    //! Context accessor.
+    virtual Context& context() = 0;
+};
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_PROTOCOL_H

--- a/src/ipc/serve_init.cpp
+++ b/src/ipc/serve_init.cpp
@@ -5,10 +5,17 @@
 #include "ipc/serve_init.h"
 
 #include "ipc/handshake.h"
-// Complete types needed for the unique_ptr<Node>/<StakingStatus> the delegated
-// factory methods return (interfaces/init.h only forward-declares them).
+// Complete types needed for the unique_ptr/shared_ptr the delegated factory
+// methods return (interfaces/init.h only forward-declares them).
+#include "interfaces/mrc.h"
 #include "interfaces/node.h"
+#include "interfaces/psgt.h"
+#include "interfaces/researcher.h"
+#include "interfaces/sidestake.h"
 #include "interfaces/staking.h"
+#include "interfaces/voting.h"
+#include "interfaces/wallet.h"
+#include "interfaces/wallet_tx_source.h"
 
 #include <stdexcept>
 #include <utility>
@@ -68,6 +75,48 @@ public:
     {
         RequireAuth();
         return m_inner->makeStakingStatus();
+    }
+
+    std::unique_ptr<interfaces::Wallet> makeWallet() override
+    {
+        RequireAuth();
+        return m_inner->makeWallet();
+    }
+
+    std::shared_ptr<interfaces::WalletTxSource> makeWalletTxSource() override
+    {
+        RequireAuth();
+        return m_inner->makeWalletTxSource();
+    }
+
+    std::unique_ptr<interfaces::MRC> makeMRC() override
+    {
+        RequireAuth();
+        return m_inner->makeMRC();
+    }
+
+    std::unique_ptr<interfaces::VotingManager> makeVotingManager() override
+    {
+        RequireAuth();
+        return m_inner->makeVotingManager();
+    }
+
+    std::unique_ptr<interfaces::ResearcherContext> makeResearcherContext() override
+    {
+        RequireAuth();
+        return m_inner->makeResearcherContext();
+    }
+
+    std::unique_ptr<interfaces::PSGTPoolContext> makePSGTPoolContext() override
+    {
+        RequireAuth();
+        return m_inner->makePSGTPoolContext();
+    }
+
+    std::unique_ptr<interfaces::SideStakeManager> makeSideStakeManager() override
+    {
+        RequireAuth();
+        return m_inner->makeSideStakeManager();
     }
 
 private:

--- a/src/ipc/serve_init.cpp
+++ b/src/ipc/serve_init.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/serve_init.h"
+
+#include "ipc/handshake.h"
+// Complete types needed for the unique_ptr<Node>/<StakingStatus> the delegated
+// factory methods return (interfaces/init.h only forward-declares them).
+#include "interfaces/node.h"
+#include "interfaces/staking.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace ipc {
+namespace {
+
+//! Auth-gating wrapper served to IPC clients. The authenticated flag is per
+//! served-Init object (one per node process); with the 0600 socket + per-user
+//! ownership that is sufficient for the single-GUI v1. Per-connection auth state
+//! (for multiple simultaneous clients) is a later hardening.
+class ServeInit : public interfaces::Init
+{
+public:
+    ServeInit(std::unique_ptr<interfaces::Init> inner, std::string cookie, interfaces::NodeIdentity identity)
+        : m_inner(std::move(inner)), m_cookie(std::move(cookie)), m_identity(std::move(identity))
+    {
+    }
+
+    bool authenticate(const std::string& cookie) override
+    {
+        m_authenticated = ConstantTimeEqual(cookie, m_cookie);
+        return m_authenticated;
+    }
+
+    interfaces::BuildInfo getBuildInfo() override
+    {
+        RequireAuth();
+        return GetLocalBuildInfo();
+    }
+
+    interfaces::NodeIdentity getIdentity() override
+    {
+        RequireAuth();
+        return m_identity;
+    }
+
+    bool isCoreReady() override
+    {
+        RequireAuth();
+        return m_inner->isCoreReady();
+    }
+
+    std::unique_ptr<interfaces::Node> makeNode() override
+    {
+        RequireAuth();
+        return m_inner->makeNode();
+    }
+
+    std::unique_ptr<interfaces::StakingStatus> makeStakingStatus() override
+    {
+        RequireAuth();
+        return m_inner->makeStakingStatus();
+    }
+
+private:
+    void RequireAuth() const
+    {
+        if (!m_authenticated) {
+            throw std::runtime_error("IPC peer is not authenticated");
+        }
+    }
+
+    std::unique_ptr<interfaces::Init> m_inner;
+    std::string m_cookie;
+    interfaces::NodeIdentity m_identity;
+    bool m_authenticated{false};
+};
+} // namespace
+
+std::unique_ptr<interfaces::Init> MakeServeInit(std::unique_ptr<interfaces::Init> inner,
+                                                std::string cookie,
+                                                interfaces::NodeIdentity identity)
+{
+    return std::make_unique<ServeInit>(std::move(inner), std::move(cookie), std::move(identity));
+}
+
+} // namespace ipc

--- a/src/ipc/serve_init.cpp
+++ b/src/ipc/serve_init.cpp
@@ -16,10 +16,13 @@
 namespace ipc {
 namespace {
 
-//! Auth-gating wrapper served to IPC clients. The authenticated flag is per
-//! served-Init object (one per node process); with the 0600 socket + per-user
-//! ownership that is sufficient for the single-GUI v1. Per-connection auth state
-//! (for multiple simultaneous clients) is a later hardening.
+//! Auth-gating wrapper served to IPC clients. The authenticated flag lives on
+//! this served object, which is shared across connections; the node caps the
+//! listener at one connection (see CapnpProtocol::listen), so in the single-GUI
+//! v1 there is no second peer to bleed state to. authenticate() only ever *sets*
+//! the flag on a valid cookie -- it never clears it -- so a later bad-cookie call
+//! cannot de-authenticate the established session. Per-connection auth state (for
+//! multiple simultaneous clients) is a later hardening.
 class ServeInit : public interfaces::Init
 {
 public:
@@ -30,8 +33,11 @@ public:
 
     bool authenticate(const std::string& cookie) override
     {
-        m_authenticated = ConstantTimeEqual(cookie, m_cookie);
-        return m_authenticated;
+        // Return whether THIS cookie is valid (the client checks the result), but
+        // only ever set -- never clear -- the sticky session flag.
+        const bool ok = ConstantTimeEqual(cookie, m_cookie);
+        if (ok) m_authenticated = true;
+        return ok;
     }
 
     interfaces::BuildInfo getBuildInfo() override

--- a/src/ipc/serve_init.h
+++ b/src/ipc/serve_init.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_SERVE_INIT_H
+#define GRIDCOIN_IPC_SERVE_INIT_H
+
+#include "interfaces/init.h"
+
+#include <memory>
+#include <string>
+
+namespace ipc {
+
+//! Wrap the node's real (in-process) Init so it can be served over IPC: it adds
+//! the connect handshake (authenticate / getBuildInfo / getIdentity) and gates
+//! the delegated methods so nothing is served before authenticate() succeeds
+//! (doc/multiprocess_design.md section 4.3). Only the IPC-exposed Init methods
+//! are wrapped; this must grow as init.capnp exposes more factories.
+std::unique_ptr<interfaces::Init> MakeServeInit(std::unique_ptr<interfaces::Init> inner,
+                                                std::string cookie,
+                                                interfaces::NodeIdentity identity);
+
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_SERVE_INIT_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -481,9 +481,9 @@ public:
 
     std::unique_ptr<StakingStatus> makeStakingStatus() override { return MakeStakingStatus(); }
 
-    std::unique_ptr<MRC> makeMRC(CWallet* wallet) override
+    std::unique_ptr<MRC> makeMRC() override
     {
-        return wallet ? MakeMRC(wallet) : nullptr;
+        return pwalletMain ? MakeMRC(pwalletMain) : nullptr;
     }
 
     std::unique_ptr<SideStakeManager> makeSideStakeManager() override
@@ -496,14 +496,14 @@ public:
         return MakeVotingManager();
     }
 
-    std::unique_ptr<ResearcherContext> makeResearcherContext(CWallet* wallet) override
+    std::unique_ptr<ResearcherContext> makeResearcherContext() override
     {
-        return wallet ? MakeResearcherContext(wallet) : nullptr;
+        return pwalletMain ? MakeResearcherContext(pwalletMain) : nullptr;
     }
 
-    std::unique_ptr<PSGTPoolContext> makePSGTPoolContext(CWallet* wallet) override
+    std::unique_ptr<PSGTPoolContext> makePSGTPoolContext() override
     {
-        return wallet ? MakePSGTPoolContext(wallet) : nullptr;
+        return pwalletMain ? MakePSGTPoolContext(pwalletMain) : nullptr;
     }
 
     std::unique_ptr<Wallet> makeWallet() override
@@ -511,9 +511,9 @@ public:
         return pwalletMain ? MakeWallet(pwalletMain) : nullptr;
     }
 
-    std::shared_ptr<WalletTxSource> makeWalletTxSource(CWallet* wallet) override
+    std::shared_ptr<WalletTxSource> makeWalletTxSource() override
     {
-        return wallet ? MakeWalletTxSource(wallet) : nullptr;
+        return pwalletMain ? MakeWalletTxSource(pwalletMain) : nullptr;
     }
 };
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -248,6 +248,14 @@ target_link_libraries(gridcoinresearch PRIVATE
     gridcoinqt
 )
 
+# The GUI connects to a separately-started daemon over IPC when run with
+# -multiprocess (qt/bitcoin.cpp -> ipc::ConnectToNode); link the IPC layer that
+# provides it, mirroring gridcoinresearchd. gridcoin_ipc is EXCLUDE_FROM_ALL, so
+# it is only built when something (here) links it.
+if(ENABLE_MULTIPROCESS)
+    target_link_libraries(gridcoinresearch PRIVATE gridcoin_ipc)
+endif()
+
 # Linux Static Math Lib Workaround
 if(UNIX AND NOT APPLE AND DEFINED DEP_LIB)
     # Ensure DEP_LIB is absolute so the link command works from any directory.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -629,16 +629,16 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
             node_connection = ipc::ConnectToNode(GetDataDir(), *local_init, ipc_error);
             if (!node_connection)
             {
-                ThreadSafeMessageBox(strprintf("Could not connect to the Gridcoin daemon: %s\n", ipc_error),
-                        "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+                // One dialog: this runs after ThreadSafeMessageBox_connect, so a
+                // uiInterface message box here would double up with the direct one.
+                GUILogPrintf("IPC: could not connect to the Gridcoin daemon: %s", ipc_error);
                 QMessageBox::critical(nullptr, PACKAGE_NAME,
                         QObject::tr("Could not connect to the Gridcoin daemon:\n%1").arg(QString::fromStdString(ipc_error)));
                 return EXIT_FAILURE;
             }
             interface_init = node_connection->init.get();
 #else
-            ThreadSafeMessageBox("This build was compiled without multiprocess (IPC) support.\n",
-                    "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+            GUILogPrintf("IPC: -multiprocess requested but this build has no multiprocess (IPC) support");
             QMessageBox::critical(nullptr, PACKAGE_NAME,
                     QObject::tr("This build was compiled without multiprocess (IPC) support."));
             return EXIT_FAILURE;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -31,6 +31,9 @@
 #include "interfaces/wallet_tx_source.h"
 #include "init.h"
 #include "node/shutdown.h"
+#ifdef ENABLE_MULTIPROCESS
+#include "ipc/connect.h"
+#endif
 #include "node/ui_interface.h"
 #include "qtipcserver.h"
 #include "txdb.h"
@@ -592,21 +595,69 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
 
         GUILogPrintf("Starting Gridcoin");
 
-        if (!threads->createThread(ThreadAppInit2,threads,"AppInit2 Thread"))
+        // Process topology (doc/multiprocess_design.md). The monolithic build
+        // runs core init in this process (ThreadAppInit2 -> AppInit2) and wraps
+        // the in-process core with a local Init. The multiprocess build
+        // (-multiprocess) runs no core here: it connects to a separately-started
+        // gridcoinresearchd, which runs the core and serves the interfaces over
+        // IPC, and drives the models through that remote Init.
+        const bool multiprocess = gArgs.GetBoolArg("-multiprocess", false);
+
+        // Owns the interface factory the models below consume core state through
+        // -- the local in-process Init in the monolith, the remote node's Init
+        // in the multiprocess build. `interface_init` points at whichever is in
+        // use; its owner (declared here) outlives every model constructed below.
+        std::unique_ptr<interfaces::Init> local_init;
+#ifdef ENABLE_MULTIPROCESS
+        std::optional<ipc::GuiConnection> node_connection;
+#endif
+        interfaces::Init* interface_init = nullptr;
+
+        if (multiprocess)
         {
-                GUILogPrintf("Error; NewThread(ThreadAppInit2) failed");
+#ifdef ENABLE_MULTIPROCESS
+            // MakeIpc needs an Init even for a connect-only client (it is the
+            // Init this process would serve if it listened, which the GUI never
+            // does); the local one wraps globals and is cheap. It must outlive
+            // node_connection, so it is declared first.
+            local_init = interfaces::MakeGridcoinInit();
+            std::string ipc_error;
+            node_connection = ipc::ConnectToNode(GetDataDir(), *local_init, ipc_error);
+            if (!node_connection)
+            {
+                ThreadSafeMessageBox(strprintf("Could not connect to the Gridcoin daemon: %s\n", ipc_error),
+                        "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+                QMessageBox::critical(nullptr, PACKAGE_NAME,
+                        QObject::tr("Could not connect to the Gridcoin daemon:\n%1").arg(QString::fromStdString(ipc_error)));
                 return EXIT_FAILURE;
+            }
+            interface_init = node_connection->init.get();
+#else
+            ThreadSafeMessageBox("This build was compiled without multiprocess (IPC) support.\n",
+                    "", CClientUIInterface::ICON_ERROR | CClientUIInterface::BTN_OK | CClientUIInterface::MODAL);
+            QMessageBox::critical(nullptr, PACKAGE_NAME,
+                    QObject::tr("This build was compiled without multiprocess (IPC) support."));
+            return EXIT_FAILURE;
+#endif
         }
         else
         {
+            if (!threads->createThread(ThreadAppInit2,threads,"AppInit2 Thread"))
+            {
+                GUILogPrintf("Error; NewThread(ThreadAppInit2) failed");
+                return EXIT_FAILURE;
+            }
             // The monolithic-build interface implementations that the models
             // consume core state through (doc/multiprocess_design.md). Created
             // here, before the readiness wait, so the GUI polls
             // interface_init->isCoreReady() rather than the raw
             // bGridcoinCoreInitComplete global; it outlives every model
             // constructed below.
-            std::unique_ptr<interfaces::Init> interface_init = interfaces::MakeGridcoinInit();
+            local_init = interfaces::MakeGridcoinInit();
+            interface_init = local_init.get();
+        }
 
+        {
              //10-31-2015
             while (!interface_init->isCoreReady())
             {
@@ -766,9 +817,16 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 window.setPSGTPoolContext(nullptr);
                 guiref = nullptr;
             }
-            // Shutdown the core and its threads, but don't exit Bitcoin-Qt here
-            GUILogPrintf("Main calling Shutdown...");
-            Shutdown(nullptr);
+            // Shut down the core and its threads (but don't exit Bitcoin-Qt
+            // here). Only in the monolithic build: there the core runs in this
+            // process. In the multiprocess build the core lives in the daemon
+            // and manages its own lifetime; the GUI merely drops its connection
+            // (node_connection's destructor) as the stack unwinds.
+            if (!multiprocess)
+            {
+                GUILogPrintf("Main calling Shutdown...");
+                Shutdown(nullptr);
+            }
         }
 
     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -451,7 +451,11 @@ int main(int argc, char *argv[])
     // but that is too late.
     fs::path dataDir = GetDataDir();
 
-    if (!LockDirectory(dataDir, ".lock", false)) {
+    // In multiprocess mode the core runs in a separate gridcoinresearchd, which
+    // owns the datadir and already holds this lock; the GUI runs no core, so it
+    // must not contend for the lock (it would always fail against the running
+    // daemon). The short-circuit skips LockDirectory entirely in that mode.
+    if (!gArgs.GetBoolArg("-multiprocess", false) && !LockDirectory(dataDir, ".lock", false)) {
         std::string str = strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running "
                                       "and using that directory."),
                                     dataDir, PACKAGE_NAME);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -644,14 +644,14 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 // WalletModel that drives it and is torn down — worker joined,
                 // producers severed — before Shutdown() destroys the wallet.
                 std::shared_ptr<interfaces::WalletTxSource> wallet_tx_source =
-                    interface_init->makeWalletTxSource(pwalletMain);
+                    interface_init->makeWalletTxSource();
                 if (!wallet_tx_source) {
                     throw std::runtime_error("wallet tx source unavailable after init");
                 }
                 // The Manual Research Claim interface over the node's wallet
                 // (Phase 1d-i). Owned here so it outlives the MRCModel that
                 // drives it.
-                std::unique_ptr<interfaces::MRC> mrc = interface_init->makeMRC(pwalletMain);
+                std::unique_ptr<interfaces::MRC> mrc = interface_init->makeMRC();
                 if (!mrc) {
                     throw std::runtime_error("MRC interface unavailable after init");
                 }
@@ -666,7 +666,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 // wallet. Owned here so it outlives the ResearcherModel that drives
                 // it (and the MRCModel/VotingModel that read researcher state).
                 std::unique_ptr<interfaces::ResearcherContext> researcher_context =
-                    interface_init->makeResearcherContext(pwalletMain);
+                    interface_init->makeResearcherContext();
                 if (!researcher_context) {
                     throw std::runtime_error("researcher interface unavailable after init");
                 }
@@ -675,7 +675,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 // PSGTPoolTableModel and MultisignPSGTDialog that use it; cleared
                 // from them on teardown below before this is destroyed.
                 std::unique_ptr<interfaces::PSGTPoolContext> psgt_pool_context =
-                    interface_init->makePSGTPoolContext(pwalletMain);
+                    interface_init->makePSGTPoolContext();
                 if (!psgt_pool_context) {
                     throw std::runtime_error("PSGT pool interface unavailable after init");
                 }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -681,7 +681,7 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 }
 
                 ClientModel clientModel(*node, *staking_status, &optionsModel);
-                WalletModel walletModel(*wallet, *wallet_tx_source, pwalletMain, &optionsModel);
+                WalletModel walletModel(*wallet, *wallet_tx_source, &optionsModel);
                 ResearcherModel researcherModel(*researcher_context);
                 MRCModel mrcModel(*mrc, &walletModel, &clientModel, &researcherModel);
                 VotingModel votingModel(*voting_manager, *researcher_context, clientModel, optionsModel, walletModel);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -39,13 +39,11 @@ static int column_alignments[] = {
 class TransactionTablePriv
 {
 public:
-    TransactionTablePriv(CWallet *wallet, WalletModel *walletModel, TransactionTableModel *parent):
-            wallet(wallet),
+    TransactionTablePriv(WalletModel *walletModel, TransactionTableModel *parent):
             walletModel(walletModel),
             parent(parent)
     {
     }
-    CWallet *wallet;
     WalletModel *walletModel;
     TransactionTableModel *parent;
 
@@ -218,11 +216,10 @@ public:
 
 };
 
-TransactionTableModel::TransactionTableModel(CWallet* wallet, WalletModel *parent):
+TransactionTableModel::TransactionTableModel(WalletModel *parent):
         QAbstractTableModel(parent),
-        wallet(wallet),
         walletModel(parent),
-        priv(new TransactionTablePriv(wallet, walletModel, this))
+        priv(new TransactionTablePriv(walletModel, this))
 {
     columns << QString() << tr("Date") << tr("Type") << tr("Address") << tr("Amount");
 

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -8,7 +8,6 @@
 
 #include <vector>
 
-class CWallet;
 class TransactionTablePriv;
 class TransactionRecord;
 class WalletModel;
@@ -19,7 +18,7 @@ class TransactionTableModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
-    explicit TransactionTableModel(CWallet* wallet, WalletModel* parent = nullptr);
+    explicit TransactionTableModel(WalletModel* parent = nullptr);
     ~TransactionTableModel();
 
     enum ColumnIndex {
@@ -86,7 +85,6 @@ public:
     void applyEventBatch(const std::vector<GRC::WalletEvent>& events);
 
 private:
-    CWallet* wallet;
     WalletModel *walletModel;
     QStringList columns;
     TransactionTablePriv *priv;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -14,7 +14,7 @@
 #include <cassert>
 
 WalletModel::WalletModel(interfaces::Wallet& wallet, interfaces::WalletTxSource& tx_source,
-                         CWallet* core_wallet, OptionsModel* optionsModel, QObject* parent)
+                         OptionsModel* optionsModel, QObject* parent)
          : QObject(parent)
          , m_wallet(wallet)
          , m_tx_source(tx_source)
@@ -37,7 +37,7 @@ WalletModel::WalletModel(interfaces::Wallet& wallet, interfaces::WalletTxSource&
     // quiesces the worker and rebuilds from the wallet, so any event enqueued in
     // the window between source creation and this snapshot is superseded by the
     // rebuild.
-    transactionTableModel = new TransactionTableModel(core_wallet, this);
+    transactionTableModel = new TransactionTableModel(this);
 
     // Drain the producer→GUI event stream at a steady cadence. 500ms is
     // imperceptible for transaction-list updates while still giving the

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -539,13 +539,13 @@ bool WalletModel::getPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
 
 bool WalletModel::getKeyFromPool(CPubKey& out_public_key, const std::string& label)
 {
-    return m_wallet.getKeyFromPool(out_public_key, label);
+    return m_wallet.getKeyFromPool(label, out_public_key);
 }
 
 QString WalletModel::getNewReceiveAddress(const QString& label)
 {
     std::string address;
-    if (!m_wallet.getNewReceiveAddress(label.toStdString(), address)) {
+    if (!m_wallet.getNewReceiveAddressWithLabel(label.toStdString(), address)) {
         return QString();
     }
     return QString::fromStdString(address);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -14,7 +14,6 @@
 class OptionsModel;
 class AddressTableModel;
 class TransactionTableModel;
-class CWallet;
 class CKeyID;
 class CPubKey;
 class COutPoint;
@@ -43,12 +42,12 @@ public:
     //! boundary (Phase 1c-i); the windowed tx-table store/event-queue
     //! machinery is reached through the interfaces::WalletTxSource boundary
     //! (Phase 1c-ii), which the model does not own — it is created node-side
-    //! (interfaces::Init::makeWalletTxSource) and must outlive the model. The
-    //! raw CWallet* leg now feeds only the address-table and
-    //! transaction-table sub-model constructors, which migrate in a later
-    //! phase — do not add new uses.
+    //! (interfaces::Init::makeWalletTxSource) and must outlive the model. No
+    //! raw CWallet* leg remains: every core interaction crosses one of the two
+    //! interface boundaries, so the model carries nothing that would prevent it
+    //! running in a separate process from the wallet (Phase 2).
     explicit WalletModel(interfaces::Wallet& wallet, interfaces::WalletTxSource& tx_source,
-                         CWallet* core_wallet, OptionsModel* optionsModel,
+                         OptionsModel* optionsModel,
                          QObject* parent = nullptr);
     ~WalletModel();
 

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(wallet_key_from_pool_labels_address_book)
 
     CPubKey pub_key;
     const std::string label = "interfaces-test-label";
-    BOOST_REQUIRE(wallet->getKeyFromPool(pub_key, label));
+    BOOST_REQUIRE(wallet->getKeyFromPool(label, pub_key));
     BOOST_CHECK(pub_key.IsValid());
 
     LOCK(pwalletMain->cs_wallet);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -297,7 +297,7 @@ public:
         return true;
     }
 
-    bool getNewReceiveAddress(const std::string& label, std::string& address_out) override
+    bool getNewReceiveAddressWithLabel(const std::string& label, std::string& address_out) override
     {
         // fAllowReuse=false to match the researcher pool page's former
         // getKeyFromPool(..., false) call: a deliberately fresh receive key.
@@ -336,7 +336,7 @@ public:
         return m_wallet->GetPubKey(address, pub_key_out);
     }
 
-    bool getKeyFromPool(CPubKey& pub_key_out, const std::string& label) override
+    bool getKeyFromPool(const std::string& label, CPubKey& pub_key_out) override
     {
         if (!m_wallet->GetKeyFromPool(pub_key_out, false)) {
             return false;


### PR DESCRIPTION
## Summary

The IPC / process-split half of RFC #2937 — sub-phases **2b–2d**, built on the 2a schemas (#3216). With `-multiprocess`, the GUI connects to a separately-started `gridcoinresearchd` over a Cap'n Proto / libmultiprocess AF_UNIX channel and drives every model through the node's served `interfaces::Init`, instead of running the core in-process.

`ENABLE_MULTIPROCESS=OFF` (the CI default) is unaffected — the whole IPC layer is compile-gated and `EXCLUDE_FROM_ALL`, and the monolith code paths stay behavior-identical.

## What's here

**2b — transport + handshake + node serving**
- `Init` connect-handshake surface (`authenticate`/`getBuildInfo`/`getIdentity` + `BuildInfo`/`NodeIdentity` DTOs).
- AF_UNIX transport (`src/ipc/`, connect + listen only — no spawn; the daemon and GUI start independently), adapted to the vendored libmultiprocess API. Socket at `<datadir>/<network>/node.sock`, 0700/0600, stale-socket recovery.
- Node seam: `gridcoinresearchd -multiprocess` writes `ipc.cookie` + `node_identity.json` after `AppInit2` and serves the auth-gated `Init`.
- Adversarial-review hardening (8 issues fixed: auth-state bleed, secure cookie/socket creation, `bind()` TOCTOU, fd leaks, loop-thread crash safety, deny-by-default `authenticate()`, malformed-JSON handling).

**2c — Wallet + event channel + GUI seam**
- `interfaces::Wallet` and `interfaces::WalletTxSource` over IPC, with `COutPoint`/`CKeyID`/`CPubKey`/`SecureString` marshalling (passphrase bytes scrubbed on the receive side). The windowed tx-table event payload is a `std::variant`; libmultiprocess has no Cap'n Proto union support, so a generic `std::variant` ↔ discriminated-struct hook (`type-variant.h`) marshals it via the ProxyStruct accessors the same way `type-pair.h` handles `std::pair`.
- Init factory refactor (drop the node-internal `CWallet*` that can't cross IPC); removed the now-vestigial `CWallet*` from the transaction-table model.
- The GUI client seam: `bitcoin.cpp` connects + authenticates and drives the models through the remote `Init`; in `-multiprocess` it runs no core (skips `ThreadAppInit2` and the in-process `Shutdown()`).

**2d — remaining domain interfaces**
- `interfaces::MRC` / `VotingManager` / `ResearcherContext` / `PSGTPoolContext` over IPC. The remote `Init` now serves every `makeX` the GUI calls.

## Tested

Validated **live in a real two-process run** on the isolated/public testnet — the full Account Overview renders with balance, staking, researcher, polls and the live transaction/event stream all crossing the process boundary. Three integration bugs were found and fixed in the run; details + the one required follow-up (`reloadAndSnapshot` pagination) in the test comment below.

## Not in this PR

- 2e handshake-failure integration tests and the 2f build-identities dialog / soft-warn banner.
- **Follow-up — paginate `WalletTxSource::reloadAndSnapshot`**: the full replica bootstrap exceeds Cap'n Proto's single-message size limit on real wallets and must be chunked before the multiprocess GUI ships (see the test comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)