### PR TITLE
gui: multiprocess GUI — clean shutdown on node disconnect + separate self-rotating log

### DIFF
--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -35,8 +35,11 @@ public:
     //! Connect to a socket address and return a pointer to the remote process's
     //! Init interface. Returns null if \p address is empty ("") or disabled
     //! ("0"), or if a connection was refused/absent but not required ("auto");
-    //! throws on an unexpected error.
-    virtual std::unique_ptr<Init> connectAddress(std::string& address) = 0;
+    //! throws on an unexpected error. If \p on_disconnect is set it is invoked
+    //! (on the IPC event-loop thread) when the remote drops the connection
+    //! unexpectedly — the GUI uses it to quit gracefully when the node exits.
+    virtual std::unique_ptr<Init> connectAddress(std::string& address,
+                                                 std::function<void()> on_disconnect = {}) = 0;
 
     //! Listen on a socket address, exposing this process's Init interface to
     //! clients. Throws on error (including a live listener already on the path).

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -46,6 +46,21 @@ void IpcLogFn(mp::LogMessage message)
     }
 }
 
+//! Invoke a caller-supplied disconnect callback with a guard. It runs on the
+//! event-loop thread, so a throw would unwind through libmultiprocess's task set
+//! and terminate the process; contain and log it instead.
+void InvokeDisconnectCb(const std::function<void()>& cb)
+{
+    if (!cb) return;
+    try {
+        cb();
+    } catch (const std::exception& e) {
+        LogPrintf("ipc: disconnect callback threw: %s\n", e.what());
+    } catch (...) {
+        LogPrintf("ipc: disconnect callback threw a non-standard exception\n");
+    }
+}
+
 class CapnpProtocol : public Protocol
 {
 public:
@@ -72,14 +87,14 @@ public:
             m_loop->sync([&] {
                 if (client->m_context.connection) {
                     client->m_context.connection->onDisconnect(
-                        [on_disconnect = std::move(on_disconnect)]() mutable { on_disconnect(); });
+                        [on_disconnect = std::move(on_disconnect)]() mutable { InvokeDisconnectCb(on_disconnect); });
                 } else {
                     // Early-disconnect race: the peer dropped between ConnectStream()
                     // and here, so libmultiprocess cleanup already nulled the
                     // connection and the onDisconnect above would never register.
                     // Notify now (on the event-loop thread, same as the handler would
                     // run) so the caller still learns the connection is gone.
-                    on_disconnect();
+                    InvokeDisconnectCb(on_disconnect);
                 }
             });
         }

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -52,10 +52,27 @@ public:
         assert(!m_loop);
     }
 
-    std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name) override
+    std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name,
+                                              std::function<void()> on_disconnect) override
     {
         startLoop(exe_name);
-        return mp::ConnectStream<messages::Init>(*m_loop, mp::MakeStream(*m_loop, fd));
+        auto client = mp::ConnectStream<messages::Init>(*m_loop, mp::MakeStream(*m_loop, fd));
+        if (on_disconnect && client) {
+            // Register a caller-facing disconnect handler ALONGSIDE ConnectStream's
+            // own (which logs and frees the Connection). Connection::onDisconnect
+            // accumulates handlers and defers each to the EventLoop task set, so
+            // both run as independent tasks; ours only forwards a notification and
+            // never touches the Connection, so it stays safe even after the
+            // internal handler frees it. Registered under m_loop->sync() because
+            // Connection state is owned by the event-loop thread.
+            m_loop->sync([&] {
+                if (client->m_context.connection) {
+                    client->m_context.connection->onDisconnect(
+                        [on_disconnect = std::move(on_disconnect)]() mutable { on_disconnect(); });
+                }
+            });
+        }
+        return client;
     }
 
     void listen(int listen_fd, const char* exe_name, interfaces::Init& init) override

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -30,16 +30,20 @@ namespace ipc {
 namespace capnp {
 namespace {
 
-//! Route libmultiprocess log messages into the Gridcoin log. Raise-level
-//! messages are turned into exceptions (mp's convention for fatal protocol
-//! errors), matching Bitcoin Core's IpcLogFn.
+//! Route libmultiprocess log messages into the Gridcoin log. This is high-volume
+//! bookkeeping (per-request send/recv, proxy create/destroy, post-disconnect
+//! "method called after disconnect" notices), so gate it behind the verbose
+//! category -- silent by default, surfaced with -debug=verbose. (Bitcoin Core
+//! gates this behind a dedicated BCLog::IPC category; Gridcoin's LogFlags bits are
+//! all allocated, so it rides the verbose category instead.) Raise-level messages
+//! are still turned into exceptions (mp's convention for a fatal protocol error);
+//! the message survives via the thrown exception if it goes uncaught.
 void IpcLogFn(mp::LogMessage message)
 {
+    LogPrint(BCLog::VERBOSE, "ipc: %s\n", message.message);
     if (message.level == mp::Log::Raise) {
-        LogPrintf("ipc: %s\n", message.message);
         throw std::runtime_error(message.message);
     }
-    LogPrintf("ipc: %s\n", message.message);
 }
 
 class CapnpProtocol : public Protocol
@@ -69,6 +73,13 @@ public:
                 if (client->m_context.connection) {
                     client->m_context.connection->onDisconnect(
                         [on_disconnect = std::move(on_disconnect)]() mutable { on_disconnect(); });
+                } else {
+                    // Early-disconnect race: the peer dropped between ConnectStream()
+                    // and here, so libmultiprocess cleanup already nulled the
+                    // connection and the onDisconnect above would never register.
+                    // Notify now (on the event-loop thread, same as the handler would
+                    // run) so the caller still learns the connection is gone.
+                    on_disconnect();
                 }
             });
         }

