### PR TITLE
ipc: per-connection ServeInit auth + SO_PEERCRED peer-uid check (Phase 3)

### DIFF
--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -27,6 +27,7 @@
 #include "interfaces/init.h"
 #include "interfaces/ipc.h"
 #include "ipc/handshake.h"
+#include "ipc/peercred.h"
 #include "ipc/serve_init.h"
 #include "wallet/wallet.h" // pwalletMain / CWallet::GetWalletUuid for the identity token
 #include <atomic>
@@ -313,9 +314,9 @@ bool AppInit(int argc, char* argv[])
         bGridcoinCoreInitComplete = true;
 #ifdef ENABLE_MULTIPROCESS
         // Multiprocess (RFC #2937): after core init, optionally listen on the
-        // AF_UNIX socket and serve the interfaces::Init to an attached GUI. The
-        // serving Init + Ipc live for the run, torn down after the wait loop.
-        std::unique_ptr<interfaces::Init> serve_init;
+        // AF_UNIX socket and serve a fresh interfaces::Init to each attached GUI.
+        // Per-connection auth: a new ServeInit is built per connection; the Ipc
+        // lives for the run, torn down after the wait loop.
         std::unique_ptr<interfaces::Ipc> ipc;
         if (gArgs.GetBoolArg("-multiprocess", false)) {
             try {
@@ -328,9 +329,19 @@ bool AppInit(int argc, char* argv[])
                 if (pwalletMain) {
                     identity.identity_token = ipc::ComputeIdentityToken(pwalletMain->GetWalletUuid());
                 }
-                serve_init = ipc::MakeServeInit(interfaces::MakeGridcoinInit(),
-                                                std::move(cookie), std::move(identity));
-                ipc = interfaces::MakeIpc("gridcoinresearchd", *serve_init);
+                // Per-connection auth (RFC #2937 §4.3 hardening): build a FRESH
+                // ServeInit for EACH accepted connection, so every client must
+                // present the cookie itself -- no shared, sticky authentication.
+                // Reject a foreign OS user before serving (CheckPeerCredentials:
+                // SO_PEERCRED / getpeereid; Windows leans on the datadir ACL).
+                // cookie + identity are captured by value and copied into each
+                // ServeInit.
+                auto make_serve_init = [cookie = std::move(cookie), identity = std::move(identity)]
+                    (int peer_fd) -> std::unique_ptr<interfaces::Init> {
+                        if (!ipc::CheckPeerCredentials(peer_fd)) return nullptr;
+                        return ipc::MakeServeInit(interfaces::MakeGridcoinInit(), cookie, identity);
+                    };
+                ipc = interfaces::MakeIpc("gridcoinresearchd", std::move(make_serve_init));
                 std::string address = "unix";
                 ipc->listenAddress(address);
                 LogPrintf("IPC: serving GUI connections on %s\n", address);

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -17,6 +17,15 @@ struct Context;
 namespace interfaces {
 class Init;
 
+//! Factory that builds the per-connection Init a listening process serves to each
+//! accepted client. Called once per accepted connection with the accepted
+//! socket's fd (\p peer_fd; -1 if unavailable). Returning nullptr REJECTS the
+//! connection before it is served (e.g. an OS peer-credential mismatch). A fresh
+//! Init per connection is what keeps authentication per-connection -- a new peer
+//! cannot ride an earlier peer's authenticated session. A connect-only process
+//! (the GUI) never listens and may pass an empty factory.
+using MakeServeInitFn = std::function<std::unique_ptr<Init>(int peer_fd)>;
+
 //! Interprocess-communication (IPC) helper. Establishes a connection between a
 //! controlling process (the GUI) and a controlled process (the node). When a
 //! connection is established the controlled process exposes its interfaces::Init,
@@ -65,9 +74,10 @@ protected:
 };
 
 //! Return an implementation of the Ipc interface. \p exe_name is this process's
-//! role name (used for the socket filename and thread names); \p init is the
-//! Init this process serves when listening.
-std::unique_ptr<Ipc> MakeIpc(const char* exe_name, Init& init);
+//! role name (used for the socket filename and thread names); \p make_serve_init
+//! builds the per-connection Init this process serves when listening (a
+//! connect-only process never listens and may pass an empty factory).
+std::unique_ptr<Ipc> MakeIpc(const char* exe_name, MakeServeInitFn make_serve_init);
 } // namespace interfaces
 
 #endif // GRIDCOIN_INTERFACES_IPC_H

--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(gridcoin_ipc STATIC EXCLUDE_FROM_ALL
     process.cpp
     interfaces.cpp
     handshake.cpp
+    peercred.cpp
     serve_init.cpp
     connect.cpp
     capnp/protocol.cpp

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -105,7 +105,7 @@ public:
         return client;
     }
 
-    void listen(int listen_fd, const char* exe_name, interfaces::Init& init) override
+    void listen(int listen_fd, const char* exe_name, interfaces::MakeServeInitFn make_init) override
     {
         startLoop(exe_name);
         if (::listen(listen_fd, /*backlog=*/5) != 0) {
@@ -115,11 +115,21 @@ public:
             throw std::system_error(errno, std::system_category());
 #endif
         }
-        // Cap at a single simultaneous connection: the served Init (and its
-        // authentication state) is shared, and the v1 model is exactly one GUI.
-        // This prevents a second peer from riding an already-authenticated session
-        // (see ServeInit). Per-connection auth would lift this cap later.
-        mp::ListenConnections<messages::Init>(*m_loop, listen_fd, init, /*max_connections=*/1);
+        // Per-connection authentication: build a FRESH Init for each accepted
+        // connection via make_init (which also runs the peer-credential check and
+        // returns null to reject a connection before serving). Each connection
+        // therefore authenticates on its own -- a new peer cannot ride an earlier
+        // peer's authenticated session. The single simultaneous-connection cap
+        // remains the v1 "one GUI" model; it is no longer load-bearing for auth.
+        // InitImpl (interfaces::Init) is specified explicitly: it cannot be deduced
+        // from the lambda, which converts to the std::function<...> parameter only
+        // once the parameter type is known.
+        mp::ListenConnectionsFactory<messages::Init, interfaces::Init>(
+            *m_loop, listen_fd,
+            [make_init = std::move(make_init)](int peer_fd) -> std::shared_ptr<interfaces::Init> {
+                return make_init(peer_fd); // unique_ptr -> shared_ptr; null => reject
+            },
+            /*max_connections=*/1);
     }
 
     void disconnectIncoming() override

--- a/src/ipc/connect.cpp
+++ b/src/ipc/connect.cpp
@@ -16,7 +16,6 @@
 namespace ipc {
 
 std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
-                                           interfaces::Init& local_init,
                                            std::string& error_out,
                                            std::function<void()> on_disconnect)
 {
@@ -30,10 +29,9 @@ std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
     }
 
     GuiConnection conn;
-    // MakeIpc requires the Init this process would serve when listening; a
-    // connect-only GUI never listens, but the reference must stay valid for the
-    // Ipc's lifetime -- local_init (owned by the caller) provides it.
-    conn.ipc = interfaces::MakeIpc("gridcoinresearch", local_init);
+    // A connect-only GUI never listens, so it serves no Init: pass an empty
+    // serve-init factory (MakeIpc only ever calls it on the listen path).
+    conn.ipc = interfaces::MakeIpc("gridcoinresearch", {});
 
     // 2. Connect to the node's default socket (<data_dir>/<network>/node.sock,
     //    resolved from GetDataDir() inside connectAddress).

--- a/src/ipc/connect.h
+++ b/src/ipc/connect.h
@@ -46,15 +46,12 @@ struct GuiConnection {
 //!      schema/protocol/network compatibility (result stashed in .handshake).
 //!
 //! On success returns the connection. On any failure returns std::nullopt and
-//! sets \p error_out to a human-readable reason. \p local_init is the GUI's own
-//! Init, which MakeIpc requires (the Init this process would serve if it
-//! listened; a connect-only GUI never does) and which must outlive the returned
-//! connection. If \p on_disconnect is set it is invoked (on the IPC event-loop
-//! thread) when the node drops the connection unexpectedly (crash / SIGKILL, or
-//! a stop that raced the shutdown handshake) — the GUI uses it to quit cleanly
-//! rather than fault on the next call to a now-dead proxy.
+//! sets \p error_out to a human-readable reason. If \p on_disconnect is set it is
+//! invoked (on the IPC event-loop thread) when the node drops the connection
+//! unexpectedly (crash / SIGKILL, or a stop that raced the shutdown handshake) —
+//! the GUI uses it to quit cleanly rather than fault on the next call to a
+//! now-dead proxy.
 std::optional<GuiConnection> ConnectToNode(const fs::path& data_dir,
-                                           interfaces::Init& local_init,
                                            std::string& error_out,
                                            std::function<void()> on_disconnect = {});
 

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -11,6 +11,7 @@
 
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <typeindex>
@@ -85,6 +86,13 @@ public:
 
     void listenAddress(std::string& address) override
     {
+        // A connect-only Ipc is built with an empty serve-init factory (the GUI).
+        // Fail fast here rather than let the empty std::function throw
+        // std::bad_function_call deep in the async accept path on first connect.
+        if (!m_make_init) {
+            throw std::logic_error("Ipc::listenAddress() called without a serve-init factory "
+                                   "(this process is connect-only)");
+        }
         int fd = m_process->bind(GetDataDir(), address);
         FdGuard guard{fd};
         m_protocol->listen(fd, m_exe_name, m_make_init);

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -48,8 +48,8 @@ struct FdGuard
 class IpcImpl : public interfaces::Ipc
 {
 public:
-    IpcImpl(const char* exe_name, interfaces::Init& init)
-        : m_exe_name(exe_name), m_init(init),
+    IpcImpl(const char* exe_name, interfaces::MakeServeInitFn make_init)
+        : m_exe_name(exe_name), m_make_init(std::move(make_init)),
           m_protocol(ipc::capnp::MakeCapnpProtocol()), m_process(ipc::MakeProcess())
     {
     }
@@ -87,7 +87,7 @@ public:
     {
         int fd = m_process->bind(GetDataDir(), address);
         FdGuard guard{fd};
-        m_protocol->listen(fd, m_exe_name, m_init);
+        m_protocol->listen(fd, m_exe_name, m_make_init);
         guard.release(); // the protocol/listener now owns the fd
     }
 
@@ -101,7 +101,7 @@ public:
     Context& context() override { return m_protocol->context(); }
 
     const char* m_exe_name;
-    interfaces::Init& m_init;
+    interfaces::MakeServeInitFn m_make_init;
     std::unique_ptr<Protocol> m_protocol;
     std::unique_ptr<Process> m_process;
 };
@@ -109,8 +109,8 @@ public:
 } // namespace ipc
 
 namespace interfaces {
-std::unique_ptr<Ipc> MakeIpc(const char* exe_name, Init& init)
+std::unique_ptr<Ipc> MakeIpc(const char* exe_name, MakeServeInitFn make_serve_init)
 {
-    return std::make_unique<ipc::IpcImpl>(exe_name, init);
+    return std::make_unique<ipc::IpcImpl>(exe_name, std::move(make_serve_init));
 }
 } // namespace interfaces

--- a/src/ipc/libmultiprocess/include/mp/proxy-io.h
+++ b/src/ipc/libmultiprocess/include/mp/proxy-io.h
@@ -929,6 +929,79 @@ void ListenConnections(EventLoop& loop, SocketId fd, InitImpl& init, std::option
     });
 }
 
