### PR TITLE
qt: only reload the transaction model when the display limit actually changes

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -380,9 +380,16 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             }
             break;
         case LimitTxnDisplay:
-            fLimitTxnDisplay = value.toBool();
-            settings.setValue(GUIUtil::nodeSettingsKey("fLimitTxnDisplay"), fLimitTxnDisplay);
-            emit LimitTxnDisplayChanged(fLimitTxnDisplay);
+            // The Options dialog commits every mapped field on OK, so setData() runs
+            // for this option on every commit; guarding on an actual change stops a
+            // full transaction-model reload from being re-triggered when the setting
+            // did not move (slow with a far-back limit date and many transactions).
+            if (fLimitTxnDisplay != value.toBool())
+            {
+                fLimitTxnDisplay = value.toBool();
+                settings.setValue(GUIUtil::nodeSettingsKey("fLimitTxnDisplay"), fLimitTxnDisplay);
+                emit LimitTxnDisplayChanged(fLimitTxnDisplay);
+            }
             break;
         case MaskValues:
             fMaskValues = value.toBool();
@@ -390,8 +397,20 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             emit MaskValuesChanged(fMaskValues);
             break;
         case LimitTxnDate:
-            limitTxnDate = value.toDate();
-            settings.setValue(GUIUtil::nodeSettingsKey("limitTxnDate"), limitTxnDate);
+            // A changed limit date only affects the displayed set while limiting is
+            // active, so persist it and drive a reload (via LimitTxnDisplayChanged,
+            // whose slot re-reads the date just stored) only then. Previously this
+            // case emitted nothing, so a date edit did not take effect until some
+            // unrelated reload.
+            if (limitTxnDate != value.toDate())
+            {
+                limitTxnDate = value.toDate();
+                settings.setValue(GUIUtil::nodeSettingsKey("limitTxnDate"), limitTxnDate);
+                if (fLimitTxnDisplay)
+                {
+                    emit LimitTxnDisplayChanged(fLimitTxnDisplay);
+                }
+            }
             break;
         case PollExpireNotification:
             pollExpireNotification = value.toDouble();


### PR DESCRIPTION
## Problem

`OptionsModel::setData()` emitted `LimitTxnDisplayChanged` **unconditionally** for the `LimitTxnDisplay` option. That signal is wired to the two transaction-model reloaders:

- `OverviewPage::updateTransactions` (`overviewpage.cpp`)
- the windowed transaction model refresh (`walletmodel.cpp`)

Because the Options dialog's data-widget-mapper commits **every** mapped field on `OK`, `setData()` runs for `LimitTxnDisplay` on every commit — so a full transaction-model reload was re-triggered on *every* options change, even when nothing transaction-related moved. With a far-back transaction display-limit date and many transactions, that reload is expensive and makes unrelated options edits feel slow (observed on a large mesh wallet).

## Fix

Gate the emit on an actual change, matching the existing `StartAtStartup`/`StartMin` idiom a few cases up in the same `switch`:

- **`LimitTxnDisplay`** — only persist + emit when the limit flag actually toggles.
- **`LimitTxnDate`** — previously this case persisted the date but emitted *nothing*, so a date edit did not take effect until some unrelated reload. Now it persists the changed date and drives a reload (reusing `LimitTxnDisplayChanged`, whose slot re-reads the just-stored date) **only** when the date actually changed **and** limiting is active (a date change has no visible effect while limiting is off). `limitTxnDate` is assigned before the emit so the reload observes the new value.

Net effect: the common "open Options, click OK" path no longer reloads the transaction model at all.

## Notes

- No new signal/state: this only guards existing emits, so the two connected slots are unaffected.
- Minor edge case: changing *both* the toggle and the date in a single commit yields two reloads instead of one — still far better than the previous reload-on-every-commit, and not worth cross-field coordination.
- Surfaced during mesh testing of the multiprocess GUI (the reload now drains events over IPC, so the redundant reloads were more visible), but the fix is monolith/MP-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
