### PR TITLE
build+init: harden the -multiprocess daemon (NO_NEW_PRIVS + systemd sandbox)

### DIFF
--- a/contrib/init/gridcoinresearchd.service
+++ b/contrib/init/gridcoinresearchd.service
@@ -23,9 +23,10 @@ ExecStart=/usr/bin/gridcoinresearchd -daemonwait \
                                      -conf=/etc/gridcoin/gridcoin.conf \
                                      -datadir=/var/lib/gridcoinresearchd
 
-# Make sure the config directory is readable by the service user
-PermissionsStartOnly=true
-ExecStartPre=/bin/chgrp gridcoin /etc/gridcoin
+# /etc/gridcoin is created and owned by the service user via ConfigurationDirectory=
+# below, so no PermissionsStartOnly/ExecStartPre chgrp is needed. (A chgrp here
+# would also need CAP_CHOWN, which the CapabilityBoundingSet= drop below removes,
+# and would fail against the read-only /etc from ProtectSystem=strict.)
 
 # Process management
 ####################
@@ -57,26 +58,66 @@ StateDirectoryMode=0710
 
 # Hardening measures
 ####################
+# This mirrors the profile proven on the maintainer's mainnet multiprocess
+# node. In the -multiprocess split the GUI connects to this daemon over an
+# AF_UNIX socket (node.sock) plus cookie in the datadir, both created 0600 and
+# owned by User= above. Do NOT add DynamicUser=/PrivateUsers= (the uid remap
+# would stop the GUI opening the socket/cookie) or PrivateNetwork= (kills the
+# P2P/RPC network).
 
 # Provide a private /tmp and /var/tmp.
 PrivateTmp=true
-
-# Mount /usr, /boot/ and /etc read-only for the process.
-ProtectSystem=full
-
-# Deny access to /home, /root and /run/user
-ProtectHome=true
-
-# Disallow the process and all of its children to gain
-# new privileges through execve().
-NoNewPrivileges=true
 
 # Use a new /dev namespace only populated with API pseudo devices
 # such as /dev/null, /dev/zero and /dev/random.
 PrivateDevices=true
 
+# Mount the whole filesystem read-only except the service's own StateDirectory
+# (/var/lib/gridcoinresearchd -- the datadir, where the IPC socket + cookie also
+# live) and RuntimeDirectory. Stronger than ProtectSystem=full.
+ProtectSystem=strict
+
+# Deny access to /home, /root and /run/user (the datadir is under /var/lib).
+ProtectHome=true
+
+# Disallow the process and all of its children from gaining new privileges
+# through execve(). Matches the in-process -nonewprivs default; both is fine.
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+
+# The service runs unprivileged and needs no capabilities; drop the whole
+# bounding set (systemd counterpart to the in-process capability-bounding-set
+# drop under -nonewprivs).
+CapabilityBoundingSet=
+
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true
+
+# Namespace / kernel-surface restrictions the daemon never needs.
+RestrictRealtime=true
+LockPersonality=true
+RestrictNamespaces=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+UMask=0077
+
+# Syscall allow-list. @system-service covers a typical long-running daemon
+# (fork for -daemonwait, socket/sendmsg/recvmsg, file I/O, ...); a denied call
+# returns EPERM rather than raising SIGSYS, so a stray syscall does not crash
+# the process. This is the maintained, declarative equivalent of an in-process
+# seccomp sandbox (which was deliberately not added -- see doc/multiprocess.md).
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# AF_UNIX for the GUI IPC socket; AF_INET/AF_INET6 for the node; AF_NETLINK for
+# getaddrinfo()/interface enumeration (omitting it breaks DNS / local-address
+# discovery).
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 
 [Install]
 WantedBy=multi-user.target

--- a/debian-testnet/gridcointestnetd.service
+++ b/debian-testnet/gridcointestnetd.service
@@ -57,26 +57,66 @@ StateDirectoryMode=0710
 
 # Hardening measures
 ####################
+# This mirrors the profile proven on the maintainer's mainnet multiprocess
+# node. In the -multiprocess split the GUI connects to this daemon over an
+# AF_UNIX socket (node.sock) plus cookie in the datadir, both created 0600 and
+# owned by User= above. Do NOT add DynamicUser=/PrivateUsers= (the uid remap
+# would stop the GUI opening the socket/cookie) or PrivateNetwork= (kills the
+# P2P/RPC network).
 
 # Provide a private /tmp and /var/tmp.
 PrivateTmp=true
