### PR TITLE
gui/ipc: Windows (win64) multiprocess support + disconnect hardening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,12 +292,13 @@ if(ENABLE_UPNP)
 endif()
 
 if(ENABLE_MULTIPROCESS)
-    # The IPC transport is pathname AF_UNIX sockets with POSIX close-on-exec /
-    # umask semantics (src/ipc/); it is a Unix-only feature. Fail with a clear
-    # message rather than a confusing compile error if it is enabled on Windows.
-    if(WIN32)
-        message(FATAL_ERROR "ENABLE_MULTIPROCESS is not supported on Windows (it requires POSIX AF_UNIX sockets).")
-    endif()
+    # The IPC transport is pathname AF_UNIX sockets (src/ipc/). AF_UNIX is not
+    # POSIX-only: Windows 10 1803+ provides it via <afunix.h> with the same
+    # sockaddr_un layout, so the same transport builds on both platforms. The
+    # Windows port swaps the POSIX socket/close-on-exec/permission primitives for
+    # their winsock equivalents (WSASocketW / handle-inherit flags / NTFS ACLs)
+    # in src/ipc/process.cpp and fences the unused fork/spawn paths in the
+    # libmultiprocess subtree; both platforms are driven by this one switch.
 
     # Cap'n Proto provides the serialization runtime and the capnp / capnpc-c++
     # code generators; libmultiprocess provides the proxy runtime and the mpgen

--- a/doc/build.md
+++ b/doc/build.md
@@ -88,6 +88,8 @@ After you build with this script with the appropriate target
 
 Please refer to [Link](cmake-options.md) (cmake-options.md) for a list of cmake configuration options.
 
+To build the **split GUI/node (multiprocess)** variant — where the GUI and daemon run as separate processes that communicate over IPC — add `-DENABLE_MULTIPROCESS=ON` to a native build, or build the depends tree with `MULTIPROCESS=1` for a static/Windows build. See [multiprocess.md](multiprocess.md) for building **and running** in multiprocess mode (including the Windows requirement that the daemon run as the same user as the GUI).
+
 Developers may want to use -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache to have ccache cache
 the compilation at the ccache level. In many instances it is required to do an rm -rf of the build directory, and this will speed up
 repeated compilations.
@@ -258,6 +260,7 @@ If you are familiar with the legacy Autotools build system (`./configure`), this
 | **Release Build** | *(default + strip)* | `-DCMAKE_BUILD_TYPE=Release` |
 | **GUI** | `--with-gui` | `-DENABLE_GUI=ON` |
 | **No GUI** | `--without-gui` | `-DENABLE_GUI=OFF` |
+| **Multiprocess (split GUI/node)** | *(n/a)* | `-DENABLE_MULTIPROCESS=ON` (see [multiprocess.md](multiprocess.md)) |
 | **UPnP** | `--with-miniupnpc` | `-DENABLE_UPNP=ON` |
 | **QR Code** | `--with-qrencode` | `-DENABLE_QRENCODE=ON` |
 | **Tests** | `--enable-tests` | `-DENABLE_TESTS=ON` |

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -1,25 +1,175 @@
-# Multiprocess (IPC) build
+# Multiprocess mode (split GUI / node)
 
