### PR TITLE
researcher: honor non-cruncher mode on auto-refresh; suppress spurious accrual-limit warning

### DIFF
--- a/src/gridcoin/researcher.cpp
+++ b/src/gridcoin/researcher.cpp
@@ -1273,6 +1273,21 @@ void Researcher::Reload()
 
 void Researcher::Reload(MiningProjectMap projects, GRC::BeaconError beacon_error)
 {
+    // Honor non-cruncher mode on every reload path -- crucially the per-block
+    // auto-refresh (Refresh() -> this 2-arg overload), not just the no-arg
+    // Reload() used at startup / by resetcpids / switchMode. Without this, a
+    // non-cruncher wallet that still has cached BOINC projects (m_projects) has
+    // its CPID re-detected on the next block, reasserting a CPID the user opted
+    // out of. On a long-lived -multiprocess daemon that stale CPID then persists
+    // indefinitely (a fresh monolith process would re-run Initialize()->Reload()
+    // and self-heal); it was the root cause of a spurious "approaching the accrual
+    // limit" warning on a magnitude-0 non-cruncher. Pass log=false: this runs on
+    // every block.
+    if (ConfiguredForNoncruncherMode(false)) {
+        StoreResearcher(Researcher()); // Non-cruncher
+        return;
+    }
+
     const std::set<std::string> team_whitelist = GetTeamWhitelist();
 
     if (team_whitelist.empty()) {
@@ -1436,7 +1451,14 @@ std::optional<CAmount> Researcher::AccrualNearLimit() const
 
     const int64_t now = OutOfSyncByAge() ? pindexBest->nTime : GetAdjustedTime();
 
-    return Tally::AccrualNearLimit(*cpid, now, pindexBest);
+    // A magnitude-0 CPID (e.g. a non-cruncher that still holds a beacon) has
+    // MaxReward() == 0, so NearRewardLimit() computes to 0. A 0 threshold is not a
+    // real "approaching the accrual cap" signal -- an account with no accrual rate
+    // can never approach a cap -- so report no limit (nullopt) rather than a
+    // degenerate 0 that a consumer's (accrual >= threshold) test would read as
+    // "at the limit" when the accrual is also 0. See ResearcherModel::formatAccrual.
+    const CAmount threshold = Tally::AccrualNearLimit(*cpid, now, pindexBest);
+    return threshold > 0 ? std::optional<CAmount>(threshold) : std::nullopt;
 }
 
 ResearcherStatus Researcher::Status() const

--- a/src/qt/researcher/researchermodel.cpp
+++ b/src/qt/researcher/researchermodel.cpp
@@ -276,7 +276,11 @@ QString ResearcherModel::formatAccrual(const int display_unit, bool& near_limit)
     const CAmount accrual = m_snapshot.accrual;
     const std::optional<CAmount> near_limit_accrual = m_snapshot.accrual_near_limit;
 
-    near_limit = near_limit_accrual && accrual >= *near_limit_accrual;
+    // Defence in depth: the node should already send nullopt when there is no
+    // real accrual cap (see Researcher::AccrualNearLimit), but guard against a
+    // non-positive threshold here too so a 0 threshold never reads as "at the
+    // limit" for a 0 accrual.
+    near_limit = near_limit_accrual && *near_limit_accrual > 0 && accrual >= *near_limit_accrual;
 
     if (outOfSync()) {
         return "...";

--- a/src/test/gridcoin/researcher_tests.cpp
+++ b/src/test/gridcoin/researcher_tests.cpp
@@ -780,6 +780,35 @@ BOOST_AUTO_TEST_CASE(it_converts_a_configured_email_address_to_lowercase)
     gArgs.ForceSetArg("email", "");
 }
 
+BOOST_AUTO_TEST_CASE(the_auto_refresh_reload_honors_noncruncher_mode)
+{
+    // Regression: the per-block auto-refresh path (Refresh() -> the 2-arg Reload)
+    // must honor non-cruncher mode, not just the no-arg Reload() used at startup /
+    // by resetcpids / switchMode. Otherwise a non-cruncher wallet re-detects a CPID
+    // it opted out of on the next block; on a long-lived -multiprocess daemon that
+    // stale CPID then persists until a core restart or resetcpids (a fresh monolith
+    // process self-heals via Initialize() -> the no-arg Reload()).
+    gArgs.ForceSetArg("forcecpid", "f5d8234352e5a5ae3915debba7258294");
+
+    // Sanity: with non-cruncher mode OFF, the 2-arg Reload adopts the forced CPID.
+    // This proves the fixture really forces a CPID, so the check below is meaningful
+    // rather than passing trivially.
+    gArgs.ForceSetArg("noncruncher", "0");
+    GRC::Researcher::Reload(GRC::MiningProjectMap());
+    BOOST_CHECK(GRC::Researcher::Get()->Id().Which() == GRC::MiningId::Kind::CPID);
+
+    // With non-cruncher mode ON, the same 2-arg Reload must resolve to NONCRUNCHER.
+    gArgs.ForceSetArg("noncruncher", "1");
+    GRC::Researcher::Reload(GRC::MiningProjectMap());
+    BOOST_CHECK(GRC::Researcher::Get()->Id() == GRC::MiningId::ForNoncruncher());
+
+    // Clean up: the researcher is already NONCRUNCHER from the check above; clear
+    // the test args without another Reload (which would parse the now-empty
+    // -forcecpid and log a benign "invalid CPID" error).
+    gArgs.ForceSetArg("forcecpid", "");
+    gArgs.ForceSetArg("noncruncher", "0");
+}
+
 BOOST_AUTO_TEST_CASE(it_provides_access_to_a_global_researcher_singleton)
 {
     GRC::ResearcherPtr researcher(GRC::Researcher::Get());


### PR DESCRIPTION
## Symptom

A magnitude-0 **non-cruncher** wallet (one that still holds a beacon/CPID) showed a spurious **"You are approaching the accrual limit … request payment via MRC"** warning (⚠) in the `-multiprocess` GUI — but **not** in a monolith wallet running the same binary.

## Root cause (two layers)

**1. The per-block auto-refresh doesn't honor non-cruncher mode.** `Researcher::Refresh()` — fired by `MarkDirty()` on every block (`validation.cpp`), beacon change, and contract — calls the **2-arg** `Reload(m_projects, beacon_error)`, which, *unlike* the no-arg `Reload()` used at startup / by `resetcpids` / `switchMode`, did **not** check `ConfiguredForNoncruncherMode`. So a non-cruncher wallet that still had cached BOINC projects had its CPID **re-detected on the next block**, reasserting a CPID the user opted out of.

This only manifested under `-multiprocess` because of **process lifecycle**, not different code:
- **Monolith:** the GUI process *is* the node, so it re-runs `Researcher::Initialize()` → the non-cruncher-honoring no-arg `Reload()` on every start and **self-heals**.
- **Multiprocess:** the node is a long-lived daemon that rarely restarts, and restarting the *GUI* doesn't restart the *core* — so the stale CPID **persisted** until a core restart or `resetcpids`.

So MP didn't cause the bug; it **promoted a latent staleness bug into a persistent one** — a useful reminder that long-lived-daemon state which monolith used to scrub on every restart now has to be correct on its own.

**Fix:** honor non-cruncher mode at the top of the 2-arg `Reload()`, so every path (including the per-block auto-refresh) is consistent with the no-arg `Reload()`.

**2. The warning logic trips at a zero threshold.** With a (stale) CPID at magnitude 0, `MaxReward()` is 0 → `NearRewardLimit()` computes to **0**, so `Researcher::AccrualNearLimit()` returned `optional(0)` and `ResearcherModel::formatAccrual()`'s `accrual >= *near_limit_accrual` read `0 >= 0` as "at the limit."
- **Producer:** return `std::nullopt` when the threshold isn't a real positive cap (a zero-accrual account can never approach a cap).
- **Consumer:** guard `*near_limit_accrual > 0` as defence in depth.

## Diagnosis notes

Confirmed the IPC layer was **not** at fault: the vendored libmultiprocess `mptest` round-trips `std::optional<primitive>` (`optional_int`) including `nullopt` correctly, and `getmininginfo` on the live node reported `NONCRUNCHER` while the stale accrual path still saw a CPID — pointing at the researcher-refresh path, not marshalling.

## Tests

Adds `Researcher/the_auto_refresh_reload_honors_noncruncher_mode`: the 2-arg `Reload` must resolve to `NONCRUNCHER` even with a `-forcecpid` set, with a sanity check that the CPID *is* adopted when non-cruncher mode is off (so the assertion isn't trivially true). Full `researcher_tests` suite green.

Built daemon + Qt6 GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