+//! Factory variants of _Serve/_Listen/ListenConnections for per-connection
+//! serving (Gridcoin): instead of sharing one long-lived Init across every
+//! connection, construct a FRESH, owned InitImpl per accepted connection via
+//! make_init(peer_fd). Auth state then lives per-connection -- a new peer must
+//! authenticate on its own and cannot ride an earlier peer's session -- and the
+//! Init is destroyed when the connection is. make_init may return nullptr to
+//! REJECT a connection before serving (e.g. an OS peer-credential mismatch): the
+//! stream is dropped and the listener re-arms without counting it. peer_fd is the
+//! accepted socket's fd (kj exposes it via getFd(); -1 when unavailable).
+
+//! Owned-init variant of _Serve: the ProxyServer co-owns `init` (real deleter),
+//! so the per-connection Init is freed when the connection is destroyed.
+template <typename InitInterface, typename InitImpl, typename OnDisconnect>
+void _ServeOwned(EventLoop& loop, kj::Own<kj::AsyncIoStream>&& stream, std::shared_ptr<InitImpl> init, OnDisconnect&& on_disconnect)
+{
+    loop.m_incoming_connections.emplace_front(loop, kj::mv(stream), [init = std::move(init)](Connection& connection) {
+        return kj::heap<ProxyServer<InitInterface>>(init, connection);
+    });
+    auto it = loop.m_incoming_connections.begin();
+    MP_LOG(loop, Log::Info) << "IPC server: socket connected.";
+    if (loop.testing_hook_connected) loop.testing_hook_connected();
+    it->onDisconnect([&loop, it, on_disconnect = std::forward<OnDisconnect>(on_disconnect)]() mutable {
+        MP_LOG(loop, Log::Info) << "IPC server: socket disconnected.";
+        loop.m_incoming_connections.erase(it);
+        on_disconnect();
+        if (loop.testing_hook_disconnected) loop.testing_hook_disconnected();
+    });
+}
+
+template <typename InitInterface, typename InitImpl>
+void _ListenFactory(const std::shared_ptr<Listener>& listener, EventLoop& loop,
+                    std::function<std::shared_ptr<InitImpl>(int)> make_init)
+{
+    if (listener->atCapacity()) return;
+
+    auto* receiver = listener->m_receiver.get();
+    loop.m_task_set->add(receiver->accept().then(
+        [&loop, make_init, listener](kj::Own<kj::AsyncIoStream>&& stream) {
+            int peer_fd = -1;
+            KJ_IF_MAYBE(fd, stream->getFd()) { peer_fd = *fd; }
+            std::shared_ptr<InitImpl> init = make_init(peer_fd);
+            if (init) {
+                ++listener->m_active_connections;
+                _ServeOwned<InitInterface>(loop, kj::mv(stream), std::move(init),
+                    [&loop, make_init, listener] {
+                        const bool resume_accept{listener->atCapacity()};
+                        assert(listener->m_active_connections > 0);
+                        --listener->m_active_connections;
+                        if (resume_accept) _ListenFactory<InitInterface>(listener, loop, make_init);
+                    });
+            } else {
+                MP_LOG(loop, Log::Info) << "IPC server: connection rejected before serving.";
+                // stream dropped here => socket closed; the connection is never
+                // counted, so only the re-arm below applies (no double-arm).
+            }
+            _ListenFactory<InitInterface>(listener, loop, make_init);
+        }));
+}
+
+//! Factory variant of ListenConnections (see _ListenFactory).
+template <typename InitInterface, typename InitImpl>
+void ListenConnectionsFactory(EventLoop& loop, SocketId fd,
+                              std::function<std::shared_ptr<InitImpl>(int)> make_init,
+                              std::optional<size_t> max_connections = std::nullopt)
+{
+    loop.sync([&]() {
+        auto listener{std::make_shared<Listener>(
+            loop.m_io_context.lowLevelProvider->wrapListenSocketFd(fd, kj::LowLevelAsyncIoProvider::TAKE_OWNERSHIP),
+            max_connections)};
+        _ListenFactory<InitInterface>(listener, loop, std::move(make_init));
+    });
+}
+
 extern thread_local ThreadContext g_thread_context; // NOLINT(bitcoin-nontrivial-threadlocal)
 // Silence nonstandard bitcoin tidy error "Variable with non-trivial destructor
 // cannot be thread_local" which should not be a problem on modern platforms, and

