### PR TITLE
gui: complete Phase 2 — mixed-build banner, serve-side handshake test, interface spec (stacked on #3237)

### DIFF
--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -149,8 +149,8 @@ GUI, close it or `SIGTERM` it as above.
   first and confirm `IPC: serving …` appears in its `debug.log`.
 - **Version/schema mismatch on connect.** The GUI and daemon are different builds.
   Use matching `gridcoinresearch` / `gridcoinresearchd` binaries. If only the commit
-  differs (not the schema), the GUI still connects and just logs a mixed-build
-  warning; suppress it per instance with `-nobuildwarn`.
+  differs (not the schema), the GUI still connects and shows a dismissible mixed-build
+  warning banner (also logged); suppress it per instance with `-nobuildwarn`.
 - **"The wallet in this data directory appears to have changed…"** The GUI binds, per
   data directory, to the wallet the daemon is serving (a per-wallet identity kept in
   `wallet.dat`). It shows this prompt when a *different* wallet answers — e.g. you

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -148,7 +148,23 @@ GUI, close it or `SIGTERM` it as above.
   different `-datadir`, or (Windows) is running as a different user. Start the daemon
   first and confirm `IPC: serving …` appears in its `debug.log`.
 - **Version/schema mismatch on connect.** The GUI and daemon are different builds.
-  Use matching `gridcoinresearch` / `gridcoinresearchd` binaries.
+  Use matching `gridcoinresearch` / `gridcoinresearchd` binaries. If only the commit
+  differs (not the schema), the GUI still connects and just logs a mixed-build
+  warning; suppress it per instance with `-nobuildwarn`.
+- **"The wallet in this data directory appears to have changed…"** The GUI binds, per
+  data directory, to the wallet the daemon is serving (a per-wallet identity kept in
+  `wallet.dat`). It shows this prompt when a *different* wallet answers — e.g. you
+  replaced or restored `wallet.dat`. Choose **Trust this wallet** to accept and
+  remember the new one, or **Quit**. The check is chain-independent: a resync,
+  re-genesis, or blockchain reset does **not** trigger it. For instances where you
+  swap wallets deliberately (or start the GUI unattended), pass `-autotrustidentity`
+  to re-bind silently instead of prompting. Note: the daemon itself always serves
+  whatever `wallet.dat` is in its datadir — this prompt only stops the *GUI* from
+  silently showing you a different wallet.
+- **First multiprocess-capable load rewrites `wallet.dat`.** The one-time wallet
+  identity (a random tag, not key material) is written on first load. If your
+  `wallet.dat` is a symlink (e.g. shared across instances), back up the symlink
+  *target*.
 - **The GUI won't share a log with the node.** In `-multiprocess` mode the GUI uses
   `debug_gui.log`; set `-guilogfile` to a distinct path if you have overridden the
   node's `-debuglogfile`.

--- a/doc/multiprocess_design.md
+++ b/doc/multiprocess_design.md
@@ -153,7 +153,7 @@ sequence in §4.3), the build-info exchange compares:
 | `schema_major` | Hard fail (incompatible wire format) |
 | `schema_minor` | GUI > node: refuse. GUI < node: soft (log-only) |
 | `protocol_version` | Hard fail outside the compatible range |
