### PR TITLE
gui: hydrate scraper icon and miner status on connect

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -102,6 +102,13 @@ struct ScraperConvergenceSnapshot
     std::vector<std::string> included_scrapers;
     std::vector<std::string> excluded_scrapers;
     std::vector<std::string> scrapers_not_publishing;
+    //! Most recent non-Log scraper event the core emitted (scrapereventtypes and
+    //! ChangeType carried as their int values), or -1/-1 when none has fired
+    //! since node startup. Lets the GUI initialize the scraper status icon at
+    //! connect time rather than waiting for the next event (matters when the GUI
+    //! attaches to an already-running node in -multiprocess mode).
+    int current_event_type = -1;
+    int current_event_status = -1;
 };
 
 //! Result of the GitHub "latest release" check the About dialog runs. Value

--- a/src/ipc/capnp/node.capnp
+++ b/src/ipc/capnp/node.capnp
@@ -152,6 +152,8 @@ struct ScraperConvergenceSnapshot $Proxy.wrap("interfaces::ScraperConvergenceSna
     includedScrapers @2 :List(Text) $Proxy.name("included_scrapers");
     excludedScrapers @3 :List(Text) $Proxy.name("excluded_scrapers");
     scrapersNotPublishing @4 :List(Text) $Proxy.name("scrapers_not_publishing");
+    currentEventType @5 :Int32 $Proxy.name("current_event_type");
+    currentEventStatus @6 :Int32 $Proxy.name("current_event_status");
 }
 
 struct LatestVersionInfo $Proxy.wrap("interfaces::LatestVersionInfo") {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -431,6 +431,11 @@ public:
         snapshot.excluded_scrapers = ConvergedScraperStatsCache.Convergence.vExcludedScrapers;
         snapshot.scrapers_not_publishing = ConvergedScraperStatsCache.Convergence.vScrapersNotPublishing;
 
+        // Current scraper status (last non-Log event), so the GUI can initialize
+        // its icon at connect time. Lock-free read; leaves the -1/-1 defaults
+        // when no event has fired yet.
+        uiInterface.GetLastScraperEvent(snapshot.current_event_type, snapshot.current_event_status);
+
         return snapshot;
     }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -432,8 +432,8 @@ public:
         snapshot.scrapers_not_publishing = ConvergedScraperStatsCache.Convergence.vScrapersNotPublishing;
 
         // Current scraper status (last non-Log event), so the GUI can initialize
-        // its icon at connect time. Lock-free read; leaves the -1/-1 defaults
-        // when no event has fired yet.
+        // its icon at connect time. Atomic read, no external locks; leaves the
+        // -1/-1 defaults when no event has fired yet.
         uiInterface.GetLastScraperEvent(snapshot.current_event_type, snapshot.current_event_status);
 
         return snapshot;

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -4,6 +4,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "uint256.h"
+#include <gridcoin/scraper/fwd.h>
 #include <node/ui_interface.h>
 
 #include <boost/signals2/optional_last_value.hpp>
