### PR TITLE
build: guard the libmultiprocess subtree find_package(CapnProto) for non-idempotent capnp configs

### DIFF
--- a/src/ipc/libmultiprocess/CMakeLists.txt
+++ b/src/ipc/libmultiprocess/CMakeLists.txt
@@ -13,14 +13,32 @@ endif()
 include("cmake/compat_find.cmake")
 
 find_package(Threads REQUIRED)
-find_package(CapnProto 0.9 QUIET NO_MODULE)
- if(NOT CapnProto_FOUND)
+# Embedding guard (Gridcoin): when the parent project has already imported Cap'n
+# Proto (Gridcoin's top-level CMakeLists calls find_package(CapnProto) before
+# adding this subtree), skip the redundant find_package here. Some system Cap'n
+# Proto CMake configs are not idempotent -- notably the pkg-config fallback in
+# Debian/Ubuntu's capnp 1.0.x config (_capnp_import_pkg_config_target) calls
+# add_library() unguarded, so a second find_package fails with "cannot create
+# imported target CapnProto::capnp because another target with the same name
+# already exists".
+#
+# The found and minimum-version requirements are enforced below regardless of
+# which side imported Cap'n Proto: the imported target's existence is the
+# authoritative "found" signal, and the 0.9 floor is re-checked against the
+# inherited CapnProto_VERSION so guarding never silently weakens it.
+if(NOT TARGET CapnProto::capnp)
+  find_package(CapnProto 0.9 QUIET NO_MODULE)
+endif()
+ if(NOT TARGET CapnProto::capnp)
    message(FATAL_ERROR
      "Cap'n Proto is required but was not found.\n"
      "To resolve, choose one of the following:\n"
      "  - Install Cap'n Proto (version 1.0+ recommended)\n"
      "  - For Bitcoin Core compilation build with -DENABLE_IPC=OFF to disable multiprocess support\n"
    )
+ endif()
+ if(DEFINED CapnProto_VERSION AND CapnProto_VERSION VERSION_LESS 0.9)
+   message(FATAL_ERROR "Cap'n Proto 0.9 or newer is required, but version ${CapnProto_VERSION} was found.")
  endif()
 
 # Cap'n Proto compatibility checks


### PR DESCRIPTION
## Problem

`-DENABLE_MULTIPROCESS=ON` configure fails on boxes whose system Cap'n Proto ships a non-idempotent CMake config:

```
CMake Error at .../CapnProto/CapnProtoTargets.cmake:135 (add_library):
  add_library cannot create imported target "CapnProto::capnp" because
  another target with the same name already exists.
Call Stack (most recent call first):
  .../CapnProtoTargets.cmake:177 (_capnp_import_pkg_config_target)
  .../CapnProtoConfig.cmake:112 (include)
  src/ipc/libmultiprocess/CMakeLists.txt:16 (find_package)
```

Reproduced on **Ubuntu 24.04 armv7l** with `capnproto 1.0.1-4`.

## Root cause

`find_package(CapnProto)` is called twice: once by Gridcoin's top-level `CMakeLists.txt` (needed so `src/ipc` can link the targets), then again by the vendored libmultiprocess subtree at `src/ipc/libmultiprocess/CMakeLists.txt:16`.

Whether the second call is a no-op depends on the distro's capnp CMake config, **not** the architecture:

| | config style | second `find_package` |
|---|---|---|
| openSUSE, capnp **1.5.0** | standard exported targets (early-return when already defined) | harmless no-op |
| Ubuntu, capnp **1.0.x** | pkg-config fallback `_capnp_import_pkg_config_target`, `add_library()` **unguarded** | **error: target already exists** |

So it's a packaging bug in the older/pkg-config-fallback capnp config, correlated with version — it bites any box with that config (Ubuntu-packaged capnp generally), which is why it never surfaced on the openSUSE build hosts or in depends builds.

## Fix

Guard the subtree's `find_package` with `if(NOT TARGET CapnProto::capnp)` — skip it when the parent project has already imported Cap'n Proto. `CapnProto_FOUND` and the version variables are inherited from the parent scope, so the subtree's FOUND check and compatibility checks still work. It's a no-op on idempotent configs and skips the buggy re-import on the pkg-config-fallback config — agnostic to capnp version/packaging.

## Validation

`-DENABLE_MULTIPROCESS=ON` configure now passes on **both**:
- openSUSE, capnp 1.5.0 (idempotent exported targets) — regression check, still clean.
- Ubuntu 24.04 armv7l, capnp 1.0.1 (pkg-config fallback) — previously failed, now configures and proceeds to compile.

## Notes

- This touches the vendored `src/ipc/libmultiprocess` subtree (like the existing Windows patches). It's a good candidate to upstream to bitcoin-core/libmultiprocess, since the double-`find_package`-on-embedding hazard is general.
- Draft pending the full armv7l compile completing (surfacing any 32-bit issues is separate from this configure fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)