--- a/src/ipc/connect.cpp
+++ b/src/ipc/connect.cpp
@@ -16,7 +16,8 @@ namespace ipc {
 
 std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
                                            interfaces::Init& local_init,
-                                           std::string& error_out)
+                                           std::string& error_out,
+                                           std::function<void()> on_disconnect)
 {
     // 1. The node writes a fresh cookie on every startup; its absence means no
     //    node is running on this datadir, so there is nothing to dial.
@@ -37,7 +38,7 @@ std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
     //    resolved from GetDataDir() inside connectAddress).
     std::string address = "unix";
     try {
-        conn.init = conn.ipc->connectAddress(address);
+        conn.init = conn.ipc->connectAddress(address, std::move(on_disconnect));
     } catch (const std::exception& e) {
         error_out = strprintf("could not connect to the daemon on %s: %s", address, e.what());
         return std::nullopt;

--- a/src/ipc/connect.h
+++ b/src/ipc/connect.h
@@ -8,6 +8,7 @@
 #include "fs.h"
 #include "interfaces/ipc.h"
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -43,10 +44,14 @@ struct GuiConnection {
 //! sets \p error_out to a human-readable reason. \p local_init is the GUI's own
 //! Init, which MakeIpc requires (the Init this process would serve if it
 //! listened; a connect-only GUI never does) and which must outlive the returned
-//! connection.
+//! connection. If \p on_disconnect is set it is invoked (on the IPC event-loop
+//! thread) when the node drops the connection unexpectedly (crash / SIGKILL, or
+//! a stop that raced the shutdown handshake) — the GUI uses it to quit cleanly
+//! rather than fault on the next call to a now-dead proxy.
 std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
                                            interfaces::Init& local_init,
-                                           std::string& error_out);
+                                           std::string& error_out,
+                                           std::function<void()> on_disconnect = {});
 
 } // namespace ipc
 

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -39,7 +39,8 @@ public:
     {
     }
 
-    std::unique_ptr<interfaces::Init> connectAddress(std::string& address) override
+    std::unique_ptr<interfaces::Init> connectAddress(std::string& address,
+                                                     std::function<void()> on_disconnect) override
     {
         if (address.empty() || address == "0") return nullptr;
         int fd;
@@ -62,7 +63,7 @@ public:
             fd = m_process->connect(GetDataDir(), address);
         }
         FdGuard guard{fd};
-        auto init = m_protocol->connect(fd, m_exe_name);
+        auto init = m_protocol->connect(fd, m_exe_name, std::move(on_disconnect));
         guard.release(); // the protocol/stream now owns the fd
         return init;
     }

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -25,8 +25,11 @@ public:
     virtual ~Protocol() = default;
 
     //! Return an Init interface that forwards calls over \p fd. I/O runs on a
-    //! background thread.
-    virtual std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name) = 0;
+    //! background thread. If \p on_disconnect is set it is invoked (on the
+    //! event-loop thread) when the peer's connection drops unexpectedly — the
+    //! GUI uses it to quit gracefully when the node process exits.
+    virtual std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name,
+                                                      std::function<void()> on_disconnect = {}) = 0;
 
     //! Listen for connections on \p listen_fd, accept them, and serve \p init on
     //! each. Non-blocking; I/O runs on a background thread.

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -471,29 +471,51 @@ bool BCLog::Logger::archive(bool fImmediate, fs::path pfile_out)
 
             std::set<fs::directory_entry, std::greater <fs::directory_entry>> SortedDirEntries;
 