-| `git_commit` | Soft warning (logged; suppress per instance with `-nobuildwarn`). A dismissible in-window banner is the intended surface (follow-up) |
+| `git_commit` | Soft warning: logged and shown as a dismissible in-window banner (`BitcoinGUI::showBuildMismatchWarning`), suppressible per instance with `-nobuildwarn` |
 | `built_at` | Informational (About dialog) |
 
 Dev builds with dirty trees carry a `-dirty` suffix in `git_commit` (from

--- a/doc/multiprocess_design.md
+++ b/doc/multiprocess_design.md
@@ -115,14 +115,26 @@ build node-emitted strings are English and only GUI-owned strings are translated
 
 ### 4.2 Matching policy (Stage 2)
 
-The node writes `<datadir>/<network>/node_identity.json` (random per-datadir UUID,
-network, canonical datadir, genesis hash). The GUI persists the expected
-`node_id` + `network` (QSettings) on first successful connect and, on every later
-launch, hard-fails when a *different* `node_id` answers at the same socket path —
-that is what catches a moved datadir, a `-reindex` identity rotation, or a foreign
-node squatting the socket. The comparison is between the stored expectation and the
-identity the node reports over IPC, never merely between the json file and the node
-that wrote it.
+The node reports its identity over IPC (post-authentication) as
+`{identity_token, network}`, where `identity_token = SHA256(domain-tag ‖ wallet_uuid)`
+and `wallet_uuid` is a random 16-byte tag minted once into `wallet.dat` (the
+`"walletuuid"` record; skipped on mockable chains, whose DB is not persisted).
+Identity thus fingerprints *which wallet* the node serves, deliberately independent
+of chain state and datadir path: a chain reset / re-genesis / resync does **not**
+change it, but replacing the wallet in the same datadir does. The GUI persists the
+token (QSettings, keyed by a hash of the canonical datadir — no path is stored) on
+first successful connect and, on every later launch, hard-fails when a *different*
+token answers — prompting "Trust this wallet / Quit" (Quit exits; Trust re-binds).
+`-autotrustidentity` turns the prompt into a silent re-bind + log, for instances that
+swap wallets deliberately and for headless/scripted starts. An empty token (mockable
+chain, or the UUID could not be minted) means "unavailable": the GUI proceeds unbound
+unless a token was already stored, which is treated as a change, never a silent skip.
+The comparison is always between the GUI's stored expectation and the token the node
+reports over the authenticated IPC channel.
+
+The identity binding guards the GUI against *misattribution* (silently showing a
+different wallet's balances); it is not a core-level control — the daemon loads
+whatever `wallet.dat` is in its datadir regardless.
 
 Both binaries embed `git_commit / built_at / schema_major / schema_minor /
 protocol_version` at compile time. The commit fingerprint builds on the existing
@@ -136,15 +148,17 @@ sequence in §4.3), the build-info exchange compares:
 
 | Field | Mismatch policy |
 |---|---|
-| `node_id` / `network` | Hard fail with explanatory dialog |
+| `identity_token` | Prompt "Trust this wallet / Quit" (re-bind or exit); `-autotrustidentity` silently re-binds. Empty-but-stored = treated as a change |
+| `network` | Hard fail with explanatory dialog |
 | `schema_major` | Hard fail (incompatible wire format) |
-| `schema_minor` | GUI > node: refuse. GUI < node: soft warn |
+| `schema_minor` | GUI > node: refuse. GUI < node: soft (log-only) |
 | `protocol_version` | Hard fail outside the compatible range |
-| `git_commit` | Soft-warn banner, dismissible, keyed by the commit-hash pair |
+| `git_commit` | Soft warning (logged; suppress per instance with `-nobuildwarn`). A dismissible in-window banner is the intended surface (follow-up) |
 | `built_at` | Informational (About dialog) |
 
-Dev builds with dirty trees get an explicit `dirty-<parent_commit>-<diff_hash>` identity;
-the banner simply triggers more often. Schema evolution: additive changes bump minor;
+Dev builds with dirty trees carry a `-dirty` suffix in `git_commit` (from
+`FormatFullVersion()`), so the soft warning simply triggers more often. Schema
+evolution: additive changes bump minor;
 breaking changes (field reorder/renumber/removal) require a major bump and a
 one-version transition release where the node speaks both — CI enforces via a
 schema-diff lint against the previous release tag.
@@ -175,15 +189,18 @@ schema-diff lint against the previous release tag.
 
 The connect-time sequence, in order (steps 1–7 add ~5–10 ms to startup):
 
-1. GUI reads `node_identity.json` → expected `node_id`, `network`
+1. GUI reads its stored identity expectation (QSettings, keyed by the canonical datadir)
 2. GUI reads `ipc.cookie` (absent cookie ⇒ node not running, do not dial)
 3. `connect(node.sock)`
 4. Peer-identity check (`SO_PEERCRED` / `LOCAL_PEERCRED` /
    `SIO_AF_UNIX_GETPEERPID`; best-effort defense-in-depth per the
    authentication layers listed earlier in this section) → hard fail on mismatch
 5. `Init::authenticate(cookie)` → hard fail on mismatch
-6. `Init::getBuildInfo()` → schema/protocol/commit comparison per §4.2
-7. `Init::getIdentity()` → compare against the stored expectation per §4.2
+6. `Init::getBuildInfo()` → schema/protocol comparison per §4.2
+7. `Init::getIdentity()` → network hard-fail + compare `identity_token` against the
+   stored expectation per §4.2 (prompt / `-autotrustidentity` re-bind). Fetched
+   together with step 6 in one guarded round-trip; an IPC throw here is a clean
+   failure, distinct from an empty token
 8. `Init::makeNode()` / `makeWallet()` / … → proceed
 
 Authentication (step 5) precedes every other exchange — build and identity

--- a/doc/multiprocess_interface_spec.md
+++ b/doc/multiprocess_interface_spec.md
@@ -391,9 +391,21 @@ versioned-refetch revision (`SideStakeSnapshot::local_revision`, design §4.4).
 `entries`, `localRevision`, `addLocal`, `setAllocation`, `setDescription`,
 `deleteLocal`, `handleRwSettingsUpdated`, `handleMandatorySideStakeChanged`.
 
-**This interface is served only in the monolithic build.** There is no
-`sidestake.capnp`, and `init.capnp`'s `Init` has no `makeSideStakeManager`
-method, so on this branch an IPC client **cannot** reach it (§10).
+**Not served over the IPC wire on this branch.** There is no `sidestake.capnp`, and
+`init.capnp`'s `Init` has no `makeSideStakeManager` method. The bundled MP GUI's
+sidestake table is nonetheless populated because `OptionsModel` (and its
+`SideStakeTableModel`) is still constructed from a **local, in-GUI-process**
+`SideStakeManager` — `bitcoin.cpp` mints it via `gui_init = MakeGridcoinInit();
+gui_init->makeSideStakeManager()` — a deliberately un-migrated Phase-2 piece (the
+`bitcoin.cpp` comment: *"Phase 2 will hand this out from the single process Init
+instead of a locally-minted one"*). That local manager reads the **GUI process's own**
+`SideStakeRegistry`, which reflects the settings-based *local* sidestakes in the shared
+datadir but **not** contract-derived *mandatory* sidestakes or any registry state that
+requires core block sync. So an alternative front end cannot obtain the node's full
+sidestake state through `interfaces::` today; use `Node::executeRpcConsoleCommand` (the
+sidestake RPCs) for the authoritative node-side view. **A follow-up migrates the
+core-state-owned parts of `OptionsModel` (sidestake included) onto the remote node Init
+over IPC** — see §10, gap 1.
 
 ---
 
@@ -648,13 +660,23 @@ foreign client is a real undertaking:
 
 Reported honestly so nobody designs against a contract that is not there yet:
 
-1. **`SideStakeManager` is not reachable over IPC.** It is a full member of the
-   C++ `Init` interface (`makeSideStakeManager`), is wrapped by `ServeInit`, and
-   works in the monolith — but there is **no `sidestake.capnp`** and **no
-   `makeSideStakeManager` in `init.capnp`**. Over the IPC seam it simply does not
-   exist on this branch. A front end that needs sidestake management must fall
-   back to `Node::executeRpcConsoleCommand` (the sidestake RPCs) until the schema
-   is added.
+1. **`SideStakeManager` is not on the IPC wire, and the MP GUI's sidestake table
+   runs on a local fallback.** `makeSideStakeManager` is a full member of the C++
+   `Init` interface and is wrapped by `ServeInit`, but there is **no
+   `sidestake.capnp`** and **no `makeSideStakeManager` in `init.capnp`**, so it is
+   not served over IPC. The bundled MP GUI still shows a sidestake table because
+   `OptionsModel` is constructed from a **local, in-GUI-process** `SideStakeManager`
+   (`bitcoin.cpp`: `gui_init = MakeGridcoinInit()`), reading the GUI process's own
+   registry — settings-based local sidestakes only, **not** contract-derived
+   mandatory sidestakes or core-synced state. This is a real gap, not just a missing
+   schema: the whole of `OptionsModel` that reads/writes *core-owned* state (the
+   sidestake registry, and any node rw-settings) currently runs against GUI-local
+   globals rather than the node. **A follow-up migrates the core-state-owned parts
+   of `OptionsModel` onto the remote node Init over IPC** (which requires adding
+   `sidestake.capnp` + `makeSideStakeManager @13` to `init.capnp`, and restructuring
+   GUI startup so `OptionsModel` is wired from the remote Init). Until then, use
+   `Node::executeRpcConsoleCommand` (the sidestake RPCs) for the authoritative
+   node-side view.
 2. **The peer-identity check is documented but unimplemented.** Design §4.3
    step 4 (`SO_PEERCRED` / `LOCAL_PEERCRED` / `SIO_AF_UNIX_GETPEERPID`) is called
    "best-effort defense-in-depth," but neither `ConnectToNode`/`ClientHandshake`

--- a/doc/multiprocess_interface_spec.md
+++ b/doc/multiprocess_interface_spec.md
@@ -1,0 +1,690 @@
+# Multiprocess Interface Specification — building an alternative front end
+
+This document is the **interface contract** for talking to a running
+`gridcoinresearchd -multiprocess` node over its IPC seam, from the point of view
+of someone writing an *alternative front end* — a different GUI, a TUI, or an
+automation client — in place of the bundled Qt wallet.
+
+It describes the interface **as it exists on this branch** (post the
+identity-handshake work: `NodeIdentity` is `{identity_token, network}`, IPC
+schema major is `2`). It is a companion to, not a replacement for:
+
+- `doc/multiprocess_design.md` — the design of record (rules, decisions, phasing).
+- `doc/multiprocess.md` — how to build, run, and stop the split binaries.
+
+Where those docs describe *why* and *how to run*, this one describes *what a
+client may call and must handle*. Every claim below traces to a symbol in
+`src/interfaces/*.h`, `src/ipc/*`, or `src/ipc/capnp/*.capnp`; when something is
+not yet exposed or is a known limitation, it says so explicitly (see
+§10, Gaps).
+
+---
+
+## 1. Overview and model
+
+The multiprocess build (RFC #2937) splits the historically monolithic wallet
+into two independently-started binaries:
+
+- **`gridcoinresearchd -multiprocess`** — the *node*. It runs the whole core
+  (chain, P2P, staking, scraper, and **the wallet**), and after core init it
+  listens on an AF_UNIX socket and *serves* a tree of `interfaces::` objects
+  over Cap'n Proto RPC (libmultiprocess). See `src/gridcoinresearchd.cpp`.
+- **`gridcoinresearch -multiprocess`** — the bundled *GUI client*. It starts no
+  core; it *connects* to the node's socket and drives the served interfaces. See
+  `src/qt/bitcoin.cpp`.
+
+An alternative front end plays exactly the role of `gridcoinresearch`: it is a
+**connect-only client**. Key consequences:
+
+- **The node is never spawned by the client.** Gridcoin's `interfaces::Ipc`
+  deliberately omits `spawnProcess` / `startSpawnedProcess`
+  (`src/interfaces/ipc.h`): the daemon is started separately (by the user, a
+  service manager, etc.), and the client only ever `connectAddress()`es. You
+  start the daemon yourself and connect to it.
+- **The wallet stays in the node, in every build configuration.** No key
+  material crosses the boundary. Signing, key generation, and passphrase
+  handling all happen node-side (see the wallet interface, §4.4, and the
+  security notes, §7). The client sends *requests* and receives *value
+  snapshots*.
+- **Only value types cross the boundary.** Every method argument and return is a
+  pointer-free, copyable, Qt-free value type. This is enforced at compile time
+  by `INTERFACES_ASSERT_MARSHALABLE` (`src/interfaces/marshal.h`) on every DTO
+  and, ultimately, by the Cap'n Proto schema generation.
+
+### Responsibility split
+
+| The node owns | The front end owns |
+|---|---|
+| Chain state, P2P, staking, scraper, contracts | Presentation, layout, localization/translation |
+| **The wallet** and all key material; signing, encryption, unlock | Deciding *when* to unlock and prompting the user |
+| All fee arithmetic, coin selection, tx construction/commit | Rendering fee/quantity summaries the node computed |
+| Filtering, sorting, and windowing the transaction table | Displaying the served row slice; driving cursors |
+| Validation of every address/amount/allocation on submit | Optional pre-validation for UX (never load-bearing) |
+| Identity token minting; cookie authentication | Cookie reading; identity *binding* (remembering it) |
+
+The last row matters: the node **authenticates** the client (cookie), but the
+node does **not** decide whether the client should trust *this* wallet. Identity
+*binding* — "is this the same wallet I connected to last time?" — is the
+client's own responsibility (§2, §7).
+
+---
+
+## 2. Establishing a connection
+
+The reference implementation is `ipc::ConnectToNode()`
+(`src/ipc/connect.{h,cpp}`), which returns a `GuiConnection`
+(the `Ipc`, the remote `Init`, and the `HandshakeResult`). A client written in
+C++ against libmultiprocess can call it directly; a client in another language
+reproduces its steps (§9).
+
+### 2.1 Socket path
+
+The node listens on:
+
+```
+<datadir>/<network>/node.sock
+```
+
+`ParseAddress()` (`src/ipc/process.cpp`) resolves the address string `"unix"`
+(or `"auto"`) to `<data_dir>/node.sock`, where `<data_dir>` is already the
+network-specific directory (`GetDataDir()`; testnet/regtest nest under the base
+datadir). A custom path may be given as `"unix:<path>"`. The socket is created
+`0600`, its parent directory forced to `0700`, and the node **fails closed** if
+it cannot restrict them (`ProcessImpl::bind`).
+
+The node caps the listener at **one simultaneous connection**
+(`mp::ListenConnections<messages::Init>(..., /*max_connections=*/1)` in
+`src/ipc/capnp/protocol.cpp`). An alternative front end must therefore be the
+*only* client attached; a second connection will not be accepted while one is
+live (see §10).
+
+### 2.2 The cookie
+
+Authentication is a shared-secret cookie:
+
+- The node writes a fresh 256-bit random cookie to `<datadir>/<network>/ipc.cookie`
+  (hex, `0600`, atomic temp-file + rename) **once per startup**
+  (`ipc::WriteCookie`, `src/ipc/handshake.cpp`).
+- The client reads it with `ipc::ReadCookie` (`src/ipc/handshake.cpp`), which
+  trims trailing whitespace. **An absent cookie means the node has never run on
+  this datadir** (or never with `-multiprocess`): there is no credential and
+  nothing to dial — do not attempt to connect.
+- The cookie is **not** removed at shutdown, so a stale cookie can outlive a
+  stopped node. That is harmless: the subsequent `connect()` simply fails with
+  no listener.
+
+### 2.3 The handshake, step by step
+
+The client-side half is `ipc::ClientHandshake()` (`src/ipc/handshake.cpp`). The
+full ordered sequence a client must perform:
+
+1. **Read the stored identity expectation** (client-side; see §2.4). The bundled
+   GUI keys this by a hash of the canonical datadir in `QSettings`.
+2. **Read `ipc.cookie`.** Absent ⇒ node not running; stop.
+3. **`connect(node.sock)`** — obtain the remote `Init` proxy
+   (`Ipc::connectAddress("unix", on_disconnect)`). Returns null if the address
+   is empty/disabled or (for `"auto"`) if nothing is listening; throws on an
+   unexpected socket error.
+4. **`Init::authenticate(cookie)`** — the **first** IPC call. The node compares
+   it constant-time (`ConstantTimeEqual`) against the cookie it wrote. A `false`
+   result is a hard fail: **build and identity are never served to an
+   unauthenticated peer**, and every other method throws until `authenticate()`
+   has returned `true` (`ServeInit::RequireAuth`, `src/ipc/serve_init.cpp`).
+5. **`Init::getBuildInfo()`** — the node's `BuildInfo` (`git_commit`,
+   `built_at`, `schema_major`, `schema_minor`, `protocol_version`). Compare per
+   §3.
+6. **`Init::getIdentity()`** — the node's `NodeIdentity` (`identity_token`,
+   `network`). Steps 5 and 6 are fetched in **one guarded round-trip**.
+7. **Compatibility checks** (all inside one `try`; see §2.5).
+8. **`Init::makeNode()` / `makeWallet()` / …** — proceed to the interface tree.
+
+Only after a successful handshake may the client call the `makeX` factories.
+The node additionally polls `Init::isCoreReady()` readiness: `authenticate()`
+succeeds as soon as the listener is up, and `makeWallet()` / `makeMRC()` / etc.
+return null until wallet startup completes — a client should tolerate a null
+factory result and retry, exactly as the bundled GUI loops on `isCoreReady()`
+(`src/qt/bitcoin.cpp`).
+
+### 2.4 Identity binding (client-side)
+
+`getIdentity()` returns `identity_token = HEX(SHA256(domain-tag ‖ LE32(len) ‖
+wallet_uuid))` (`ipc::ComputeIdentityToken`), where `wallet_uuid` is a random
+16-byte tag minted once into `wallet.dat` (`CWallet::GetWalletUuid`,
+`src/wallet/wallet.h`). The token fingerprints *which wallet* the node serves; it
+is deliberately independent of chain state and datadir path (a resync does not
+change it; replacing the wallet does). The raw UUID never crosses the wire — only
+the hash.
+
+The node does not judge the token; the *client* decides whether to trust it. The
+pure comparison helper is `ipc::CheckIdentityBinding(reported, stored)`, which
+returns a `BindOutcome`:
+
+| `BindOutcome` | Meaning | Client action (reference: `ResolveNodeIdentity`) |
+|---|---|---|
+| `FirstSeen` | Nothing stored, token present | Persist it, proceed |
+| `Match` | Stored == reported | Proceed |
+| `Mismatch` | Stored != reported | Prompt "trust / quit", or rebind under a `-autotrustidentity`-style flag |
+| `UnavailableFresh` | Reported empty, nothing stored | Proceed unbound (log once) |
+| `UnavailableStored` | Reported empty **but** a token was stored | Treat as a **mismatch** (downgrade signal), never a silent skip |
+
+An **empty token = "unavailable"** (mockable/regtest chain, or the UUID could
+not be minted). The `UnavailableStored` case is the important adversarial edge:
+if the client once bound a token and the node now reports empty, treat it as a
+change — do not silently drop the guard.
+
+### 2.5 Failure modes a client must handle
+
+`ClientHandshake` classifies these; a client MUST handle each:
+
+| Condition | Detected by | Severity |
+|---|---|---|
+| Wrong / stale cookie | `authenticate()` returns false | **Hard fail** — "node may have restarted; reconnect" |
+| `schema_major` mismatch | `remote.schema_major != local.schema_major` | **Hard fail** — incompatible wire format |
+| `protocol_version` mismatch | `remote.protocol_version != local.protocol_version` | **Hard fail** |
+| Client `schema_minor` **>** node's | `local.schema_minor > remote.schema_minor` | **Hard fail** — "update the node" |
+| `network` mismatch | `ident.network != local_network` | **Hard fail** — wrong chain |
+| Node `schema_minor` **>** client's | (soft) | `SoftWarn::GuiOlderMinor` — forward-compatible, log only |
+| `git_commit` mismatch | (soft) | `SoftWarn::GitCommitMismatch` — mixed-build banner |
+| Identity token change | client-side `CheckIdentityBinding` | prompt / rebind / quit |
+| **Daemon vanished mid-handshake** | any IPC call throws | **Hard fail** — `ClientHandshake` catches `std::exception`, clears soft findings, returns `ok=false` with "lost connection …" |
+
+That last row is the critical robustness point: **any IPC call can throw** if the
+daemon disconnects mid-flight. `ClientHandshake` wraps steps 4–7 in one
+`try/catch` so a throw becomes a clean `ok=false` rather than an escaping
+exception. A client must apply the same discipline to *every* later call, not
+just the handshake (§6).
+
+> **Doc/code divergence (see §10):** design §4.3 lists an additional step 4,
+> a `SO_PEERCRED` / `LOCAL_PEERCRED` peer-identity check, before
+> `authenticate()`. That check is **not implemented** on this branch —
+> neither `ConnectToNode` nor the node performs it. The cookie is the sole
+> authenticator today.
+
+---
+
+## 3. Versioning contract
+
+Three constants are embedded in **both** binaries and compared during the
+handshake (`ipc/handshake.h`):
+
+```cpp
+constexpr uint32_t IPC_SCHEMA_MAJOR   = 2;
+constexpr uint32_t IPC_SCHEMA_MINOR   = 0;
+constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
+```
+
+Rules a client must honor (from `ClientHandshake` and design §4.2):
+
+- **`schema_major`** — the Cap'n Proto wire contract. Must match exactly; any
+  difference is a hard fail. **Major 2** reflects the identity model being
+  re-based onto the wallet UUID (the former `node_id` / `datadir` /
+  `genesis_hash` fields were retired — a breaking change). A breaking schema
+  change bumps this and requires a one-version transition release.
+- **`schema_minor`** — additive schema changes. Asymmetric:
+  *client minor > node minor* is a **hard fail** ("update the node"); *client
+  minor < node minor* is a **soft, forward-compatible** finding (the node has
+  features the client does not use).
+- **`protocol_version`** — the transport/handshake shape. Must match exactly.
+- **`git_commit`** / **`built_at`** — not compatibility gates; a `git_commit`
+  mismatch is a soft mixed-build warning, `built_at` is informational.
+
+**Identity-token domain tag:** `ipc::IDENTITY_TOKEN_DOMAIN =
+"gridcoin-node-identity-v1"` (`ipc/handshake.h`). It is hashed in with its
+trailing NUL excluded and the UUID length-prefixed (LE32) so the tag/UUID
+boundary is unambiguous. Bump the `-vN` suffix only if the token *algorithm*
+changes, independent of the capnp schema version.
+
+---
+
+## 4. The interface surface
+
+`Init` is the root capability; every other interface is reached through one of
+its `makeX` factories. All interfaces below are pure-virtual C++ classes in
+`src/interfaces/`, mirrored 1:1 by a Cap'n Proto schema in `src/ipc/capnp/`
+(pure-abstract classes must be fully schema'd, or the generated `ProxyClient`
+stays abstract). DTOs are documented at their definition sites — this section is
+a map, not a field-by-field restatement.
+
+### 4.0 Init — `src/interfaces/init.h`, `ipc/capnp/init.capnp`
+
+The per-process bootstrap. Beyond the handshake methods (`authenticate`,
+`getBuildInfo`, `getIdentity`, §2) and `isCoreReady()`, it hands out:
+
+| Factory | Returns | Notes |
+|---|---|---|
+| `makeNode()` | `Node` | always available |
+| `makeStakingStatus()` | `StakingStatus` | always available |
+| `makeWallet()` | `Wallet` | null before wallet startup |
+| `makeWalletTxSource()` | `shared_ptr<WalletTxSource>` | null before wallet startup |
+| `makeMRC()` | `MRC` | null before wallet startup |
+| `makeVotingManager()` | `VotingManager` | |
+| `makeResearcherContext()` | `ResearcherContext` | null before wallet startup |
+| `makePSGTPoolContext()` | `PSGTPoolContext` | null before wallet startup |
+| `makeSideStakeManager()` | `SideStakeManager` | **monolith only — not in `init.capnp`; see §10** |
+
+The `init.capnp` `Init` interface additionally declares `construct @0
+(threadMap …)` — the libmultiprocess lifecycle entry point (a `ThreadMap`
+exchange), not a Gridcoin method (§9).
+
+### 4.1 Node — `src/interfaces/node.h`, `node.capnp`
+
+Chain/network state plus node-side notification registration. Query methods
+include `getNodeCount`, `getNumBlocks`, `getBestBlockHash` (returns `uint256`),
+`getLastBlockTime`, `getDifficulty`, `isInitialBlockDownload`,
+`isOutOfSyncByAge`, `getWarnings`, `getClientVersion`, `isTestNet`, and the
+byte counters. Note the `try*` variants (`tryGetNumBlocksOfPeers`) that return
+`std::nullopt` instead of blocking on `cs_main` — provided for callers that must
+never wait on a core lock.
+
+Command/action methods: `startShutdown`, `banNode`, `unban`, `disconnectNode`,
+`executeRpcConsoleCommand(method, args) -> RpcConsoleResult` (the whole UniValue
+round trip happens node-side; only formatted text crosses), `listRpcCommands`,
+the typed settings getters (`getSettingBool/Int/Str`, `isSettingSet`) and
+`changeSettings(...) -> SettingChangeResult`, plus `checkForLatestUpdate` and
+`runDiagnostics`.
+
+DTOs: `BannedNode`, `PeerInfo`, `RpcConsoleResult`, `SettingChangeResult`,
+`ScraperConvergenceSnapshot`, `LatestVersionInfo`, `DiagnosticResult` (+ the
+`DiagnosticTest` / `DiagnosticStatus` enums whose integer values mirror the core
+enums).
+
+Notification bridges (each returns a `Handler`, §5): `handleRwSettingsUpdated`,
+`handleInitShutdown` (the **core→client shutdown** signal — a client must react
+by quitting its own process), `handleNotifyBlocksChanged`,
+`handleNotifyNumConnectionsChanged`, `handleBannedListChanged`,
+`handleNotifyAlertChanged`, `handleMinerStatusChanged`, `handlePSGTPoolChanged`,
+`handleNotifyScraperEvent`.
+
+`executeRpcConsoleCommand` is worth calling out for an automation client: it is
+the full RPC dispatch surface behind one method, so a headless client can drive
+essentially any RPC through `Node` without a separate HTTP-RPC port.
+
+### 4.2 StakingStatus — `src/interfaces/staking.h`, `staking.capnp`
+
+Queries only (status *changes* arrive via `Node::handleMinerStatusChanged`):
+`isStaking`, `getErrors`, `getCoinWeight`, `getNetworkWeight` (blocking) plus
+non-blocking `tryGetNetworkWeight` / `tryGetEstimatedTimeToStake`.
+
+### 4.3 Wallet — `src/interfaces/wallet.h`, `wallet.capnp`
+
+The node's single wallet. Balances (`getBalance`, `getStake`,
+`getUnconfirmedBalance`, `getImmatureBalance`, and the atomic
+`tryGetBalances(WalletBalances&)` that bows out without blocking); lock/encryption
+state (`getLockState -> WalletLockState`, `isUnlockedForStakingOnly`,
+`getUnlockStakingOnlyFlag`); mutation of lock state (`encryptWallet`,
+`lockWallet`, `unlockWallet`, `changeWalletPassphrase` — all taking a
+`SecureString` passphrase, §7).
+
+Coin control / send: `getOutputs`, `listCoins`, `computeCoinControlSummary(...)
+-> CoinControlSummary` (all fee math runs node-side), `getMaxConsolidationInputs`,
+and `sendCoins(recipients, coin_control, accepted_fee) -> SendCoinsResult`. Note
+the fee-confirmation protocol: `sendCoins` returns
+`SendCoinsStatus::FeeConfirmationRequired` with the fee to confirm and commits
+**nothing**; the client re-invokes with `accepted_fee >= fee`. This replaces the
+old modal "ask fee" dialog that blocked inside core locks (design §4.5) — a
+client MUST implement the re-invoke, not assume a single call commits.
+
+Addresses / messages: `getAddresses`, `getAddressLabel`, `isMine`,
+`setAddressBook`, `delAddressBook`, `getNewReceiveAddress`,
+`getNewReceiveAddressWithLabel`, `getUnbookedReceiveAddresses`, `getPubKey` /
+`getKeyFromPool` (**public keys only**), and `signMessage` / `verifyMessage`
+(private key never leaves the node).
+
+DTOs: `WalletBalances`, `WalletLockState`, `WalletOutput`, `WalletAddress`,
+`WalletCoinControl` (the client-owned coin-selection container, keyed by
+`COutPoint`), `CoinControlSummary`, `WalletSendRecipient`, `SendCoinsResult`
+(+ `SendCoinsStatus`, `MessageSignStatus`, `MessageVerifyStatus` enums).
+
+Bridges: `handleStatusChanged`, `handleAddressBookChanged`,
+`handleTransactionChanged`.
+
+### 4.4 WalletTxSource — `src/interfaces/wallet_tx_source.h`, `wallet_tx_source.capnp`
+
+The windowed transaction-table channel — see §5.2 for the full model.
+
+### 4.5 MRC — `src/interfaces/mrc.h`, `mrc.capnp`
+
+Manual Research Claims. `snapshot(fee_boost, wallet_locked, researcher_eligible)
+-> MRCSnapshot` (one atomic node-side read of eligibility + fee-queue state);
+`submit(fee_boost, wallet_locked) -> MRCSubmitResult`; `isOutOfSync()`;
+`handleMRCChanged`.
+
+### 4.6 VotingManager — `src/interfaces/voting.h`, `voting.capnp`
+
+Polls and votes. `buildPollTable(filter_flags) -> vector<PollTableItem>`
+(tallied node-side against a pinned tip — call it off any UI thread),
+`getPollTypes`, `pollV3Enabled`, `estimatePollFee`, `currentPollTitle`,
+`latestActivePollTime`, `submitPoll(PollSubmission) -> VotingSubmitResult`,
+`submitVote(poll_txid, choice_offsets) -> VotingSubmitResult`;
+`handleNewPollReceived`, `handleNewVoteReceived`. The wallet must already be
+unlocked by the caller for the submit commands. DTOs carry precomputed display
+values (types/weights already string-ified and scaled to whole GRC), so no core
+voting types cross.
+
+### 4.7 ResearcherContext — `src/interfaces/researcher.h`, `researcher.capnp`
+
+Beacon / magnitude / accrual. `snapshot() -> ResearcherSnapshot` (blocking) and
+`trySnapshot()` (non-blocking); `outOfSync`; the fused `projects(extended) ->
+vector<ResearcherProjectRow>` (whitelist + local projects + scraper magnitude in
+one node-side pass); `whitelistProjects`, `v3CapableProjects`, `hasV3CapableProjects`,
+`maxProjectNameLength` / `maxProjectUrlLength`; commands `switchMode`,
+`advertiseBeacon`, `generateBeaconKeyForV3`, `advertiseBeaconV3`, `reload`; and
+the `handleResearcherChanged` / `handleBeaconChanged` / `handleAccrualChanged` /
+`handleBlocksChanged` bridges. `BeaconStatus` / `ResearcherMode` enums classify
+state node-side.
+
+### 4.8 PSGTPoolContext — `src/interfaces/psgt.h`, `psgt.capnp`
+
+Partially-Signed Gridcoin Transactions: the pool table + multisig workbench. PSGTs
+cross as `PSGTBytes` (the core `SerializePSGT()` byte format), never a live core
+type. Pool: `entries`, `signPoolEntry`, `removePoolEntry`, `poolStatus`,
+`poolEntryPsgt`. Workbench: `describePSGT`, `signPSGT`, `combinePSGTs`,
+`submitPSGTToPool`, `finalizeToRawTxHex`, `decodePSGT`, `walletHasSignature`,
+`walletMustSignRevision`. Rich result DTOs (`PSGTDescription`, `PSGTSignResult`,
+`PSGTSubmitResult`, …) plus the several status enums mirror the core results.
+Pool *change* notifications arrive via `Node::handlePSGTPoolChanged`.
+
+### 4.9 SideStakeManager — `src/interfaces/sidestake.h` (no capnp schema)
+
+The unified mandatory + local sidestake table with add/edit/delete commands and a
+versioned-refetch revision (`SideStakeSnapshot::local_revision`, design §4.4).
+`entries`, `localRevision`, `addLocal`, `setAllocation`, `setDescription`,
+`deleteLocal`, `handleRwSettingsUpdated`, `handleMandatorySideStakeChanged`.
+
+**This interface is served only in the monolithic build.** There is no
+`sidestake.capnp`, and `init.capnp`'s `Init` has no `makeSideStakeManager`
+method, so on this branch an IPC client **cannot** reach it (§10).
+
+---
+
+## 5. Notifications and the transaction model
+
+### 5.1 The Handler subscription pattern
+
+Every `handleXxx(...)` method registers a callback and returns a
+`std::unique_ptr<interfaces::Handler>` (`src/interfaces/handler.h`,
+`handler.capnp`). The `Handler` is an RAII subscription: `disconnect()` cancels
+it, and destroying it also disconnects. A client keeps the `Handler` alive for as
+long as it wants the callback, and drops it to unsubscribe.
+
+Over IPC the callback is itself a capability: `node.capnp` wraps each
+`std::function` signature as a `ProxyCallback<…>` interface (e.g.
+`VoidCallback`, `NotifyBlocksChangedCallback`), so the node calls *back into the
+client* over the same connection. Two rules bind a client's callback code
+(`src/interfaces/README.md`, `node.h`):
+
+- **Callbacks fire on core threads, often while core locks are held.** A callback
+  must **enqueue and return** — it must not take core locks or re-enter interface
+  methods that do. In practice: post the event to your own thread/loop and return
+  immediately.
+- **Payload-free "refetch trigger" signals.** Many notifications
+  (`ResearcherChanged`, `BeaconChanged`, `MRCChanged`, `RwSettingsUpdated`,
+  `BannedListChanged`, …) carry no data; the contract is that you re-call the
+  corresponding `snapshot()` / `entries()` / query on your own thread. Do not try
+  to reconstruct state from the notification itself.
+
+The node also guards *its* side: `interfaces::GuardNotify` (`handler.h`) swallows
+the "IPC client method called after disconnect" exception that libmultiprocess
+raises when it tries to deliver a notification to a client that has gone away, so
+a departed client cannot unwind a core thread. A client should expect that its
+in-flight notifications are simply dropped after it disconnects.
+
+The `Node::handleInitShutdown` callback is special: it is the **core→client
+shutdown** signal (RPC `stop`, SIGTERM, low-disk abort, …). A client must treat
+it as "the node is going down" and quit its own process — otherwise its next
+proxy call will throw against a dead connection.
+
+### 5.2 The windowed transaction channel
+
+`WalletTxSource` (`wallet_tx_source.h`, and its DTOs in `wallet_tx_channel.h` /
+`wallet_tx_record.h` / `wallet_tx_filter.h`) lets a front end show a transaction
+list **without ever pulling the whole wallet across the boundary**. The node owns
+the ordered record store, a worker thread, and the producer subscriptions; the
+client drives per-view *cursors* and pulls a bounded event stream. This is the
+one interface returned by `shared_ptr` (a producer callback in flight keeps the
+source alive across teardown — see §6).
+
+Lifecycle and usage:
+
+1. **Attach.** `Init::makeWalletTxSource()` constructs the node-side store and
+   worker — "headless pays nothing": a client that never calls this incurs no
+   cost. Releasing the last reference detaches (unsubscribes, joins the worker).
+2. **`prime(limit_enabled, limit_time)`** — scan the wallet, (re)build the ordered
+   record table and every registered cursor, and push each a `Reset`. Returns
+   nothing; the list is never shipped whole. `limit_*` is the datetime-display
+   cutoff; call again when it changes. (This replaced the old full-wallet
+   snapshot; do not expect a "give me everything" call.)
+3. **Register views.** `registerView(view_id, FilterSpec, sort_column, sort_order)`
+   creates a server-side cursor (filter + sort). `view_id` is one of
+   `GRC::VIEW_FULL` (0), `VIEW_OVERVIEW` (1), `VIEW_DETAILED` (2). Adjust with
+   `setViewSort` / `setViewFilter` / `setViewLimit`; drop with `unregisterView`
+   (idempotent, but must be called **while the source is still alive** — teardown
+   order matters, §6).
+4. **Fetch rows.** `getRows(view_id, first, count) -> GRC::RowsResult` returns the
+   `[first, first+count)` slice **plus** the view's `total_accepted`, `epoch`, and
+   `high_water`, all sampled under one store-lock hold. `getAllRows` returns every
+   accepted row (for export). `rowForKey` / `getRowDetail` resolve a single
+   transaction; `getRowDetail -> GRC::WalletTxDetail` is the fully-structured,
+   translation-free detail for a double-click dialog.
+5. **Drain events.** `drainEvents(max_batch) -> vector<GRC::WalletEvent>` pulls
+   pending events in `seqno` order (a client polls this periodically). Payloads:
+   `RowsInsertedPayload`, `RowsRemovedPayload`, `RowsResetPayload`,
+   `RowCountChangedPayload`, `RowsChangedPayload`, `ChainTipChangedPayload` (a
+   `std::variant`, marshalled as a discriminated `WalletEventPayloadWire` struct).
+6. **Address-book feedback.** `noteAddressBookChanged(address, label)` tells the
+   source a label changed so it re-snapshots the affected rows' sort/filter key.
+
+**Race-free reconciliation.** Each event and result carries `viewId` + `epoch` +
+`seqno`/`high_water`. A cursor rebuild bumps `epoch`; a content fetch is only
+adopted when its `epoch` and `high_water` match the structural (event-stream)
+channel. The commentary in `wallet_tx_channel.h` (`RowsResult`) is the normative
+description — a client that windows the list must implement this two-channel
+reconciliation or it will drop/double-count rows during concurrent updates.
+
+`FilterSpec` (`wallet_tx_filter.h`) is a plain value type: date range, a
+`type_mask` bitfield of `(1u << TransactionRecord::Type)`, an `address_substr`
+matched case-insensitively against address *or* label, `min_amount`,
+`limit_rows`, and the `show_inactive` / `show_orphans` gates. `TransactionRecord`
+/ `TransactionStatus` (`wallet_tx_record.h`) are the row DTOs; the *translated*
+type/status rendering is the client's job (only locale-free data crosses).
+
+---
+
+## 6. Lifecycle and threading
+
+- **Proxy lifetime is bounded by the `Ipc`.** The remote `Init` and every
+  interface reached through it are proxies valid **only while the `Ipc` (and its
+  background event loop) lives** (`GuiConnection` keeps `ipc`, `init`, and the
+  `HandshakeResult` together for exactly this reason — `connect.h`). Keep the
+  connection object alive for as long as you use *any* interface obtained from
+  it. Destroy children before the connection.
+- **Factory objects own node-side machinery.** A `WalletTxSource` owns a store +
+  worker thread + subscriptions; other `makeX` results own their node-side
+  wrappers. Releasing the client-side handle tears the node-side object down. The
+  bundled GUI constructs these *before* its readiness wait and destroys them
+  *before* the node shuts the wallet down (`src/qt/bitcoin.cpp`); an alt client
+  must respect the same ordering — e.g. `unregisterView` before releasing the
+  source, and release wallet-derived interfaces before the connection.
+- **`WalletTxSource` is `shared_ptr` on purpose.** Its producer subscriptions
+  hold a `weak_ptr` and lock it per callback, so a core producer thread executing
+  a callback at the moment the owner releases keeps the source alive until that
+  callback returns. This closes a cross-thread teardown race; the single client
+  owner still governs lifetime.
+- **Disconnect can surface at any call.** If the daemon exits (crash, `SIGKILL`,
+  or a `stop` that races the shutdown handshake), the next proxy call throws.
+  There are two client-side hooks:
+  - The **`on_disconnect` callback** passed to `connectAddress` /
+    `ConnectToNode`, invoked *on the IPC event-loop thread* when the connection
+    drops unexpectedly. The bundled GUI routes it to a graceful quit
+    (`QuitOnDaemonConnectionLost`, `src/qt/bitcoin.cpp`).
+  - A **top-level exception guard** around your event loop: the GUI wraps its Qt
+    event dispatch (`GridcoinApplication::notify`) to treat the "called after
+    disconnect" exception as "node went away" rather than letting it escape (Qt
+    forbids exceptions crossing the event loop). A non-Qt client must likewise
+    never let an IPC throw unwind its main loop.
+- **Reentrancy / locks.** Notification callbacks must not take core locks or
+  re-enter locking interface methods (§5.1). On the request side, prefer the
+  `try*` variants for anything on a latency-sensitive thread — the blocking
+  variants take `cs_main` and can stall.
+
+---
+
+## 7. Security model for clients
+
+- **The cookie is the authenticator.** It is 256 bits of strong randomness,
+  written `0600`, fresh per node startup, and compared constant-time
+  (`ConstantTimeEqual`). Possession of the cookie *is* authorization: anything
+  that can read `<datadir>/<network>/ipc.cookie` can drive the wallet. Protect
+  it exactly as you would `wallet.dat`.
+- **Transport is local AF_UNIX only.** The socket is `0600` inside a `0700`
+  directory, and the node fails closed if it cannot enforce that (POSIX
+  `chmod`; on Windows the socket and cookie inherit the owner-only datadir ACL).
+  There is no network transport and no TLS — the trust boundary is the local
+  filesystem's access control.
+- **Identity binding is *your* responsibility.** The node authenticates you but
+  does not stop you from attaching to a *different wallet* than you expect. If
+  your front end shows balances, you should persist the `identity_token` per
+  datadir and re-check it on every connect (§2.4), or you risk silently
+  displaying the wrong wallet after a wallet swap/restore. `CheckIdentityBinding`
+  gives you the decision; the persistence and prompt are yours.
+- **Passphrases cross the wire.** `encryptWallet` / `unlockWallet` /
+  `changeWalletPassphrase` take a `SecureString`, which travels over the socket
+  to the node (the wallet lives there). It is zeroed on both sides after the call
+  and unlock is time-bounded, but a client author should be aware the secret
+  transits the AF_UNIX socket. Keys and signing never cross — only the
+  passphrase, and only for these calls.
+- **What the node does *not* protect against.** It does not verify *which*
+  process holds the cookie (the design's optional `SO_PEERCRED` peer-credential
+  check is not implemented on this branch, §10). It caps concurrency at one
+  connection but its auth flag is process-global and *sticky* — once any peer
+  authenticates, the flag stays set for the life of the served `Init`
+  (`ServeInit`); per-connection auth is a later hardening. And identity binding,
+  as above, is not enforced node-side at all.
+
+---
+
+## 8. A minimal client walkthrough
+
+The smallest sequence to connect, authenticate, and read the balance, using the
+real symbols (C++/libmultiprocess client):
+
+```cpp
+// 0. You need an Init to hand MakeIpc even as a connect-only client: it is the
+//    Init this process *would* serve if it listened (the GUI never does). The
+//    in-process monolith Init is cheap. It must outlive the connection.
+std::unique_ptr<interfaces::Init> local_init = interfaces::MakeGridcoinInit();
+
+// 1-3, 4-7. ConnectToNode does the whole handshake: read cookie, connect,
+//    authenticate(cookie), getBuildInfo()/getIdentity(), compatibility checks.
+std::string err;
+std::optional<ipc::GuiConnection> conn =
+    ipc::ConnectToNode(GetDataDir(), *local_init, err,
+        /*on_disconnect=*/[]{ /* node went away: quit your loop */ });
+if (!conn) { /* err explains the hard fail */ return; }
+
+// 2.4. Identity binding is yours: compare conn->handshake.remote_ident against
+//    what you stored for this datadir.
+switch (ipc::CheckIdentityBinding(conn->handshake.remote_ident.identity_token,
+                                  stored_token)) { /* Match / FirstSeen / ... */ }
+
+// 8. Wait for the wallet, then read a value snapshot.
+while (!conn->init->isCoreReady()) { /* sleep briefly */ }
+std::unique_ptr<interfaces::Wallet> wallet = conn->init->makeWallet();
+if (!wallet) { /* wallet not up yet; retry */ }
+
+interfaces::WalletBalances b;
+if (wallet->tryGetBalances(b)) {
+    // b.balance / b.stake / b.unconfirmed_balance / b.immature_balance
+}
+// Keep `conn` alive while you use `wallet` (proxies die with the Ipc).
+```
+
+`src/qt/bitcoin.cpp` (search `ConnectToNode`, `ResolveNodeIdentity`,
+`isCoreReady`, `makeWallet`) is the complete, production reference for this flow.
+
+---
+
+## 9. Non-C++ / non-libmultiprocess clients
+
+Nothing about the wire is C++-specific — it is Cap'n Proto RPC over an AF_UNIX
+stream — but the framing is **libmultiprocess's**, not vanilla Cap'n Proto, so a
+foreign client is a real undertaking:
+
+- **The schemas** are in `src/ipc/capnp/*.capnp`. Each interface is declared with
+  `$Proxy.wrap("interfaces::X")`, and struct fields carry `$Proxy.name("…")`
+  annotations that map camelCase wire names to the C++ snake_case members (e.g.
+  `gitCommit @0 :Text $Proxy.name("git_commit")` in `init.capnp`). A foreign
+  client can ignore the C++ names and speak the wire field ordinals directly, but
+  the `.capnp` files are the source of truth for the message shapes.
+- **`mpgen`** (built from the vendored `src/ipc/libmultiprocess` subtree, wired
+  through `target_capnp_sources` in `src/ipc/CMakeLists.txt`) is what turns each
+  `.capnp` into the `ProxyClient`/`ProxyServer` glue for the C++ build. A foreign
+  client does not use `mpgen`; it must reproduce libmultiprocess's **runtime
+  conventions** by hand:
+  - **The `construct @0 (threadMap …)` / `Proxy.Context` handshake.** Every method
+    takes a `context :Proxy.Context`, and `Init.construct` exchanges a
+    `ThreadMap`. This is libmultiprocess's threading model (request/response
+    thread affinity), layered *on top of* Cap'n Proto — a foreign client must
+    implement it, not just the application methods.
+  - **Capability passing.** `makeX` returns a Cap'n Proto *interface capability*,
+    and `handleXxx` passes a client-hosted `ProxyCallback<…>` capability back to
+    the node. A foreign client must host these callback capabilities to receive
+    notifications.
+  - **`std::variant` framing.** Discriminated unions like
+    `WalletEventPayloadWire` (a `which` tag plus one field per alternative, in the
+    C++ variant's order — see `wallet_tx_source.capnp` and
+    `ipc/capnp/type-variant.h`) are a libmultiprocess convention, not a Cap'n
+    Proto union.
+- **Practical recommendation.** Because of the ThreadMap/Context layer, the
+  realistic path for a foreign-language front end today is to **link
+  libmultiprocess** (it is C++), or to talk to the node through
+  `Node::executeRpcConsoleCommand` after a minimal C++ shim — rather than to
+  reimplement the libmultiprocess framing from scratch. Treat a pure-foreign
+  Cap'n Proto client as a research effort, not a supported path, on this branch.
+
+---
+
+## 10. Gaps and doc/code divergences an alt-front-end author will hit
+
+Reported honestly so nobody designs against a contract that is not there yet:
+
+1. **`SideStakeManager` is not reachable over IPC.** It is a full member of the
+   C++ `Init` interface (`makeSideStakeManager`), is wrapped by `ServeInit`, and
+   works in the monolith — but there is **no `sidestake.capnp`** and **no
+   `makeSideStakeManager` in `init.capnp`**. Over the IPC seam it simply does not
+   exist on this branch. A front end that needs sidestake management must fall
+   back to `Node::executeRpcConsoleCommand` (the sidestake RPCs) until the schema
+   is added.
+2. **The peer-identity check is documented but unimplemented.** Design §4.3
+   step 4 (`SO_PEERCRED` / `LOCAL_PEERCRED` / `SIO_AF_UNIX_GETPEERPID`) is called
+   "best-effort defense-in-depth," but neither `ConnectToNode`/`ClientHandshake`
+   nor the node performs it. The cookie is the only authenticator. Do not assume
+   the node will reject a wrong-PID peer.
+3. **Auth is process-global and sticky, and capped at one connection.**
+   `ServeInit::m_authenticated` is set once and never cleared, shared across the
+   (single allowed) connection; the listener is `max_connections=1`. Per-connection
+   auth and multi-client support are explicitly deferred (`serve_init.cpp`,
+   `protocol.cpp`). An alt front end must be the sole client and cannot rely on
+   any multi-client isolation.
+4. **Versioned-refetch is only partly realized.** Design §4.4 describes every
+   void signal growing a `registry_version` parameter. In practice only
+   `SideStakeManager` carries a revision (`local_revision`) — and it is not even
+   IPC-exposed (gap 1). All other notifications are payload-free refetch triggers
+   with no coalescing version on the wire; a client must refetch on every one and
+   cannot dedupe by version except for sidestake.
+5. **The mixed-build warning surfaces as a dismissible banner.**
+   `SoftWarn::GitCommitMismatch` is both logged (`ResolveNodeIdentity`) and shown
+   as a dismissible in-window banner (`BitcoinGUI::showBuildMismatchWarning`) in
+   the reference GUI, suppressible per instance with `-nobuildwarn`. A client gets
+   the soft finding in `HandshakeResult::soft` and decides how to present it.
+6. **Identity-token algorithm precision.** `init.h` and design §4.2 describe the
+   token as `SHA256(domain-tag ‖ wallet_uuid)`; the actual implementation
+   (`ComputeIdentityToken`) is `HEX(SHA256(domain-tag_without_NUL ‖ LE32(len) ‖
+   uuid))`. A client only ever *compares* the string the node reports, so the
+   shorthand is harmless in practice — but the length-prefixed form is the real
+   algorithm if you ever need to reproduce it.
+7. **Interfaces grow per migration.** The surface is intentionally only as wide
+   as the bundled GUI's migrated consumers need (see each header's phase notes and
+   `src/interfaces/README.md`). Methods are added when a consumer needs them, not
+   speculatively — so absence of a capability is expected, and
+   `Node::executeRpcConsoleCommand` is the general-purpose escape hatch.

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -28,6 +28,7 @@
 #include "interfaces/ipc.h"
 #include "ipc/handshake.h"
 #include "ipc/serve_init.h"