-Gridcoin is moving toward a split between the GUI process and the node process
-(RFC #2937). The wallet/node logic is being factored behind `interfaces::`
-boundaries so those boundaries can eventually be driven over IPC instead of
-in-process function calls.
+Gridcoin can run the GUI and the node (daemon) as **two separate processes** that
+communicate over a local IPC socket, instead of the default **monolithic** mode
+where the GUI runs the node in-process. This is RFC #2937.
 
-This document covers the **build toolchain** for that work. Turning the flag on
-does **not** by itself change any runtime behavior yet — it only wires in the
-Cap'n Proto dependency and the libmultiprocess runtime + `mpgen` code generator
-so the IPC layer can be built on top in later phases.
+Multiprocess mode is **opt-in at both build time and run time**:
+
+- The binaries must be built with multiprocess support (`ENABLE_MULTIPROCESS`; see
+  [Building with multiprocess support](#building-with-multiprocess-support) below).
+- Each process must be started with the `-multiprocess` flag.
+
+For the internal architecture, see [multiprocess_design.md](multiprocess_design.md).
+
+## Why run split?
+
+- The node keeps running when you close the GUI — attach and detach the GUI on
+  demand.
+- Run the node headless (or as a service) and only open the GUI when you need it.
+- Crash isolation: a GUI problem doesn't take the node (and its wallet and staking)
+  down with it.
+
+## How it works (in brief)
+
+When started with `-multiprocess`, the **daemon** listens on an `AF_UNIX` socket,
+`node.sock`, in its data directory and serves the GUI over IPC (Cap'n Proto). The
+**GUI**, also started with `-multiprocess`, connects to that socket instead of
+running the node in-process.
+
+- **Connect-only.** The GUI does **not** start the daemon. Start the daemon first,
+  then the GUI.
+- **Same data directory.** Both processes must use the same `-datadir`; that is how
+  the GUI finds `node.sock`.
+- **Authentication.** On start, the daemon writes a random cookie, `ipc.cookie`, in
+  the data directory (owner-readable only); the GUI reads it to authenticate. The
+  socket and the cookie are created with owner-only permissions.
+- **Matching builds.** The GUI and daemon must be the same build — the connection
+  handshake rejects mismatched IPC schema/protocol versions. Use `gridcoinresearch`
+  and `gridcoinresearchd` from the same release.
+- **Separate logs.** The GUI writes its own log, `debug_gui.log`, alongside the
+  node's `debug.log` (override with `-guilogfile`). The two may not share a file.
+
+Availability: Linux, and Windows 10 (1803+) / Windows 11, which provide `AF_UNIX`.
+
+## Running
+
+### Linux
+
+1. **Start the daemon** with `-multiprocess`:
+
+   ```bash
+   gridcoinresearchd -multiprocess -datadir=/path/to/data -daemon
+   ```
+
+   Wait until it is serving — the node's `debug.log` shows a line like:
+
+   ```
+   IPC: serving GUI connections on unix:/path/to/data/node.sock
+   ```
+
+2. **Start the GUI** with `-multiprocess` and the **same** data directory:
+
+   ```bash
+   gridcoinresearch -multiprocess -datadir=/path/to/data
+   ```
+
+   It connects to the running daemon. If no daemon is listening, the GUI reports
+   that it could not connect — it will not start one for you.
+
+(You can omit `-datadir` on both if you use the default data directory.)
+
+### Windows
+
+The Windows daemon has no Unix-style `-daemon` background mode, and — importantly —
+it must run **as the same Windows user account that runs the GUI**. The IPC socket
+(`node.sock`) and the cookie (`ipc.cookie`) are created in that user's data
+directory with owner-only NTFS permissions, so a GUI running as a different user
+(or a daemon running as `LocalSystem`) cannot read them.
+
+The practical setup today:
+
+1. Create a **Scheduled Task** (Task Scheduler) that runs
+   `gridcoinresearchd.exe -multiprocess` **as your user account** — for example,
+   triggered *At log on* of your account, with *Run only when user is logged on*.
+   Do **not** configure it to run as `SYSTEM` / `LocalSystem`.
+2. Start the GUI normally with `-multiprocess` (same account, same data directory).
+
+Do not run the daemon as a conventional Windows **service** under `LocalSystem`:
+the GUI, running as you, would not share the data directory or the socket's ACL.
+
+> **Future work:** the Windows installer may offer to enable multiprocess mode and
+> create this scheduled task for you at install time. Until then, set it up manually
+> as above.
+
+## Stopping
+
+The key mental model: **the GUI and the daemon are independent processes.**
+
+- **Closing the GUI does not stop the daemon** — that is the whole point of split
+  mode. The node keeps running (staking, syncing, serving RPC).
+- The command `gridcoinresearchd ... stop` stops the **daemon**, not the GUI. (In
+  monolithic mode `stop` stops everything; in split mode it stops only the node.)
+
+### Stop only the GUI (leave the node running)
+
+- Close the GUI window, **or**
+- Linux: send it `SIGTERM` — `kill -TERM <gui-pid>`. The GUI installs a handler that
+  turns `SIGTERM`/`SIGINT` into a clean shutdown.
+- Windows: close the window, or `taskkill /IM gridcoinresearch.exe` (a graceful
+  close request; avoid `/F`, which is a hard kill).
+
+### Stop the node
+
+- `gridcoinresearchd -multiprocess -datadir=/path/to/data stop` (RPC), **or**
+- send the daemon `SIGTERM` (Linux) / stop its scheduled task (Windows).
+
+If the GUI is connected when the daemon stops, it detects the lost connection and
+exits cleanly on its own.
+
+### Running the daemon as a service (Linux)
+
+You can run the daemon under `systemd` (or any supervisor) with `-multiprocess` and
+attach the GUI on demand. A minimal unit:
+
+```ini
+[Unit]
+Description=Gridcoin daemon (multiprocess)
+After=network-online.target
+
+[Service]
+User=<your-user>
+ExecStart=/usr/local/bin/gridcoinresearchd -multiprocess -datadir=/path/to/data -printtoconsole
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Run the daemon under the **same user** whose account will run the GUI (so the data
+directory and socket permissions line up), then start the GUI with `-multiprocess`.
+Stopping the service stops the node (a connected GUI then exits); to stop just the
+GUI, close it or `SIGTERM` it as above.
+
+## Troubleshooting
+
+- **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**
+  The daemon is not running yet, was not started with `-multiprocess`, is using a
+  different `-datadir`, or (Windows) is running as a different user. Start the daemon
+  first and confirm `IPC: serving …` appears in its `debug.log`.
+- **Version/schema mismatch on connect.** The GUI and daemon are different builds.
+  Use matching `gridcoinresearch` / `gridcoinresearchd` binaries.
+- **The GUI won't share a log with the node.** In `-multiprocess` mode the GUI uses
+  `debug_gui.log`; set `-guilogfile` to a distinct path if you have overridden the
+  node's `-debuglogfile`.
+
+# Building with multiprocess support
+
+The runtime behavior above is available only in binaries built with the
+`ENABLE_MULTIPROCESS` option. Turning the flag on wires in the Cap'n Proto
+dependency and the libmultiprocess runtime + `mpgen` code generator that the IPC
+layer is built on.
 
 ## What it pulls in
 
-- **Cap'n Proto** — the serialization runtime plus the `capnp` / `capnpc-c++`
-  code generators. This is an external dependency (system package, or the depends
+- **Cap'n Proto** — the serialization runtime plus the `capnp` / `capnpc-c++` code
+  generators. This is an external dependency (system package, or the depends
   `capnp` recipe).
-- **libmultiprocess** — the proxy runtime plus `mpgen`, the generator that turns
-  an `interfaces` `.capnp` schema into client/server proxy classes. This is
-  **vendored in-tree** as a git subtree at `src/ipc/libmultiprocess` and compiled
-  by the Gridcoin build itself (like Bitcoin Core); it is not a system or depends
-  runtime package.
+- **libmultiprocess** — the proxy runtime plus `mpgen`, the generator that turns an
+  `interfaces` `.capnp` schema into client/server proxy classes. This is **vendored
+  in-tree** as a git subtree at `src/ipc/libmultiprocess` and compiled by the
+  Gridcoin build itself (like Bitcoin Core); it is not a system or depends runtime
+  package.
 
 `WITH_EXTERNAL_LIBMULTIPROCESS` (default `OFF`) can be set to `ON` to link an
 external libmultiprocess instead of the subtree — mainly useful when developing
@@ -53,8 +203,8 @@ translation units only.
 
 ## Depends build (cross-compile / static)
 
-Build the depends tree with `MULTIPROCESS=1` to add the Cap'n Proto runtime and
-the native code generators:
+Build the depends tree with `MULTIPROCESS=1` to add the Cap'n Proto runtime and the
+native code generators:
 
 ```bash
 make -C depends HOST=x86_64-w64-mingw32 MULTIPROCESS=1
@@ -90,8 +240,8 @@ git subtree pull --prefix src/ipc/libmultiprocess \
 ### Version pinning
 
 The Cap'n Proto version (`depends/packages/native_capnp.mk`) must stay compatible
-with the vendored libmultiprocess commit: libmultiprocess's generated code embeds
-a Cap'n Proto version check and the build fails with *"Version mismatch between
+with the vendored libmultiprocess commit: libmultiprocess's generated code embeds a
+Cap'n Proto version check and the build fails with *"Version mismatch between
 generated code and library headers"* if they diverge. The current pins are Cap'n
 Proto **1.5.0** and libmultiprocess **3f221b5**. When bumping the subtree, bump
 `native_capnp.mk` (and the system package, which tracks the distro's Cap'n Proto)

--- a/src/gridcoin/interfaces.cpp
+++ b/src/gridcoin/interfaces.cpp
@@ -321,7 +321,7 @@ public:
 
     std::unique_ptr<Handler> handleMRCChanged(MRCChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.MRCChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.MRCChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
 private:
@@ -500,12 +500,12 @@ public:
         // emission-time revision could predate the reload. The consumer reads
         // localRevision() itself when handling the notification — see
         // interfaces/sidestake.h.
-        return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleMandatorySideStakeChanged(MandatorySideStakeChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.MandatorySideStakeChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.MandatorySideStakeChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
 private:
@@ -789,7 +789,7 @@ public:
 
     std::unique_ptr<Handler> handleNewPollReceived(NewPollReceivedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.NewPollReceived_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.NewPollReceived_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleNewVoteReceived(NewVoteReceivedFn fn) override
@@ -797,7 +797,7 @@ public:
         // The core signal carries a uint256; hand the consumer its hex form so no
         // core type crosses the boundary.
         return MakeSignalHandler(uiInterface.NewVoteReceived_connect(
-            [fn = std::move(fn)](const uint256& poll_txid) { fn(poll_txid.ToString()); }));
+            interfaces::GuardNotify([fn = std::move(fn)](const uint256& poll_txid) { fn(poll_txid.ToString()); })));
     }
 
 private:
@@ -1294,22 +1294,22 @@ public:
 
     std::unique_ptr<Handler> handleResearcherChanged(ResearcherChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.ResearcherChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.ResearcherChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleBeaconChanged(BeaconChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.BeaconChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.BeaconChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleAccrualChanged(AccrualChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.AccrualChangedFromStakeOrMRC_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.AccrualChangedFromStakeOrMRC_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleBlocksChanged(BlocksChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.NotifyBlocksChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.NotifyBlocksChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
 private:

--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -4,11 +4,21 @@
 
 #include "interfaces/handler.h"
 
+#include "logging.h"
+
 #include <boost/signals2/connection.hpp>
 
 #include <utility>
 
 namespace interfaces {
+
+void LogDroppedNotification(const char* what)
+{
+    // Verbose category only: on a clean shutdown many peers drop at once, so this
+    // can fire repeatedly; it is expected, not an error. Surfaces with -debug=verbose.
+    LogPrint(BCLog::VERBOSE, "IPC: dropped a notification to a disconnected client: %s\n", what);
+}
+
 namespace {
 
 class SignalHandler : public Handler

--- a/src/interfaces/handler.h
+++ b/src/interfaces/handler.h
@@ -5,8 +5,10 @@
 #ifndef GRIDCOIN_INTERFACES_HANDLER_H
 #define GRIDCOIN_INTERFACES_HANDLER_H
 
+#include <exception>
 #include <functional>
 #include <memory>
+#include <utility>
 
 namespace boost {
 namespace signals2 {
@@ -34,6 +36,37 @@ std::unique_ptr<Handler> MakeSignalHandler(boost::signals2::connection connectio
 
 //! Return a Handler that runs a cleanup function on disconnect/destruction.
 std::unique_ptr<Handler> MakeCleanupHandler(std::function<void()> cleanup);
+
+//! Log (at the verbose category) that a one-way notification was dropped because
+//! the IPC client had already disconnected. Defined out of line so this header
+//! stays free of the logging dependency; used by GuardNotify below.
+void LogDroppedNotification(const char* what);
+
+//! Wrap a one-way (void) notification callback so that an exception raised while
+//! delivering it is dropped instead of propagating into the core thread that
+//! emitted the uiInterface signal.
+//!
+//! In the multiprocess build the server-side forwarder registered on a uiInterface
+//! signal calls the GUI's proxy client. If the GUI has disconnected (crash, close,
+//! or a shutdown race), libmultiprocess raises "IPC client method called after
+//! disconnect." at Log::Raise, which Gridcoin's IpcLogFn turns into a
+//! std::runtime_error -- and that would otherwise unwind into core threads such as
+//! ThreadMessageHandler / ProcessMessages. A notification to a client that is gone
+//! is a no-op by definition, so swallow it. In the monolithic build the wrapped
+//! callback does not throw, so the guard is inert.
+template <typename Fn>
+auto GuardNotify(Fn fn)
+{
+    return [fn = std::move(fn)](auto&&... args) {
+        try {
+            fn(std::forward<decltype(args)>(args)...);
+        } catch (const std::exception& e) {
+            LogDroppedNotification(e.what());
+        } catch (...) {
+            LogDroppedNotification("non-standard exception");
+        }
+    };
+}
 
 } // namespace interfaces
 

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -14,6 +14,17 @@ if(NOT WITH_EXTERNAL_LIBMULTIPROCESS)
     add_libmultiprocess(libmultiprocess)
 endif()
 
+# Do NOT put this directory (src/ipc) on the header search path. On Windows,
+# mingw's <pthread.h> does `#include <process.h>` (the CRT threading header);
+# with src/ipc on the search path that angle-bracket include resolves to our
+# ipc/process.h instead, which drags fs.h/<fstream> into the middle of libstdc++'s
+# gthreads bootstrap and shatters <ios>/<istream> (seekdir/__gthread errors) in
+# every generated proxy TU. Our own sources include "ipc/..." (resolved via src/)
+# and the generated proxies include "ipc/capnp/..." (resolved via the build tree),
+# so the current directory is never needed on the include path here. (The
+# libmultiprocess subtree is unaffected: its current dir is src/ipc/libmultiprocess.)
+set(CMAKE_INCLUDE_CURRENT_DIR OFF)
+
 # The IPC layer: the hand-written transport (process/protocol/interfaces) plus the
 # generated Cap'n Proto proxy layer. target_capnp_sources runs mpgen on each
 # .capnp, generating the raw capnp types (.capnp.h/.c++) and the ProxyClient/
@@ -63,3 +74,16 @@ target_compile_features(gridcoin_ipc PUBLIC cxx_std_20)
 target_link_libraries(gridcoin_ipc PUBLIC
     gridcoin_util
 )
+
+# On Windows the transport uses winsock (AF_UNIX via <afunix.h>: WSAStartup,
+# WSASocketW, closesocket, WSAGetLastError) and libmultiprocess's kj-async pulls
+# in the IOCP backend. ws2_32/wsock32 already arrive transitively through
+# gridcoin_util's WIN32 block; list ws2_32 here too so the IPC layer's socket
+# dependency is self-documenting, and add mswsock (AcceptEx/ConnectEx) for the
+# kj-async Win32 async I/O backend.
+if(WIN32)
+    target_link_libraries(gridcoin_ipc PUBLIC
+        ws2_32
+        mswsock
+    )
+endif()

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -21,7 +21,11 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#ifndef WIN32
 #include <sys/socket.h>
+#else
+#include <winsock2.h>
+#endif
 #include <system_error>
 #include <thread>
 #include <typeindex>
@@ -105,7 +109,11 @@ public:
     {
         startLoop(exe_name);
         if (::listen(listen_fd, /*backlog=*/5) != 0) {
+#ifdef WIN32
+            throw std::system_error(::WSAGetLastError(), std::system_category());
+#else
             throw std::system_error(errno, std::system_category());
+#endif
         }
         // Cap at a single simultaneous connection: the served Init (and its
         // authentication state) is shared, and the v1 model is exactly one GUI.

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -19,7 +19,19 @@
 #include <fstream>
 #include <sys/stat.h>
 #include <system_error>
+#ifndef WIN32
 #include <unistd.h>
+#else
+#include <io.h>     // _wsopen_s / _write / _commit / _close
+#include <share.h>  // _SH_DENYRW
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h> // MoveFileExW
+#endif
 
 namespace ipc {
 namespace {
@@ -39,6 +51,54 @@ std::optional<std::string> ReadFile(const fs::path& path)
 //! created with mode 0600 from the start (no umask window that could expose the
 //! secret cookie), the write is verified, and any failure throws so the caller
 //! knows the file does not hold what it expects.
+#ifdef WIN32
+//! Windows port of the atomic cookie writer. Same guarantees as the POSIX path,
+//! mapped to winsock/CRT: _O_NOINHERIT for close-on-exec, _SH_DENYRW for an
+//! exclusive open, _commit() for fsync, and MoveFileExW(REPLACE_EXISTING) for the
+//! atomic replace (boost::filesystem::rename's overwrite behaviour on Windows is
+//! version-dependent, so do not rely on it). There is no chmod: the file inherits
+//! the per-user, owner-only datadir ACL. O_NOFOLLOW has no direct analogue, but
+//! the secret only needs protecting from *other* users, which that ACL provides.
+//! TODO(win-mp W4): validate the exclusive-open / replace semantics on-device.
+void WriteFileAtomic(const fs::path& path, const std::string& contents)
+{
+    fs::path tmp = path;
+    tmp += ".tmp";
+    const std::string tmp_str = tmp.string();
+
+    int fd = -1;
+    const errno_t oerr = ::_wsopen_s(&fd, tmp.wstring().c_str(),
+                                     _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY | _O_NOINHERIT,
+                                     _SH_DENYRW, _S_IREAD | _S_IWRITE);
+    if (oerr != 0 || fd == -1) {
+        throw std::system_error(oerr ? oerr : errno, std::generic_category(), "open " + tmp_str);
+    }
+    size_t written = 0;
+    while (written < contents.size()) {
+        const int n = ::_write(fd, contents.data() + written,
+                               static_cast<unsigned int>(contents.size() - written));
+        if (n < 0) {
+            const int e = errno;
+            ::_close(fd);
+            throw std::system_error(e, std::generic_category(), "write " + tmp_str);
+        }
+        written += static_cast<size_t>(n);
+    }
+    if (::_commit(fd) != 0) { // flush to disk (fsync equivalent)
+        const int e = errno;
+        ::_close(fd);
+        throw std::system_error(e, std::generic_category(), "commit " + tmp_str);
+    }
+    if (::_close(fd) != 0) {
+        throw std::system_error(errno, std::generic_category(), "close " + tmp_str);
+    }
+    if (!::MoveFileExW(tmp.wstring().c_str(), path.wstring().c_str(),
+                       MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        throw std::system_error(static_cast<int>(::GetLastError()), std::system_category(),
+                                "MoveFileEx " + tmp_str + " -> " + path.string());
+    }
+}
+#else
 void WriteFileAtomic(const fs::path& path, const std::string& contents)
 {
     fs::path tmp = path;
@@ -71,6 +131,7 @@ void WriteFileAtomic(const fs::path& path, const std::string& contents)
     }
     fs::rename(tmp, path); // throws (boost::filesystem) on failure
 }
+#endif
 
 //! 16 strong random bytes as hex -- a per-datadir node identifier.
 std::string GenerateNodeId()

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -59,7 +59,9 @@ std::optional<std::string> ReadFile(const fs::path& path)
 //! version-dependent, so do not rely on it). There is no chmod: the file inherits
 //! the per-user, owner-only datadir ACL. O_NOFOLLOW has no direct analogue, but
 //! the secret only needs protecting from *other* users, which that ACL provides.
-//! TODO(win-mp W4): validate the exclusive-open / replace semantics on-device.
+//! On-device (W4): validated -- the cookie handshake round-trips (daemon writes it
+//! fresh each start, GUI reads and authenticates) and the file inherits the
+//! owner-only datadir NTFS ACL (owner + SYSTEM + Administrators, per icacls).
 void WriteFileAtomic(const fs::path& path, const std::string& contents)
 {
     fs::path tmp = path;

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -33,10 +33,14 @@ struct FdGuard
     ~FdGuard()
     {
         if (fd == -1) return;
-        // compat.h closesocket(): close() on POSIX, closesocket() on Windows.
-        // Takes a SOCKET& (it zeroes the handle), so pass an lvalue.
+#ifdef WIN32
+        // compat.h closesocket() -> myclosesocket() -> the winsock closesocket();
+        // it takes a SOCKET& (zeroes the handle), so pass an lvalue.
         SOCKET s = static_cast<SOCKET>(fd);
         closesocket(s);
+#else
+        ::close(fd);
+#endif
     }
     void release() { fd = -1; }
 };

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -14,7 +14,11 @@
 #include <string>
 #include <system_error>
 #include <typeindex>
+#ifndef WIN32
 #include <unistd.h>
+#else
+#include <winsock2.h> // closesocket
+#endif
 #include <utility>
 
 namespace ipc {
@@ -26,7 +30,14 @@ namespace {
 struct FdGuard
 {
     int fd;
-    ~FdGuard() { if (fd != -1) ::close(fd); }
+    ~FdGuard()
+    {
+        if (fd == -1) return;
+        // compat.h closesocket(): close() on POSIX, closesocket() on Windows.
+        // Takes a SOCKET& (it zeroes the handle), so pass an lvalue.
+        SOCKET s = static_cast<SOCKET>(fd);
+        closesocket(s);
+    }
     void release() { fd = -1; }
 };
 

--- a/src/ipc/libmultiprocess/src/mp/proxy.cpp
+++ b/src/ipc/libmultiprocess/src/mp/proxy.cpp
@@ -28,6 +28,25 @@
 #include <kj/memory.h>
 #include <kj/string.h>
 #include <cstdint>
+#ifdef WIN32
+#include <system_error>
+// The Windows wakeup writer below needs SOCKET / send / SOCKET_ERROR /
+// WSAGetLastError from <winsock2.h>. Define NOGDI first so windows.h does not
+// pull in <wingdi.h>, whose `#define ERROR 0` would otherwise clobber the
+// KJ_LOG(ERROR, ...) calls in this file; WIN32_LEAN_AND_MEAN/NOMINMAX trim the
+// rest of the Win32 surface. (proxy.cpp includes no other windows header, so
+// these take effect here.)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef NOGDI
+#define NOGDI
+#endif
+#include <winsock2.h>
+#endif
 #include <map>
 #include <memory>
 #include <optional>
@@ -249,6 +268,36 @@ void EventLoop::addAsyncCleanup(std::function<void()> fn)
     startAsyncThread();
 }
 
+#ifdef WIN32
+namespace {
+//! Windows counterpart of kj::FdOutputStream for the EventLoop wakeup. kj's
+//! two-way pipe on Windows is socket-backed: the write end exposes a SOCKET via
+//! getWin32Handle() (getFd() returns none, so kj::FdOutputStream cannot wrap it).
+//! post()/EventLoopRef::reset() write a single wakeup byte through this; send() is
+//! the Windows equivalent of the ::write that FdOutputStream performs on POSIX.
+class Win32SocketOutputStream : public kj::OutputStream
+{
+public:
+    explicit Win32SocketOutputStream(SOCKET sock) : m_sock(sock) {}
+    void write(const void* buffer, size_t size) override
+    {
+        auto* data{static_cast<const char*>(buffer)};
+        while (size > 0) {
+            const int n{::send(m_sock, data, static_cast<int>(size), 0)};
+            if (n == SOCKET_ERROR) {
+                throw std::system_error(::WSAGetLastError(), std::system_category(),
+                                        "EventLoop wakeup send");
+            }
+            data += n;
+            size -= static_cast<size_t>(n);
+        }
+    }
+private:
+    SOCKET m_sock;
+};
+} // namespace
+#endif // WIN32
+
 EventLoop::EventLoop(const char* exe_name, LogOptions log_opts, void* context)
     : m_exe_name(exe_name),
       m_io_context(kj::setupAsyncIo()),
@@ -261,6 +310,11 @@ EventLoop::EventLoop(const char* exe_name, LogOptions log_opts, void* context)
     m_post_stream = kj::mv(pipe.ends[1]);
     KJ_IF_MAYBE(fd, m_post_stream->getFd()) {
         m_post_writer = kj::heap<kj::FdOutputStream>(*fd);
+#ifdef WIN32
+    } else KJ_IF_MAYBE(handle, m_post_stream->getWin32Handle()) {
+        // Windows: the pipe end is a SOCKET, not a POSIX fd (see above).
+        m_post_writer = kj::heap<Win32SocketOutputStream>(reinterpret_cast<SOCKET>(*handle));
+#endif
     } else {
         throw std::logic_error("Could not get file descriptor for new pipe.");
     }

--- a/src/ipc/libmultiprocess/src/mp/util.cpp
+++ b/src/ipc/libmultiprocess/src/mp/util.cpp
@@ -15,10 +15,17 @@
 #include <sstream>
 #include <string>
 #include <sys/types.h>
+#ifndef WIN32
+// POSIX process-spawning / socketpair machinery. Gridcoin uses a connect-only
+// IPC model (the GUI connects to an already-running node; nothing is ever
+// spawned), so none of the fork/exec/socketpair/waitpid path below is reached
+// on any platform -- on Windows these headers do not exist, so fence them out
+// and provide throwing stubs for the public entry points (see below).
 #include <spawn.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
+#endif
 #include <system_error>
 #include <thread> // NOLINT(misc-include-cleaner) // IWYU pragma: keep
 #include <unistd.h>
@@ -33,9 +40,13 @@
 #include <pthread_np.h>
 #endif // HAVE_PTHREAD_GETTHREADID_NP
 
-extern "C" char **environ; // NOLINT(readability-redundant-declaration)
+#ifndef WIN32
+extern "C" char **environ; // NOLINT(readability-redundant-declaration) // only used by StartProcess (POSIX spawn path)
+#endif
 
 namespace mp {
+
+#ifndef WIN32
 namespace {
 
 std::vector<char*> MakeArgv(const std::vector<std::string>& args)
@@ -61,6 +72,7 @@ size_t MaxFd()
 }
 
 } // namespace
+#endif // !WIN32
 
 std::string ThreadName(const char* exe_name)
 {
@@ -117,6 +129,21 @@ std::string LogEscape(const kj::StringTree& string, size_t max_size)
     return result;
 }
 
+#ifdef WIN32
+// Connect-only IPC: Gridcoin never spawns a child, so these never run. Provide
+// stubs that link and fail loudly if the spawn path is ever entered on Windows.
+[[noreturn]] static void ThrowSpawnUnsupported(const char* fn)
+{
+    throw std::runtime_error(std::string(fn) +
+        " is not supported on Windows: the multiprocess build uses a connect-only "
+        "model (the GUI connects to an already-running node) and never spawns.");
+}
+
+std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&&)
+{
+    ThrowSpawnUnsupported("mp::SpawnProcess");
+}
+#else
 std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_info_to_args)
 {
     auto fds{SocketPair()};
@@ -173,7 +200,11 @@ std::tuple<ProcessId, SocketId> SpawnProcess(SpawnConnectInfoToArgsFn&& connect_
     }
     return {pid, fds[1]};
 }
+#endif // WIN32
 
+// Portable: parses the socket id the parent passed on the command line. Gridcoin
+// does not use the spawn path, but this contains no platform code, so it stays
+// unconditional.
 SocketId StartSpawned(const SpawnConnectInfo& connect_info)
 {
     try {
@@ -184,6 +215,11 @@ SocketId StartSpawned(const SpawnConnectInfo& connect_info)
     }
 }
 
+#ifdef WIN32
+std::array<SocketId, 2> SocketPair() { ThrowSpawnUnsupported("mp::SocketPair"); }
+ProcessId StartProcess(const std::vector<std::string>&) { ThrowSpawnUnsupported("mp::StartProcess"); }
+int WaitProcess(ProcessId) { ThrowSpawnUnsupported("mp::WaitProcess"); }
+#else
 std::array<SocketId, 2> SocketPair()
 {
     int pair[2];
@@ -211,5 +247,6 @@ int WaitProcess(ProcessId pid)
     }
     return status;
 }
+#endif // WIN32
 
 } // namespace mp

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -11,14 +11,23 @@
 
 #include <cerrno>
 #include <cstring>
-#include <fcntl.h>
 #include <stdexcept>
 #include <string>
+#include <system_error>
+#ifndef WIN32
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
-#include <system_error>
 #include <unistd.h>
+#else
+// winsock2.h must precede afunix.h/ws2tcpip.h. AF_UNIX for Windows lives in
+// <afunix.h> (Windows 10 1803+); sockaddr_un has the same sun_family/sun_path
+// layout ParseAddress relies on.
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <afunix.h>
+#endif
 
 namespace ipc {
 namespace {
@@ -56,13 +65,54 @@ fs::path ParseAddress(std::string& address, const fs::path& data_dir, struct soc
     return path;
 }
 
-//! Create an AF_UNIX SOCK_STREAM socket with close-on-exec set, so the IPC fd
-//! cannot leak into an exec'd child. Uses SOCK_CLOEXEC atomically where the
-//! platform provides it (Linux, the BSDs); falls back to fcntl(FD_CLOEXEC) on
-//! platforms that lack it (notably macOS). Returns -1 with errno set on failure.
+//! Platform-uniform socket helpers. Gridcoin/libmultiprocess carry socket
+//! descriptors as int (SocketId); on Windows a SOCKET is uintptr_t but AF_UNIX
+//! handles fit in the low 32 bits, so int is used here and converted only at the
+//! winsock boundary. INVALID_SOCKET is represented as -1 in int space.
+// compat.h provides a cross-platform SOCKET type and closesocket() macro
+// (myclosesocket: real closesocket() on Windows, close() on POSIX). It takes a
+// SOCKET& lvalue, so hand it one rather than an rvalue cast.
+void CloseSocket(int fd) { SOCKET s = static_cast<SOCKET>(fd); closesocket(s); }
+#ifdef WIN32
+int LastSocketError() { return ::WSAGetLastError(); }
+
+//! Translate a winsock error into a std::error_code whose comparison against
+//! std::errc still works: interfaces.cpp classifies a connect failure as
+//! connection_refused / no_such_file_or_directory / not_a_directory to detect a
+//! not-running daemon, and libstdc++'s system_category() does not map the WSA
+//! range. Map the connect-relevant codes to their POSIX errc; keep the raw code
+//! under system_category() otherwise so the message is still meaningful.
+//! TODO(win-mp W4): confirm on-device which WSA/Win32 code Windows AF_UNIX
+//! actually returns for a missing vs. unlistened socket path.
+std::error_code SocketErrorCode(int err)
+{
+    switch (err) {
+    case WSAECONNREFUSED:      return std::make_error_code(std::errc::connection_refused);
+    case WSAEACCES:            return std::make_error_code(std::errc::permission_denied);
+    case WSAEADDRINUSE:        return std::make_error_code(std::errc::address_in_use);
+    case WSAENETDOWN:
+    case WSAENETUNREACH:       return std::make_error_code(std::errc::network_unreachable);
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND: return std::make_error_code(std::errc::no_such_file_or_directory);
+    default:                   return std::error_code(err, std::system_category());
+    }
+}
+#else
+int LastSocketError() { return errno; }
+std::error_code SocketErrorCode(int err) { return std::error_code(err, std::system_category()); }
+#endif
+
+//! Create an AF_UNIX SOCK_STREAM socket that is not inherited by child processes,
+//! so the IPC fd cannot leak into an exec'd child. POSIX uses SOCK_CLOEXEC
+//! atomically where available (Linux, the BSDs) and falls back to
+//! fcntl(FD_CLOEXEC) (notably macOS); Windows uses WSA_FLAG_NO_HANDLE_INHERIT.
+//! Returns -1 with the platform socket error set on failure.
 int MakeCloexecStreamSocket()
 {
-#ifdef SOCK_CLOEXEC
+#ifdef WIN32
+    SOCKET s = ::WSASocketW(AF_UNIX, SOCK_STREAM, 0, nullptr, 0, WSA_FLAG_NO_HANDLE_INHERIT);
+    return s == INVALID_SOCKET ? -1 : static_cast<int>(s);
+#elif defined(SOCK_CLOEXEC)
     return ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 #else
     int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
@@ -84,15 +134,15 @@ int TryConnect(const struct sockaddr_un& addr, int& out_errno)
 {
     int fd = MakeCloexecStreamSocket();
     if (fd == -1) {
-        out_errno = errno;
+        out_errno = LastSocketError();
         return -1;
     }
     if (::connect(fd, (const struct sockaddr*)&addr, sizeof(addr)) == 0) {
         out_errno = 0;
         return fd;
     }
-    out_errno = errno;
-    ::close(fd);
+    out_errno = LastSocketError();
+    CloseSocket(fd);
     return -1;
 }
 
@@ -106,7 +156,7 @@ public:
         int connect_errno = 0;
         int fd = TryConnect(addr, connect_errno);
         if (fd == -1) {
-            throw std::system_error(connect_errno, std::system_category());
+            throw std::system_error(SocketErrorCode(connect_errno));
         }
         return fd;
     }
@@ -116,14 +166,20 @@ public:
         struct sockaddr_un addr;
         const fs::path path = ParseAddress(address, data_dir, addr);
 
-        // Socket directory 0700 (design section 4.3). Fail closed: if we cannot
-        // restrict the directory, refuse to listen rather than expose the socket
-        // in a world-accessible directory.
+        // Socket directory access control (design section 4.3). On POSIX we chmod
+        // the parent 0700 and fail closed: if we cannot restrict it, refuse to
+        // listen rather than expose the socket in a world-accessible directory.
+        // Windows has no chmod/umask for AF_UNIX; the socket instead inherits the
+        // NTFS ACL of the per-user-profile data directory (owner-only by default) --
+        // the same reliance Bitcoin Core has on the datadir ACL. Explicit DACLs are
+        // a hardening follow-up (design decision 3 / Windows hardening).
         if (path.has_parent_path()) {
             fs::create_directories(path.parent_path());
+#ifndef WIN32
             if (::chmod(path.parent_path().string().c_str(), 0700) != 0) {
                 throw std::system_error(errno, std::system_category());
             }
+#endif
         }
 
         // Try to bind; only if the path already exists (EADDRINUSE) do we probe it.
@@ -136,41 +192,63 @@ public:
         for (int attempt = 0; attempt < 2; ++attempt) {
             int fd = MakeCloexecStreamSocket();
             if (fd == -1) {
-                throw std::system_error(errno, std::system_category());
+                throw std::system_error(SocketErrorCode(LastSocketError()));
             }
+#ifndef WIN32
             // Create the socket node with 0600 from the start: bind() honors the
             // umask, so a permissive umask would otherwise leave a world-accessible
-            // window before an after-the-fact chmod.
+            // window before an after-the-fact chmod. (No umask on Windows; the
+            // datadir ACL governs access -- see the directory comment above.)
             const mode_t old_umask = ::umask(0177);
+#endif
             const int rc = ::bind(fd, (const struct sockaddr*)&addr, sizeof(addr));
-            const int bind_errno = errno;
+            const int bind_errno = LastSocketError();
+#ifndef WIN32
             ::umask(old_umask);
+#endif
             if (rc == 0) {
+#ifndef WIN32
                 // Belt-and-suspenders after the umask above. Fail closed: if the
                 // socket cannot be confirmed 0600, refuse to serve rather than
                 // leave the wallet IPC socket potentially accessible.
                 if (::chmod(path.string().c_str(), 0600) != 0) {
                     const int chmod_errno = errno;
-                    ::close(fd);
+                    CloseSocket(fd);
                     throw std::system_error(chmod_errno, std::system_category());
                 }
+#endif
                 return fd;
             }
-            ::close(fd);
-            if (bind_errno != EADDRINUSE || attempt == 1) {
-                throw std::system_error(bind_errno, std::system_category());
+            CloseSocket(fd);
+            const std::error_code bind_ec = SocketErrorCode(bind_errno);
+            if (bind_ec != std::errc::address_in_use || attempt == 1) {
+                throw std::system_error(bind_ec);
             }
             int probe_errno = 0;
             int probe_fd = TryConnect(addr, probe_errno);
             if (probe_fd != -1) {
-                ::close(probe_fd);
+                CloseSocket(probe_fd);
                 throw std::runtime_error(strprintf(
                     "Another process is already listening on the IPC socket '%s'; refusing to start.",
                     path.string()));
             }
+            // Stale socket path from a crashed node: the liveness probe above just
+            // confirmed nothing is listening, so remove it and retry the bind. On
+            // POSIX we additionally confirm it is a socket file before unlinking;
+            // on Windows an AF_UNIX socket is a reparse point that fs::symlink_status
+            // does not report as socket_file and bind() cannot overwrite an existing
+            // path, so remove any leftover path (best-effort).
+#ifndef WIN32
             if (fs::symlink_status(path).type() == fs::socket_file) {
                 fs::remove(path); // stale: safe to remove, then retry the bind
             }
+#else
+            try {
+                fs::remove(path);
+            } catch (const fs::filesystem_error&) {
+                // already gone -- fine, retry the bind
+            }
+#endif
         }
         throw std::runtime_error("Failed to bind the IPC socket"); // unreachable
     }

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -24,6 +24,7 @@
 // winsock2.h must precede afunix.h/ws2tcpip.h. AF_UNIX for Windows lives in
 // <afunix.h> (Windows 10 1803+); sockaddr_un has the same sun_family/sun_path
 // layout ParseAddress relies on.
+#include <climits>
 #include <mutex>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -136,7 +137,18 @@ int MakeCloexecStreamSocket()
     // WSA_FLAG_NO_HANDLE_INHERIT is the close-on-exec equivalent.
     SOCKET s = ::WSASocketW(AF_UNIX, SOCK_STREAM, 0, nullptr, 0,
                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
-    return s == INVALID_SOCKET ? -1 : static_cast<int>(s);
+    if (s == INVALID_SOCKET) return -1;
+    // The descriptor is carried as int (libmultiprocess SocketId) across the
+    // transport. Windows AF_UNIX handles fit in the low 32 bits in practice, but
+    // guard the assumption: a value that would not round-trip through int is
+    // unusable, so fail loudly here rather than silently truncate to a bogus
+    // (possibly negative, non-INVALID) fd downstream.
+    if (s > static_cast<SOCKET>(INT_MAX)) {
+        closesocket(s);
+        ::WSASetLastError(WSAEMFILE);
+        return -1;
+    }
+    return static_cast<int>(s);
 #elif defined(SOCK_CLOEXEC)
     return ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 #else

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -129,7 +129,13 @@ void EnsureWinsock() {} // no-op on POSIX
 int MakeCloexecStreamSocket()
 {
 #ifdef WIN32
-    SOCKET s = ::WSASocketW(AF_UNIX, SOCK_STREAM, 0, nullptr, 0, WSA_FLAG_NO_HANDLE_INHERIT);
+    // WSA_FLAG_OVERLAPPED is required: libmultiprocess drives these sockets with
+    // kj's IOCP async backend (overlapped AcceptEx / WSARecv). Without it kj cannot
+    // post an async accept, so the daemon never accepts and clients get
+    // WSAECONNREFUSED even though node.sock exists and listen() succeeded.
+    // WSA_FLAG_NO_HANDLE_INHERIT is the close-on-exec equivalent.
+    SOCKET s = ::WSASocketW(AF_UNIX, SOCK_STREAM, 0, nullptr, 0,
+                            WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     return s == INVALID_SOCKET ? -1 : static_cast<int>(s);
 #elif defined(SOCK_CLOEXEC)
     return ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -101,8 +101,9 @@ void EnsureWinsock()
 //! not-running daemon, and libstdc++'s system_category() does not map the WSA
 //! range. Map the connect-relevant codes to their POSIX errc; keep the raw code
 //! under system_category() otherwise so the message is still meaningful.
-//! TODO(win-mp W4): confirm on-device which WSA/Win32 code Windows AF_UNIX
-//! actually returns for a missing vs. unlistened socket path.
+//! On-device (W4): a missing socket path returns WSAECONNREFUSED (-> connection_refused,
+//! the clean no-daemon fallback, confirmed live). The unlistened case (a stale socket
+//! file with no listener) is still mapped generically -- not yet separately exercised.
 std::error_code SocketErrorCode(int err)
 {
     switch (err) {
@@ -210,8 +211,11 @@ public:
         // listen rather than expose the socket in a world-accessible directory.
         // Windows has no chmod/umask for AF_UNIX; the socket instead inherits the
         // NTFS ACL of the per-user-profile data directory (owner-only by default) --
-        // the same reliance Bitcoin Core has on the datadir ACL. Explicit DACLs are
-        // a hardening follow-up (design decision 3 / Windows hardening).
+        // the same reliance Bitcoin Core has on the datadir ACL. Confirmed on-device
+        // (icacls): node.sock and ipc.cookie grant only the owner, SYSTEM and
+        // Administrators -- no Everyone/Users/Authenticated-Users -- so an
+        // unprivileged local user cannot read the cookie. Explicit DACLs remain a
+        // possible hardening follow-up (design decision 3 / Windows hardening).
         if (path.has_parent_path()) {
             fs::create_directories(path.parent_path());
 #ifndef WIN32

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -24,6 +24,7 @@
 // winsock2.h must precede afunix.h/ws2tcpip.h. AF_UNIX for Windows lives in
 // <afunix.h> (Windows 10 1803+); sockaddr_un has the same sun_family/sun_path
 // layout ParseAddress relies on.
+#include <mutex>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <afunix.h>
@@ -76,6 +77,23 @@ void CloseSocket(int fd) { SOCKET s = static_cast<SOCKET>(fd); closesocket(s); }
 #ifdef WIN32
 int LastSocketError() { return ::WSAGetLastError(); }
 
+//! Initialize winsock once before the first IPC socket call. The daemon already
+//! calls WSAStartup for its P2P stack (net.cpp), but the -multiprocess GUI
+//! process connects to the node without necessarily starting that stack, so the
+//! IPC layer initializes winsock itself. WSAStartup is reference-counted, so this
+//! composes safely with net.cpp's call; a process-lifetime init needs no cleanup.
+void EnsureWinsock()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        WSADATA wsadata;
+        const int ret = ::WSAStartup(MAKEWORD(2, 2), &wsadata);
+        if (ret != 0) {
+            throw std::system_error(ret, std::system_category(), "WSAStartup");
+        }
+    });
+}
+
 //! Translate a winsock error into a std::error_code whose comparison against
 //! std::errc still works: interfaces.cpp classifies a connect failure as
 //! connection_refused / no_such_file_or_directory / not_a_directory to detect a
@@ -100,6 +118,7 @@ std::error_code SocketErrorCode(int err)
 #else
 int LastSocketError() { return errno; }
 std::error_code SocketErrorCode(int err) { return std::error_code(err, std::system_category()); }
+void EnsureWinsock() {} // no-op on POSIX
 #endif
 
 //! Create an AF_UNIX SOCK_STREAM socket that is not inherited by child processes,
@@ -151,6 +170,7 @@ class ProcessImpl : public Process
 public:
     int connect(const fs::path& data_dir, std::string& address) override
     {
+        EnsureWinsock();
         struct sockaddr_un addr;
         ParseAddress(address, data_dir, addr);
         int connect_errno = 0;
@@ -163,6 +183,7 @@ public:
 
     int bind(const fs::path& data_dir, std::string& address) override
     {
+        EnsureWinsock();
         struct sockaddr_un addr;
         const fs::path path = ParseAddress(address, data_dir, addr);
 

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -71,10 +71,18 @@ fs::path ParseAddress(std::string& address, const fs::path& data_dir, struct soc
 //! descriptors as int (SocketId); on Windows a SOCKET is uintptr_t but AF_UNIX
 //! handles fit in the low 32 bits, so int is used here and converted only at the
 //! winsock boundary. INVALID_SOCKET is represented as -1 in int space.
-// compat.h provides a cross-platform SOCKET type and closesocket() macro
-// (myclosesocket: real closesocket() on Windows, close() on POSIX). It takes a
-// SOCKET& lvalue, so hand it one rather than an rvalue cast.
-void CloseSocket(int fd) { SOCKET s = static_cast<SOCKET>(fd); closesocket(s); }
+// Close an IPC socket descriptor with explicit per-platform dispatch: ::close()
+// on POSIX; on Windows compat.h's closesocket() macro (myclosesocket -> the
+// winsock closesocket(), which takes a SOCKET& lvalue, so hand it one).
+void CloseSocket(int fd)
+{
+#ifdef WIN32
+    SOCKET s = static_cast<SOCKET>(fd);
+    closesocket(s);
+#else
+    ::close(fd);
+#endif
+}
 #ifdef WIN32
 int LastSocketError() { return ::WSAGetLastError(); }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -412,12 +412,12 @@ public:
 
     std::unique_ptr<Handler> handleRwSettingsUpdated(RwSettingsUpdatedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.RwSettingsUpdated_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleInitShutdown(InitShutdownFn fn) override
     {
-        return MakeSignalHandler(uiInterface.QueueShutdown_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.QueueShutdown_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     ScraperConvergenceSnapshot getScraperConvergenceSnapshot() override
@@ -436,37 +436,37 @@ public:
 
     std::unique_ptr<Handler> handleNotifyBlocksChanged(NotifyBlocksChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.NotifyBlocksChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.NotifyBlocksChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleNotifyNumConnectionsChanged(NotifyNumConnectionsChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.NotifyNumConnectionsChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.NotifyNumConnectionsChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleBannedListChanged(BannedListChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.BannedListChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.BannedListChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.NotifyAlertChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.NotifyAlertChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleMinerStatusChanged(MinerStatusChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.MinerStatusChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.MinerStatusChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handlePSGTPoolChanged(PSGTPoolChangedFn fn) override
     {
-        return MakeSignalHandler(uiInterface.PSGTPoolChanged_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.PSGTPoolChanged_connect(interfaces::GuardNotify(std::move(fn))));
     }
 
     std::unique_ptr<Handler> handleNotifyScraperEvent(NotifyScraperEventFn fn) override
     {
-        return MakeSignalHandler(uiInterface.NotifyScraperEvent_connect(std::move(fn)));
+        return MakeSignalHandler(uiInterface.NotifyScraperEvent_connect(interfaces::GuardNotify(std::move(fn))));
     }
 };
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -328,11 +328,32 @@ extern "C" void GuiTerminationSignalHandler(int)
     const ssize_t rc = ::write(g_signal_pipe[1], &byte, 1);
     (void)rc; // best-effort; nothing safe to do on failure inside a signal handler
 }
+//! Set O_NONBLOCK + FD_CLOEXEC on one end of the self-pipe. Returns false on any
+//! fcntl failure.
+static bool SetSelfPipeFdFlags(int fd)
+{
+    const int fl = ::fcntl(fd, F_GETFL, 0);
+    if (fl == -1 || ::fcntl(fd, F_SETFL, fl | O_NONBLOCK) == -1) return false;
+    const int fdfl = ::fcntl(fd, F_GETFD, 0);
+    if (fdfl == -1 || ::fcntl(fd, F_SETFD, fdfl | FD_CLOEXEC) == -1) return false;
+    return true;
+}
 static void InstallGuiTerminationHandler(QCoreApplication& app)
 {
-    if (::pipe2(g_signal_pipe, O_CLOEXEC | O_NONBLOCK) != 0) {
+    // pipe() + fcntl() rather than pipe2(O_CLOEXEC | O_NONBLOCK): pipe2() is
+    // Linux/BSD-only and absent on macOS. Set non-blocking and close-on-exec on
+    // both ends explicitly for portability.
+    if (::pipe(g_signal_pipe) != 0) {
         GUILogPrintf("IPC: could not install the GUI termination-signal handler "
-                     "(pipe2 failed); SIGTERM/SIGINT will hard-terminate the GUI");
+                     "(pipe failed); SIGTERM/SIGINT will hard-terminate the GUI");
+        return;
+    }
+    if (!SetSelfPipeFdFlags(g_signal_pipe[0]) || !SetSelfPipeFdFlags(g_signal_pipe[1])) {
+        GUILogPrintf("IPC: could not install the GUI termination-signal handler "
+                     "(fcntl failed); SIGTERM/SIGINT will hard-terminate the GUI");
+        ::close(g_signal_pipe[0]);
+        ::close(g_signal_pipe[1]);
+        g_signal_pipe[0] = g_signal_pipe[1] = -1;
         return;
     }
     auto* notifier = new QSocketNotifier(g_signal_pipe[0], QSocketNotifier::Read, &app);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -246,6 +246,56 @@ static void handleRunawayException(std::exception *e)
     exit(1);
 }
 
+//! Latch so the graceful-quit path (and its log line) fires only once even if
+//! many proxy calls fail in quick succession while the connection tears down.
+static std::atomic<bool> g_daemon_connection_lost{false};
+
+//! Post a graceful, popup-free GUI quit to the Qt main thread when the node
+//! connection is lost -- the same path a core-initiated shutdown takes
+//! (QueueShutdown / requestQuit). Deliberately NO modal dialog: a modal would
+//! hang an unattended or remote GUI. Idempotent and safe if the QCoreApplication
+//! is already gone.
+static void QuitOnDaemonConnectionLost(const char* reason)
+{
+    if (g_daemon_connection_lost.exchange(true)) return;
+    GUILogPrintf("IPC: %s; closing the GUI", reason);
+    if (QCoreApplication* qapp = QCoreApplication::instance()) {
+        QMetaObject::invokeMethod(qapp, [] { BitcoinGUI::requestQuit(); }, Qt::QueuedConnection);
+    }
+}
+
+//! QApplication subclass that contains exceptions escaping Qt event handlers.
+//! In -multiprocess mode the GUI polls the node with synchronous proxy calls from
+//! timers/slots; if the daemon vanishes mid-call, libmultiprocess raises "IPC
+//! client method call interrupted/called after disconnect", which must not
+//! propagate through Qt (Qt forbids exceptions crossing the event loop -- it is
+//! undefined behavior). Treat that as the node going away and route to the same
+//! silent quit as the on_disconnect callback; any genuine exception still goes to
+//! handleRunawayException, exactly as the outer try/catch around exec() does.
+class GridcoinApplication : public QApplication
+{
+public:
+    using QApplication::QApplication;
+
+    bool notify(QObject* receiver, QEvent* event) override
+    {
+        try {
+            return QApplication::notify(receiver, event);
+        } catch (std::exception& e) {
+            const std::string msg{e.what()};
+            if (msg.find("interrupted by disconnect") != std::string::npos ||
+                msg.find("called after disconnect") != std::string::npos) {
+                QuitOnDaemonConnectionLost("a GUI call was interrupted by the daemon disconnecting");
+                return true;
+            }
+            handleRunawayException(&e);
+        } catch (...) {
+            handleRunawayException(nullptr);
+        }
+        return false;
+    }
+};
+
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
@@ -306,7 +356,7 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin_locale);
 
     RegisterMetaTypes();
-    QApplication app(argc, argv);
+    GridcoinApplication app(argc, argv);
 
 #if defined(WIN32) && defined(QT_GUI)
     SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
@@ -686,22 +736,13 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 /*on_disconnect=*/[] {
                     // Fires on the IPC event-loop thread when the daemon vanishes
                     // without a clean shutdown message (crash / SIGKILL, or a stop
-                    // that raced the handshake). Post a graceful quit to the Qt
-                    // main thread — the same path as a core-initiated shutdown
-                    // (QueueShutdown) — so the GUI tears down cleanly instead of
-                    // faulting on the next call to a now-dead proxy. requestQuit()
-                    // is idempotent, so a duplicate (e.g. a drain that also failed)
-                    // is harmless.
-                    GUILogPrintf("IPC: lost connection to the Gridcoin daemon; closing the GUI");
-                    // Guard the instance(): a disconnect that races the GUI's own
-                    // shutdown (local teardown normally cancels this handler first,
-                    // but the connection delete is async) could arrive after the
-                    // QCoreApplication is gone.
-                    if (QCoreApplication* qapp = QCoreApplication::instance()) {
-                        QMetaObject::invokeMethod(qapp,
-                                                  [] { BitcoinGUI::requestQuit(); },
-                                                  Qt::QueuedConnection);
-                    }
+                    // that raced the handshake). Route to the shared graceful-quit
+                    // path (same as a core-initiated shutdown) so the GUI tears down
+                    // cleanly instead of faulting on the next call to a now-dead
+                    // proxy. Shares the once-latch with GridcoinApplication::notify(),
+                    // so whichever detects the loss first wins and the other is a
+                    // no-op; safe if the QCoreApplication is already gone.
+                    QuitOnDaemonConnectionLost("lost connection to the Gridcoin daemon");
                 });
             if (!node_connection)
             {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -48,6 +48,12 @@
 #include "decoration.h"
 
 #include <atomic>
+#ifndef WIN32
+#include <QSocketNotifier>
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+#endif
 #include <stdexcept>
 #include <thread>
 
@@ -304,6 +310,46 @@ public:
         return false;
     }
 };
+
+#ifndef WIN32
+//! Self-pipe so a Unix termination signal can reach the Qt event loop. The signal
+//! handler is async-signal-safe -- it only write()s one byte -- and a
+//! QSocketNotifier on the read end fires on the Qt main thread and requests a
+//! graceful quit (the same path QueueShutdown / on_disconnect use). This is only
+//! needed in the -multiprocess GUI: the monolithic GUI runs the core in-process
+//! and inherits init.cpp's HandleSIGTERM. Without it a SIGTERM/SIGINT -- e.g.
+//! `kill(1)`, or the wallet control script stopping a split instance's GUI while
+//! its core keeps running under systemd -- hits the default disposition and
+//! hard-terminates the GUI with no teardown or final log flush.
+static int g_signal_pipe[2] = {-1, -1};
+extern "C" void GuiTerminationSignalHandler(int)
+{
+    const char byte = 0;
+    const ssize_t rc = ::write(g_signal_pipe[1], &byte, 1);
+    (void)rc; // best-effort; nothing safe to do on failure inside a signal handler
+}
+static void InstallGuiTerminationHandler(QCoreApplication& app)
+{
+    if (::pipe2(g_signal_pipe, O_CLOEXEC | O_NONBLOCK) != 0) {
+        GUILogPrintf("IPC: could not install the GUI termination-signal handler "
+                     "(pipe2 failed); SIGTERM/SIGINT will hard-terminate the GUI");
+        return;
+    }
+    auto* notifier = new QSocketNotifier(g_signal_pipe[0], QSocketNotifier::Read, &app);
+    QObject::connect(notifier, &QSocketNotifier::activated, &app, [] {
+        char buf;
+        while (::read(g_signal_pipe[0], &buf, 1) > 0) { /* drain */ }
+        GUILogPrintf("IPC: received a termination signal; closing the GUI");
+        BitcoinGUI::requestQuit();
+    });
+    struct sigaction sa = {};
+    sa.sa_handler = GuiTerminationSignalHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    ::sigaction(SIGTERM, &sa, nullptr);
+    ::sigaction(SIGINT, &sa, nullptr);
+}
+#endif // !WIN32
 
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
@@ -961,6 +1007,14 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 // Regenerate startup link, to fix links to old versions
                 GUIUtil::SetStartOnSystemStartup(optionsModel.getStartAtStartup(), optionsModel.getStartMin());
 
+#ifndef WIN32
+                // In the split (-multiprocess) build the GUI runs no in-process
+                // core, so it lacks init.cpp's SIGTERM/SIGINT handler. Install one
+                // here so `kill`/the wallet control script can stop the GUI
+                // gracefully while the systemd core keeps running. (Windows uses
+                // WM_CLOSE via WinShutdownMonitor; the monolith uses the core's.)
+                if (multiprocess) InstallGuiTerminationHandler(app);
+#endif
                 app.exec();
 
                 // Stop the GUI-process-local URI-listener thread now that the

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -282,9 +282,18 @@ public:
         try {
             return QApplication::notify(receiver, event);
         } catch (std::exception& e) {
+            // Route IPC-disconnect exceptions to the silent quit rather than the
+            // modal fatal-error path. Detect them two ways so we do not depend
+            // solely on libmultiprocess's exact raise text:
+            //   (a) that raise text ("... interrupted/called after disconnect"), and
+            //   (b) the connection already being known lost -- once on_disconnect
+            //       (or a prior notify()) has latched g_daemon_connection_lost, the
+            //       GUI is tearing down and further proxy calls will keep throwing,
+            //       so any event-handler exception in that state is disconnect fallout.
             const std::string msg{e.what()};
-            if (msg.find("interrupted by disconnect") != std::string::npos ||
-                msg.find("called after disconnect") != std::string::npos) {
+            if (g_daemon_connection_lost.load()
+                || msg.find("interrupted by disconnect") != std::string::npos
+                || msg.find("called after disconnect") != std::string::npos) {
                 QuitOnDaemonConnectionLost("a GUI call was interrupted by the daemon disconnecting");
                 return true;
             }


### PR DESCRIPTION
## Overview

Brings the `-multiprocess` GUI/node split to **Windows (win64, mingw cross-build)** — the first Gridcoin multiprocess GUI running on Windows, validated live daemon↔GUI over AF_UNIX + Cap'n Proto / libmultiprocess. Bitcoin Core's multiprocess is Unix-only (no upstream template), so this is original work; it's tractable because AF_UNIX exists on Windows 10 1803+ (`<afunix.h>`, same `sockaddr_un` layout) and Gridcoin's IPC is **connect-only** (the GUI connects to an already-running node; nothing is ever spawned), so libmultiprocess's fork/spawn/socketpair machinery only has to compile, not run.

Driven by the existing `ENABLE_MULTIPROCESS` switch — no new build option. The monolithic and native (Linux) multiprocess builds are unaffected (all changes are `#ifdef`-fenced or WIN32-guarded; native build + unit tests are green).

## What's here

**Build path (win64 `ENABLE_MULTIPROCESS` now configures + links):**
- Drop the `if(WIN32) FATAL_ERROR` kill-switch (`CMakeLists.txt`); link `ws2_32`/`mswsock` for `gridcoin_ipc` on WIN32.
- `set(CMAKE_INCLUDE_CURRENT_DIR OFF)` for `src/ipc`: with `src/ipc` on the header path, mingw's `<pthread.h>` (`#include <process.h>`) resolved to our `ipc/process.h`, dragging `fs.h`/`<fstream>` into libstdc++'s gthreads bootstrap and shattering `<ios>`/`<istream>` in every generated proxy TU. Our sources use `ipc/…`, generated proxies use `ipc/capnp/…`, so the current dir isn't needed.

**libmultiprocess subtree:**
- `util.cpp`: fence the POSIX spawn/socketpair/waitpid path (`spawn.h`/`sys/socket.h`/`sys/wait.h`/`sys/resource.h` + `SpawnProcess`/`SocketPair`/`StartProcess`/`WaitProcess`) `#ifndef WIN32` with throwing Windows stubs — connect-only means they never run. `ThreadName` works as-is.
- `proxy.cpp`: the `mp::EventLoop` cross-thread wakeup wrote its byte via `kj::FdOutputStream`, but on Windows kj's pipe is socket-backed (`getFd()` is none) so the ctor threw. Add a minimal `Win32SocketOutputStream` that writes the wakeup byte with `send()` to the SOCKET from `getWin32Handle()`. `loop()`/`post()` and the entire POSIX path are unchanged. `NOGDI` before `<winsock2.h>` so `wingdi`'s `#define ERROR 0` can't clobber `KJ_LOG(ERROR, …)`.

**Transport (`src/ipc/`), descriptor carried as `int` (libmultiprocess `SocketId`), converted only at the winsock boundary:**
- `process.cpp`: `<afunix.h>`/winsock headers; `WSASocketW(… WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT)` (**OVERLAPPED is required** — kj's IOCP backend posts overlapped `AcceptEx`; without it the daemon never accepts and clients get `WSAECONNREFUSED` despite a bound `node.sock`); `SocketErrorCode()` maps the connect-relevant WSA codes to `std::errc` so the no-daemon `auto` fallback still classifies correctly; `chmod`/`umask` fenced out (Windows relies on the per-user datadir NTFS ACL); Windows stale-socket removal; one-time `WSAStartup`; and a guard against a socket handle that wouldn't round-trip through `int`.
- `capnp/protocol.cpp`: winsock header + `WSAGetLastError()` on `listen()`.
- `handshake.cpp`: Windows `WriteFileAtomic` via `_wsopen_s(_O_NOINHERIT/_SH_DENYRW)` + `_commit` + `MoveFileExW(REPLACE_EXISTING|WRITE_THROUGH)` (boost `fs::rename` overwrite on Windows is version-dependent).
- `interfaces.cpp`: `FdGuard` closes via compat.h's cross-platform `closesocket`.

**Disconnect hardening (not Windows-specific — hardens the multiprocess seam on all platforms; surfaced by the live win64 shutdown test against a mid-sync, high-notification-velocity node):**
- `interfaces::GuardNotify` (`handler.h`/`handler.cpp`): wraps every server-side `uiInterface.*_connect(...)` forwarder so a "called after disconnect" raise can't unwind into a core thread (`ProcessMessages`). Applied across `node/interfaces.cpp` + `gridcoin/interfaces.cpp`.
- `GridcoinApplication::notify()` (`bitcoin.cpp`): contains exceptions escaping Qt event handlers — an in-flight GUI→node proxy call interrupted by daemon disconnect is routed to the same silent `requestQuit` path as `on_disconnect` (shared once-latch), not the modal fatal-error path (a modal would hang a remote/unattended GUI).

## Validation

Live on a native Windows 11 VM (win64 build, default mainnet datadir):
- **Connect + handshake** — GUI connects to the daemon over `node.sock`; account overview, balances, tx history render from the remote node.
- **Live notifications** — block-tip updates flow core→GUI across the seam (sync progress display), then **synced to 100%** and steady-state operation with no issues (sustained bidirectional IPC under load).
- **Clean shutdown** — Ctrl-C the daemon → GUI self-quits, both processes exit with **zero exceptions** on either side (after the two hardening guards above).
- **Separate GUI log** (`debug_gui.log`) distinct from the daemon's `debug.log` (the #3227 feature) works.

Build/test: native + win64 both build clean (`-DENABLE_GUI=ON -DUSE_QT6=ON -DENABLE_MULTIPROCESS=ON`); native `interfaces_tests` pass; lint clean. Includes an adversarial self-review (two findings fixed in the last commit; the rest documented).

## Known follow-ups (not blockers for review)
- `TODO(win-mp W4)` on-device security validation: exact WSA/Win32 codes Windows AF_UNIX returns; the cookie atomic-replace semantics; and the NTFS-ACL substitute for the POSIX fail-closed `chmod 0600/0700` invariant (explicit DACLs are a possible hardening).
- Native (Linux) multiprocess **runtime** re-validation of the two disconnect guards on the mesh (native build + unit tests pass; runtime unchanged in intent).
- Part of the multiprocess program (tracking issue #3153).
