### PR TITLE
test: retry functional tests that fail on a transient P2P port-bind collision

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -258,8 +258,17 @@ class TestNode():
         last_failure = None
         for _ in range(poll_per_s * self.rpc_timeout):
             if self.process.poll() is not None:
+                # Surface the node's own stderr in the error so the failure REASON
+                # (e.g. a transient P2P port-bind collision -- "Failed to listen on
+                # any port") lands in the test's captured stderr. Otherwise it lives
+                # only in the node stderr file / combined log, invisible to the
+                # test_runner RETRY_SIGNATURES match, so the flake can never retry.
+                self.stderr.seek(0)
+                node_stderr = self.stderr.read().decode('utf-8', 'replace').strip()
                 raise FailedToStartError(self._node_msg(
-                    'gridcoinresearchd exited with status {} during initialization'.format(self.process.returncode)))
+                    'gridcoinresearchd exited with status {} during initialization{}'.format(
+                        self.process.returncode,
+                        '\n' + node_stderr if node_stderr else '')))
             try:
                 rpc = get_rpc_proxy(
                     rpc_url(self.datadir, self.index, self.chain, self.rpchost),

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -348,9 +348,16 @@ def main():
 #     (util.py: 'Predicate <x> not true after <n> {attempts|seconds}') -- emitted
 #     ONLY by a wait_until()/wait_until_stopped() timeout (a node too slow to reach
 #     a state / shut down), never by assert_equal or other assertions.
+#   - "Failed to listen on any port": the node aborted init because it could not
+#     bind its P2P port -- another (leftover or concurrent) node transiently held
+#     it ("Gridcoin is probably already running"). Ports are re-derived per run,
+#     so a retry lands on a free port. Purely environmental: a real assertion/logic
+#     failure never emits this, and a genuinely stuck port would fail every attempt
+#     (reported red, never masked).
 RETRY_SIGNATURES = (
     "Unable to connect to gridcoinresearchd after",
     "not true after",
+    "Failed to listen on any port",
 )
 
 def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, attempts=1, use_term_control):


### PR DESCRIPTION
## Problem

A functional test can abort during node init when its regtest P2P port is transiently held by a leftover or concurrent node:

```
node0 … Unable to bind to 0.0.0.0:41036 … Gridcoin is probably already running.
node0 … Failed to listen on any port. Use -listen=0 if you want this.
```

which cascades to `gridcoinresearchd exited with status -6 during initialization` → `Error: no RPC connection`. Observed on `p2p_version_handshake.py` (native `build_targets.sh` runs, on a busy box). The port frees and each re-run re-derives fresh ports, so a retry succeeds — but the runner only retries on the RPC-connect-timeout and `wait_until` signatures, so this bind flake stuck red, while `p2p_psgt_relay` (RPC-startup signature) retried and passed in the *same* run.

## Why the obvious one-liner isn't enough

Adding `"Failed to listen on any port"` to `RETRY_SIGNATURES` alone does **not** work: the runner's retry check (`test_runner.py`) matches only against the test process's own `stdout`/`stderr`. The bind message is emitted on the **node's** stderr, which the framework captures to a per-node temp file (`test_node.py`); `FailedToStartError` carries only the exit status, and the node output surfaces solely via the separately-fetched combined log — *after* the retry decision. So the signature would never match.

## Fix (two parts)

- **`test_node.py`** — include the node's own stderr in the `FailedToStartError` raised when `gridcoinresearchd` exits during init, so the failure *reason* reaches the test's captured stderr (and the traceback — a general debuggability win).
- **`test_runner.py`** — add `"Failed to listen on any port"` to `RETRY_SIGNATURES`, with a matching doc entry.

## Safety

Tightly scoped, per the existing comment's rule:
- A real assertion/logic failure never emits `"Failed to listen on any port"`.
- A *genuinely* stuck port fails every retry attempt, so it's still reported red — retries only ever rescue a transient collision, never mask a deterministic failure.
- `assert_start_raises_init_error` is unaffected: it matches `expected_msg` against the node stderr **file**, not the exception message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