+#include "wallet/wallet.h" // pwalletMain / CWallet::GetWalletUuid for the identity token
 #include <atomic>
 #include <memory>
 #endif
@@ -319,7 +320,14 @@ bool AppInit(int argc, char* argv[])
         if (gArgs.GetBoolArg("-multiprocess", false)) {
             try {
                 std::string cookie = ipc::WriteCookie(GetDataDir());
-                interfaces::NodeIdentity identity = ipc::WriteIdentity(GetDataDir());
+                interfaces::NodeIdentity identity;
+                identity.network = Params().NetworkIDString();
+                // Fingerprint the wallet this node serves. Empty when there is no
+                // wallet, or its UUID could not be minted (e.g. a mockable chain) --
+                // the GUI then treats identity as "unavailable".
+                if (pwalletMain) {
+                    identity.identity_token = ipc::ComputeIdentityToken(pwalletMain->GetWalletUuid());
+                }
                 serve_init = ipc::MakeServeInit(interfaces::MakeGridcoinInit(),
                                                 std::move(cookie), std::move(identity));
                 ipc = interfaces::MakeIpc("gridcoinresearchd", *serve_init);

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -39,17 +39,20 @@ struct BuildInfo
     uint32_t protocol_version = 0;
 };
 
-//! The node's per-datadir identity. The GUI persists the expected node_id +
-//! network on first successful connect and hard-fails on every later launch when
-//! a different node_id answers at the same socket path (a moved datadir, a
-//! -reindex rotation, or a foreign node squatting the socket). See
-//! doc/multiprocess_design.md section 4.2. Value snapshot; crosses IPC.
+//! The node's identity, reported over IPC (post-auth) so the GUI can confirm it is
+//! still managing the same wallet it bound to before. identity_token =
+//! SHA256(domain-tag ‖ wallet_uuid); it changes iff the wallet is replaced, and is
+//! deliberately independent of chain state and datadir path (a chain reset / resync
+//! must NOT change it). An empty token means "unavailable" (mockable chain, or the
+//! wallet UUID could not be minted). The GUI persists the token per datadir on
+//! first connect and prompts — or, with -autotrustidentity, silently rebinds — when
+//! it changes. network is a separate binary guard against attaching a GUI to a node
+//! on a different chain. See doc/multiprocess_design.md section 4.2. Value snapshot;
+//! crosses IPC.
 struct NodeIdentity
 {
-    std::string node_id;      //!< Random per-datadir UUID (from node_identity.json).
-    std::string network;      //!< Chain name ("main" / "test" / "regtest").
-    std::string datadir;      //!< Canonical datadir path.
-    std::string genesis_hash; //!< Genesis block hash, hex.
+    std::string identity_token; //!< SHA256(tag ‖ wallet_uuid), hex; empty = unavailable.
+    std::string network;        //!< Chain name ("main" / "test" / "regtest").
 };
 
 //! Per-process bootstrap interface: hands out the other interfaces. In the

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -41,7 +41,8 @@ struct BuildInfo
 
 //! The node's identity, reported over IPC (post-auth) so the GUI can confirm it is
 //! still managing the same wallet it bound to before. identity_token =
-//! SHA256(domain-tag ‖ wallet_uuid); it changes iff the wallet is replaced, and is
+//! HEX(SHA256(domain-tag ‖ LE32(len) ‖ wallet_uuid)) (see ipc::ComputeIdentityToken);
+//! it changes iff the wallet is replaced, and is
 //! deliberately independent of chain state and datadir path (a chain reset / resync
 //! must NOT change it). An empty token means "unavailable" (mockable chain, or the
 //! wallet UUID could not be minted). The GUI persists the token per datadir on
@@ -51,7 +52,7 @@ struct BuildInfo
 //! crosses IPC.
 struct NodeIdentity
 {
-    std::string identity_token; //!< SHA256(tag ‖ wallet_uuid), hex; empty = unavailable.
+    std::string identity_token; //!< HEX(SHA256(tag ‖ LE32(len) ‖ wallet_uuid)); empty = unavailable.
     std::string network;        //!< Chain name ("main" / "test" / "regtest").
 };
 

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -53,9 +53,12 @@ struct BuildInfo $Proxy.wrap("interfaces::BuildInfo") {
     protocolVersion @4 :UInt32 $Proxy.name("protocol_version");
 }
 
+# Ordinals renumbered under the schema-major 2 bump (identity model re-based onto
+# the wallet UUID; former nodeId/datadir/genesisHash retired). Cap'n Proto requires
+# consecutive ordinals from 0, so @0/@1 are reused (both Text) rather than left as
+# gaps; safe because nothing persists this struct (live IPC only) and a stale peer
+# hard-fails on schema_major before reading it.
 struct NodeIdentity $Proxy.wrap("interfaces::NodeIdentity") {
-    nodeId @0 :Text $Proxy.name("node_id");
+    identityToken @0 :Text $Proxy.name("identity_token");
     network @1 :Text;
-    datadir @2 :Text;
-    genesisHash @3 :Text $Proxy.name("genesis_hash");
 }

--- a/src/ipc/connect.cpp
+++ b/src/ipc/connect.cpp
@@ -4,6 +4,7 @@
 
 #include "ipc/connect.h"
 
+#include "chainparams.h"
 #include "ipc/handshake.h"
 #include "interfaces/init.h"
 #include "interfaces/ipc.h"
@@ -48,13 +49,16 @@ std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
         return std::nullopt;
     }
 