-
-# Mount /usr, /boot/ and /etc read-only for the process.
-ProtectSystem=full
-
-# Deny access to /home, /root and /run/user
-ProtectHome=true
-
-# Disallow the process and all of its children to gain
-# new privileges through execve().
-NoNewPrivileges=true
 
 # Use a new /dev namespace only populated with API pseudo devices
 # such as /dev/null, /dev/zero and /dev/random.
 PrivateDevices=true
 
+# Mount the whole filesystem read-only except the service's own StateDirectory
+# (/var/lib/gridcointestnetd -- the datadir, where the IPC socket + cookie also
+# live) and RuntimeDirectory. Stronger than ProtectSystem=full.
+ProtectSystem=strict
+
+# Deny access to /home, /root and /run/user (the datadir is under /var/lib).
+ProtectHome=true
+
+# Disallow the process and all of its children from gaining new privileges
+# through execve(). Matches the in-process -nonewprivs default; both is fine.
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+
+# The service runs unprivileged and needs no capabilities; drop the whole
+# bounding set (systemd counterpart to the in-process capability-bounding-set
+# drop under -nonewprivs).
+CapabilityBoundingSet=
+
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true
+
+# Namespace / kernel-surface restrictions the daemon never needs.
+RestrictRealtime=true
+LockPersonality=true
+RestrictNamespaces=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+UMask=0077
+
+# Syscall allow-list. @system-service covers a typical long-running daemon
+# (fork for -daemonwait, socket/sendmsg/recvmsg, file I/O, ...); a denied call
+# returns EPERM rather than raising SIGSYS, so a stray syscall does not crash
+# the process. This is the maintained, declarative equivalent of an in-process
+# seccomp sandbox (which was deliberately not added -- see doc/multiprocess.md).
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# AF_UNIX for the GUI IPC socket; AF_INET/AF_INET6 for the node; AF_NETLINK for
+# getaddrinfo()/interface enumeration (omitting it breaks DNS / local-address
+# discovery).
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/gridcoinresearchd.service
+++ b/debian/gridcoinresearchd.service
@@ -56,26 +56,66 @@ StateDirectoryMode=0710
 
 # Hardening measures
 ####################
+# This mirrors the profile proven on the maintainer's mainnet multiprocess
+# node. In the -multiprocess split the GUI connects to this daemon over an
+# AF_UNIX socket (node.sock) plus cookie in the datadir, both created 0600 and
+# owned by User= above. Do NOT add DynamicUser=/PrivateUsers= (the uid remap
+# would stop the GUI opening the socket/cookie) or PrivateNetwork= (kills the
+# P2P/RPC network).
 
 # Provide a private /tmp and /var/tmp.
 PrivateTmp=true
-
-# Mount /usr, /boot/ and /etc read-only for the process.
-ProtectSystem=full
-
-# Deny access to /home, /root and /run/user
-ProtectHome=true
-
-# Disallow the process and all of its children to gain
-# new privileges through execve().
-NoNewPrivileges=true
 
 # Use a new /dev namespace only populated with API pseudo devices
 # such as /dev/null, /dev/zero and /dev/random.
 PrivateDevices=true
 