--- a/src/ipc/peercred.cpp
+++ b/src/ipc/peercred.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/peercred.h"
+
+#include "util.h" // LogPrintf
+
+#include <cerrno>
+
+#ifndef WIN32
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace ipc {
+
+bool CheckPeerCredentials(int peer_fd)
+{
+#ifdef WIN32
+    // AF_UNIX on Windows exposes no peer-credential API (no SO_PEERCRED /
+    // getpeereid); the owner-only datadir NTFS ACL on node.sock + ipc.cookie is
+    // the guard (see ipc/process.cpp).
+    (void)peer_fd;
+    return true;
+#else
+    if (peer_fd < 0) {
+        LogPrintf("IPC: WARNING: no peer fd available; skipping peer-credential check\n");
+        return true;
+    }
+
+    const uid_t self_uid = ::geteuid();
+    uid_t peer_uid;
+
+#if defined(SO_PEERCRED)
+    // Linux: struct ucred captured at connect time.
+    struct ucred cred;
+    socklen_t len = sizeof(cred);
+    if (::getsockopt(peer_fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) != 0) {
+        LogPrintf("IPC: WARNING: SO_PEERCRED failed (errno %d); skipping peer-credential check\n", errno);
+        return true;
+    }
+    if (len != sizeof(cred)) {
+        LogPrintf("IPC: WARNING: SO_PEERCRED returned an unexpected size; skipping peer-credential check\n");
+        return true;
+    }
+    peer_uid = cred.uid;
+#else
+    // *BSD / macOS.
+    gid_t peer_gid;
+    if (::getpeereid(peer_fd, &peer_uid, &peer_gid) != 0) {
+        LogPrintf("IPC: WARNING: getpeereid failed (errno %d); skipping peer-credential check\n", errno);
+        return true;
+    }
+#endif
+
+    if (peer_uid != self_uid) {
+        LogPrintf("IPC: rejecting connection: peer uid %d does not match serving uid %d\n",
+                  static_cast<int>(peer_uid), static_cast<int>(self_uid));
+        return false;
+    }
+    return true;
+#endif // WIN32
+}
+
+} // namespace ipc