-    // 3. Authenticate with the cookie and verify schema/protocol compatibility.
-    //    (Identity binding and the git-commit soft-warn are layered on GUI-side.)
-    std::string auth_error;
-    if (!ClientAuthenticateAndCheck(*conn.init, *cookie, auth_error)) {
-        error_out = auth_error;
+    // 3. Authenticate, verify compatibility (schema/protocol/network), and fetch
+    //    the node's build + identity. Identity *binding* (vs the GUI's stored
+    //    expectation) and the git_commit soft-warn banner are the caller's
+    //    GUI-side steps, driven off conn.handshake.
+    HandshakeResult hr = ClientHandshake(*conn.init, *cookie, Params().NetworkIDString());
+    if (!hr.ok) {
+        error_out = hr.error;
         return std::nullopt;
     }
+    conn.handshake = std::move(hr);
 
     return conn;
 }

--- a/src/ipc/connect.h
+++ b/src/ipc/connect.h
@@ -7,6 +7,7 @@
 
 #include "fs.h"
 #include "interfaces/ipc.h"
+#include "ipc/handshake.h" // HandshakeResult (build/identity/soft-warnings)
 
 #include <functional>
 #include <memory>
@@ -26,6 +27,10 @@ namespace ipc {
 struct GuiConnection {
     std::unique_ptr<interfaces::Ipc> ipc;
     std::unique_ptr<interfaces::Init> init;
+    //! The successful handshake's build fingerprint, node identity token, and any
+    //! soft (non-fatal) findings -- consumed GUI-side for identity binding and the
+    //! mixed-build banner.
+    HandshakeResult handshake;
 };
 
 //! GUI side: perform the connect handshake against a node listening on
@@ -37,8 +42,8 @@ struct GuiConnection {
 //!      removed at shutdown, so a stale one may outlive a stopped node; that is
 //!      harmless -- connectAddress in step 2 then simply fails with no listener;
 //!   2. MakeIpc + connectAddress("unix") to obtain the remote Init;
-//!   3. ClientAuthenticateAndCheck -- authenticate with the cookie and verify
-//!      schema/protocol compatibility.
+//!   3. ClientHandshake -- authenticate with the cookie and verify
+//!      schema/protocol/network compatibility (result stashed in .handshake).
 //!
 //! On success returns the connection. On any failure returns std::nullopt and
 //! sets \p error_out to a human-readable reason. \p local_init is the GUI's own

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -200,7 +200,8 @@ std::string ComputeIdentityToken(const std::vector<unsigned char>& wallet_uuid)
 }
 
 HandshakeResult ClientHandshake(interfaces::Init& init, const std::string& cookie,
-                                const std::string& local_network)
+                                const std::string& local_network,
+                                const interfaces::BuildInfo& local)
 {
     HandshakeResult result;
     try {
@@ -213,7 +214,6 @@ HandshakeResult ClientHandshake(interfaces::Init& init, const std::string& cooki
         // Fetch build + identity once, up front: a second getIdentity() call would
         // be a redundant round-trip and could, in principle, race a divergent value.
         const interfaces::BuildInfo remote = init.getBuildInfo();
-        const interfaces::BuildInfo local = GetLocalBuildInfo();
         const interfaces::NodeIdentity ident = init.getIdentity();
 
         if (remote.schema_major != local.schema_major) {

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -4,17 +4,16 @@
 
 #include "ipc/handshake.h"
 
-#include "chainparams.h"
 #include "clientversion.h"
+#include "crypto/sha256.h"
 #include "random.h"
 #include "tinyformat.h"
-#include "util.h"
 #include "util/strencodings.h"
-
-#include <univalue.h>
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <exception>
 #include <fcntl.h>
 #include <fstream>
 #include <sys/stat.h>
@@ -36,7 +35,6 @@
 namespace ipc {
 namespace {
 const char* const COOKIE_FILE = "ipc.cookie";
-const char* const IDENTITY_FILE = "node_identity.json";
 
 //! Read an entire file into a string; nullopt if it cannot be opened.
 std::optional<std::string> ReadFile(const fs::path& path)
@@ -134,14 +132,6 @@ void WriteFileAtomic(const fs::path& path, const std::string& contents)
     fs::rename(tmp, path); // throws (boost::filesystem) on failure
 }
 #endif
-
-//! 16 strong random bytes as hex -- a per-datadir node identifier.
-std::string GenerateNodeId()
-{
-    std::array<unsigned char, 16> buf{};
-    GetStrongRandBytes(buf);
-    return HexStr(buf);
-}
 } // namespace
 
 interfaces::BuildInfo GetLocalBuildInfo()
@@ -185,90 +175,105 @@ std::optional<std::string> ReadCookie(const fs::path& dir)
     return contents;
 }
 
-interfaces::NodeIdentity WriteIdentity(const fs::path& dir)
+std::string ComputeIdentityToken(const std::vector<unsigned char>& wallet_uuid)
 {
-    const fs::path path = dir / IDENTITY_FILE;
+    if (wallet_uuid.empty()) return std::string();
 
-    // Preserve the existing per-datadir node_id across restarts (the GUI binds to
-    // it); generate one only on first run.
-    std::string node_id;
-    if (auto existing = ReadFile(path)) {
-        UniValue obj;
-        if (obj.read(*existing) && obj.isObject() && obj.exists("node_id") && obj["node_id"].isStr()) {
-            node_id = obj["node_id"].get_str();
+    CSHA256 hasher;
+    // Domain tag (exclude the trailing NUL of the string literal).
+    hasher.Write(reinterpret_cast<const unsigned char*>(IDENTITY_TOKEN_DOMAIN),
+                 sizeof(IDENTITY_TOKEN_DOMAIN) - 1);
+    // Length-prefix the UUID (LE32) so the tag/UUID boundary is unambiguous.
+    const uint32_t len = static_cast<uint32_t>(wallet_uuid.size());
+    const unsigned char len_le[4] = {
+        static_cast<unsigned char>(len & 0xff),
+        static_cast<unsigned char>((len >> 8) & 0xff),
+        static_cast<unsigned char>((len >> 16) & 0xff),
+        static_cast<unsigned char>((len >> 24) & 0xff),
+    };
+    hasher.Write(len_le, sizeof(len_le));
+    hasher.Write(wallet_uuid.data(), wallet_uuid.size());
+
+    std::array<unsigned char, CSHA256::OUTPUT_SIZE> out{};
+    hasher.Finalize(out.data());
+    return HexStr(out);
+}
+
+HandshakeResult ClientHandshake(interfaces::Init& init, const std::string& cookie,
+                                const std::string& local_network)
+{
+    HandshakeResult result;
+    try {
+        if (!init.authenticate(cookie)) {
+            result.error = "The node rejected the authentication cookie. It may have restarted "
+                           "since the cookie was written; try reconnecting.";
+            return result;
         }
-        // A malformed/non-string node_id falls through to a freshly generated one.
+
+        // Fetch build + identity once, up front: a second getIdentity() call would
+        // be a redundant round-trip and could, in principle, race a divergent value.
+        const interfaces::BuildInfo remote = init.getBuildInfo();
+        const interfaces::BuildInfo local = GetLocalBuildInfo();
+        const interfaces::NodeIdentity ident = init.getIdentity();
+
+        if (remote.schema_major != local.schema_major) {
+            result.error = strprintf("Incompatible IPC schema: this GUI speaks schema major %u but "
+                                     "the node speaks %u. Use matching builds of gridcoinresearch "
+                                     "and gridcoinresearchd.",
+                                     local.schema_major, remote.schema_major);
+            return result;
+        }
+        if (remote.protocol_version != local.protocol_version) {
+            result.error = strprintf("Incompatible IPC protocol version: GUI %u, node %u.",
+                                     local.protocol_version, remote.protocol_version);
+            return result;
+        }
+        if (local.schema_minor > remote.schema_minor) {
+            result.error = strprintf("This GUI is newer than the node (IPC schema minor GUI %u > "
+                                     "node %u). Update the node.",
+                                     local.schema_minor, remote.schema_minor);
+            return result;
+        }
+        if (ident.network != local_network) {
+            result.error = strprintf("This GUI is configured for the '%s' network but the daemon is "
+                                     "running '%s'.",
+                                     local_network, ident.network);
+            return result;
+        }
+
+        // Soft findings (non-fatal). GUI schema_minor < node is forward-compatible
+        // (log-only); a git_commit mismatch is the mixed-build banner.
+        if (local.schema_minor < remote.schema_minor) {
+            result.soft.push_back(SoftWarn::GuiOlderMinor);
+        }
+        if (remote.git_commit != local.git_commit) {
+            result.soft.push_back(SoftWarn::GitCommitMismatch);
+        }
+
+        result.remote_build = remote;
+        result.remote_ident = ident;
+        result.ok = true;
+        return result;
+    } catch (const std::exception& e) {
+        // An IPC call threw (daemon vanished mid-handshake). Distinct from an empty
+        // identity token: this is a hard failure, not a graceful degrade.
+        result.ok = false;
+        result.soft.clear();
+        result.error = strprintf("lost connection to the daemon during the handshake: %s", e.what());
+        return result;
     }
-    if (node_id.empty()) node_id = GenerateNodeId();
-
-    interfaces::NodeIdentity id;
-    id.node_id = node_id;
-    id.network = Params().NetworkIDString();
-    // Record the directory this identity file actually lives in (the caller's
-    // dir), not the process-global GetDataDir(), so the two cannot diverge.
-    id.datadir = dir.string();
-    id.genesis_hash = Params().GetConsensus().hashGenesisBlock.ToString();
-
-    UniValue obj(UniValue::VOBJ);
-    obj.pushKV("node_id", id.node_id);
-    obj.pushKV("network", id.network);
-    obj.pushKV("datadir", id.datadir);
-    obj.pushKV("genesis_hash", id.genesis_hash);
-    WriteFileAtomic(path, obj.write(2) + "\n");
-    return id;
 }
 
-std::optional<interfaces::NodeIdentity> ReadIdentity(const fs::path& dir)
+BindOutcome CheckIdentityBinding(const std::string& reported_token, const std::string& stored_token)
 {
-    auto contents = ReadFile(dir / IDENTITY_FILE);
-    if (!contents) return std::nullopt;
-    UniValue obj;
-    if (!obj.read(*contents) || !obj.isObject()) return std::nullopt;
-
-    // Guard each field with isStr(): UniValue::get_str() throws on a non-string,
-    // but a malformed file must yield nullopt (the documented contract), not an
-    // exception the GUI caller may not catch.
-    interfaces::NodeIdentity id;
-    if (obj.exists("node_id") && obj["node_id"].isStr()) id.node_id = obj["node_id"].get_str();
-    if (obj.exists("network") && obj["network"].isStr()) id.network = obj["network"].get_str();
-    if (obj.exists("datadir") && obj["datadir"].isStr()) id.datadir = obj["datadir"].get_str();
-    if (obj.exists("genesis_hash") && obj["genesis_hash"].isStr()) id.genesis_hash = obj["genesis_hash"].get_str();
-    if (id.node_id.empty()) return std::nullopt;
-    return id;
-}
-
-bool ClientAuthenticateAndCheck(interfaces::Init& init, const std::string& cookie, std::string& error_out)
-{
-    if (!init.authenticate(cookie)) {
-        error_out = "The node rejected the authentication cookie. It may have restarted since the "
-                    "cookie was written; try reconnecting.";
-        return false;
+    if (reported_token.empty()) {
+        // Empty reported token = identity unavailable. If we already have a stored
+        // token this is a downgrade signal -- treat it as a mismatch, never a
+        // silent skip (an attacker could force the node to report empty).
+        return stored_token.empty() ? BindOutcome::UnavailableFresh : BindOutcome::UnavailableStored;
     }
-
-    const interfaces::BuildInfo remote = init.getBuildInfo();
-    const interfaces::BuildInfo local = GetLocalBuildInfo();
-
-    if (remote.schema_major != local.schema_major) {
-        error_out = strprintf("Incompatible IPC schema: this GUI speaks schema major %u but the node "
-                              "speaks %u. Use matching builds of gridcoinresearch and "
-                              "gridcoinresearchd.",
-                              local.schema_major, remote.schema_major);
-        return false;
-    }
-    if (remote.protocol_version != local.protocol_version) {
-        error_out = strprintf("Incompatible IPC protocol version: GUI %u, node %u.",
-                              local.protocol_version, remote.protocol_version);
-        return false;
-    }
-    if (local.schema_minor > remote.schema_minor) {
-        error_out = strprintf("This GUI is newer than the node (IPC schema minor GUI %u > node %u). "
-                              "Update the node.",
-                              local.schema_minor, remote.schema_minor);
-        return false;
-    }
-    // GUI schema_minor < node: forward-compatible, accepted. A git_commit
-    // mismatch is a dismissible soft-warn handled GUI-side, not a failure here.
-    return true;
+    if (stored_token.empty()) return BindOutcome::FirstSeen;
+    return reported_token == stored_token ? BindOutcome::Match : BindOutcome::Mismatch;
 }
 
 } // namespace ipc

--- a/src/ipc/handshake.cpp
+++ b/src/ipc/handshake.cpp
@@ -259,7 +259,7 @@ HandshakeResult ClientHandshake(interfaces::Init& init, const std::string& cooki
         // identity token: this is a hard failure, not a graceful degrade.
         result.ok = false;
         result.soft.clear();
-        result.error = strprintf("lost connection to the daemon during the handshake: %s", e.what());
+        result.error = strprintf("Lost connection to the daemon during the handshake: %s", e.what());
         return result;
     }
 }

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace ipc {
 
@@ -18,9 +19,16 @@ namespace ipc {
 //! the connect handshake (doc/multiprocess_design.md section 4.2). Bump the minor
 //! for additive schema changes, the major for breaking ones (which also require a
 //! transition release); bump protocol for transport/handshake changes.
-constexpr uint32_t IPC_SCHEMA_MAJOR = 1;
+//!
+//! Major 2: the NodeIdentity model was re-based onto the wallet UUID (former
+//! node_id/datadir/genesis_hash retired), a breaking wire change.
+constexpr uint32_t IPC_SCHEMA_MAJOR = 2;
 constexpr uint32_t IPC_SCHEMA_MINOR = 0;
 constexpr uint32_t IPC_PROTOCOL_VERSION = 1;
+
+//! Domain-separation tag hashed into the node identity token. Bump the suffix if
+//! the token *algorithm* ever changes (independent of the capnp schema version).
+constexpr char IDENTITY_TOKEN_DOMAIN[] = "gridcoin-node-identity-v1";
 
 //! This process's build fingerprint (git commit, build time, schema/protocol
 //! versions) for the handshake build-info exchange.
@@ -38,24 +46,55 @@ std::string WriteCookie(const fs::path& dir);
 //! file is absent (the node is not running -- do not dial).
 std::optional<std::string> ReadCookie(const fs::path& dir);
 
-//! Node side: load the persistent per-datadir node_id from
-//! <dir>/node_identity.json (generating a new UUID on first run), then rewrite
-//! the file with the current network / datadir / genesis and return the identity.
-interfaces::NodeIdentity WriteIdentity(const fs::path& dir);
+//! Compute the node identity token: HEX(SHA256(domain-tag ‖ LE32(len) ‖ uuid)).
+//! Deterministic in \p wallet_uuid; returns "" (identity unavailable) when the
+//! UUID is empty. The raw UUID never crosses the wire -- only this hash does.
+std::string ComputeIdentityToken(const std::vector<unsigned char>& wallet_uuid);
 
-//! GUI side: read <dir>/node_identity.json. Returns nullopt when absent or
-//! malformed.
-std::optional<interfaces::NodeIdentity> ReadIdentity(const fs::path& dir);
+//! Soft (non-fatal) handshake findings surfaced to the GUI.
+enum class SoftWarn {
+    GitCommitMismatch, //!< GUI and node built from different commits (banner).
+    GuiOlderMinor,     //!< GUI schema_minor < node: forward-compatible (log-only).
+};
 
-//! GUI side: run the authentication + build-info compatibility half of the
-//! connect handshake (design section 4.3 steps 5-6) against a freshly-connected
-//! remote Init. Calls authenticate(\p cookie) then getBuildInfo() and compares
-//! versions against this build. Returns true on success; on failure returns false
-//! and sets \p error_out to a human-readable reason. Hard-fail conditions: wrong
-//! cookie, schema_major mismatch (incompatible wire format), protocol_version
-//! mismatch, and the GUI's schema_minor being newer than the node's. (The
-//! identity binding and the git_commit soft-warn are handled GUI-side.)
-bool ClientAuthenticateAndCheck(interfaces::Init& init, const std::string& cookie, std::string& error_out);
+//! Result of the connect handshake. On ok==false the connection must be rejected
+//! and \p error shown/logged. On ok==true \p remote_build / \p remote_ident are
+//! valid and \p soft carries any non-fatal findings.
+struct HandshakeResult {
+    bool ok = false;
+    std::string error;
+    interfaces::BuildInfo remote_build;
+    interfaces::NodeIdentity remote_ident;
+    std::vector<SoftWarn> soft;
+};
+
+//! GUI side: the authentication + compatibility half of the connect handshake
+//! (design section 4.3). Against a freshly-connected remote Init, calls
+//! authenticate(cookie), getBuildInfo() and getIdentity() -- all inside one
+//! try/catch, so an IPC throw (daemon vanished mid-handshake) becomes a clean
+//! ok==false rather than an escaping exception. Hard-fail (ok==false) on: wrong
+//! cookie, schema_major mismatch, protocol_version mismatch, GUI schema_minor >
+//! node's, and a network mismatch vs \p local_network. Soft findings (git_commit
+//! mismatch, GUI older minor) are returned in \p soft, not failures. The identity
+//! token is returned in \p remote_ident for the caller's GUI-side binding step
+//! (CheckIdentityBinding) -- this function does not judge it.
+HandshakeResult ClientHandshake(interfaces::Init& init, const std::string& cookie,
+                                const std::string& local_network);
+
+//! Outcome of comparing a node's reported identity token against the GUI's stored
+//! expectation for this datadir.
+enum class BindOutcome {
+    FirstSeen,         //!< No stored token: persist \p reported and proceed.
+    Match,             //!< Stored == reported: proceed.
+    Mismatch,          //!< Stored != reported: prompt / -autotrustidentity / exit.
+    UnavailableFresh,  //!< Reported empty, nothing stored: proceed unbound (log once).
+    UnavailableStored, //!< Reported empty but a token was stored: treat as a mismatch
+                       //!< (a downgrade signal -- never silently skip).
+};
+
+//! Pure comparison of a reported token against a stored one. No I/O; the caller
+//! owns the QSettings read/write and the prompt. See BindOutcome.
+BindOutcome CheckIdentityBinding(const std::string& reported_token, const std::string& stored_token);
 
 } // namespace ipc
 

--- a/src/ipc/handshake.h
+++ b/src/ipc/handshake.h
@@ -78,8 +78,12 @@ struct HandshakeResult {
 //! mismatch, GUI older minor) are returned in \p soft, not failures. The identity
 //! token is returned in \p remote_ident for the caller's GUI-side binding step
 //! (CheckIdentityBinding) -- this function does not judge it.
+//! \p local defaults to this build's GetLocalBuildInfo(); it is a parameter only
+//! so tests can drive every comparison branch (e.g. GUI-newer-minor) regardless
+//! of the compiled-in schema constants.
 HandshakeResult ClientHandshake(interfaces::Init& init, const std::string& cookie,
-                                const std::string& local_network);
+                                const std::string& local_network,
+                                const interfaces::BuildInfo& local = GetLocalBuildInfo());
 
 //! Outcome of comparing a node's reported identity token against the GUI's stored
 //! expectation for this datadir.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -283,6 +283,7 @@ static void QuitOnDaemonConnectionLost(const char* reason)
     }
 }
 
+#ifdef ENABLE_MULTIPROCESS
 //! QSettings key under which the GUI remembers the node identity token it bound to
 //! for this data directory. Keyed by a hash of the canonical datadir so no path is
 //! stored; the datadir is the rendezvous point the GUI and node already share.
@@ -377,6 +378,7 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
     }
     return true;
 }
+#endif // ENABLE_MULTIPROCESS
 
 //! QApplication subclass that contains exceptions escaping Qt event handlers.
 //! In -multiprocess mode the GUI polls the node with synchronous proxy calls from

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -33,6 +33,7 @@
 #include "node/shutdown.h"
 #ifdef ENABLE_MULTIPROCESS
 #include "ipc/connect.h"
+#include "ipc/handshake.h"
 #endif
 #include "node/ui_interface.h"
 #include "qtipcserver.h"
@@ -58,6 +59,9 @@
 #include <thread>
 
 #include <QMessageBox>
+#include <QCryptographicHash>
+#include <QPushButton>
+#include <QSettings>
 #include <QGridLayout>
 #include <QDebug>
 #include <QTextCodec>
@@ -131,6 +135,15 @@ static void SetupUIArgs(ArgsManager& argsman)
                    ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-showorphans", "Include stale (orphaned) coinstake transactions in the transaction list",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-autotrustidentity",
+                   "In -multiprocess mode, silently re-bind when the daemon's wallet identity changes "
+                   "for this data directory instead of prompting -- for instances where the wallet is "
+                   "swapped deliberately, and for headless/scripted starts (default: 0)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+    argsman.AddArg("-nobuildwarn",
+                   "In -multiprocess mode, suppress the warning logged when the GUI and daemon were "
+                   "built from different commits (default: 0)",
+                   ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-guilogfile=<file>",
                    "In -multiprocess mode the GUI runs as a separate process from the node and MUST NOT "
                    "share the node's debug log file (the node rotates it by rename, which would orphan the "
@@ -268,6 +281,101 @@ static void QuitOnDaemonConnectionLost(const char* reason)
     if (QCoreApplication* qapp = QCoreApplication::instance()) {
         QMetaObject::invokeMethod(qapp, [] { BitcoinGUI::requestQuit(); }, Qt::QueuedConnection);
     }
+}
+
+//! QSettings key under which the GUI remembers the node identity token it bound to
+//! for this data directory. Keyed by a hash of the canonical datadir so no path is
+//! stored; the datadir is the rendezvous point the GUI and node already share.
+static QString NodeIdentitySettingsKey()
+{
+    fs::path dir;
+    try {
+        dir = fs::canonical(GetDataDir());
+    } catch (const std::exception&) {
+        dir = GetDataDir(); // canonical() can throw (permissions); a stable raw path still works
+    }
+    const std::string s = dir.string();
+    const QByteArray h = QCryptographicHash::hash(QByteArray(s.data(), static_cast<int>(s.size())),
+                                                  QCryptographicHash::Sha256)
+                             .toHex();
+    return QStringLiteral("ipc/identity/") + QString::fromLatin1(h);
+}
+
+//! GUI-side identity binding + soft-warnings after a successful handshake
+//! (Phase-2 design section 4.2/4.3). The wire compatibility (schema/protocol/
+//! network) was already verified in ClientHandshake; here we confirm the node is
+//! serving the same wallet the GUI bound to for this datadir, and surface any
+//! mixed-build warning. Returns false only when the GUI must exit (a wallet change
+//! the user declined). -autotrustidentity turns the prompt into a silent rebind
+//! for instances that swap wallets deliberately (and for headless/scripted starts).
+static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
+{
+    QSettings settings;
+    const QString key = NodeIdentitySettingsKey();
+    const QString reported = QString::fromStdString(hs.remote_ident.identity_token);
+    const QString stored = settings.value(key).toString();
+
+    const auto persist = [&](const QString& token) {
+        settings.setValue(key, token);
+        settings.sync();
+        if (settings.status() != QSettings::NoError) {
+            GUILogPrintf("IPC: WARNING: could not persist the node-identity binding "
+                         "(QSettings status %d); the wallet-swap guard is disabled this session",
+                         static_cast<int>(settings.status()));
+        }
+    };
+
+    switch (ipc::CheckIdentityBinding(reported.toStdString(), stored.toStdString())) {
+    case ipc::BindOutcome::Match:
+        break;
+    case ipc::BindOutcome::UnavailableFresh:
+        GUILogPrintf("IPC: the daemon reported no wallet identity (binding unavailable); "
+                     "proceeding without the wallet-swap guard");
+        break;
+    case ipc::BindOutcome::FirstSeen:
+        GUILogPrintf("IPC: bound to the daemon's wallet identity for this data directory");
+        persist(reported);
+        break;
+    case ipc::BindOutcome::Mismatch:
+    case ipc::BindOutcome::UnavailableStored: {
+        if (gArgs.GetBoolArg("-autotrustidentity", false)) {
+            GUILogPrintf("IPC: the daemon's wallet identity changed; -autotrustidentity set -> "
+                         "re-binding to the new wallet without prompting");
+            persist(reported);
+            break;
+        }
+        QMessageBox box(QMessageBox::Warning, PACKAGE_NAME,
+                        QObject::tr("The wallet in this data directory appears to have changed since "
+                                    "you last connected to the Gridcoin daemon from here (it may have "
+                                    "been replaced or restored).\n\nTrust this wallet and remember it, "
+                                    "or quit?"));
+        QPushButton* trust = box.addButton(QObject::tr("Trust this wallet"), QMessageBox::AcceptRole);
+        QPushButton* quit = box.addButton(QObject::tr("Quit"), QMessageBox::RejectRole);
+        box.setDefaultButton(quit);
+        box.exec();
+        if (box.clickedButton() == trust) {
+            GUILogPrintf("IPC: user trusted the changed wallet identity -> re-binding");
+            persist(reported);
+            break;
+        }
+        GUILogPrintf("IPC: user declined the changed wallet identity -> quitting "
+                     "(relaunch with -autotrustidentity to accept it non-interactively)");
+        return false;
+    }
+    }
+
+    // Soft (non-fatal) findings.
+    for (const ipc::SoftWarn w : hs.soft) {
+        if (w == ipc::SoftWarn::GuiOlderMinor) {
+            GUILogPrintf("IPC: the daemon speaks a newer IPC schema minor than this GUI "
+                         "(forward-compatible; some newer features may be unavailable)");
+        } else if (w == ipc::SoftWarn::GitCommitMismatch && !gArgs.GetBoolArg("-nobuildwarn", false)) {
+            GUILogPrintf("IPC: WARNING: the GUI (%s) and daemon (%s) were built from different "
+                         "commits; mixed builds can behave unexpectedly",
+                         ipc::GetLocalBuildInfo().git_commit, hs.remote_build.git_commit);
+        }
+    }
+    return true;
 }
 
 //! QApplication subclass that contains exceptions escaping Qt event handlers.