-            // Iterate through the log archive directory and delete the oldest files beyond the retention rule
-            // The names are in format <logname base>-YYYYMMDDHHMMSS.log for the logs, so filter by containing <logname base>.
-            // The greater than sort in the set should then return descending order by datetime.
-            for (fs::directory_entry& DirEntry : fs::directory_iterator(LogArchiveDir))
-            {
-                std::string sFilename = DirEntry.path().filename().string();
-                size_t FoundPos = sFilename.find(m_file_path.filename().stem().string());
+            // Archive names are "<stem>-YYYYMMDDHHMMSS<ext>.gz" (see pfile_out
+            // above). Match only THIS log's archives by an exact "<stem>-" PREFIX,
+            // not a substring search: with a substring search a stem that is a
+            // prefix of another (e.g. the node's "debug" vs the multiprocess GUI's
+            // "debug_gui") would also match — and delete — the other log's archives,
+            // since they share this one logarchive directory. The '-' separator is
+            // included so "debug-" cannot match "debug_gui-".
+            const std::string archive_prefix = m_file_path.filename().stem().string() + "-";
 
-                if (FoundPos != std::string::npos) SortedDirEntries.insert(DirEntry);
-            }
-
-            // Now iterate through set of filtered filenames. Delete all files greater than retention count.
-            unsigned int i = 0;
-            for (auto const& iter : SortedDirEntries)
+            // The logarchive directory can be modified concurrently by another
+            // process that shares it: in -multiprocess mode the GUI archives its own
+            // debug_gui.log alongside the node's debug.log. A file vanishing between
+            // the directory read and its use can throw a filesystem_error mid-scan;
+            // contain it so retention degrades to a skipped pass instead of
+            // propagating out of archive() (the log file is already reopened above,
+            // so logging continues; the next archive retries). Each process only
+            // ever removes its OWN "<stem>-" archives, so their cleanups never
+            // target the same files.
+            try
             {
-                if (i >= nRetention)
+                // The greater than sort in the set should then return descending order by datetime.
+                for (fs::directory_entry& DirEntry : fs::directory_iterator(LogArchiveDir))
                 {
-                    fs::remove(iter.path());
+                    std::string sFilename = DirEntry.path().filename().string();
 
-                    LogPrintf("INFO: Logger: Removed old archive gzip file %s.", iter.path().filename().string());
+                    if (sFilename.rfind(archive_prefix, 0) == 0) SortedDirEntries.insert(DirEntry);
                 }
 
-                ++i;
+                // Now iterate through set of filtered filenames. Delete all files greater than retention count.
+                unsigned int i = 0;
+                for (auto const& iter : SortedDirEntries)
+                {
+                    if (i >= nRetention)
+                    {
+                        fs::remove(iter.path());
+
+                        LogPrintf("INFO: Logger: Removed old archive gzip file %s.", iter.path().filename().string());
+                    }
+
+                    ++i;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                LogPrintf("WARNING: Logger: archive retention pass skipped: %s", e.what());
             }
         }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -734,19 +734,27 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 if (!gui_archive_running.compare_exchange_strong(expected, true)) {
                     return;  // a previous archive pass is still running
                 }
-                std::thread([] {
-                    RenameThread("gui-log-archive");
-                    try {
-                        fs::path plogfile_out;
-                        LogInstance().archive(false, plogfile_out);
-                    } catch (const std::exception& e) {
-                        // A throw here would terminate the detached thread (and the
-                        // process); contain it. The logger is left valid (the file is
-                        // reopened before the cleanup step); the next tick retries.
-                        GUILogPrintf("WARNING: GUI log archive pass failed: %s", e.what());
-                    }
+                try {
+                    std::thread([] {
+                        RenameThread("gui-log-archive");
+                        try {
+                            fs::path plogfile_out;
+                            LogInstance().archive(false, plogfile_out);
+                        } catch (const std::exception& e) {
+                            // A throw here would terminate the detached thread (and the
+                            // process); contain it. The logger is left valid (the file is
+                            // reopened before the cleanup step); the next tick retries.
+                            GUILogPrintf("WARNING: GUI log archive pass failed: %s", e.what());
+                        }
+                        gui_archive_running = false;
+                    }).detach();
+                } catch (const std::exception& e) {
+                    // std::thread construction can throw (e.g. resource exhaustion).
+                    // Reset the guard so a later tick can retry, and don't let it
+                    // escape the Qt slot (which would abort the GUI).
+                    GUILogPrintf("WARNING: could not start GUI log archive thread: %s", e.what());
                     gui_archive_running = false;
-                }).detach();
+                }
             });
             logArchiveTimer->start(300000);  // 5 minutes, matching the node's schedule
 #else

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -626,7 +626,27 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
             // node_connection, so it is declared first.
             local_init = interfaces::MakeGridcoinInit();
             std::string ipc_error;
