### PR TITLE
gui: show IPC connection facts in the About dialog (Phase 3)

### DIFF
--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -65,6 +65,32 @@ void AboutDialog::setModel(ClientModel *model)
     }
 }
 
+void AboutDialog::setIpcConnectionInfo(const GuiIpcInfo& info)
+{
+    // In the monolithic build the GUI and node share one process, so there is no
+    // IPC connection to describe -- hide the section.
+    if (!info.active) {
+        ui->ipcInfoLabel->hide();
+        return;
+    }
+
+    const QString identity = info.node_identity.isEmpty() ? tr("unavailable") : info.node_identity;
+
+    // <b>/<br> make QLabel auto-detect rich text. Captions are translated; the
+    // values (versions, schema, socket path, identity) are shown verbatim.
+    const QString text =
+        tr("<b>Multiprocess connection</b>") + QStringLiteral("<br>") +
+        tr("GUI version: %1").arg(info.gui_version) + QStringLiteral("<br>") +
+        tr("Node version: %1").arg(info.node_version) + QStringLiteral("<br>") +
+        tr("Node built: %1").arg(info.node_built_at) + QStringLiteral("<br>") +
+        tr("IPC schema %1, protocol %2").arg(info.ipc_schema, info.ipc_protocol) + QStringLiteral("<br>") +
+        tr("Node identity: %1 (%2)").arg(identity, info.network) + QStringLiteral("<br>") +
+        tr("Socket: %1").arg(info.socket_path);
+
+    ui->ipcInfoLabel->setText(text);
+    ui->ipcInfoLabel->show();
+}
+
 AboutDialog::~AboutDialog()
 {
     delete ui;

--- a/src/qt/aboutdialog.cpp
+++ b/src/qt/aboutdialog.cpp
@@ -74,18 +74,22 @@ void AboutDialog::setIpcConnectionInfo(const GuiIpcInfo& info)
         return;
     }
 
-    const QString identity = info.node_identity.isEmpty() ? tr("unavailable") : info.node_identity;
+    // The label is Qt::RichText, so every interpolated value must be HTML-escaped
+    // before insertion: the node-sourced strings (versions, build date, identity,
+    // network) arrive over IPC from the daemon and must not be able to inject
+    // markup, and a benign '&' or '<' in a local value (e.g. a data-dir path in
+    // the socket) would otherwise break rendering. Captions are our own literals.
+    const QString identity = info.node_identity.isEmpty()
+        ? tr("unavailable") : info.node_identity.toHtmlEscaped();
 
-    // <b>/<br> make QLabel auto-detect rich text. Captions are translated; the
-    // values (versions, schema, socket path, identity) are shown verbatim.
     const QString text =
         tr("<b>Multiprocess connection</b>") + QStringLiteral("<br>") +
-        tr("GUI version: %1").arg(info.gui_version) + QStringLiteral("<br>") +
-        tr("Node version: %1").arg(info.node_version) + QStringLiteral("<br>") +
-        tr("Node built: %1").arg(info.node_built_at) + QStringLiteral("<br>") +
-        tr("IPC schema %1, protocol %2").arg(info.ipc_schema, info.ipc_protocol) + QStringLiteral("<br>") +
-        tr("Node identity: %1 (%2)").arg(identity, info.network) + QStringLiteral("<br>") +
-        tr("Socket: %1").arg(info.socket_path);
+        tr("GUI version: %1").arg(info.gui_version.toHtmlEscaped()) + QStringLiteral("<br>") +
+        tr("Node version: %1").arg(info.node_version.toHtmlEscaped()) + QStringLiteral("<br>") +
+        tr("Node built: %1").arg(info.node_built_at.toHtmlEscaped()) + QStringLiteral("<br>") +
+        tr("IPC schema %1, protocol %2").arg(info.ipc_schema.toHtmlEscaped(), info.ipc_protocol.toHtmlEscaped()) + QStringLiteral("<br>") +
+        tr("Node identity: %1 (%2)").arg(identity, info.network.toHtmlEscaped()) + QStringLiteral("<br>") +
+        tr("Socket: %1").arg(info.socket_path.toHtmlEscaped());
 
     ui->ipcInfoLabel->setText(text);
     ui->ipcInfoLabel->show();