@@ -830,6 +938,15 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 return EXIT_FAILURE;
             }
             interface_init = node_connection->init.get();
+
+            // GUI-side identity binding + soft-warnings: confirm the daemon serves
+            // the same wallet the GUI bound to for this datadir (prompt / rebind on
+            // change), and surface a mixed-build warning. Exits if a wallet change
+            // is declined.
+            if (!ResolveNodeIdentity(node_connection->handshake))
+            {
+                return EXIT_FAILURE;
+            }
 
             // The multiprocess GUI logs to its own file (set up in main() before
             // this function) but, unlike the node, runs no core scheduler to rotate

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -317,6 +317,10 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
     const QString stored = settings.value(key).toString();
 
     const auto persist = [&](const QString& token) {
+        // Never persist an empty token: that would erase the binding and silently
+        // disable the wallet-swap guard. (Only Mismatch/FirstSeen persist, and both
+        // have a non-empty reported token; this is a defensive backstop.)
+        if (token.isEmpty()) return;
         settings.setValue(key, token);
         settings.sync();
         if (settings.status() != QSettings::NoError) {
@@ -325,6 +329,8 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
                          static_cast<int>(settings.status()));
         }
     };
+
+    const bool autotrust = gArgs.GetBoolArg("-autotrustidentity", false);
 
     switch (ipc::CheckIdentityBinding(reported.toStdString(), stored.toStdString())) {
     case ipc::BindOutcome::Match:
@@ -337,9 +343,9 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
         GUILogPrintf("IPC: bound to the daemon's wallet identity for this data directory");
         persist(reported);
         break;
-    case ipc::BindOutcome::Mismatch:
-    case ipc::BindOutcome::UnavailableStored: {
-        if (gArgs.GetBoolArg("-autotrustidentity", false)) {
+    case ipc::BindOutcome::Mismatch: {
+        // A different (non-empty) wallet identity than the one bound here.
+        if (autotrust) {
             GUILogPrintf("IPC: the daemon's wallet identity changed; -autotrustidentity set -> "
                          "re-binding to the new wallet without prompting");
             persist(reported);
@@ -361,6 +367,33 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
         }
         GUILogPrintf("IPC: user declined the changed wallet identity -> quitting "
                      "(relaunch with -autotrustidentity to accept it non-interactively)");
+        return false;
+    }
+    case ipc::BindOutcome::UnavailableStored: {
+        // The daemon reports NO wallet identity though a binding exists here (a
+        // downgrade signal -- e.g. the node's UUID could not be minted). Never
+        // erase the existing binding by persisting empty; keep it armed so a later
+        // real token is still checked. Do not silently auto-trust this away, even
+        // under -autotrustidentity (that flag accepts a *changed* wallet, not the
+        // loss of the identity we bound to).
+        if (autotrust) {
+            GUILogPrintf("IPC: the daemon reports no wallet identity though a binding exists; "
+                         "-autotrustidentity set -> proceeding, keeping the existing binding");
+            break;
+        }
+        QMessageBox box(QMessageBox::Warning, PACKAGE_NAME,
+                        QObject::tr("The Gridcoin daemon is no longer reporting a wallet identity, "
+                                    "though this front end was bound to one for this data directory. "
+                                    "Proceed this time (the existing binding is kept), or quit?"));
+        QPushButton* proceed = box.addButton(QObject::tr("Proceed"), QMessageBox::AcceptRole);
+        QPushButton* quit = box.addButton(QObject::tr("Quit"), QMessageBox::RejectRole);
+        box.setDefaultButton(quit);
+        box.exec();
+        if (box.clickedButton() == proceed) {
+            GUILogPrintf("IPC: user proceeded past the missing wallet identity -> keeping the binding");
+            break;
+        }
+        GUILogPrintf("IPC: user declined the missing wallet identity -> quitting");
         return false;
     }
     }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -983,6 +983,22 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
                 return EXIT_FAILURE;
             }
 
+            // Mixed-build (git_commit) soft-warning: a dismissible banner in the
+            // main window. The handshake already logged it; -nobuildwarn suppresses
+            // both. window is constructed above, so the banner is set before show().
+            if (!gArgs.GetBoolArg("-nobuildwarn", false))
+            {
+                for (const ipc::SoftWarn w : node_connection->handshake.soft)
+                {
+                    if (w == ipc::SoftWarn::GitCommitMismatch)
+                    {
+                        window.showBuildMismatchWarning(
+                            QString::fromStdString(ipc::GetLocalBuildInfo().git_commit),
+                            QString::fromStdString(node_connection->handshake.remote_build.git_commit));
+                    }
+                }
+            }
+
             // The multiprocess GUI logs to its own file (set up in main() before
             // this function) but, unlike the node, runs no core scheduler to rotate
             // it. Drive the same daily-archive check the node schedules in

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -63,6 +63,8 @@
 #include <QIcon>
 #include <QTabWidget>
 #include <QVBoxLayout>
+#include <QFrame>
+#include <QHBoxLayout>
 #include <QToolBar>
 #include <QToolButton>
 #include <QStatusBar>
@@ -209,7 +211,32 @@ BitcoinGUI::BitcoinGUI(QWidget* parent)
     centralWidget->addWidget(votingPage);
     centralWidget->addWidget(psgtPoolPage);
 
-    setCentralWidget(centralWidget);
+    // Dismissible warning banner above the page stack (multiprocess mixed-build
+    // warning; hidden until showBuildMismatchWarning()). Wrap the stack + banner
+    // in a container so the banner reflows the pages rather than overlaying them.
+    m_build_warning_banner = new QFrame(this);
+    m_build_warning_banner->setObjectName("buildWarningBanner");
+    m_build_warning_banner->setStyleSheet(
+        "#buildWarningBanner { background-color: #8a6d3b; }"
+        "#buildWarningBanner QLabel { color: white; }");
+    m_build_warning_banner->setVisible(false);
+    QHBoxLayout *bannerLayout = new QHBoxLayout(m_build_warning_banner);
+    bannerLayout->setContentsMargins(8, 4, 8, 4);
+    m_build_warning_label = new QLabel(m_build_warning_banner);
+    m_build_warning_label->setWordWrap(true);
+    QToolButton *bannerDismiss = new QToolButton(m_build_warning_banner);
+    bannerDismiss->setText(tr("Dismiss"));
+    connect(bannerDismiss, &QToolButton::clicked, m_build_warning_banner, &QWidget::hide);
+    bannerLayout->addWidget(m_build_warning_label, 1);
+    bannerLayout->addWidget(bannerDismiss, 0);
+
+    QWidget *centralContainer = new QWidget(this);
+    QVBoxLayout *centralContainerLayout = new QVBoxLayout(centralContainer);
+    centralContainerLayout->setContentsMargins(0, 0, 0, 0);
+    centralContainerLayout->setSpacing(0);
+    centralContainerLayout->addWidget(m_build_warning_banner);
+    centralContainerLayout->addWidget(centralWidget);
+    setCentralWidget(centralContainer);
 
     // Create sync overlay — sits on top of the central widget and blocks
     // interaction until the wallet is in sync (or the user dismisses it).
@@ -767,6 +794,15 @@ void BitcoinGUI::createToolBars()
     statusBar()->addPermanentWidget(frameBlocks);
 
     addToolBarBreak(Qt::TopToolBarArea);
+}
+
+void BitcoinGUI::showBuildMismatchWarning(const QString& gui_commit, const QString& node_commit)
+{
+    if (!m_build_warning_banner || !m_build_warning_label) return;
+    m_build_warning_label->setText(tr("The GUI (%1) and the Gridcoin daemon (%2) were built from "
+                                      "different commits. Mixed builds can behave unexpectedly.")
+                                       .arg(gui_commit, node_commit));
+    m_build_warning_banner->setVisible(true);
 }
 
 void BitcoinGUI::setClientModel(ClientModel *clientModel)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -44,6 +44,7 @@ class SyncOverlay;
 class UpdateDialog;
 
 QT_BEGIN_NAMESPACE