-            node_connection = ipc::ConnectToNode(GetDataDir(), *local_init, ipc_error);
+            node_connection = ipc::ConnectToNode(GetDataDir(), *local_init, ipc_error,
+                /*on_disconnect=*/[] {
+                    // Fires on the IPC event-loop thread when the daemon vanishes
+                    // without a clean shutdown message (crash / SIGKILL, or a stop
+                    // that raced the handshake). Post a graceful quit to the Qt
+                    // main thread — the same path as a core-initiated shutdown
+                    // (QueueShutdown) — so the GUI tears down cleanly instead of
+                    // faulting on the next call to a now-dead proxy. requestQuit()
+                    // is idempotent, so a duplicate (e.g. a drain that also failed)
+                    // is harmless.
+                    GUILogPrintf("IPC: lost connection to the Gridcoin daemon; closing the GUI");
+                    // Guard the instance(): a disconnect that races the GUI's own
+                    // shutdown (local teardown normally cancels this handler first,
+                    // but the connection delete is async) could arrive after the
+                    // QCoreApplication is gone.
+                    if (QCoreApplication* qapp = QCoreApplication::instance()) {
+                        QMetaObject::invokeMethod(qapp,
+                                                  [] { BitcoinGUI::requestQuit(); },
+                                                  Qt::QueuedConnection);
+                    }
+                });
             if (!node_connection)
             {
                 // One dialog: this runs after ThreadSafeMessageBox_connect, so a

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -47,7 +47,9 @@
 #include "validation.h"
 #include "decoration.h"
 
+#include <atomic>
 #include <stdexcept>
+#include <thread>
 
 #include <QMessageBox>
 #include <QGridLayout>
@@ -123,7 +125,27 @@ static void SetupUIArgs(ArgsManager& argsman)
                    ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-showorphans", "Include stale (orphaned) coinstake transactions in the transaction list",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-guilogfile=<file>",
+                   "In -multiprocess mode the GUI runs as a separate process from the node and MUST NOT "
+                   "share the node's debug log file (the node rotates it by rename, which would orphan the "
+                   "GUI's writes). The GUI logs to its own file: this option names it (relative paths are "
+                   "under the data directory). Default: the -debuglogfile name with \"_gui\" inserted "
+                   "(e.g. debug_gui.log). Must resolve to a different path than -debuglogfile. Ignored "
+                   "outside -multiprocess.",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
 }
+
+#ifdef ENABLE_MULTIPROCESS
+//! Derive the default GUI log path from the node's log path by inserting "_gui"
+//! before the extension (e.g. /data/debug.log -> /data/debug_gui.log), so the two
+//! processes default to distinct files in the shared data directory.
+static fs::path DeriveGuiLogPath(const fs::path& node_log)
+{
+    const std::string stem = node_log.stem().string();
+    const std::string ext = node_log.extension().string();
+    return node_log.parent_path() / fs::path(stem + "_gui" + ext);
+}
+#endif
 
 static void ThreadSafeMessageBox(const std::string& message, const std::string& caption, int style)
 {
@@ -495,6 +517,40 @@ int main(int argc, char *argv[])
     // the user had in Gridcoin-Qt.conf into the core read-write settings (one-time).
     optionsModel.migrateCoreSettings();
 
+#ifdef ENABLE_MULTIPROCESS
+    // In -multiprocess mode the GUI and the node are separate processes sharing a
+    // data directory, and they must NOT write the same log file. The node rotates
+    // its debug log by renaming it (BCLog::Logger::archive), which would orphan a
+    // second writer's open fd -- the GUI's lines would then trail into the renamed,
+    // soon-unlinked file rather than the live one -- and on Windows the node's
+    // rename would be blocked outright while the GUI holds the file open. So the GUI
+    // logs to its OWN file. InitLogging() (below) reads -debuglogfile and opens the
+    // log (it calls StartLogging), so the redirect has to happen HERE, before it:
+    // compute the GUI path, refuse a same-file override, and force -debuglogfile to
+    // the GUI file for this (GUI) process only. InitLogging then opens/shrinks the
+    // GUI file exactly as it would the node's. The node is a separate process and
+    // keeps its own -debuglogfile.
+    if (gArgs.GetBoolArg("-multiprocess", false)) {
+        const fs::path node_log = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
+        const fs::path gui_log = gArgs.IsArgSet("-guilogfile")
+            ? AbsPathForConfigVal(fs::path(gArgs.GetArg("-guilogfile", "")))
+            : DeriveGuiLogPath(node_log);
+
+        if (gui_log == node_log) {
+            const std::string msg = strprintf(
+                "The GUI and the Gridcoin daemon cannot share the log file %s in -multiprocess mode. "
+                "Set -guilogfile to a different path, or unset it to use the default (%s).",
+                node_log.string(), DeriveGuiLogPath(node_log).string());
+            // Logging is not up yet, so report to stderr as well as a dialog.
+            tfm::format(std::cerr, "%s\n", msg.c_str());
+            QMessageBox::critical(nullptr, PACKAGE_NAME, QString::fromStdString(msg));
+            return EXIT_FAILURE;
+        }
+
+        gArgs.ForceSetArg("-debuglogfile", gui_log.string());
+    }
+#endif
+
     // Initialize logging as early as possible.
     InitLogging();
 
@@ -657,6 +713,42 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 return EXIT_FAILURE;
             }
             interface_init = node_connection->init.get();