--- a/src/ipc/peercred.h
+++ b/src/ipc/peercred.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_IPC_PEERCRED_H
+#define GRIDCOIN_IPC_PEERCRED_H
+
+namespace ipc {
+
+//! Verify that the peer on an accepted AF_UNIX connection is the SAME OS user as
+//! this (serving) process. This is defense-in-depth on top of the cookie: the
+//! cookie file is already owner-only (0600 in an owner-only datadir), so a
+//! different user should never possess it -- but rejecting a foreign uid up front
+//! closes the connection before any handshake, rather than relying solely on the
+//! cookie gate.
+//!
+//! Platform coverage: Linux uses SO_PEERCRED; *BSD/macOS use getpeereid(); on
+//! Windows AF_UNIX exposes no peer-credential API, so this returns true and the
+//! owner-only datadir NTFS ACL on node.sock + ipc.cookie remains the guard (see
+//! ipc/process.cpp).
+//!
+//! Returns false ONLY on a definite uid mismatch (logged). If the peer uid cannot
+//! be determined (peer_fd < 0, or the getsockopt/getpeereid call fails), it logs
+//! and returns true -- we do not hard-fail a connection we simply could not
+//! inspect, because the cookie remains the root of trust.
+bool CheckPeerCredentials(int peer_fd);
+
+} // namespace ipc
+
+#endif // GRIDCOIN_IPC_PEERCRED_H

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -6,6 +6,7 @@
 #define GRIDCOIN_IPC_PROTOCOL_H
 
 #include "interfaces/init.h"