+class QFrame;
 class QLabel;
 class QLineEdit;
 class QTableView;
@@ -75,6 +76,11 @@ public:
         functionality.
     */
     void setWalletModel(WalletModel *walletModel);
+
+    //! Show a dismissible banner warning that the GUI and daemon were built from
+    //! different commits (the multiprocess mixed-build soft-warning). Safe to call
+    //! before the window is shown; a no-op if the banner widgets are absent.
+    void showBuildMismatchWarning(const QString& gui_commit, const QString& node_commit);
 
     /** Provide the PSGT pool interface (Phase 1d-v) to the PSGT pool page and the
         multisign dialog. Set before setWalletModel(), which builds the page's
@@ -132,6 +138,11 @@ private:
     VotingModel *votingModel;
 
     QStackedWidget *centralWidget;
+
+    //! Dismissible warning banner shown above the page stack (multiprocess
+    //! mixed-build warning). Hidden until showBuildMismatchWarning().
+    QFrame *m_build_warning_banner = nullptr;
+    QLabel *m_build_warning_label = nullptr;
 
     OverviewPage *overviewPage;
     FavoritesPage *addressBookPage;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -89,6 +89,13 @@ add_executable(test_gridcoin
     # null-wallet-safe getRowDetail early-returns. Core lives in gridcoin_util,
     # so only the suite is listed here (GUI-OFF).
     qt_wallettxstore_tests.cpp
+    # Multiprocess connect-handshake logic (src/ipc/handshake.cpp): identity-token
+    # hashing, the ClientHandshake matching policy, and CheckIdentityBinding. The
+    # TU has no Cap'n Proto / libmultiprocess dependency, so it compiles into the
+    # ordinary (non-multiprocess) test binary directly -- these unit tests run in
+    # every CI config, not just the multiprocess job.
+    ${CMAKE_SOURCE_DIR}/src/ipc/handshake.cpp
+    ipc_handshake_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -96,6 +96,11 @@ add_executable(test_gridcoin
     # every CI config, not just the multiprocess job.
     ${CMAKE_SOURCE_DIR}/src/ipc/handshake.cpp
     ipc_handshake_tests.cpp
+    # Serve-side handshake gating (src/ipc/serve_init.cpp): ServeInit refuses to
+    # serve anything until authenticate() succeeds. Also Cap'n Proto-free, so it
+    # compiles into the ordinary test binary alongside handshake.cpp.
+    ${CMAKE_SOURCE_DIR}/src/ipc/serve_init.cpp
+    ipc_serve_init_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/ipc_handshake_tests.cpp
+++ b/src/test/ipc_handshake_tests.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/init.h"
+#include "ipc/handshake.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+//! Minimal interfaces::Init stub: drives ClientHandshake with canned responses so
+//! every matching-policy branch is exercised deterministically, no socket. Only
+//! the three handshake methods are overridden; the base Init defaults (return
+//! nullptr) cover the makeX factories.
+struct FakeInit : public interfaces::Init {
+    bool auth_ok{true};
+    bool throw_on_identity{false};
+    interfaces::BuildInfo build;
+    interfaces::NodeIdentity ident;
+
+    bool authenticate(const std::string&) override { return auth_ok; }
+    interfaces::BuildInfo getBuildInfo() override { return build; }
+    interfaces::NodeIdentity getIdentity() override
+    {
+        if (throw_on_identity) throw std::runtime_error("daemon vanished mid-handshake");
+        return ident;
+    }
+};
+
+//! A local build the fakes below match for a clean handshake. schema_minor is 1 so
+//! both the GUI-newer (hard) and GUI-older (soft) minor branches are reachable.
+interfaces::BuildInfo MakeLocal()
+{
+    interfaces::BuildInfo b;
+    b.git_commit = "local-commit";
+    b.built_at = "now";
+    b.schema_major = 2;
+    b.schema_minor = 1;
+    b.protocol_version = 1;
+    return b;
+}
+
+bool HasSoft(const ipc::HandshakeResult& r, ipc::SoftWarn w)
+{
+    return std::find(r.soft.begin(), r.soft.end(), w) != r.soft.end();
+}
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(ipc_handshake_tests)
+
+// ---- ComputeIdentityToken ----
+
+BOOST_AUTO_TEST_CASE(identity_token_empty_uuid_is_empty)
+{
+    BOOST_CHECK(ipc::ComputeIdentityToken({}).empty());
+}
+
+BOOST_AUTO_TEST_CASE(identity_token_is_deterministic_and_hex_sha256)
+{
+    const std::vector<unsigned char> uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    BOOST_CHECK_EQUAL(ipc::ComputeIdentityToken(uuid), ipc::ComputeIdentityToken(uuid));
+    BOOST_CHECK_EQUAL(ipc::ComputeIdentityToken(uuid).size(), 64u); // 32-byte SHA256 as hex
+}
+
+BOOST_AUTO_TEST_CASE(identity_token_changes_with_uuid)
+{
+    const std::vector<unsigned char> a{1, 2, 3}, b{1, 2, 4};
+    BOOST_CHECK(ipc::ComputeIdentityToken(a) != ipc::ComputeIdentityToken(b));
+    // Different lengths must also differ (the LE32 length prefix guarantees it).
+    const std::vector<unsigned char> c{1, 2};
+    BOOST_CHECK(ipc::ComputeIdentityToken(a) != ipc::ComputeIdentityToken(c));
+}
+
+// ---- CheckIdentityBinding ----
+
+BOOST_AUTO_TEST_CASE(bind_first_seen)
+{
+    BOOST_CHECK(ipc::CheckIdentityBinding("tok", "") == ipc::BindOutcome::FirstSeen);
+}
+
+BOOST_AUTO_TEST_CASE(bind_match)
+{
+    BOOST_CHECK(ipc::CheckIdentityBinding("tok", "tok") == ipc::BindOutcome::Match);
+}
+
+BOOST_AUTO_TEST_CASE(bind_mismatch)
+{
+    BOOST_CHECK(ipc::CheckIdentityBinding("tok", "other") == ipc::BindOutcome::Mismatch);
+}
+
+BOOST_AUTO_TEST_CASE(bind_unavailable_fresh)
+{
+    BOOST_CHECK(ipc::CheckIdentityBinding("", "") == ipc::BindOutcome::UnavailableFresh);
+}
+
+BOOST_AUTO_TEST_CASE(bind_unavailable_stored_is_a_downgrade)
+{
+    // Node reports empty but the GUI had a bound token: must be a downgrade signal,
+    // never a silent skip (an attacker could force the node to report empty).
+    BOOST_CHECK(ipc::CheckIdentityBinding("", "tok") == ipc::BindOutcome::UnavailableStored);
+}
+
+// ---- ClientHandshake (hard fails) ----
+
+BOOST_AUTO_TEST_CASE(handshake_rejects_bad_cookie)
+{
+    FakeInit f;
+    f.auth_ok = false;
+    const auto r = ipc::ClientHandshake(f, "cookie", "main", MakeLocal());
+    BOOST_CHECK(!r.ok);
+    BOOST_CHECK(!r.error.empty());
+}
+
+BOOST_AUTO_TEST_CASE(handshake_rejects_schema_major_mismatch)
+{
+    const auto local = MakeLocal();
+    FakeInit f;
+    f.build = local;
+    f.build.schema_major += 1;
+    f.ident.network = "main";
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(!r.ok);
+}
+
+BOOST_AUTO_TEST_CASE(handshake_rejects_protocol_mismatch)
+{
+    const auto local = MakeLocal();
+    FakeInit f;
+    f.build = local;
+    f.build.protocol_version += 1;
+    f.ident.network = "main";
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(!r.ok);
+}
+
+BOOST_AUTO_TEST_CASE(handshake_rejects_gui_newer_minor)
+{
+    const auto local = MakeLocal(); // schema_minor 1
+    FakeInit f;
+    f.build = local;
+    f.build.schema_minor = 0; // node is older -> GUI newer -> hard fail
+    f.ident.network = "main";
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(!r.ok);
+}
+
+BOOST_AUTO_TEST_CASE(handshake_rejects_network_mismatch)
+{
+    const auto local = MakeLocal();
+    FakeInit f;
+    f.build = local;
+    f.ident.network = "test"; // GUI asked for main
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(!r.ok);
+}
+
+BOOST_AUTO_TEST_CASE(handshake_ipc_throw_is_clean_failure)
+{
+    const auto local = MakeLocal();
+    FakeInit f;
+    f.build = local;
+    f.ident.network = "main";
+    f.throw_on_identity = true; // getIdentity() throws mid-handshake
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(!r.ok);
+    BOOST_CHECK(!r.error.empty());
+    BOOST_CHECK(r.soft.empty());
+}
+
+// ---- ClientHandshake (soft findings + clean) ----
+
+BOOST_AUTO_TEST_CASE(handshake_soft_gui_older_minor)
+{
+    const auto local = MakeLocal(); // schema_minor 1
+    FakeInit f;
+    f.build = local;
+    f.build.schema_minor = 2; // node newer -> forward-compatible soft finding (log-only)
+    f.ident.network = "main";
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(r.ok);
+    BOOST_CHECK(HasSoft(r, ipc::SoftWarn::GuiOlderMinor));
+}
+
+BOOST_AUTO_TEST_CASE(handshake_soft_git_commit_mismatch)
+{
+    const auto local = MakeLocal();
+    FakeInit f;
+    f.build = local;
+    f.build.git_commit = "a-different-commit";
+    f.ident.network = "main";
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(r.ok);
+    BOOST_CHECK(HasSoft(r, ipc::SoftWarn::GitCommitMismatch));
+}
+
+BOOST_AUTO_TEST_CASE(handshake_clean_match_no_soft)
+{
+    const auto local = MakeLocal();
+    FakeInit f;
+    f.build = local;
+    f.ident.network = "main";
+    f.ident.identity_token = "deadbeef";
+    const auto r = ipc::ClientHandshake(f, "c", "main", local);
+    BOOST_CHECK(r.ok);
+    BOOST_CHECK(r.soft.empty());
+    BOOST_CHECK_EQUAL(r.remote_ident.identity_token, "deadbeef");
+    BOOST_CHECK_EQUAL(r.remote_build.git_commit, local.git_commit);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ipc_serve_init_tests.cpp
+++ b/src/test/ipc_serve_init_tests.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "interfaces/init.h"
+#include "ipc/handshake.h"
+#include "ipc/serve_init.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace {
+//! Inner Init the served wrapper delegates to. isCoreReady() is overridden so we
+//! can observe that it is reachable only after authentication; getIdentity() would
+//! be ignored (ServeInit serves the identity it was constructed with), so it is
+//! left as the base default.
+struct StubInit : public interfaces::Init {
+    bool isCoreReady() override { return true; }
+};
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(ipc_serve_init_tests)
+
+// The serve-side counterpart to ipc_handshake_tests' client coverage: ServeInit
+// must refuse to serve build/identity/delegated methods until authenticate()
+// succeeds with the right cookie, and must serve THIS process's build info + the
+// identity it was handed (not the inner Init's).
+BOOST_AUTO_TEST_CASE(serve_init_gates_everything_on_authentication)
+{
+    interfaces::NodeIdentity id;
+    id.identity_token = "expected-token";
+    id.network = "main";
+    auto serve = ipc::MakeServeInit(std::make_unique<StubInit>(), "s3cr3t-cookie", id);
+
+    // Pre-auth: nothing is served.
+    BOOST_CHECK_THROW(serve->getBuildInfo(), std::exception);
+    BOOST_CHECK_THROW(serve->getIdentity(), std::exception);
+    BOOST_CHECK_THROW(serve->isCoreReady(), std::exception);
+
+    // Wrong cookie: authenticate() reports false and the session stays gated.
+    BOOST_CHECK(!serve->authenticate("wrong-cookie"));
+    BOOST_CHECK_THROW(serve->getBuildInfo(), std::exception);
+
+    // Correct cookie: authenticate() succeeds and the gate opens.
+    BOOST_CHECK(serve->authenticate("s3cr3t-cookie"));
+    BOOST_CHECK_NO_THROW(serve->getBuildInfo());
+    BOOST_CHECK(serve->isCoreReady());
+
+    // getIdentity() serves the identity ServeInit was constructed with.
+    const interfaces::NodeIdentity served = serve->getIdentity();
+    BOOST_CHECK_EQUAL(served.identity_token, "expected-token");
+    BOOST_CHECK_EQUAL(served.network, "main");
+}
+
+BOOST_AUTO_TEST_CASE(serve_init_getbuildinfo_is_this_builds_info)
+{
+    interfaces::NodeIdentity id;
+    id.network = "main";
+    auto serve = ipc::MakeServeInit(std::make_unique<StubInit>(), "cookie", id);
+    BOOST_CHECK(serve->authenticate("cookie"));
+    // Served build info is this process's embedded fingerprint, not the inner's.
+    BOOST_CHECK_EQUAL(serve->getBuildInfo().git_commit, ipc::GetLocalBuildInfo().git_commit);
+    BOOST_CHECK_EQUAL(serve->getBuildInfo().schema_major, ipc::IPC_SCHEMA_MAJOR);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3758,6 +3758,24 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
         fFirstRunRet = !vchDefaultKey.IsValid();
     }
 
+    // Mint a persistent per-wallet UUID on first load if absent, for the
+    // multiprocess identity handshake (fingerprints *which wallet* a node serves).
+    // Skipped on mockable chains (regtest), whose wallet DB is not persisted -- a
+    // fresh UUID every restart would false-trip the GUI's identity binding. Not
+    // secret, not key-derived; a write failure just leaves it empty (identity is
+    // then reported as "unavailable" and the GUI skips binding).
+    if (m_wallet_uuid.empty() && !Params().IsMockableChain())
+    {
+        std::vector<unsigned char> uuid(16);
+        GetStrongRandBytes(uuid);
+        if (CWalletDB(strWalletFile).WriteWalletUuid(uuid)) {
+            m_wallet_uuid = std::move(uuid);
+        } else {
+            LogPrintf("%s: WARNING: could not persist wallet UUID; multiprocess "
+                      "identity binding is disabled for this wallet", __func__);
+        }
+    }
+
     NewThread(ThreadFlushWalletDB, &strWalletFile);
 
     LogPrintf("LoadWallet: started wallet flush thread.");

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -130,6 +130,12 @@ private:
     /* the HD chain data model (external chain counters) */
     CHDChain hdChain;
 