@@ -81,7 +82,29 @@ void CClientUIInterface::PSGTPoolChanged(const uint256& revision_hash, ChangeTyp
 void CClientUIInterface::NewPollReceived(int64_t poll_time) { return g_ui_signals.NewPollReceived(poll_time); }
 void CClientUIInterface::NewVoteReceived(const uint256& poll_txid) { return g_ui_signals.NewVoteReceived(poll_txid); }
 void CClientUIInterface::NotifyAlertChanged(const uint256 &hash, ChangeType status) { return g_ui_signals.NotifyAlertChanged(hash, status); }
-void CClientUIInterface::NotifyScraperEvent(const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message) { return g_ui_signals.NotifyScraperEvent(ScraperEventtype, status, message); }
+void CClientUIInterface::NotifyScraperEvent(const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message)
+{
+    // Remember the last icon-relevant event so a late-connecting UI can hydrate
+    // (see GetLastScraperEvent). Log events carry console text, not an icon
+    // state, and the GUI routes them separately, so they must not overwrite the
+    // cached status. relaxed ordering: the value is a self-contained snapshot
+    // read independently, with no other memory it must synchronize against.
+    if (ScraperEventtype != scrapereventtypes::Log) {
+        const uint32_t packed = (static_cast<uint32_t>(static_cast<int>(ScraperEventtype)) << 16)
+                                | (static_cast<uint32_t>(static_cast<int>(status)) & 0xFFFFu);
+        m_last_scraper_event.store(packed, std::memory_order_relaxed);
+    }
+    return g_ui_signals.NotifyScraperEvent(ScraperEventtype, status, message);
+}
+
+bool CClientUIInterface::GetLastScraperEvent(int& event_type, int& status) const
+{
+    const uint32_t packed = m_last_scraper_event.load(std::memory_order_relaxed);
+    if (packed == kNoScraperEvent) return false;
+    event_type = static_cast<int>(packed >> 16);
+    status = static_cast<int>(packed & 0xFFFFu);
+    return true;
+}
 void CClientUIInterface::RwSettingsUpdated() { return g_ui_signals.RwSettingsUpdated(); }
 void CClientUIInterface::MandatorySideStakeChanged() { return g_ui_signals.MandatorySideStakeChanged(); }
 

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -7,6 +7,7 @@
 #ifndef BITCOIN_NODE_UI_INTERFACE_H
 #define BITCOIN_NODE_UI_INTERFACE_H
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -157,6 +158,22 @@ public:
      * @note called with lock cs_ConvergedScraperStatsCache held.
      */
     ADD_SIGNALS_DECL_WRAPPER(NotifyScraperEvent, void, const scrapereventtypes& ScraperEventtype, ChangeType status, const std::string& message);
+
+    //! Snapshot of the most recent non-Log scraper event, so a UI that connects
+    //! after the event was emitted -- notably the -multiprocess GUI attaching to
+    //! an already-running node whose scraper already converged -- can initialize
+    //! its status icon to the current state instead of a stale default. Written
+    //! from the scraper thread inside NotifyScraperEvent, read from the GUI/IPC
+    //! thread; lock-free. Returns false (leaving the args untouched) when no
+    //! non-Log event has been emitted since node startup.
+    bool GetLastScraperEvent(int& event_type, int& status) const;
+
+private:
+    //! (event_type << 16) | (status & 0xFFFF) of the last non-Log scraper event,
+    //! or kNoScraperEvent when none has been emitted. scrapereventtypes and
+    //! ChangeType are small enums, so they pack losslessly into 32 bits.
+    static constexpr uint32_t kNoScraperEvent = 0xFFFFFFFFu;
+    std::atomic<uint32_t> m_last_scraper_event{kNoScraperEvent};
 };
 
 /** Show warning message **/

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -164,8 +164,9 @@ public:
     //! an already-running node whose scraper already converged -- can initialize
     //! its status icon to the current state instead of a stale default. Written
     //! from the scraper thread inside NotifyScraperEvent, read from the GUI/IPC
-    //! thread; lock-free. Returns false (leaving the args untouched) when no
-    //! non-Log event has been emitted since node startup.
+    //! thread through a single std::atomic -- no external locks. Returns false
+    //! (leaving the args untouched) when no non-Log event has been emitted since
+    //! node startup.
     bool GetLastScraperEvent(int& event_type, int& status) const;
 
 private:

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -809,9 +809,27 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
 
         setMinerStatus(false, 0.0, 0.0, 0.0);
         connect(clientModel, &ClientModel::minerStatusChanged, this, &BitcoinGUI::setMinerStatus);
+        // Hydrate the miner status from the core's current staking state now that
+        // the signal is connected. Otherwise the fields sit at the false/0 default
+        // until the next MinerStatusChanged push -- which, when the GUI attaches to
+        // an already-running node (-multiprocess), may be a long way off.
+        clientModel->refreshMinerStatus();
 
-        // Start with out-of-sync message for scraper/NN.
-        updateScraperIcon((int)scrapereventtypes::OutOfSync, CT_UPDATING);
+        // Initialize the scraper icon from the core's current scraper status. We
+        // subscribe to future NotifyScraperEvent pushes below, but the last event
+        // may have fired before we connected (e.g. attaching to an already-
+        // converged node in -multiprocess mode), so hydrate now rather than
+        // leaving the icon on a stale out-of-sync default.
+        int scraper_event_type = (int)scrapereventtypes::OutOfSync;
+        int scraper_event_status = CT_UPDATING;
+        {
+            const interfaces::ScraperConvergenceSnapshot snapshot = clientModel->getScraperConvergenceSnapshot();
+            if (snapshot.current_event_type >= 0) {
+                scraper_event_type = snapshot.current_event_type;
+                scraper_event_status = snapshot.current_event_status;
+            }
+        }
+        updateScraperIcon(scraper_event_type, scraper_event_status);
         connect(clientModel, &ClientModel::updateScraperStatus, this, &BitcoinGUI::updateScraperIcon);
 
         // Report errors from network/worker thread

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -11,6 +11,7 @@
 #include "interfaces/wallet.h"
 #include "key_io.h"
 #include "node/ui_interface.h"
+#include "gridcoin/scraper/fwd.h"
 #include "sync.h"
 #include "util.h"
 #include "wallet/wallet.h"
@@ -361,6 +362,40 @@ BOOST_AUTO_TEST_CASE(node_value_queries_are_safe_in_empty_environment)
 
     // Pure conversion: the difficulty-1 compact target maps to ~1.0.
     BOOST_CHECK_CLOSE(node->getBlockDifficulty(0x1d00ffff), 1.0, 0.1);