--- a/src/qt/aboutdialog.h
+++ b/src/qt/aboutdialog.h
@@ -4,6 +4,8 @@
 #include <QDialog>
 #include <QFutureWatcher>
 
+#include "guiipcinfo.h"
+
 #include <string>
 
 namespace Ui {
@@ -22,6 +24,11 @@ public:
     ~AboutDialog();
 
     void setModel(ClientModel *model);
+
+    //! Populate the multiprocess connection section (GUI/node versions, IPC
+    //! schema/protocol, socket, node identity) from the connect handshake. Shows
+    //! it only when info.active (the -multiprocess split build); hidden otherwise.
+    void setIpcConnectionInfo(const GuiIpcInfo& info);
 private:
     //! Result of the off-thread GitHub version check (see
     //! handlePressVersionInfoButton). upgrade_type is carried as an int so the

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -8,6 +8,7 @@
 #include <QTimer>
 
 #include "bitcoingui.h"
+#include "guiipcinfo.h"
 #include "chainparams.h"
 #include "chainparamsbase.h"
 #include "clientmodel.h"
@@ -116,7 +117,7 @@ static void RegisterMetaTypes()
 
 int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel,
                     interfaces::Node& gui_node, interfaces::Init* interface_init,
-                    const QString& mismatch_gui_commit, const QString& mismatch_node_commit);
+                    const GuiIpcInfo& ipc_info);
 
 //! Early, deliberately LIMITED local settings read — run in main() BEFORE the Qt
 //! translator is installed and BEFORE the Intro data-directory dialog.
@@ -891,7 +892,7 @@ int main(int argc, char *argv[])
     // getters/setters reach the daemon over IPC in the split build; OptionsModel's
     // QSettings-backed GUI-local prefs are unaffected by that.
     interfaces::Init* interface_init = local_init.get();
-    QString mismatch_gui_commit, mismatch_node_commit;
+    GuiIpcInfo ipc_info;
     const bool multiprocess = gArgs.GetBoolArg("-multiprocess", false);
 #ifdef ENABLE_MULTIPROCESS
     std::optional<ipc::GuiConnection> node_connection;
@@ -922,14 +923,28 @@ int main(int argc, char *argv[])
         {
             return EXIT_FAILURE;
         }
+        // Gather the IPC connection facts for the About dialog (and the mixed-build
+        // banner). This is the -multiprocess split build, so the section is active.
+        const interfaces::BuildInfo local_build = ipc::GetLocalBuildInfo();
+        const interfaces::BuildInfo& node_build = node_connection->handshake.remote_build;
+        const interfaces::NodeIdentity& node_ident = node_connection->handshake.remote_ident;
+        ipc_info.active = true;
+        ipc_info.gui_version = QString::fromStdString(local_build.git_commit);
+        ipc_info.node_version = QString::fromStdString(node_build.git_commit);
+        ipc_info.node_built_at = QString::fromStdString(node_build.built_at);
+        ipc_info.ipc_schema = QStringLiteral("%1.%2").arg(node_build.schema_major).arg(node_build.schema_minor);
+        ipc_info.ipc_protocol = QString::number(node_build.protocol_version);
+        ipc_info.socket_path = QString::fromStdString((GetDataDir() / "node.sock").string());
+        // Raw token (empty = unavailable); the dialog renders the empty case.
+        ipc_info.node_identity = QString::fromStdString(node_ident.identity_token);
+        ipc_info.network = QString::fromStdString(node_ident.network);
         if (!gArgs.GetBoolArg("-nobuildwarn", false))
         {
             for (const ipc::SoftWarn w : node_connection->handshake.soft)
             {
                 if (w == ipc::SoftWarn::GitCommitMismatch)
                 {
-                    mismatch_gui_commit = QString::fromStdString(ipc::GetLocalBuildInfo().git_commit);
-                    mismatch_node_commit = QString::fromStdString(node_connection->handshake.remote_build.git_commit);
+                    ipc_info.git_commit_mismatch = true;
                 }
             }
         }
@@ -992,8 +1007,7 @@ int main(int argc, char *argv[])
     }
 
     /** Start Qt as normal before it was moved into this function **/