+    //! Random per-wallet identity tag (16 bytes), minted once and persisted in
+    //! wallet.dat as the "walletuuid" record. Used by the multiprocess handshake
+    //! to fingerprint *which wallet* a node is serving (independent of chain state
+    //! or datadir path). Not secret, not key-derived. Empty until loaded/minted.
+    std::vector<unsigned char> m_wallet_uuid;
+
     /* the seed phrase record for a phrase-backed HD hierarchy */
     CSeedPhraseData m_seed_phrase_data GUARDED_BY(cs_wallet);
 
@@ -568,6 +574,15 @@ public:
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() { return hdChain; }
+
+    //! Load the persisted wallet UUID (called by CWalletDB during LoadWallet). No
+    //! disk write.
+    void LoadWalletUuid(const std::vector<unsigned char>& uuid) { m_wallet_uuid = uuid; }
+
+    //! The per-wallet identity tag (16 bytes), or empty if none has been minted
+    //! (e.g. a mockable-chain wallet, or a write failure at mint time). Immutable
+    //! after load; safe to read without cs_wallet.
+    std::vector<unsigned char> GetWalletUuid() const { return m_wallet_uuid; }
 
     /* Load the seed phrase record during wallet db load (memory only) */
     bool LoadSeedPhraseData(const CSeedPhraseData& data, bool crypted);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -467,6 +467,12 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
         }