+}
+
+BOOST_AUTO_TEST_CASE(node_caches_last_scraper_event_for_icon_hydration)
+{
+    std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
+
+    // A non-Log scraper event is remembered and surfaces on the convergence
+    // snapshot, so a GUI that connects after the event fired (e.g. the
+    // -multiprocess GUI attaching to an already-running node) can initialize its
+    // status icon to the current state instead of a stale default. Each check
+    // follows an explicit emission, so suite order does not matter.
+    uiInterface.NotifyScraperEvent(scrapereventtypes::Convergence, CT_NEW, {});
+    {
+        const interfaces::ScraperConvergenceSnapshot snapshot = node->getScraperConvergenceSnapshot();
+        BOOST_CHECK_EQUAL(snapshot.current_event_type, (int)scrapereventtypes::Convergence);
+        BOOST_CHECK_EQUAL(snapshot.current_event_status, (int)CT_NEW);
+    }
+
+    // Log events carry console text rather than an icon state and must not
+    // overwrite the cached status.
+    uiInterface.NotifyScraperEvent(scrapereventtypes::Log, CT_NEW, "a scraper log line");
+    {
+        const interfaces::ScraperConvergenceSnapshot snapshot = node->getScraperConvergenceSnapshot();
+        BOOST_CHECK_EQUAL(snapshot.current_event_type, (int)scrapereventtypes::Convergence);
+        BOOST_CHECK_EQUAL(snapshot.current_event_status, (int)CT_NEW);
+    }
+
+    // A later non-Log event replaces the cached status.
+    uiInterface.NotifyScraperEvent(scrapereventtypes::Sleep, CT_UPDATED, {});
+    {
+        const interfaces::ScraperConvergenceSnapshot snapshot = node->getScraperConvergenceSnapshot();
+        BOOST_CHECK_EQUAL(snapshot.current_event_type, (int)scrapereventtypes::Sleep);
+        BOOST_CHECK_EQUAL(snapshot.current_event_status, (int)CT_UPDATED);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(staking_status_wraps_miner_status)


### PR DESCRIPTION
## Problem

The GUI's scraper status icon and staking/miner status fields are only moved by future `NotifyScraperEvent` / `MinerStatusChanged` pushes. At startup they are seeded with hardcoded defaults (scraper: out-of-sync yellow; miner: not-staking / zero weight).

In the **monolithic** build this is invisible — the GUI launches with the node and witnesses the live transitions, so the defaults are momentarily correct.

In **`-multiprocess`** mode the GUI attaches to an already-running node whose scraper may have converged long ago. No new event fires, so the scraper icon sits on the stale out-of-sync (yellow) default until the next housekeeping cycle re-emits an event. Reproduced cleanly by restarting just the GUI against a running, in-sync, converged node: the icon comes up yellow and only goes green on the next housekeeping round.

This is a connect-time state-hydration gap, not a missing capnp seam — the `NotifyScraperEvent` callback already crosses the boundary correctly. `convergencereport` is unrelated (it only recomputes, and thus only emits, when the convergence cache is stale — mode-independent).

## Fix

Hydrate both at connect time, mirroring the existing block-count / difficulty pattern (pull current state, then subscribe):

- **Miner** — call `ClientModel::refreshMinerStatus()` after wiring the signal. It re-feeds the live staking state and coin weight already exposed through the `interfaces::StakingStatus` seam. **No core or capnp change.**
- **Scraper** — cache the last non-`Log` scraper event (lock-free `std::atomic`) at the single choke point `CClientUIInterface::NotifyScraperEvent`, expose it via `GetLastScraperEvent()`, and surface it on the existing `ScraperConvergenceSnapshot` as `current_event_type` / `current_event_status` (two new capnp fields, **no new interface method**). The GUI initializes the icon from that snapshot instead of the hardcoded default. `Log` events carry console text rather than an icon state and do not overwrite the cache.

Zero call-site churn in the scraper; the cache rides the one function every emitter already goes through.

## Testing

- New `interfaces_tests` case `node_caches_last_scraper_event_for_icon_hydration` covers emit → cache → snapshot including the `Log`-skip and later-event replacement. Passes.
- Full native `RelWithDebInfo` build with `-DENABLE_GUI=ON -DENABLE_MULTIPROCESS=ON -DENABLE_TESTS=ON -DUSE_QT6=ON` is clean.
- Lint (whitespace / include-guards / circular-dependencies) clean — the new `node → gridcoin/scraper/fwd.h` include introduces no cycle.
- Live `-multiprocess` GUI-restart-against-running-node validation recommended before merge.

## Notes

Draft: pending live multiprocess validation on the isolated testnet / main instance.