-    StartGridcoinQt(argc, argv, app, *optionsModel, *gui_node, interface_init,
-                    mismatch_gui_commit, mismatch_node_commit);
+    StartGridcoinQt(argc, argv, app, *optionsModel, *gui_node, interface_init, ipc_info);
 
     // We received a request to remove blockchain data so client user can start to sync from 0
     if (fResetBlockchainRequest)
@@ -1022,7 +1036,7 @@ int main(int argc, char *argv[])
 
 int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& optionsModel,
                     interfaces::Node& gui_node, interfaces::Init* interface_init,
-                    const QString& mismatch_gui_commit, const QString& mismatch_node_commit)
+                    const GuiIpcInfo& ipc_info)
 {
     // Set global boolean to indicate intended presence of GUI to core.
     fQtActive = true;
@@ -1089,10 +1103,12 @@ int StartGridcoinQt(int argc, char *argv[], QApplication& app, OptionsModel& opt
             // loop: surface the mixed-build banner (empty commit strings = nothing
             // to warn about, or -nobuildwarn), and start the GUI's own log-archive
             // timer.
-            if (!mismatch_gui_commit.isEmpty())
+            if (ipc_info.git_commit_mismatch)
             {
-                window.showBuildMismatchWarning(mismatch_gui_commit, mismatch_node_commit);
+                window.showBuildMismatchWarning(ipc_info.gui_version, ipc_info.node_version);
             }
+            // Populate the About dialog's multiprocess connection section.
+            window.setIpcConnectionInfo(ipc_info);
 
             // The multiprocess GUI logs to its own file (set up in main() before
             // this function) but, unlike the node, runs no core scheduler to rotate

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -934,7 +934,7 @@ int main(int argc, char *argv[])
         ipc_info.node_built_at = QString::fromStdString(node_build.built_at);
         ipc_info.ipc_schema = QStringLiteral("%1.%2").arg(node_build.schema_major).arg(node_build.schema_minor);
         ipc_info.ipc_protocol = QString::number(node_build.protocol_version);
-        ipc_info.socket_path = QString::fromStdString((GetDataDir() / "node.sock").string());
+        ipc_info.socket_path = GUIUtil::boostPathToQString(GetDataDir() / "node.sock");
         // Raw token (empty = unavailable); the dialog renders the empty case.
         ipc_info.node_identity = QString::fromStdString(node_ident.identity_token);
         ipc_info.network = QString::fromStdString(node_ident.network);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -805,6 +805,11 @@ void BitcoinGUI::showBuildMismatchWarning(const QString& gui_commit, const QStri
     m_build_warning_banner->setVisible(true);
 }
 
+void BitcoinGUI::setIpcConnectionInfo(const GuiIpcInfo& info)
+{
+    m_ipc_info = info;
+}
+
 void BitcoinGUI::setClientModel(ClientModel *clientModel)
 {
     this->clientModel = clientModel;
@@ -1143,6 +1148,7 @@ void BitcoinGUI::aboutClicked()
 {
     AboutDialog dlg;
     dlg.setModel(clientModel);
+    dlg.setIpcConnectionInfo(m_ipc_info);
     dlg.exec();
 }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 #include "guiconstants.h"
+#include "guiipcinfo.h"
 #include "interfaces/wallet_tx_channel.h" // GRC::WalletEvent for processDrainedTransactions
 
 #ifdef Q_OS_MAC
@@ -82,6 +83,11 @@ public:
     //! before the window is shown; a no-op if the banner widgets are absent.
     void showBuildMismatchWarning(const QString& gui_commit, const QString& node_commit);
 
+    //! Provide the IPC connection facts for the About dialog's multiprocess
+    //! section (populated in main() from the connect handshake; inert in the
+    //! monolith build, where ipc_info.active is false).
+    void setIpcConnectionInfo(const GuiIpcInfo& info);
+
     /** Provide the PSGT pool interface (Phase 1d-v) to the PSGT pool page and the
         multisign dialog. Set before setWalletModel(), which builds the page's
         interface-backed table model. */
@@ -143,6 +149,10 @@ private:
     //! mixed-build warning). Hidden until showBuildMismatchWarning().
     QFrame *m_build_warning_banner = nullptr;
     QLabel *m_build_warning_label = nullptr;
+
+    //! IPC connection facts shown in the About dialog's multiprocess section
+    //! (setIpcConnectionInfo()). Inactive/empty in the monolith build.
+    GuiIpcInfo m_ipc_info;
 
     OverviewPage *overviewPage;
     FavoritesPage *addressBookPage;

--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -86,6 +86,25 @@
       </layout>
      </item>
      <item>
+      <widget class="QLabel" name="ipcInfoLabel">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="copyrightLabel">
        <property name="cursor">
         <cursorShape>IBeamCursor</cursorShape>

--- a/src/qt/guiipcinfo.h
+++ b/src/qt/guiipcinfo.h
@@ -24,7 +24,8 @@ struct GuiIpcInfo
     QString ipc_schema;                //!< Negotiated IPC schema, "major.minor".
     QString ipc_protocol;              //!< Negotiated IPC protocol version.
     QString socket_path;               //!< The AF_UNIX socket the GUI connected on.
-    QString node_identity;             //!< The node's identity token (or "unavailable").
+    QString node_identity;             //!< The node's raw identity token; empty means unavailable
+                                       //!< (the About dialog substitutes an "unavailable" label).
     QString network;                   //!< The node's chain network ("main"/"test"/...).
 };
 

--- a/src/qt/guiipcinfo.h
+++ b/src/qt/guiipcinfo.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_QT_GUIIPCINFO_H
+#define GRIDCOIN_QT_GUIIPCINFO_H
+
+#include <QString>
+
+//! Pre-formatted facts about the GUI<->node IPC connection, for the About
+//! dialog's multiprocess section and the mixed-build banner. Populated in main()
+//! from the connect handshake in the -multiprocess split build; in the monolith
+//! build (GUI and node share one process) `active` is false and there is nothing
+//! to show. Strings are display-ready values (not tr()-wrapped captions); the
+//! dialog owns the labels. Doing the formatting in main() keeps the GUI widgets
+//! free of any ipc/handshake dependency.
+struct GuiIpcInfo
+{
+    bool active = false;               //!< Split (-multiprocess) build: show the section.
+    bool git_commit_mismatch = false;  //!< GUI and node built from different commits (banner).
+    QString gui_version;               //!< The GUI process's own version (FormatFullVersion).
+    QString node_version;              //!< The connected daemon's version.
+    QString node_built_at;             //!< The daemon's build timestamp.
+    QString ipc_schema;                //!< Negotiated IPC schema, "major.minor".
+    QString ipc_protocol;              //!< Negotiated IPC protocol version.
+    QString socket_path;               //!< The AF_UNIX socket the GUI connected on.
+    QString node_identity;             //!< The node's identity token (or "unavailable").
+    QString network;                   //!< The node's chain network ("main"/"test"/...).
+};
+
+#endif // GRIDCOIN_QT_GUIIPCINFO_H


### PR DESCRIPTION
Phase 3 (umbrella #3153): surface the IPC connection facts in the About dialog for the `-multiprocess` split GUI.

## What

In the split build the About dialog's version label **already** shows the connected daemon's version (`ClientModel::formatFullVersion` round-trips over IPC). This adds a **multiprocess-only** section with the rest of the connection facts — which were fetched at connect but dropped for display:

- **GUI version** (the GUI process's own) alongside the node version
- **Node build date**
- Negotiated **IPC schema** + **protocol version**
- The **AF_UNIX socket** path the GUI connected on
- **Node identity** token + network

The section is hidden in the monolith build (GUI and node share one process — nothing to describe).

## How

`main()` formats the facts from the connect `HandshakeResult` (plus `GetLocalBuildInfo()` and the socket path) into a small `GuiIpcInfo` struct, threaded `main()` → `StartGridcoinQt` → `BitcoinGUI` → `AboutDialog` — mirroring the existing mixed-build banner path, which this **consolidates**: the git-commit-mismatch flag + commit strings now ride in the same struct, replacing the two `mismatch_*_commit` parameters. The dialog itself has **no `ipc/handshake` dependency** — it just displays pre-formatted strings and hides the section when `ipc_info.active` is false.

## Scope

Static / handshake facts only — **no new instrumentation**. Live IPC call/byte counters were out of scope: they'd need a metrics API on `interfaces::Ipc` plus counters in the vendored libmultiprocess layer.

Built Qt6 GUI **both** multiprocess and monolith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