+
+            // The multiprocess GUI logs to its own file (set up in main() before
+            // this function) but, unlike the node, runs no core scheduler to rotate
+            // it. Drive the same daily-archive check the node schedules in
+            // GRC::ScheduleBackgroundJobs: every 5 minutes archive(false) is a cheap
+            // no-op until the day boundary is crossed (and a full no-op when
+            // -logarchivedaily=false). Run it OFF the Qt main thread: when it does
+            // archive, archive()'s gzip compression is synchronous and would freeze
+            // the UI (the node runs archive() on its scheduler thread for the same
+            // reason). archive() serializes on the logger mutex, so it is safe
+            // off-thread; a guard skips a tick while a previous (slow) archive is
+            // still compressing. The GUI owns this file exclusively, so the
+            // close-rename-reopen is safe on every platform. Timer parented to
+            // `app`, so it lives for the run.
+            static std::atomic<bool> gui_archive_running{false};
+            QTimer* logArchiveTimer = new QTimer(&app);
+            QObject::connect(logArchiveTimer, &QTimer::timeout, [] {
+                bool expected = false;
+                if (!gui_archive_running.compare_exchange_strong(expected, true)) {
+                    return;  // a previous archive pass is still running
+                }
+                std::thread([] {
+                    RenameThread("gui-log-archive");
+                    try {
+                        fs::path plogfile_out;
+                        LogInstance().archive(false, plogfile_out);
+                    } catch (const std::exception& e) {
+                        // A throw here would terminate the detached thread (and the
+                        // process); contain it. The logger is left valid (the file is
+                        // reopened before the cleanup step); the next tick retries.
+                        GUILogPrintf("WARNING: GUI log archive pass failed: %s", e.what());
+                    }
+                    gui_archive_running = false;
+                }).detach();
+            });
+            logArchiveTimer->start(300000);  // 5 minutes, matching the node's schedule
 #else
             GUILogPrintf("IPC: -multiprocess requested but this build has no multiprocess (IPC) support");
             QMessageBox::critical(nullptr, PACKAGE_NAME,

--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -4,6 +4,7 @@
 
 #include "qt/detailedtxmodel.h"
 
+#include "qt/guilog.h"
 #include "qt/transactiontablemodel.h"
 #include "qt/walletmodel.h"
 #include "interfaces/wallet_tx_source.h"
@@ -89,13 +90,15 @@ DetailedTxModel::~DetailedTxModel()
     if (m_walletModel) {
         try {
             m_walletModel->txSource().unregisterView(GRC::VIEW_DETAILED);
-        } catch (const std::exception&) {
+        } catch (const std::exception& e) {
             // Multiprocess teardown after the node connection dropped: the remote
             // cursor died with the core, so this proxy call throws "IPC client
             // method called after disconnect." Swallow — a destructor must not
             // propagate, and there is nothing left to unregister. The disconnect
             // hook (bitcoin.cpp) already logged the lost connection and drove the
-            // quit that is running this teardown.
+            // quit that is running this teardown. Log at verbose so a failure for
+            // any OTHER reason is still observable.
+            GUILogPrint(GUILogCategory::VERBOSE, "DetailedTxModel: unregisterView skipped: %s", e.what());
         }
     }
 }

--- a/src/qt/detailedtxmodel.cpp
+++ b/src/qt/detailedtxmodel.cpp
@@ -86,8 +86,18 @@ DetailedTxModel::~DetailedTxModel()
     // the node-side store stops maintaining a per-view index for a consumer that
     // is gone (Phase 1c-ii-c). m_walletModel — and the WalletTxSource it hands
     // out — outlives this model by the teardown-ordering contract (bitcoin.cpp).
-    if (m_walletModel)
-        m_walletModel->txSource().unregisterView(GRC::VIEW_DETAILED);
+    if (m_walletModel) {
+        try {
+            m_walletModel->txSource().unregisterView(GRC::VIEW_DETAILED);
+        } catch (const std::exception&) {
+            // Multiprocess teardown after the node connection dropped: the remote
+            // cursor died with the core, so this proxy call throws "IPC client
+            // method called after disconnect." Swallow — a destructor must not
+            // propagate, and there is nothing left to unregister. The disconnect
+            // hook (bitcoin.cpp) already logged the lost connection and drove the
+            // quit that is running this teardown.
+        }
+    }
 }
 
 void DetailedTxModel::updateDisplayUnit()

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -49,8 +49,18 @@ OverviewTxModel::~OverviewTxModel()
     // the node-side store stops maintaining a per-view index for a consumer that
     // is gone (Phase 1c-ii-c). m_walletModel — and the WalletTxSource it hands
     // out — outlives this model by the teardown-ordering contract (bitcoin.cpp).
-    if (m_walletModel)
-        m_walletModel->txSource().unregisterView(GRC::VIEW_OVERVIEW);
+    if (m_walletModel) {
+        try {
+            m_walletModel->txSource().unregisterView(GRC::VIEW_OVERVIEW);
+        } catch (const std::exception&) {
+            // Multiprocess teardown after the node connection dropped: the remote
+            // cursor died with the core, so this proxy call throws "IPC client
+            // method called after disconnect." Swallow — a destructor must not
+            // propagate, and there is nothing left to unregister. The disconnect
+            // hook (bitcoin.cpp) already logged the lost connection and drove the
+            // quit that is running this teardown.
+        }
+    }
 }
 
 int OverviewTxModel::rowCount(const QModelIndex& parent) const