+# Mount the whole filesystem read-only except the service's own StateDirectory
+# (/var/lib/gridcoinresearchd -- the datadir, where the IPC socket + cookie also
+# live) and RuntimeDirectory. Stronger than ProtectSystem=full.
+ProtectSystem=strict
+
+# Deny access to /home, /root and /run/user (the datadir is under /var/lib).
+ProtectHome=true
+
+# Disallow the process and all of its children from gaining new privileges
+# through execve(). Matches the in-process -nonewprivs default; both is fine.
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+
+# The service runs unprivileged and needs no capabilities; drop the whole
+# bounding set (systemd counterpart to the in-process capability-bounding-set
+# drop under -nonewprivs).
+CapabilityBoundingSet=
+
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true
+
+# Namespace / kernel-surface restrictions the daemon never needs.
+RestrictRealtime=true
+LockPersonality=true
+RestrictNamespaces=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+UMask=0077
+
+# Syscall allow-list. @system-service covers a typical long-running daemon
+# (fork for -daemonwait, socket/sendmsg/recvmsg, file I/O, ...); a denied call
+# returns EPERM rather than raising SIGSYS, so a stray syscall does not crash
+# the process. This is the maintained, declarative equivalent of an in-process
+# seccomp sandbox (which was deliberately not added -- see doc/multiprocess.md).
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# AF_UNIX for the GUI IPC socket; AF_INET/AF_INET6 for the node; AF_NETLINK for
+# getaddrinfo()/interface enumeration (omitting it breaks DNS / local-address
+# discovery).
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -141,6 +141,56 @@ directory and socket permissions line up), then start the GUI with `-multiproces
 Stopping the service stops the node (a connected GUI then exits); to stop just the
 GUI, close it or `SIGTERM` it as above.
 
+### Hardening the service
+
+The snippet above is deliberately minimal. A fully hardened packaged unit ships at
+[`contrib/init/gridcoinresearchd.service`](../contrib/init/gridcoinresearchd.service);
+prefer it for real deployments. Beyond the usual `ProtectSystem=strict` /
+`ProtectHome` / `PrivateTmp` / `MemoryDenyWriteExecute` sandboxing it adds a syscall
+allow-list and an address-family restriction — the OS-maintained equivalent of an
+in-process seccomp sandbox:
+
+```ini
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+CapabilityBoundingSet=
+NoNewPrivileges=true
+```
+
+Multiprocess-specific gotchas when hardening the unit:
+
+- **Keep `AF_NETLINK`** in `RestrictAddressFamilies=`. It is needed for
+  `getaddrinfo()` / local interface enumeration; dropping it breaks DNS and
+  local-address discovery, not just the obvious `AF_UNIX`/`AF_INET*`.
+- **Do not use `DynamicUser=` or `PrivateUsers=`.** They remap the uid, and the
+  GUI could then no longer open the `0600` `node.sock` / `ipc.cookie` the daemon
+  creates in the datadir.
+- **Do not use `PrivateNetwork=`** — it severs the P2P/RPC network.
+- If the datadir lives under `/home` (a personal, non-packaged install), set
+  `ProtectHome=read-only` **plus** `ReadWritePaths=<datadir>` instead of
+  `ProtectHome=true`, or the daemon cannot write the datadir / create the socket.
+  The packaged unit uses `/var/lib/gridcoinresearchd` (a `StateDirectory=`), so it
+  keeps the stronger `ProtectHome=true`.
+
+For supervisors other than systemd (or launches with none), the daemon also applies
+a best-effort in-process hardening at startup: `-nonewprivs` (default on, Linux)
+sets `NO_NEW_PRIVS` and drops the capability bounding set, so the node and its
+children can never gain privileges via a setuid binary. It is a no-op on other
+platforms and secondary to the systemd sandbox above; disable with `-nonewprivs=0`.
+
+**Why no in-process seccomp syscall sandbox?** An internal seccomp-bpf filter was
+considered and deliberately not added. Bitcoin Core shipped one, had to exclude the
+GUI process from it (the Qt/display syscall surface is too large and volatile), and
+then [removed it entirely](https://github.com/bitcoin/bitcoin/pull/27896) as not
+worth maintaining versus externally-maintained sandboxing. A hand-rolled in-tree BPF
+policy is brittle — every glibc/kernel/library update can introduce a syscall the
+filter has not allow-listed, turning a benign call into a `SIGSYS` crash. The
+declarative `systemd` `SystemCallFilter=` above gets the same post-exploitation
+confinement (no `execve` of a shell, no new socket families for exfiltration, no
+`ptrace` into sibling processes) with the policy maintained by the OS instead of by
+this project.
+
 ## Troubleshooting
 
 - **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,6 +240,7 @@ add_library(gridcoin_util STATIC
     uint256.cpp
     util.cpp
     util/bip32.cpp
+    util/proc_hardening.cpp
     util/settings.cpp
     util/sock.cpp
     util/strencodings.cpp

--- a/src/gridcoinresearchd.cpp
+++ b/src/gridcoinresearchd.cpp
@@ -10,6 +10,7 @@
 #include "chainparams.h"
 #include "chainparamsbase.h"
 #include "util.h"
+#include <util/proc_hardening.h>
 #include <util/syserror.h>
 #include "util/threadnames.h"
 #include <util/tokenpipe.h>
@@ -230,6 +231,15 @@ bool AppInit(int argc, char* argv[])
         gArgs.SoftSetBoolArg("-server", true);
         // Initialize logging as early as possible.
         InitLogging();
+
+        // Best-effort in-process privilege hardening (Linux): NO_NEW_PRIVS +
+        // capability-bounding-set drop, inherited across the daemonizing fork
+        // below. Defence-in-depth secondary to the hardened systemd unit; a
+        // no-op on non-Linux. Runs for the daemon / -multiprocess node only,
+        // never the GUI process.
+        if (gArgs.GetBoolArg("-nonewprivs", DEFAULT_NO_NEW_PRIVS)) {
+            HardenProcess();
+        }
 
         // Check to see if the user requested to reset blockchain data -- We allow reset blockchain data on testnet.
         if (gArgs.IsArgSet("-resetblockchaindata"))

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -31,6 +31,7 @@
 #include "node/coherence.h"
 #include "node/mempool_persist.h"
 #include "node/psgt_pool.h"
+#include <util/proc_hardening.h>
 #include <util/string.h>
 #include <util/syserror.h>
 
@@ -474,6 +475,11 @@ void SetupServerArgs()
                                             " location. (default: %s)", GRIDCOIN_PID_FILENAME),
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-nonewprivs", strprintf("On Linux, set NO_NEW_PRIVS and drop the capability bounding set at "
+                                            "startup so the daemon and its children can never gain privileges "
+                                            "(e.g. via a setuid binary). Best-effort defence-in-depth; ignored on "
+                                            "other platforms (default: %u)", DEFAULT_NO_NEW_PRIVS),
+                   ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
     argsman.AddArg("-wallet=<dir>", "Specify wallet file (within data directory)",
                    ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-dbcache=<n>", strprintf("Set database cache size in megabytes (%d to %d, default: %d)",

--- a/src/util/proc_hardening.cpp
+++ b/src/util/proc_hardening.cpp
@@ -33,7 +33,8 @@ void HardenProcess()
     // longer grant privileges via setuid/setgid bits or file capabilities, for
     // this process and every descendant. The daemon never needs to gain
     // privileges, so this closes a whole class of local escalation.
-    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+    const bool no_new_privs = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == 0;
+    if (!no_new_privs) {
         LogPrintf("HardenProcess: warning: PR_SET_NO_NEW_PRIVS failed: %s", std::strerror(errno));
     }
 
@@ -51,7 +52,8 @@ void HardenProcess()
             ++dropped;
         }
     }
-    LogPrintf("HardenProcess: NO_NEW_PRIVS set; dropped %d bounding-set capabilities "
-              "(0 is expected for an unprivileged launch).", dropped);
+    LogPrintf("HardenProcess: NO_NEW_PRIVS %s; dropped %d bounding-set capabilities "
+              "(0 is expected for an unprivileged launch).",
+              no_new_privs ? "set" : "NOT set (see warning above)", dropped);
 #endif // __linux__
 }

--- a/src/util/proc_hardening.cpp
+++ b/src/util/proc_hardening.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#include <config/gridcoin-config.h>
+
+#include <util/proc_hardening.h>
+
+#include <logging.h>
+
+#if defined(__linux__)
+#include <cerrno>
+#include <cstring>
+#include <sys/prctl.h>
+
+// Fallbacks in case the libc headers predate these prctl operations (all have
+// been in the kernel ABI for years; the numbers are stable).
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
+#ifndef PR_CAPBSET_READ
+#define PR_CAPBSET_READ 23
+#endif
+#ifndef PR_CAPBSET_DROP
+#define PR_CAPBSET_DROP 24
+#endif
+#endif // __linux__
+
+void HardenProcess()
+{
+#if defined(__linux__)
+    // PR_SET_NO_NEW_PRIVS: any process may set this. Once set, execve() can no
+    // longer grant privileges via setuid/setgid bits or file capabilities, for
+    // this process and every descendant. The daemon never needs to gain
+    // privileges, so this closes a whole class of local escalation.
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+        LogPrintf("HardenProcess: warning: PR_SET_NO_NEW_PRIVS failed: %s", std::strerror(errno));
+    }
+
+    // Drop the capability bounding set so neither this process nor its children
+    // can ever acquire these capabilities, even by executing a setuid-root
+    // helper. PR_CAPBSET_DROP requires CAP_SETPCAP, so this only has an effect
+    // when the daemon was started privileged; for an already-unprivileged launch
+    // each drop returns EPERM and is a harmless no-op. PR_CAPBSET_READ returns
+    // -1 (EINVAL) once cap exceeds the highest capability the running kernel
+    // knows, which terminates the loop without needing CAP_LAST_CAP at build
+    // time.
+    int dropped = 0;
+    for (int cap = 0; prctl(PR_CAPBSET_READ, cap, 0, 0, 0) >= 0; ++cap) {
+        if (prctl(PR_CAPBSET_DROP, cap, 0, 0, 0) == 0) {
+            ++dropped;
+        }
+    }
+    LogPrintf("HardenProcess: NO_NEW_PRIVS set; dropped %d bounding-set capabilities "
+              "(0 is expected for an unprivileged launch).", dropped);
+#endif // __linux__
+}

--- a/src/util/proc_hardening.cpp
+++ b/src/util/proc_hardening.cpp
@@ -40,16 +40,23 @@ void HardenProcess()
 
     // Drop the capability bounding set so neither this process nor its children
     // can ever acquire these capabilities, even by executing a setuid-root
-    // helper. PR_CAPBSET_DROP requires CAP_SETPCAP, so this only has an effect
-    // when the daemon was started privileged; for an already-unprivileged launch
-    // each drop returns EPERM and is a harmless no-op. PR_CAPBSET_READ returns
-    // -1 (EINVAL) once cap exceeds the highest capability the running kernel
-    // knows, which terminates the loop without needing CAP_LAST_CAP at build
-    // time.
+    // helper. Dropping needs CAP_SETPCAP, so it only bites when the daemon was
+    // started privileged; an already-unprivileged launch gets EPERM on the first
+    // real drop and we stop there (the systemd unit's CapabilityBoundingSet= is
+    // the authoritative drop in that case). PR_CAPBSET_READ returns 1 if the cap
+    // is in the set, 0 if already absent, and -1 (EINVAL) once cap exceeds the
+    // highest capability the running kernel knows -- which ends the loop without
+    // needing CAP_LAST_CAP at build time. Only count caps we actually removed
+    // (drop also "succeeds" for an already-absent cap, which would over-report).
     int dropped = 0;
-    for (int cap = 0; prctl(PR_CAPBSET_READ, cap, 0, 0, 0) >= 0; ++cap) {
+    for (int cap = 0;; ++cap) {
+        const int present = prctl(PR_CAPBSET_READ, cap, 0, 0, 0);
+        if (present < 0) break;      // past the last capability the kernel knows
+        if (present == 0) continue;  // already not in the bounding set
         if (prctl(PR_CAPBSET_DROP, cap, 0, 0, 0) == 0) {
             ++dropped;
+        } else if (errno == EPERM) {
+            break;                   // no CAP_SETPCAP -> cannot drop any; stop
         }
     }
     LogPrintf("HardenProcess: NO_NEW_PRIVS %s; dropped %d bounding-set capabilities "

--- a/src/util/proc_hardening.h
+++ b/src/util/proc_hardening.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 The Gridcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/licenses/mit-license.php.
+
+#ifndef GRIDCOIN_UTIL_PROC_HARDENING_H
+#define GRIDCOIN_UTIL_PROC_HARDENING_H
+
+//! Default for the -nonewprivs startup option (on).
+static const bool DEFAULT_NO_NEW_PRIVS = true;
+
+//! Best-effort, in-process privilege hardening for the daemon.
+//!
+//! On Linux this sets \c PR_SET_NO_NEW_PRIVS -- which blocks this process and
+//! all of its children from gaining privileges through \c execve() of a setuid /
+//! file-capability binary -- and then drops the capability bounding set so those
+//! capabilities can never be acquired, even by executing a setuid-root helper.
+//!
+//! \c NO_NEW_PRIVS works for any process; the bounding-set drop needs
+//! \c CAP_SETPCAP, so it only takes effect when the daemon was started
+//! privileged (e.g. by root before a privilege drop). For an already-unprivileged
+//! launch each drop returns EPERM and is a harmless no-op -- the systemd unit's
+//! \c CapabilityBoundingSet= is the authoritative drop for packaged installs.
+//!
+//! This is defence-in-depth that complements, and is secondary to, the hardened
+//! systemd unit (contrib/init/gridcoinresearchd.service). It is deliberately NOT
+//! a syscall sandbox: an in-process seccomp-bpf filter was considered and
+//! rejected (Bitcoin Core added then removed theirs as unmaintainable; the
+//! declarative systemd SystemCallFilter= is the maintained equivalent).
+//!
+//! No-op on non-Linux platforms. Logs via LogPrintf, so call after
+//! InitLogging(). The caller gates this on the -nonewprivs option.
+void HardenProcess();
+
+#endif // GRIDCOIN_UTIL_PROC_HARDENING_H


### PR DESCRIPTION
Phase 3 hardening (umbrella #3153) for the `-multiprocess` split: reduce the node daemon's post-exploitation surface.

> Rebased onto `development` after #3244 merged — this PR is now standalone (one commit).

## Approach — and what was deliberately *not* done

An in-process **seccomp-bpf** syscall sandbox was considered and rejected. Bitcoin Core shipped one, had to exclude the GUI process (the Qt/display syscall surface is too large and volatile), then [removed it entirely](https://github.com/bitcoin/bitcoin/pull/27896) as not worth maintaining versus external sandboxing. A hand-rolled in-tree BPF policy is brittle — every glibc/kernel/library bump can introduce a syscall the filter hasn't allow-listed, turning a benign call into a `SIGSYS` crash. So this splits the work into a cheap in-process anti-privesc piece plus the **declarative systemd** filter, which gets the same confinement with the policy maintained by the OS.

## In-process (Linux, opt-out `-nonewprivs`, default on)

New `src/util/proc_hardening.{h,cpp}` — `HardenProcess()`:
- sets `PR_SET_NO_NEW_PRIVS` (blocks privilege gain via `execve()` of setuid / file-capability binaries, for the process and all children), and
- drops the capability bounding set — best-effort: `PR_CAPBSET_DROP` needs `CAP_SETPCAP`, so it only bites for a *privileged* launch; for an already-unprivileged launch each drop is a harmless `EPERM` no-op. The loop uses `PR_CAPBSET_READ` to find the kernel's highest capability, so it needs no `CAP_LAST_CAP` at build time.

No-op on non-Linux. Called from the daemon's `AppInit` right after `InitLogging()`, so it's inherited across the daemonizing fork and covers the `-multiprocess` node. Runs for the **daemon only**, never the Qt GUI process.

## Declarative — the maintained seccomp equivalent

Brought the shipped systemd units (`contrib/init/` + `debian/` + `debian-testnet/`) up to the profile proven on the maintainer's mainnet multiprocess node:
- `SystemCallFilter=@system-service` + `SystemCallErrorNumber=EPERM`, `SystemCallArchitectures=native`
- `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK` — **keeping `AF_NETLINK`**, which `getaddrinfo()` / interface enumeration needs (dropping it silently breaks DNS)
- `CapabilityBoundingSet=` (empty), `ProtectSystem=strict`, `RestrictSUIDSGID`/`RestrictRealtime`/`LockPersonality`/`RestrictNamespaces`/`ProtectKernel*`/`ProtectControlGroups`/`ProtectClock`/`ProtectHostname`, `UMask=0077`
- Dropped the legacy `PermissionsStartOnly`/`ExecStartPre chgrp` in `contrib/init/` (the `ConfigurationDirectory=` owns `/etc/gridcoin`; the chgrp would need `CAP_CHOWN` and fight `ProtectSystem=strict`), matching `debian/`.

Multiprocess gotchas captured in the unit comments: no `DynamicUser=`/`PrivateUsers=` (the uid remap breaks the `0600` `node.sock`/`ipc.cookie` the GUI must open) and no `PrivateNetwork=`.

`doc/multiprocess.md` gains a **"Hardening the service"** section covering the unit, the `-nonewprivs` option, and the rationale above.

## Testing

- Qt6 multiprocess build clean.
- Daemon start/stop on regtest: logs `HardenProcess: NO_NEW_PRIVS set; dropped 0 bounding-set capabilities` and shuts down cleanly — `NO_NEW_PRIVS` doesn't break the daemon.
- **Forking daemon under the filter**: ran `gridcoinresearchd -daemonwait` as a transient `Type=forking` service with `SystemCallFilter=@system-service` + `RestrictAddressFamilies=…` → `Result=success`, full init (`Done loading`), no `SIGSYS`. (The maintainer's proven unit is `Type=simple`; this confirms the *packaged* forking path survives the filter.)
- `systemd-analyze verify` passes on all three units.

No unit test: calling `HardenProcess()` from `test_gridcoin` would irreversibly set `NO_NEW_PRIVS` on the test process, so the runtime smoke test above is the appropriate level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)