+        else if (strType == "walletuuid")
+        {
+            std::vector<unsigned char> vchUuid;
+            ssValue >> vchUuid;
+            pwallet->LoadWalletUuid(vchUuid);
+        }
         else if (strType == "seedphrase" || strType == "cseedphrase")
         {
             CSeedPhraseData seed_phrase;
@@ -812,7 +818,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
             string strType, strErr;
             bool fReadOK = ReadKeyValue(&dummyWallet, ssKey, ssValue,
                                         wss, strType, strErr);
-            if (!IsKeyType(strType) && strType != "hdchain")
+            if (!IsKeyType(strType) && strType != "hdchain" && strType != "walletuuid")
                 continue;
             if (!fReadOK)
             {
@@ -840,6 +846,12 @@ bool CWalletDB::WriteHDChain(const CHDChain& chain)
 {
     nWalletDBUpdated++;
     return Write(std::string("hdchain"), chain);
+}
+
+bool CWalletDB::WriteWalletUuid(const std::vector<unsigned char>& uuid)
+{
+    nWalletDBUpdated++;
+    return Write(std::string("walletuuid"), uuid);
 }
 
 bool CWalletDB::WriteSeedPhrase(const CSeedPhraseData& data)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -471,7 +471,15 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             std::vector<unsigned char> vchUuid;
             ssValue >> vchUuid;
-            pwallet->LoadWalletUuid(vchUuid);
+            // The UUID is always exactly 16 bytes; reject any other size (a
+            // corrupted record) rather than binding to garbage. Treated as absent,
+            // so LoadWallet re-mints a fresh one.
+            if (vchUuid.size() == 16) {
+                pwallet->LoadWalletUuid(vchUuid);
+            } else {
+                LogPrintf("%s: WARNING: ignoring walletuuid record of unexpected size %u",
+                          __func__, static_cast<unsigned>(vchUuid.size()));
+            }
         }
         else if (strType == "seedphrase" || strType == "cseedphrase")
         {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -290,6 +290,7 @@ public:
 
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
+    bool WriteWalletUuid(const std::vector<unsigned char>& uuid);
 
     //! write the seed phrase record with a plaintext blob (unencrypted wallet)
     bool WriteSeedPhrase(const CSeedPhraseData& data);


### PR DESCRIPTION
## Summary

Completes **Phase 2** of the multiprocess GUI/node split (RFC #2937, tracker #3153): the remaining ① identity-handshake polish, the ② serve-side handshake test, and a reference spec for alternative front ends.

> **Stacked on #3237** (the identity handshake). Until #3237 merges, this PR's diff also shows #3237's commits; it should merge *after* #3237. The commits unique to this PR are the last three.

## Changes

### ① Mixed-build warning banner (`0677b415`)
The `git_commit` soft-warning was log-only. `BitcoinGUI` now wraps its page stack in a container hosting a hidden **dismissible warning banner** (`showBuildMismatchWarning`); `bitcoin.cpp` shows it after a successful handshake when the node reports a `GitCommitMismatch`, suppressed per instance by `-nobuildwarn`. (The `SyncOverlay` still tracks the stack via its parent-resize eventFilter; nothing uses the `QMainWindow::centralWidget()` method, so the re-parenting is safe.)

### ② Serve-side handshake auth-gating test (`6d64a298`)
The serve-side counterpart to #3237's `FakeInit` client suite: `ServeInit` must refuse to serve build/identity/delegated methods until `authenticate()` succeeds with the right cookie, and must serve *this* process's build info + the identity it was handed. `serve_init.cpp` has no Cap'n Proto dependency, so (like `handshake.cpp`) it compiles into the ordinary test binary and runs in **every** CI config. Together with the client suite, this covers both halves of the handshake matching/auth policy at the logic level.

*(Scope note: a full two-process **wire** test — real socket + Cap'n Proto marshalling of the renumbered `NodeIdentity` — is validated by the live MP build/mesh, not yet automated; a functional-test harness for it is a reasonable follow-up if we want it in CI.)*

### Interface spec reference (`145278cb`)
`doc/multiprocess_interface_spec.md` — for someone writing an **alternative front end** (a different GUI, TUI, or automation client) against `gridcoinresearchd -multiprocess`. Covers the connect handshake + failure modes, the versioning contract, the full `interfaces::` surface and its value-type DTOs, the `Handler` notification pattern and the windowed `WalletTxSource` model, lifecycle/threading rules, the client security model, a minimal walkthrough, and an **honest gaps section**. Every claim traces to a real symbol.

Notable gaps it surfaces (accurate as of this branch):
- **`SideStakeManager` is not reachable over IPC** — full C++ `Init` member, but no `sidestake.capnp` / `makeSideStakeManager` in `init.capnp`; clients fall back to `Node::executeRpcConsoleCommand`.
- The **peer-identity (`SO_PEERCRED`) check is documented but unimplemented** — the cookie is the sole authenticator.
- Auth is **process-global / sticky / single-connection** (the `ServeInit::m_authenticated` item — a Phase-3 hardening target).

## Testing
- Native **multiprocess** (Qt6, tests) **and** native **non-multiprocess** GUI (Qt6, tests) both build clean and pass all suites, including the new `ipc_serve_init_tests`.
- `lint-whitespace.sh` clean.

## After this
Phase 2 is functionally complete. The final PR will do **Phase 3** hardening: IPC metrics, Linux capability drop, and per-connection `ServeInit` auth (retiring the sticky flag). Optional Phase-2 extra not done here: surfacing the remote daemon build in the About dialog, and an automated two-process wire test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