--- a/src/qt/overviewtxmodel.cpp
+++ b/src/qt/overviewtxmodel.cpp
@@ -5,6 +5,7 @@
 #include "qt/overviewtxmodel.h"
 
 #include "interfaces/wallet_tx_filter.h"
+#include "qt/guilog.h"
 #include "qt/transactiontablemodel.h"
 #include "qt/walletmodel.h"
 #include "interfaces/wallet_tx_source.h"
@@ -52,13 +53,15 @@ OverviewTxModel::~OverviewTxModel()
     if (m_walletModel) {
         try {
             m_walletModel->txSource().unregisterView(GRC::VIEW_OVERVIEW);
-        } catch (const std::exception&) {
+        } catch (const std::exception& e) {
             // Multiprocess teardown after the node connection dropped: the remote
             // cursor died with the core, so this proxy call throws "IPC client
             // method called after disconnect." Swallow — a destructor must not
             // propagate, and there is nothing left to unregister. The disconnect
             // hook (bitcoin.cpp) already logged the lost connection and drove the
-            // quit that is running this teardown.
+            // quit that is running this teardown. Log at verbose so a failure for
+            // any OTHER reason is still observable.
+            GUILogPrint(GUILogCategory::VERBOSE, "OverviewTxModel: unregisterView skipped: %s", e.what());
         }
     }
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -249,7 +249,9 @@ void WalletModel::drainEventQueue()
             QTimer::singleShot(0, this, &WalletModel::drainEventQueue);
         }
     } catch (const std::exception& e) {
-        GUILogPrintf("WalletModel: event drain failed (core connection lost): %s", e.what());
+        // Almost always the node connection dropping mid-drain (multiprocess), but
+        // do not assert the cause in the message — any drain exception lands here.
+        GUILogPrintf("WalletModel: wallet event drain failed; stopping the periodic drain: %s", e.what());
         if (eventDrainTimer) {
             eventDrainTimer->stop();
         }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -182,59 +182,77 @@ void WalletModel::drainEventQueue()
     // request that arrives after this point schedules a new kick (PR4-fix D).
     m_event_drain_requested = false;
 
-    // Bound the per-tick batch so a large backlog (reorg flood, IBD catch-up)
-    // cannot freeze the Qt main thread in a single apply pass. If the queue
-    // still has events after this batch, re-arm immediately (see below)
-    // instead of waiting MODEL_EVENT_DRAIN_INTERVAL for the periodic tick.
-    auto events = m_tx_source.drainEvents(MODEL_EVENT_DRAIN_MAX_BATCH);
-    if (events.empty()) {
-        return;
-    }
-
-    GUILogPrint(GUILogCategory::VERBOSE,
-             "WalletModel::drainEventQueue: applying %u events (front seqno=%llu, back seqno=%llu)",
-             static_cast<unsigned int>(events.size()),
-             static_cast<unsigned long long>(events.front().seqno),
-             static_cast<unsigned long long>(events.back().seqno));
-
-    // Cache the pushed tip height (GUI-thread-owned) so the windowed views can
-    // derive live confirmation counts on read — no cs_main, no reach-through to
-    // core state; the wallet model is self-contained for the process split.
-    // Last tip event in the batch wins.
-    for (const auto& ev : events) {
-        if (const auto* tip = std::get_if<GRC::ChainTipChangedPayload>(&ev.payload)) {
-            cachedNumBlocks = tip->height;
+    // Multiprocess safety net: every core-touching call in this drain — the
+    // drainEvents() round-trip AND the apply path reached through
+    // walletEventsDrained (each windowed view's getRows) and checkBalanceChanged
+    // — is a synchronous IPC call that throws std::runtime_error("IPC client
+    // method called after disconnect.") once the node process is gone. A drop can
+    // land mid-drain, and a posted BitcoinGUI::requestQuit() (from the IPC
+    // disconnect hook, bitcoin.cpp) cannot preempt a drain already running on this
+    // thread, so an uncaught throw here would escape a Qt slot and abort the GUI.
+    // Catch it, stop the periodic drain, and bail; the disconnect hook drives the
+    // graceful quit. e.what() is logged so a non-disconnect exception is still
+    // surfaced rather than silently swallowed.
+    try {
+        // Bound the per-tick batch so a large backlog (reorg flood, IBD catch-up)
+        // cannot freeze the Qt main thread in a single apply pass. If the queue
+        // still has events after this batch, re-arm immediately (see below)
+        // instead of waiting MODEL_EVENT_DRAIN_INTERVAL for the periodic tick.
+        std::vector<GRC::WalletEvent> events = m_tx_source.drainEvents(MODEL_EVENT_DRAIN_MAX_BATCH);
+        if (events.empty()) {
+            return;
         }
-    }
 
-    // General "wallet transactions changed" pulse (OverviewPage refreshes its
-    // recent list on it). The windowed views (OverviewTxModel / DetailedTxModel)
-    // and the new-transaction balloon consume the event batch directly through
-    // walletEventsDrained below; per-row confirmation refresh is likewise driven
-    // by each view's own ChainTipChanged handling, not a full-replica model.
-    emit transactionUpdated();
+        GUILogPrint(GUILogCategory::VERBOSE,
+                 "WalletModel::drainEventQueue: applying %u events (front seqno=%llu, back seqno=%llu)",
+                 static_cast<unsigned int>(events.size()),
+                 static_cast<unsigned long long>(events.front().seqno),
+                 static_cast<unsigned long long>(events.back().seqno));
 
-    // Fan the same batch out to the per-view windowed consumers (OverviewTxModel),
-    // which filter to their own viewId. The queue is drained exactly once, here.
-    emit walletEventsDrained(events);
+        // Cache the pushed tip height (GUI-thread-owned) so the windowed views can
+        // derive live confirmation counts on read — no cs_main, no reach-through to
+        // core state; the wallet model is self-contained for the process split.
+        // Last tip event in the batch wins.
+        for (const auto& ev : events) {
+            if (const auto* tip = std::get_if<GRC::ChainTipChangedPayload>(&ev.payload)) {
+                cachedNumBlocks = tip->height;
+            }
+        }
 
-    // Balance and number of transactions might have changed.
-    checkBalanceChanged();
+        // General "wallet transactions changed" pulse (OverviewPage refreshes its
+        // recent list on it). The windowed views (OverviewTxModel / DetailedTxModel)
+        // and the new-transaction balloon consume the event batch directly through
+        // walletEventsDrained below; per-row confirmation refresh is likewise driven
+        // by each view's own ChainTipChanged handling, not a full-replica model.
+        emit transactionUpdated();
 
-    int newNumTransactions = getNumTransactions();
-    if (cachedNumTransactions != newNumTransactions) {
-        cachedNumTransactions = newNumTransactions;
+        // Fan the same batch out to the per-view windowed consumers (OverviewTxModel),
+        // which filter to their own viewId. The queue is drained exactly once, here.
+        emit walletEventsDrained(events);
 
-        emit numTransactionsChanged(newNumTransactions);
-    }
+        // Balance and number of transactions might have changed.
+        checkBalanceChanged();
 
-    // If this drain hit the per-tick batch cap there is still a backlog.
-    // Re-arm immediately (0ms) rather than waiting for the next periodic
-    // tick: this returns control to the Qt event loop — keeping the GUI
-    // responsive between batches — but resumes draining straight away so a
-    // burst clears in a few event-loop turns instead of one per 500ms.
-    if (events.size() >= static_cast<std::size_t>(MODEL_EVENT_DRAIN_MAX_BATCH)) {
-        QTimer::singleShot(0, this, &WalletModel::drainEventQueue);
+        int newNumTransactions = getNumTransactions();
+        if (cachedNumTransactions != newNumTransactions) {
+            cachedNumTransactions = newNumTransactions;
+
+            emit numTransactionsChanged(newNumTransactions);
+        }
+
+        // If this drain hit the per-tick batch cap there is still a backlog.
+        // Re-arm immediately (0ms) rather than waiting for the next periodic
+        // tick: this returns control to the Qt event loop — keeping the GUI
+        // responsive between batches — but resumes draining straight away so a
+        // burst clears in a few event-loop turns instead of one per 500ms.
+        if (events.size() >= static_cast<std::size_t>(MODEL_EVENT_DRAIN_MAX_BATCH)) {
+            QTimer::singleShot(0, this, &WalletModel::drainEventQueue);
+        }
+    } catch (const std::exception& e) {
+        GUILogPrintf("WalletModel: event drain failed (core connection lost): %s", e.what());
+        if (eventDrainTimer) {
+            eventDrainTimer->stop();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Multiprocess shutdown-handshake, GUI side. In the `-multiprocess` build the GUI drives every model through the node's remote `Init` over an AF_UNIX socket. Today the GUI has no handling for the daemon going away while attached: it keeps calling now-dead proxies, and libmultiprocess turns a post-disconnect call into `std::runtime_error("IPC client method called after disconnect.")` (`protocol.cpp` `IpcLogFn` on `Log::Raise`). Uncaught in a Qt slot or a destructor, that aborts the GUI — the "runaway exception" seen when the core is stopped underneath a live GUI.

The complementary direction — **GUI quit while the core runs** — already works (the multiprocess build skips core `Shutdown()`; teardown just detaches and RAII closes the socket), which is why repeated GUI restarts against a running core are clean. This PR fills in the **core-death-while-attached** case.

## Changes

- **Detection (event-driven):** thread an optional `on_disconnect` callback through `Protocol::connect` → `Ipc::connectAddress` → `ConnectToNode`. `protocol.cpp` registers it on the client `Connection` **alongside** libmultiprocess's own handler (not touching the vendored subtree) — `Connection::onDisconnect` accumulates handlers and defers each to the EventLoop task set, so ours stays safe even after the internal handler frees the `Connection`, and it never dereferences it. `bitcoin.cpp` registers a callback that logs and posts `BitcoinGUI::requestQuit()` to the Qt main thread — the same graceful, minimize-on-close-safe path as a core-initiated shutdown (`QueueShutdown`), guarded against a null `QCoreApplication` during shutdown. `requestQuit()` is idempotent.
  - On a **normal** GUI quit the local `Connection` is destroyed first, which cancels the handler's `TaskSet`, so `on_disconnect` fires **only on a genuine remote drop** — the reconnect flow is unaffected.
- **Teardown safety:** the two windowed-view destructors (`DetailedTxModel`/`OverviewTxModel`) call `unregisterView()` *explicitly* (proxy destructors are already null-guarded; explicit calls are not), which throws on a dead connection during the `requestQuit` teardown → `std::terminate` from a destructor. Wrapped both in try/catch (nothing left to unregister; a destructor must not propagate).
- **Mid-drain safety:** a disconnect can land while `drainEventQueue()` is executing — its `drainEvents()` round-trip *and* the apply-path IPC calls (`walletEventsDrained`→each view's `getRows`, `checkBalanceChanged`→`tryGetBalances`) — and a posted `requestQuit` cannot preempt an in-flight drain. Wrapped the whole drain body in try/catch: log `e.what()` (so a non-disconnect exception stays visible rather than silently masked), stop the periodic drain, and bail; the disconnect hook drives the quit.

## Why the exception type is safe to catch

`clientInvoke` (libmultiprocess) routes a post-disconnect call through `MP_LOGPLAIN(loop, Log::Raise)`, and Gridcoin's `IpcLogFn` (`src/ipc/capnp/protocol.cpp`) does `throw std::runtime_error(message.message)` on `Log::Raise`. So every guard catches `std::runtime_error` (a `std::exception`), verified against the source.

## Testing

- Build (`ENABLE_GUI=ON ENABLE_TESTS=ON ENABLE_MULTIPROCESS=ON USE_QT6=ON`): `gridcoinresearch`, `gridcoinresearchd`, `test_gridcoin` all build.
- `test_gridcoin` `interfaces_tests` / `qt_wallettxstore_tests` / `qt_wallet_event_queue_tests` / `qt_transactionrecord_tests` / `wallet_tests`: **no errors**.
- `test/lint/lint-all.sh`: clean.
- Adversarial self-review (`/code-review`, high effort) — caught two real issues now fixed in this PR: the drain guard was initially too narrow (only `drainEvents`), and the `on_disconnect` callback lacked a null-`QCoreApplication` guard.
- Runtime: pending a live mesh/mainnet test of a `systemctl stop`/kill of the core under an attached multiprocess GUI.

## Scope note

This is the GUI half of the shutdown handshake. A **core→GUI "shutdown imminent"** notification (so `systemctl stop` tells an attached GUI to detach *before* the socket drops, rather than relying on this disconnect fallback) and a **reconnect** UX are the natural Phase 2e/2f follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR (added during review/testing)

**Separate GUI log file (`c006a4382`).** In `-multiprocess` the GUI and node are separate processes sharing a datadir and were both opening the same `debug.log` (via `InitLogging`) and interleaving into it. Worse, the node rotates `debug.log` by *rename* (`BCLog::Logger::archive`), which orphans any other writer's fd — and on Windows (a real target; the `CMakeLists` WIN32 guard is interim) the rename would be blocked while the GUI holds the file open. So the GUI now logs to its **own** file:
- Default `debug_gui.log` (the `-debuglogfile` name with `_gui` inserted), overridable with `-guilogfile=<file>`. Redirected by force-setting `-debuglogfile` for the GUI process *before* `InitLogging` opens it (no interleave option).
- **Same-file guard (GUI-side):** if the resolved GUI log path equals the node's `-debuglogfile`, the GUI refuses with a clear error and exits.
- The GUI owns and rotates its file: startup shrink (as the node) + a 5-min `archive(false)` mirroring `ScheduleBackgroundJobs`, run **off the Qt main thread** (the gzip is synchronous and would freeze the UI), guarded against overlap.
- `logging.cpp`: archive retention now matches by exact `"<stem>-"` prefix (not stem *substring*), so the node's `debug` retention no longer deletes the GUI's `debug_gui-*.gz` (and vice-versa) in the shared `logarchive/`; the retention scan tolerates the now-concurrent two-process access.

**Quiet libmultiprocess logging (`8960c6d42`).** `IpcLogFn` logged every mp message unconditionally (`LogPrintf`), flooding the log. It's now gated behind the **verbose** category (`LogPrint(BCLog::VERBOSE, …)`) — silent by default, surfaced with `-debug=verbose`. (Bitcoin Core uses a dedicated `BCLog::IPC` category; Gridcoin's `LogFlags` bits are all allocated.)

Live-validated on mainnet inst 0: clean disconnect self-quit; the GUI writes `debug_gui.log` while `debug.log` stays daemon-only; `-guilogfile=debug.log` is refused. Copilot round-1 comments addressed in `8960c6d42`.