+#include "interfaces/ipc.h"
 
 #include <functional>
 #include <memory>
@@ -31,9 +32,11 @@ public:
     virtual std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name,
                                                       std::function<void()> on_disconnect = {}) = 0;
 
-    //! Listen for connections on \p listen_fd, accept them, and serve \p init on
-    //! each. Non-blocking; I/O runs on a background thread.
-    virtual void listen(int listen_fd, const char* exe_name, interfaces::Init& init) = 0;
+    //! Listen for connections on \p listen_fd and, for each accepted connection,
+    //! build a fresh Init via \p make_init and serve it (per-connection auth).
+    //! \p make_init returns null to reject a connection before serving.
+    //! Non-blocking; I/O runs on a background thread.
+    virtual void listen(int listen_fd, const char* exe_name, interfaces::MakeServeInitFn make_init) = 0;
 
     //! Disconnect any incoming connections that are still connected.
     virtual void disconnectIncoming() = 0;

--- a/src/ipc/serve_init.cpp
+++ b/src/ipc/serve_init.cpp
@@ -23,13 +23,14 @@
 namespace ipc {
 namespace {
 
-//! Auth-gating wrapper served to IPC clients. The authenticated flag lives on
-//! this served object, which is shared across connections; the node caps the
-//! listener at one connection (see CapnpProtocol::listen), so in the single-GUI
-//! v1 there is no second peer to bleed state to. authenticate() only ever *sets*
-//! the flag on a valid cookie -- it never clears it -- so a later bad-cookie call
-//! cannot de-authenticate the established session. Per-connection auth state (for
-//! multiple simultaneous clients) is a later hardening.
+//! Auth-gating wrapper served to IPC clients. A FRESH ServeInit is built per
+//! accepted connection (CapnpProtocol::listen via the make_serve_init factory),
+//! so the authenticated flag is PER-CONNECTION: it starts false and every peer
+//! must present the cookie itself -- a new connection can never inherit an
+//! earlier peer's authenticated session, and the flag is destroyed with the
+//! connection. authenticate() only ever *sets* the flag on a valid cookie (it
+//! never clears it), so a later bad-cookie call on the SAME connection cannot
+//! de-authenticate it.
 class ServeInit : public interfaces::Init
 {
 public:
@@ -40,8 +41,9 @@ public:
 
     bool authenticate(const std::string& cookie) override
     {
-        // Return whether THIS cookie is valid (the client checks the result), but
-        // only ever set -- never clear -- the sticky session flag.
+        // Return whether THIS cookie is valid (the client checks the result), and
+        // set the (per-connection) authenticated flag on success. Never cleared: a
+        // later bad-cookie call on the same connection cannot de-authenticate it.
         const bool ok = ConstantTimeEqual(cookie, m_cookie);
         if (ok) m_authenticated = true;
         return ok;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -873,8 +873,8 @@ int main(int argc, char *argv[])
     // deliberately: routing handleInitShutdown over IPC would turn a daemon stop
     // into a core->GUI "shutdown-imminent" push, which is out of scope -- the split
     // GUI quits on the socket disconnect (#3227), not on a remote notification.
-    // local_init also backs MakeIpc (a connect-only client still needs an Init) and
-    // IS the interface_init in the monolithic build.
+    // local_init IS the interface_init in the monolithic build (and provides the
+    // LOCAL gui_node above).
     std::unique_ptr<interfaces::Init> local_init = interfaces::MakeGridcoinInit();
     std::unique_ptr<interfaces::Node> gui_node = local_init->makeNode();
 
@@ -901,7 +901,7 @@ int main(int argc, char *argv[])
         // so OptionsModel can be built from the remote Init). Logging is up
         // (InitLogging above), so failures land in the GUI log file.
         std::string ipc_error;
-        node_connection = ipc::ConnectToNode(GetDataDir(), *local_init, ipc_error,
+        node_connection = ipc::ConnectToNode(GetDataDir(), ipc_error,
             /*on_disconnect=*/[] {
                 QuitOnDaemonConnectionLost("lost connection to the Gridcoin daemon");
             });

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -101,6 +101,11 @@ add_executable(test_gridcoin
     # compiles into the ordinary test binary alongside handshake.cpp.
     ${CMAKE_SOURCE_DIR}/src/ipc/serve_init.cpp
     ipc_serve_init_tests.cpp
+    # Peer-credential check (src/ipc/peercred.cpp): SO_PEERCRED / getpeereid
+    # same-user enforcement. No Cap'n Proto, so it compiles into the ordinary
+    # test binary alongside the sources above.
+    ${CMAKE_SOURCE_DIR}/src/ipc/peercred.cpp
+    ipc_peercred_tests.cpp
     random_tests.cpp
     rpc_tests.cpp
     rpchelpman_tests.cpp

--- a/src/test/ipc_peercred_tests.cpp
+++ b/src/test/ipc_peercred_tests.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include "ipc/peercred.h"
+
+#include <boost/test/unit_test.hpp>
+
+#ifndef WIN32
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+BOOST_AUTO_TEST_SUITE(ipc_peercred_tests)
+
+// A peer fd that is not available (< 0) cannot be inspected. CheckPeerCredentials
+// does not enforce what it cannot read -- the cookie remains the root of trust --
+// so it allows and logs rather than rejecting a connection it simply could not
+// examine. (On Windows there is no peer-credential API at all, and this is the
+// only meaningful case.)
+BOOST_AUTO_TEST_CASE(peercred_unavailable_fd_is_allowed)
+{
+    BOOST_CHECK(ipc::CheckPeerCredentials(-1));
+}
+
+#ifndef WIN32
+// Both ends of a socketpair belong to THIS process, so the peer uid equals our
+// own effective uid and CheckPeerCredentials must accept both ends. A cross-user
+// rejection cannot be exercised from a single-process unit test; it is validated
+// live (the mesh) and by the same-user requirement documented for split runs.
+BOOST_AUTO_TEST_CASE(peercred_same_user_socketpair_is_allowed)
+{
+    int sv[2];
+    BOOST_REQUIRE_EQUAL(::socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    BOOST_CHECK(ipc::CheckPeerCredentials(sv[0]));
+    BOOST_CHECK(ipc::CheckPeerCredentials(sv[1]));
+    ::close(sv[0]);
+    ::close(sv[1]);
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ipc_serve_init_tests.cpp
+++ b/src/test/ipc_serve_init_tests.cpp
@@ -66,4 +66,27 @@ BOOST_AUTO_TEST_CASE(serve_init_getbuildinfo_is_this_builds_info)
     BOOST_CHECK_EQUAL(serve->getBuildInfo().schema_major, ipc::IPC_SCHEMA_MAJOR);
 }
 
+// Per-connection auth (Phase 3): the node builds a FRESH ServeInit for each
+// accepted connection (make_serve_init factory), so authentication is per
+// instance. A second connection -- a distinct ServeInit -- starts gated even
+// after an earlier one authenticated; auth can never leak across connections.
+BOOST_AUTO_TEST_CASE(serve_init_authentication_is_per_instance)
+{
+    interfaces::NodeIdentity id;
+    id.network = "main";
+
+    // First "connection": authenticate it.
+    auto first = ipc::MakeServeInit(std::make_unique<StubInit>(), "cookie", id);
+    BOOST_CHECK(first->authenticate("cookie"));
+    BOOST_CHECK(first->isCoreReady());
+
+    // Second "connection" (a fresh ServeInit) is independently gated: it must
+    // present the cookie itself; the first instance's auth does not carry over.
+    auto second = ipc::MakeServeInit(std::make_unique<StubInit>(), "cookie", id);
+    BOOST_CHECK_THROW(second->getBuildInfo(), std::exception);
+    BOOST_CHECK_THROW(second->isCoreReady(), std::exception);
+    BOOST_CHECK(second->authenticate("cookie"));
+    BOOST_CHECK(second->isCoreReady());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Phase 3 hardening (umbrella #3153): closes the sticky-authentication gap in the multiprocess node and adds an `SO_PEERCRED` peer-UID check.

## The gap

The node served a **single shared `ServeInit`** to every connection, and its `m_authenticated` flag — set on the first valid cookie — was **never cleared**. The `max_connections=1` cap stops two *simultaneous* peers but not *sequential* ones: after an authenticated GUI disconnected, the listener re-armed and the next connection **inherited `m_authenticated == true`**, so a second local process could call `makeWallet()` / `makeNode()` **without ever presenting the cookie**. That's the fund-critical hole this closes.

## Fix — per-connection `ServeInit`

Thread a `MakeServeInitFn` factory (builds a `unique_ptr<Init>` per accepted connection, given the accepted socket fd) through `MakeIpc` → `IpcImpl` → `Protocol::listen` → a new libmultiprocess factory serve path:

- `_ServeOwned` / `_ListenFactory` / `ListenConnectionsFactory` (distinctly named so there's no overload ambiguity with the upstream `InitImpl&` versions) construct a **fresh, owned** `InitImpl` per connection. The `ProxyServer` co-owns it, so it's destroyed when the connection is.
- The daemon's factory builds a fresh `ServeInit` per connection, so **every peer authenticates on its own** — a new connection can never ride an earlier peer's session.
- The reject path (`make_init` returns null) drops the stream and re-arms accept **without** counting the connection (no double-arm, no `m_active_connections` miscount).
- The connect-only GUI passes an **empty factory** (it never listens); `ConnectToNode` dropped its now-unused `local_init` param accordingly.

## Fix — `SO_PEERCRED`

`CheckPeerCredentials(fd)` rejects, *before serving*, a connection whose peer OS uid ≠ the serving process's uid: Linux `SO_PEERCRED`, `*BSD`/macOS `getpeereid`. Windows AF_UNIX has no peer-credential API, so it keeps relying on the owner-only datadir ACL on `node.sock` + `ipc.cookie`. This is **defense-in-depth on top of the cookie** — when it can't inspect the peer (fd unavailable / syscall failure) it logs and allows, because the cookie remains the root of trust, so a fail-open there is not a bypass.

The single-connection cap is retained as the v1 "one GUI" model but is **no longer load-bearing for authentication**.

## Tests

- `serve_init_authentication_is_per_instance` — a fresh `ServeInit` is gated even after another instance authenticated (auth never carries across connections).
- `ipc_peercred_tests` — a same-user socketpair is accepted; an unavailable fd (`-1`) is allowed (can't-inspect ⇒ cookie remains the gate). A cross-user rejection can't be exercised in a single-process unit test; it's validated live.

Built Qt6 multiprocess GUI + daemon; all ipc suites green. Adversarially self-reviewed (lifetime/ownership, reject-path accounting, peercred platform paths, empty-factory safety, no move-out of the captured cookie/identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
