### PR TITLE
wallettools: harden the autounlock helper against credential exposure

### DIFF
--- a/contrib/wallettools/gridcoin_autounlock.py
+++ b/contrib/wallettools/gridcoin_autounlock.py
@@ -7,13 +7,53 @@
 External autounlock engine for the Linux systemd service and the Windows
 scheduled task (see doc/multiprocess.md). Reads RPC connection details from
 the config file (gridcoinresearch.conf, or gridcoin.conf), takes the passphrase
-from a file the platform credential store
-populates (never from argv), and sends `walletpassphrase <pass> <timeout> true`
-whenever it sees a fresh core instance. Python 3 stdlib only.
+from a file the platform credential store populates (never from argv), and
+sends `walletpassphrase <pass> <timeout> true` whenever it sees a fresh core
+instance. Python 3 stdlib only.
+
+Security-critical behaviour (mirrors the mainnet-validated prototype in the
+gridcoinresearchd-autounlock.service design lineage):
+
+  * Listener-ownership gate. On a normal core start the RPC port is UNBOUND for
+    minutes -- LoadBlockIndex (init.cpp) runs long before StartRPCThreads -- and
+    the RPC port is unprivileged, so any local account can bind it first. HTTP
+    Basic authenticates the client to the server, never the reverse, so a naive
+    readiness poll would hand rpcuser:rpcpassword (and then the passphrase) to
+    whatever answers. Before sending anything over the wire we require that every
+    LISTEN socket on the port belongs to our own uid (parsed from /proc/net/tcp
+    and /proc/net/tcp6). A foreign owner, or a /proc that cannot be fully read,
+    fails closed. The gate needs a POSIX uid model + /proc (Linux). When the
+    target is loopback but the platform cannot verify ownership (e.g. Windows),
+    the helper REFUSES to send unless --allow-unverified-listener is given. When
+    the target is a non-loopback (remote) host the gate cannot apply at all and
+    the helper proceeds, having warned at startup -- that is the operator opting
+    into network-exposed RPC. A Windows-native owner check (GetExtendedTcpTable)
+    is a follow-up that will let the gate run there too.
+
+  * Proxy-free opener. urllib's default opener honours *_proxy from the
+    environment and proxy_bypass_environment() does not exempt loopback unless
+    no_proxy is set, so an inherited http_proxy could divert the passphrase POST
+    -- body and Authorization header -- to a remote host in cleartext. We build a
+    proxy-free opener so that cannot happen regardless of the environment.
+
+  * Redaction. The passphrase and rpcpassword are scrubbed out of every log line,
+    and a top-level catch-all ensures no unexpected exception prints an
+    unredacted traceback or kills the resident poll loop.
+
+Exit status (returned by main(); meaningful mainly in --once mode, where the
+systemd oneshot keys RestartPreventExitStatus on it):
+  0 -- unlocked, or nothing to do (already unlocked / not encrypted)
+  1 -- transient; retrying may help (core not up, RPC not bound yet, transport)
+  2 -- unrecoverable; retrying cannot help (wrong passphrase, bad RPC
+       credentials/HTTP 401, a foreign process holding the RPC port, or a
+       loopback target whose owner cannot be verified on this platform)
+In the resident (default, non---once) mode the loop never exits on these; it
+logs and keeps polling so an admin can clear the condition without a restart.
 """
 
 import argparse
 import base64
+import http.client
 import json
 import os
 import sys
@@ -21,12 +61,62 @@ import time
 import urllib.error
 import urllib.request
 
+EXIT_OK = 0
+EXIT_TRANSIENT = 1
+EXIT_UNRECOVERABLE = 2
+
+# Mainnet RPC port (CBaseChainParams::MAIN, src/chainparamsbase.cpp). The daemon
+# defaults to this when rpcport is unset, and a packaged gridcoinresearch.conf
+# commonly omits it, so default to it here too (matching contrib/api-proxy). A
+# non-mainnet node must set rpcport in the config or pass --rpcport.
+DEFAULT_RPC_PORT = 15715
+
+# RPC error codes we react to (src/rpc/protocol.h).
+RPC_INVALID_PARAMETER = -8
+RPC_WALLET_PASSPHRASE_INCORRECT = -14
+RPC_WALLET_WRONG_ENC_STATE = -15
+RPC_WALLET_ALREADY_UNLOCKED = -17
+
+# urllib's module-level urlopen() uses the default opener, whose ProxyHandler is
+# built from getproxies(); an inherited http_proxy would silently divert the
+# walletpassphrase POST off-box in cleartext. This opener carries no proxy.
+_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+_SECRETS = []
+
+
+def register_secret(value):
+    """Record a secret so redact() can scrub it from any later log line."""
+    if value:
+        _SECRETS.append(value)
+
+
+def redact(text):
+    """Strip any known secret out of text before it reaches a log."""
+    out = str(text)
+    for secret in _SECRETS:
+        if secret:
+            out = out.replace(secret, "<REDACTED>")
+    return out
+
+
+def log(msg):
+    sys.stdout.write("gridcoin_autounlock: " + redact(msg) + "\n")
+    sys.stdout.flush()
+
+
+def warn(msg):
+    sys.stderr.write("gridcoin_autounlock: WARNING: " + redact(msg) + "\n")
+    sys.stderr.flush()
+
 
 def parse_conf(text):
-    """Parse a Gridcoin config blob, matching the core parser (GetConfigOptions):
-    strip an inline '#' comment (everything from the first '#', which also drops
-    full-line comments), then key=value with whitespace trimmed; last value wins.
-    (The core disallows '#' in rpcpassword, so stripping from the first '#' is safe.)
+    """Parse a Gridcoin config blob the way the core does: strip an inline '#'
+    comment (everything from the first '#', which also drops full-line comments),
+    then key=value with whitespace trimmed. On a repeated key the FIRST value wins
+    -- matching the core, whose config-file settings use reverse_precedence and
+    "take the first assigned value instead of last" (src/util/settings.cpp). (The
+    core disallows '#' in rpcpassword, so stripping from the first '#' is safe.)
     """
     conf = {}
     for raw in text.splitlines():
@@ -34,7 +124,7 @@ def parse_conf(text):
         if not line or "=" not in line:
             continue
         key, _, value = line.partition("=")
-        conf[key.strip()] = value.strip()
+        conf.setdefault(key.strip(), value.strip())  # first occurrence wins
     return conf
 
 
@@ -43,23 +133,124 @@ def resolve_connection(conf, args):
     user = getattr(args, "rpcuser", None) or conf.get("rpcuser")
     password = getattr(args, "rpcpassword", None) or conf.get("rpcpassword")
     host = getattr(args, "rpcconnect", None) or conf.get("rpcconnect") or "127.0.0.1"
-    port = getattr(args, "rpcport", None) or conf.get("rpcport")
+    port = getattr(args, "rpcport", None) or conf.get("rpcport") or DEFAULT_RPC_PORT
     if not user or not password:
         raise ValueError("rpcuser and rpcpassword must be set (in the config file or via --rpcuser/--rpcpassword)")
-    if not port:
-        raise ValueError("rpcport must be set (in the config file or via --rpcport)")
-    return {"host": str(host), "port": int(port), "user": str(user), "password": str(password)}
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        raise ValueError("rpcport must be an integer (got %r)" % (port,))
+    return {"host": str(host), "port": port, "user": str(user), "password": str(password)}
+
+
+def is_loopback(host):
+    """True if host addresses this machine's loopback (so the /proc gate applies)."""
+    h = str(host).strip().lower()
+    return h in ("127.0.0.1", "::1", "localhost") or h.startswith("127.")
+
+
+def _platform_can_gate():
+    """True if this platform can verify RPC-listener ownership: it needs a POSIX
+    uid model (os.getuid). /proc availability is handled separately -- a missing
+    /proc yields 'unreadable' (fail closed), which is correct on e.g. macOS."""
+    return hasattr(os, "getuid")
+
+
+def parse_listen_uids(text, port):
+    """UIDs owning LISTEN sockets on `port` in one /proc/net/tcp{,6} blob.
+
+    Fields (whitespace-split): local_address is index 1 as HEX_IP:HEX_PORT; st is
+    index 3 ('0A' == TCP_LISTEN); uid is index 7 (the kernel joins tx_queue:rx_queue
+    and tr:tm->when into single colon-tokens, so four header columns collapse to
+    two data fields). The bind address is deliberately ignored -- requiring every
+    listener on the port to be ours is simpler and strictly more conservative than
+    decoding v4-mapped IPv6 / v6_only, which /proc does not expose.
+    """
+    uids = set()
+    for line in text.splitlines()[1:]:  # skip the header row
+        fields = line.split()
+        if len(fields) < 8 or fields[3] != "0A":
+            continue
+        try:
+            if int(fields[1].rsplit(":", 1)[1], 16) != port:
+                continue
+            uids.add(int(fields[7]))
+        except (IndexError, ValueError):
+            continue
+    return uids
+
+
+def listening_uids(port):
+    """Return (uids, readable, unreadable): UIDs owning LISTEN sockets on `port`
+    across IPv4 and IPv6, how many of the two /proc tables were read successfully,
+    and whether any table was present but could NOT be read.
+
+    FileNotFoundError means that address family is simply absent (e.g. IPv6
+    disabled) and is not an error. Any other OSError means the table exists but we
+    could not read it -- which must fail closed (see check_listener_ownership),
+    because a listener we cannot see could be a foreign one on the port.
+    """
+    uids = set()
+    readable = 0
+    unreadable = False
+    for path in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(path, "r", encoding="ascii", errors="replace") as handle:
+                text = handle.read()
+        except FileNotFoundError:
+            continue  # this family is absent -- not an error
+        except OSError:
+            unreadable = True  # present but unreadable -- must fail closed
+            continue
+        readable += 1
+        uids |= parse_listen_uids(text, port)
+    return uids, readable, unreadable
+
+
+def check_listener_ownership(port):
+    """Classify who is listening on `port` before any credential goes on the wire.
+
+    Returns one of:
+      'ours'       -- one or more LISTEN sockets, all owned by our uid: proceed
+      'none'       -- nothing is listening yet (core not up): transient
+      'foreign'    -- a uid other than ours owns a LISTEN socket: refuse
+      'unreadable' -- a /proc table could not be read, or none could: refuse.
+                      This is fail-closed: an unreadable table might hide a foreign
+                      listener (e.g. an attacker on ::1 when tcp6 is unreadable).
+    """
+    uids, readable, unreadable = listening_uids(port)
+    if unreadable or readable == 0:
+        return "unreadable"
+    me = os.getuid()
+    if uids - {me}:
+        return "foreign"
+    if uids:
+        return "ours"
+    return "none"
 
 
 class RpcError(Exception):
-    pass
+    """A JSON-RPC or transport failure. `code` is the JSON-RPC error code when one
+    was returned (else None); `http_status` is the HTTP status when relevant."""
+
+    def __init__(self, message, code=None, http_status=None):
+        super().__init__(message)
+        self.code = code
+        self.http_status = http_status
 
 
 class RpcClient:
-    def __init__(self, conn):
-        self._url = "http://%s:%d/" % (conn["host"], conn["port"])
+    def __init__(self, conn, allow_unverified=False):
+        self.host = conn["host"]
+        self.port = conn["port"]
+        self._url = "http://%s:%d/" % (self.host, self.port)
         token = base64.b64encode(("%s:%s" % (conn["user"], conn["password"])).encode()).decode()
         self._auth = "Basic " + token
+        register_secret(token)  # so an accidental echo of the auth header is scrubbed
+        # Whether the target is our own loopback (the /proc gate applies) and
+        # whether the operator has accepted proceeding without a verifiable owner.
+        self.loopback = is_loopback(self.host)
+        self.allow_unverified = allow_unverified
 
     def call(self, method, params):
         body = json.dumps({"jsonrpc": "1.0", "id": "autounlock",
@@ -68,22 +259,34 @@ class RpcClient:
                                      headers={"Authorization": self._auth,
                                               "Content-Type": "application/json"})
         try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with _OPENER.open(req, timeout=10) as resp:
                 payload = json.loads(resp.read().decode())
         except urllib.error.HTTPError as e:
-            # Gridcoin returns application-level JSON-RPC errors with an HTTP 500/401/
-            # etc status. Parse the body so the real message (e.g. "already unlocked",
-            # bad credentials) surfaces instead of a bare "HTTP Error 500". (HTTPError
-            # is a URLError subclass, so this except must precede the URLError one.)
+            # Gridcoin returns application-level JSON-RPC errors with an HTTP 500
+            # status and the error object in the body; auth failure is 401. Parse
+            # the body so the real code/message surfaces. (HTTPError is a URLError
+            # subclass, so this except must precede the URLError one.)
+            if e.code == 401:
+                raise RpcError("HTTP 401 Unauthorized: rpcuser/rpcpassword rejected by the daemon",
+                               http_status=401)
             try:
                 err = json.loads(e.read().decode()).get("error")
             except (ValueError, OSError):
                 err = None
-            raise RpcError(str(err) if err else str(e))
-        except (urllib.error.URLError, OSError, ValueError) as e:
+            if isinstance(err, dict):
+                raise RpcError(str(err.get("message") or err), code=err.get("code"), http_status=e.code)
+            raise RpcError("HTTP %d error" % e.code, http_status=e.code)
+        except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as e:
+            # Transport-level (connection refused, timeout, malformed HTTP such as
+            # BadStatusLine, non-JSON body). No JSON-RPC code; retry may help.
             raise RpcError(str(e))
-        if payload.get("error"):
-            raise RpcError(str(payload["error"]))
+        if not isinstance(payload, dict):
+            raise RpcError("RPC returned a non-object JSON payload for %r" % method)
+        err = payload.get("error")
+        if err:
+            if isinstance(err, dict):
+                raise RpcError(str(err.get("message") or err), code=err.get("code"))
+            raise RpcError(str(err))
         return payload.get("result")
 
 
@@ -92,35 +295,92 @@ def should_unlock(prev_uptime, cur_uptime):
     return prev_uptime is None or cur_uptime < prev_uptime
 
 
-def run_once(client, passphrase, timeout, prev_uptime):
-    """One poll: unlock (stake-only) if a fresh core instance is seen.
+def gate(client):
+    """Run the listener-ownership gate for `client`. Returns an EXIT_* code to
+    stop this poll (nothing was sent), or None to proceed with RPC calls."""
+    if not getattr(client, "loopback", False):
+        return None  # remote target: the /proc gate cannot apply (warned at startup)
+    if not _platform_can_gate():
+        # Loopback target, but this platform has no way to verify who owns the
+        # port. Fail closed unless the operator explicitly accepted the risk.
+        if getattr(client, "allow_unverified", False):
+            return None
+        warn("cannot verify the owner of the loopback RPC port %d on this platform; "
+             "refusing to send credentials. Use --allow-unverified-listener on a "
+             "trusted single-user host to override." % client.port)
+        return EXIT_UNRECOVERABLE
+    status = check_listener_ownership(client.port)
+    if status == "foreign":
+        warn("REFUSING TO SEND CREDENTIALS: a process owned by another uid is "
+             "listening on the RPC port %d. Either the core runs as a different "
+             "user than expected, or a local account has bound the RPC port. "
+             "Investigate before relying on autounlock." % client.port)
+        return EXIT_UNRECOVERABLE
+    if status == "unreadable":
+        warn("cannot read /proc/net/tcp{,6} to verify who owns the RPC port %d; "
+             "refusing to send credentials to an unverified listener" % client.port)
+        return EXIT_UNRECOVERABLE
+    if status == "none":
+        return EXIT_TRANSIENT  # nothing listening yet; the core is still coming up
+    return None  # 'ours': proceed
 
-    Returns the new uptime baseline, or prev_uptime unchanged if the core is
-    unreachable / RPC not up yet.
+
+def run_once(client, passphrase, timeout, prev_uptime):
+    """One poll: gate on listener ownership, then unlock (stake-only) if a fresh
+    core instance is seen. Returns (new_uptime, exit_code). The exit_code reflects
+    this poll's outcome; the resident loop ignores it, --once returns it.
     """
+    gate_code = gate(client)
+    if gate_code is not None:
+        return prev_uptime, gate_code
+
     try:
         info = client.call("getinfo", [])
     except RpcError:
-        return prev_uptime  # core down or RPC not bound yet; try again next poll
-    cur_uptime = int(info.get("uptime", 0))
-    if should_unlock(prev_uptime, cur_uptime):
-        try:
-            client.call("walletpassphrase", [passphrase, timeout, True])  # stake-only
-        except RpcError as e:
-            # Never crash the resident helper on a walletpassphrase error. The most
-            # common one is "wallet already unlocked" when the helper (not the core)
-            # restarts while the wallet is still unlocked -- benign. Others (wrong
-            # passphrase, unencrypted wallet) are logged but must not kill the loop.
-            sys.stderr.write("gridcoin_autounlock: walletpassphrase failed: %s\n" % e)
-    return cur_uptime  # record this instance either way; do not retry-storm it
+        return prev_uptime, EXIT_TRANSIENT  # core down or RPC not bound yet
+    if not isinstance(info, dict):
+        return prev_uptime, EXIT_TRANSIENT
+    try:
+        cur_uptime = int(info.get("uptime", 0))
+    except (TypeError, ValueError):
+        return prev_uptime, EXIT_TRANSIENT
+    if not should_unlock(prev_uptime, cur_uptime):
+        return cur_uptime, EXIT_OK
+
+    try:
+        client.call("walletpassphrase", [passphrase, timeout, True])  # stake-only
+    except RpcError as e:
+        code = e.code
+        if code == RPC_WALLET_ALREADY_UNLOCKED:
+            # -17 is thrown before the stake-only flag is assigned, so the wallet
+            # is unlocked but by another path and the staking-only restriction was
+            # NOT re-asserted -- if that path was a full GUI unlock it is spendable.
+            # No RPC exposes the flag, so we can only report it.
+            warn("wallet was already unlocked by another path (-17); the staking-only "
+                 "restriction was NOT re-asserted and may not be in effect")
+            return cur_uptime, EXIT_OK
+        if code == RPC_WALLET_WRONG_ENC_STATE:
+            warn("wallet is not encrypted (-15); there is nothing to unlock")
+            return cur_uptime, EXIT_OK
+        if code in (RPC_WALLET_PASSPHRASE_INCORRECT, RPC_INVALID_PARAMETER):
+            warn("walletpassphrase was rejected (%s): %s -- retrying cannot fix this"
+                 % (code, e))
+            return cur_uptime, EXIT_UNRECOVERABLE
+        # Unknown/transport error: log and let the next poll (or systemd) retry.
+        warn("walletpassphrase failed: %s" % e)
+        return cur_uptime, EXIT_TRANSIENT
+    return cur_uptime, EXIT_OK
 
 
 def read_passphrase(path):
-    with open(path, "r", encoding="utf8") as f:
+    # utf-8-sig transparently drops a UTF-8 BOM, which Windows editors / PowerShell
+    # redirection routinely prepend -- an unstripped BOM would make walletpassphrase
+    # reject the passphrase (-14).
+    with open(path, "r", encoding="utf-8-sig") as f:
         pw = f.read()
-    pw = pw.rstrip("\r\n")  # strip trailing CR/LF (Windows credential files are CRLF)
-    if not pw:
-        raise ValueError("passphrase file %s is empty" % path)
+    pw = pw.rstrip("\r\n")  # strip trailing CR/LF only (do not touch chosen spaces)
+    if not pw.strip():
+        raise ValueError("passphrase file %s is empty or whitespace-only" % path)
     return pw
 
 
@@ -155,27 +415,53 @@ def build_arg_parser():
                    help="File the platform credential store populates with the wallet passphrase. "
                         "Never pass the passphrase on the command line.")
     p.add_argument("--rpcconnect", default=None)
-    p.add_argument("--rpcport", type=int, default=None)
+    p.add_argument("--rpcport", type=int, default=None,
+                   help="RPC port (defaults to the config's rpcport, else %d -- the mainnet "
+                        "default; a non-mainnet node must set it here or in the config)." % DEFAULT_RPC_PORT)
     p.add_argument("--rpcuser", default=None)
     p.add_argument("--rpcpassword", default=None,
                    help="RPC password (visible in the process list; prefer setting it in the config file).")
     p.add_argument("--timeout", type=int, default=99999999,
                    help="walletpassphrase timeout seconds (node clamps > 100000000).")
     p.add_argument("--interval", type=int, default=20, help="Poll interval seconds.")
-    p.add_argument("--once", action="store_true", help="Poll once and exit (testing / one-shot).")
+    p.add_argument("--once", action="store_true", help="Poll once and exit (testing / one-shot service).")
+    p.add_argument("--allow-unverified-listener", action="store_true", dest="allow_unverified_listener",
+                   help="Proceed even when the RPC listener's owner cannot be verified on this platform "
+                        "(e.g. Windows, which lacks the /proc-based gate). INSECURE unless the host is "
+                        "single-user and trusted: without owner verification the passphrase could be sent "
+                        "to a local process that squatted the RPC port during core startup.")
     return p
 
 
 def main(argv=None):
     args = build_arg_parser().parse_args(argv)
     passphrase = read_passphrase(args.passphrase_file)
+    register_secret(passphrase)
     conn = resolve_connection(_load_conf(args), args)
-    client = RpcClient(conn)
+    register_secret(conn["password"])
+    client = RpcClient(conn, allow_unverified=args.allow_unverified_listener)
+    if not client.loopback:
+        warn("RPC target %s is not loopback; the listener-ownership gate cannot "
+             "apply and credentials will be sent to the configured host." % conn["host"])
+    elif not _platform_can_gate():
+        if args.allow_unverified_listener:
+            warn("the listener-ownership gate is unavailable on this platform; proceeding "
+                 "because --allow-unverified-listener was given (trusted single-user host assumed)")
+        else:
+            warn("the listener-ownership gate is unavailable on this platform (no POSIX uid "
+                 "model); credentials will NOT be sent until --allow-unverified-listener is set "
+                 "or native listener verification is added")
     prev_uptime = None
     while True:
-        prev_uptime = run_once(client, passphrase, args.timeout, prev_uptime)
+        try:
+            prev_uptime, code = run_once(client, passphrase, args.timeout, prev_uptime)
+        except Exception as e:
+            # The resident loop must never die and must never print an unredacted
+            # traceback. Treat anything unexpected as a transient poll failure.
+            warn("unexpected error during poll: %s: %s" % (type(e).__name__, e))
+            code = EXIT_TRANSIENT
         if args.once:
-            return 0
+            return code
         time.sleep(args.interval)
 
 

--- a/contrib/wallettools/gridcoin_autounlock.py
+++ b/contrib/wallettools/gridcoin_autounlock.py
@@ -243,7 +243,11 @@ class RpcClient:
     def __init__(self, conn, allow_unverified=False):
         self.host = conn["host"]
         self.port = conn["port"]
-        self._url = "http://%s:%d/" % (self.host, self.port)
+        # Bracket an IPv6 literal host so the URL is valid: http://[::1]:port/,
+        # not the ambiguous http://::1:port/. is_loopback() accepts ::1, so an
+        # IPv6 loopback target would otherwise fail every poll.
+        url_host = "[%s]" % self.host if (":" in self.host and not self.host.startswith("[")) else self.host
+        self._url = "http://%s:%d/" % (url_host, self.port)
         token = base64.b64encode(("%s:%s" % (conn["user"], conn["password"])).encode()).decode()
         self._auth = "Basic " + token
         register_secret(token)  # so an accidental echo of the auth header is scrubbed
@@ -336,7 +340,13 @@ def run_once(client, passphrase, timeout, prev_uptime):
 
     try:
         info = client.call("getinfo", [])
-    except RpcError:
+    except RpcError as e:
+        if e.http_status == 401:
+            # Wrong rpcuser/rpcpassword: retrying with the same credentials cannot
+            # help, so this is unrecoverable (the oneshot then parks in "failed").
+            warn("RPC rejected the credentials (HTTP 401): rpcuser/rpcpassword are "
+                 "wrong -- retrying cannot fix this")
+            return prev_uptime, EXIT_UNRECOVERABLE
         return prev_uptime, EXIT_TRANSIENT  # core down or RPC not bound yet
     if not isinstance(info, dict):
         return prev_uptime, EXIT_TRANSIENT
@@ -350,6 +360,9 @@ def run_once(client, passphrase, timeout, prev_uptime):
     try:
         client.call("walletpassphrase", [passphrase, timeout, True])  # stake-only
     except RpcError as e:
+        if e.http_status == 401:
+            warn("RPC rejected the credentials (HTTP 401) -- retrying cannot fix this")
+            return cur_uptime, EXIT_UNRECOVERABLE
         code = e.code
         if code == RPC_WALLET_ALREADY_UNLOCKED:
             # -17 is thrown before the stake-only flag is assigned, so the wallet

--- a/contrib/wallettools/gridcoin_autounlock.py
+++ b/contrib/wallettools/gridcoin_autounlock.py
@@ -47,8 +47,9 @@ systemd oneshot keys RestartPreventExitStatus on it):
   2 -- unrecoverable; retrying cannot help (wrong passphrase, bad RPC
        credentials/HTTP 401, a foreign process holding the RPC port, or a
        loopback target whose owner cannot be verified on this platform)
-In the resident (default, non---once) mode the loop never exits on these; it
-logs and keeps polling so an admin can clear the condition without a restart.
+In the resident (default) mode -- i.e. without --once -- the loop never exits on
+these; it logs and keeps polling so an admin can clear the condition without a
+restart.
 """
 
 import argparse

--- a/contrib/wallettools/test_gridcoin_autounlock.py
+++ b/contrib/wallettools/test_gridcoin_autounlock.py
@@ -1,6 +1,11 @@
 import unittest
+import io
 import os
 import tempfile
+import urllib.error
+import urllib.request
+from unittest import mock
+
 import gridcoin_autounlock as au
 
 
@@ -27,6 +32,12 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(conf["rpcuser"], "alice")
         self.assertEqual(conf["rpcport"], "15715")
 
+    def test_parse_conf_duplicate_key_first_wins(self):
+        # Matches the core: config-file settings take the FIRST assigned value
+        # (src/util/settings.cpp reverse_precedence), not the last.
+        conf = au.parse_conf("rpcpassword=first\nrpcpassword=second\n")
+        self.assertEqual(conf["rpcpassword"], "first")
+
     def test_resolve_connection_from_conf(self):
         conf = {"rpcuser": "alice", "rpcpassword": "s3cret", "rpcport": "15715"}
         c = au.resolve_connection(conf, Args())
@@ -46,13 +57,165 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             au.resolve_connection({"rpcuser": "alice"}, Args())  # no password
 
-    def test_resolve_connection_requires_port(self):
-        with self.assertRaises(ValueError):
-            au.resolve_connection({"rpcuser": "a", "rpcpassword": "b"}, Args())
+    def test_resolve_connection_defaults_port_to_mainnet(self):
+        # A packaged gridcoinresearch.conf commonly omits rpcport; default to the
+        # mainnet RPC port like the daemon (and contrib/api-proxy) do.
+        c = au.resolve_connection({"rpcuser": "a", "rpcpassword": "b"}, Args())
+        self.assertEqual(c["port"], au.DEFAULT_RPC_PORT)
+        self.assertEqual(c["port"], 15715)
 
+    def test_resolve_connection_rejects_non_numeric_port(self):
+        with self.assertRaises(ValueError):
+            au.resolve_connection({"rpcuser": "a", "rpcpassword": "b", "rpcport": "abc"}, Args())
+
+
+class TestLoopback(unittest.TestCase):
+    def test_loopback_hosts(self):
+        for h in ("127.0.0.1", "::1", "localhost", "LOCALHOST", "127.5.5.5", " 127.0.0.1 "):
+            self.assertTrue(au.is_loopback(h), h)
+
+    def test_non_loopback_hosts(self):
+        for h in ("10.0.0.2", "192.168.1.5", "example.com", "0.0.0.0", "::2"):
+            self.assertFalse(au.is_loopback(h), h)
+
+
+# --- /proc listener-ownership gate: pure parser ------------------------------
+
+_PROC_HEADER = ("  sl  local_address rem_address   st tx_queue rx_queue tr "
+                "tm->when retrnsmt   uid  timeout inode")
+
+
+def _proc_line(port, st="0A", uid=1000, ip="0100007F"):
+    """One /proc/net/tcp row: fields[1]=local ip:port, [3]=st, [7]=uid."""
+    return ("   0: %s:%04X 00000000:0000 %s 00000000:00000000 "
+            "00:00000000 00000000 %5d 0 12345 1 0000 100 0 0 10 0"
+            % (ip, port, st, uid))
+
+
+def _proc_table(*rows):
+    return "\n".join([_PROC_HEADER] + list(rows)) + "\n"
+
+
+class TestParseListenUids(unittest.TestCase):
+    def test_listen_socket_owned_by_uid(self):
+        text = _proc_table(_proc_line(15715, st="0A", uid=1000))
+        self.assertEqual(au.parse_listen_uids(text, 15715), {1000})
+
+    def test_ignores_other_ports(self):
+        text = _proc_table(_proc_line(9999, uid=1000))
+        self.assertEqual(au.parse_listen_uids(text, 15715), set())
+
+    def test_ignores_non_listen_state(self):
+        # 01 == TCP_ESTABLISHED; only 0A (LISTEN) counts.
+        text = _proc_table(_proc_line(15715, st="01", uid=1000))
+        self.assertEqual(au.parse_listen_uids(text, 15715), set())
+
+    def test_collects_multiple_owners(self):
+        text = _proc_table(_proc_line(15715, uid=1000), _proc_line(15715, uid=1001))
+        self.assertEqual(au.parse_listen_uids(text, 15715), {1000, 1001})
+
+    def test_skips_malformed_lines(self):
+        text = _PROC_HEADER + "\ngarbage\n" + _proc_line(15715, uid=1000) + "\n"
+        self.assertEqual(au.parse_listen_uids(text, 15715), {1000})
+
+    def test_empty_table(self):
+        self.assertEqual(au.parse_listen_uids(_proc_table(), 15715), set())
+
+
+# --- /proc listener-ownership gate: the real reader (fail-closed accounting) --
+
+def _fake_open(mapping):
+    """A stand-in for builtins.open that serves `mapping` (path -> str content or
+    an OSError instance to raise) and defers to the real builtin otherwise."""
+    real_open = open
+
+    def opener(path, *a, **k):
+        if path in mapping:
+            val = mapping[path]
+            if isinstance(val, OSError):
+                raise val
+            return io.StringIO(val)
+        return real_open(path, *a, **k)
+    return opener
+
+
+class TestListeningUidsReal(unittest.TestCase):
+    def test_both_tables_unreadable_fails_closed(self):
+        m = {"/proc/net/tcp": PermissionError(), "/proc/net/tcp6": PermissionError()}
+        with mock.patch("builtins.open", _fake_open(m)):
+            uids, readable, unreadable = au.listening_uids(15715)
+        self.assertEqual((uids, readable, unreadable), (set(), 0, True))
+
+    def test_partial_unreadable_is_flagged(self):
+        # tcp readable (only us), tcp6 unreadable -> a foreign listener could hide
+        # in the unread tcp6 table, so this MUST fail closed.
+        m = {"/proc/net/tcp": _proc_table(_proc_line(15715, uid=1000)),
+             "/proc/net/tcp6": PermissionError()}
+        with mock.patch("builtins.open", _fake_open(m)):
+            uids, readable, unreadable = au.listening_uids(15715)
+        self.assertTrue(unreadable)
+        with mock.patch("builtins.open", _fake_open(m)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "unreadable")
+
+    def test_ipv6_absent_is_not_unreadable(self):
+        # tcp readable+ours, tcp6 absent (IPv6 disabled) -> 'ours', not fail-closed.
+        m = {"/proc/net/tcp": _proc_table(_proc_line(15715, uid=1000)),
+             "/proc/net/tcp6": FileNotFoundError()}
+        with mock.patch("builtins.open", _fake_open(m)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "ours")
+
+    def test_foreign_owner_in_readable_table(self):
+        m = {"/proc/net/tcp": _proc_table(_proc_line(15715, uid=1001)),  # attacker
+             "/proc/net/tcp6": FileNotFoundError()}
+        with mock.patch("builtins.open", _fake_open(m)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "foreign")
+
+    def test_nothing_listening_is_none(self):
+        m = {"/proc/net/tcp": _proc_table(), "/proc/net/tcp6": _proc_table()}
+        with mock.patch("builtins.open", _fake_open(m)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "none")
+
+
+class TestCheckListenerOwnership(unittest.TestCase):
+    def test_ours(self):
+        with mock.patch.object(au, "listening_uids", return_value=({1000}, 2, False)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "ours")
+
+    def test_foreign_when_any_owner_differs(self):
+        with mock.patch.object(au, "listening_uids", return_value=({1000, 1001}, 2, False)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "foreign")
+
+    def test_none_when_nothing_listening(self):
+        with mock.patch.object(au, "listening_uids", return_value=(set(), 2, False)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "none")
+
+    def test_unreadable_when_zero_readable(self):
+        with mock.patch.object(au, "listening_uids", return_value=(set(), 0, False)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "unreadable")
+
+    def test_unreadable_when_any_table_unreadable(self):
+        # Even with a readable table showing only us, a present-but-unreadable
+        # table forces fail-closed.
+        with mock.patch.object(au, "listening_uids", return_value=({1000}, 1, True)), \
+                mock.patch.object(au.os, "getuid", create=True, return_value=1000):
+            self.assertEqual(au.check_listener_ownership(15715), "unreadable")
+
+
+# --- unlock decision + poll --------------------------------------------------
 
 class FakeClient:
-    """Records calls; returns queued getinfo responses."""
+    """Records calls; returns queued getinfo responses. loopback=False so the
+    gate is skipped and these tests exercise the unlock logic."""
+    loopback = False
+
     def __init__(self, uptimes):
         self._uptimes = list(uptimes)
         self.calls = []
@@ -80,46 +243,314 @@ class TestUnlockDecision(unittest.TestCase):
 
     def test_run_once_unlocks_stake_only_on_first_contact(self):
         c = FakeClient([42])
-        new = au.run_once(c, "s3cret", 99999999, None)
-        self.assertEqual(new, 42)
+        new, code = au.run_once(c, "s3cret", 99999999, None)
+        self.assertEqual((new, code), (42, au.EXIT_OK))
         self.assertIn(("walletpassphrase", ["s3cret", 99999999, True]), c.calls)
 
     def test_run_once_no_unlock_when_uptime_grows(self):
         c = FakeClient([200])
-        new = au.run_once(c, "s3cret", 99999999, 100)
-        self.assertEqual(new, 200)
+        new, code = au.run_once(c, "s3cret", 99999999, 100)
+        self.assertEqual((new, code), (200, au.EXIT_OK))
         self.assertNotIn("walletpassphrase", [m for m, _ in c.calls])
 
     def test_run_once_reunlocks_after_restart(self):
         c = FakeClient([5])
-        new = au.run_once(c, "s3cret", 99999999, 200)
-        self.assertEqual(new, 5)
+        new, code = au.run_once(c, "s3cret", 99999999, 200)
+        self.assertEqual((new, code), (5, au.EXIT_OK))
         self.assertIn(("walletpassphrase", ["s3cret", 99999999, True]), c.calls)
 
     def test_run_once_keeps_baseline_when_unreachable(self):
         c = FakeClient([])  # getinfo raises RpcError
-        new = au.run_once(c, "s3cret", 99999999, 100)
-        self.assertEqual(new, 100)  # unchanged; no unlock attempted
+        new, code = au.run_once(c, "s3cret", 99999999, 100)
+        self.assertEqual((new, code), (100, au.EXIT_TRANSIENT))
         self.assertNotIn("walletpassphrase", [m for m, _ in c.calls])
 
-    def test_run_once_survives_walletpassphrase_error(self):
-        class FailingUnlockClient:
-            def __init__(self):
-                self.calls = []
 
-            def call(self, method, params):
-                self.calls.append(method)
-                if method == "getinfo":
-                    return {"uptime": 5}
-                if method == "walletpassphrase":
-                    raise au.RpcError("Error: Wallet is already unlocked.")
-                raise AssertionError("unexpected method " + method)
+class MalformedInfoClient:
+    """getinfo returns something that is not a well-formed {uptime:int} dict."""
+    loopback = False
 
-        c = FailingUnlockClient()
-        new = au.run_once(c, "s3cret", 99999999, None)  # first contact -> attempts unlock
-        self.assertEqual(new, 5)                    # baseline recorded, did not crash
-        self.assertIn("walletpassphrase", c.calls)  # it did attempt the unlock
+    def __init__(self, info):
+        self._info = info
+        self.calls = []
 
+    def call(self, method, params):
+        self.calls.append(method)
+        if method == "getinfo":
+            return self._info
+        return None
+
+
+class TestMalformedGetinfo(unittest.TestCase):
+    def test_non_dict_getinfo_is_transient_not_a_crash(self):
+        for bad in (None, "x", [1, 2], 5):
+            c = MalformedInfoClient(bad)
+            new, code = au.run_once(c, "pw", 60, None)
+            self.assertEqual((new, code), (None, au.EXIT_TRANSIENT))
+            self.assertNotIn("walletpassphrase", c.calls)
+
+    def test_null_or_bad_uptime_is_transient_not_a_crash(self):
+        # None / non-numeric uptime would raise TypeError/ValueError on int();
+        # they must be swallowed as transient rather than killing the loop.
+        for bad in ({"uptime": None}, {"uptime": "notanumber"}):
+            c = MalformedInfoClient(bad)
+            new, code = au.run_once(c, "pw", 60, None)
+            self.assertEqual((new, code), (None, au.EXIT_TRANSIENT))
+            self.assertNotIn("walletpassphrase", c.calls)
+
+    def test_missing_uptime_defaults_to_zero_and_unlocks(self):
+        # A dict without 'uptime' is not malformed: it defaults to 0 (fresh
+        # instance) and proceeds to unlock -- not a transient failure.
+        c = MalformedInfoClient({})
+        new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual((new, code), (0, au.EXIT_OK))
+        self.assertIn("walletpassphrase", c.calls)
+
+
+class ErrClient:
+    """getinfo succeeds (fresh instance); walletpassphrase raises a coded RpcError."""
+    loopback = False
+
+    def __init__(self, code):
+        self._code = code
+        self.calls = []
+
+    def call(self, method, params):
+        self.calls.append(method)
+        if method == "getinfo":
+            return {"uptime": 5}
+        if method == "walletpassphrase":
+            raise au.RpcError("boom", code=self._code)
+        raise AssertionError("unexpected method " + method)
+
+
+class TestWalletpassphraseErrors(unittest.TestCase):
+    def test_already_unlocked_is_ok(self):
+        c = ErrClient(au.RPC_WALLET_ALREADY_UNLOCKED)  # -17
+        self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_OK))
+
+    def test_not_encrypted_is_ok(self):
+        c = ErrClient(au.RPC_WALLET_WRONG_ENC_STATE)  # -15
+        self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_OK))
+
+    def test_wrong_passphrase_is_unrecoverable(self):
+        c = ErrClient(au.RPC_WALLET_PASSPHRASE_INCORRECT)  # -14
+        self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_UNRECOVERABLE))
+
+    def test_bad_parameter_is_unrecoverable(self):
+        c = ErrClient(au.RPC_INVALID_PARAMETER)  # -8
+        self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_UNRECOVERABLE))
+
+    def test_unknown_error_is_transient(self):
+        c = ErrClient(None)  # transport / unknown -> retry may help
+        self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_TRANSIENT))
+
+    def test_helper_never_crashes_on_walletpassphrase_error(self):
+        for code in (au.RPC_WALLET_ALREADY_UNLOCKED, au.RPC_WALLET_PASSPHRASE_INCORRECT,
+                     au.RPC_INVALID_PARAMETER, None):
+            au.run_once(ErrClient(code), "pw", 60, None)  # must not raise
+
+
+# --- the listener gate, wired through run_once (security-critical path) -------
+
+class GateFake:
+    """loopback=True so run_once consults the gate. allow_unverified default False."""
+    loopback = True
+    allow_unverified = False
+    port = 15715
+
+    def __init__(self):
+        self.calls = []
+
+    def call(self, method, params):
+        self.calls.append((method, params))
+        if method == "getinfo":
+            return {"uptime": 7}
+        if method == "walletpassphrase":
+            return None
+        raise AssertionError("unexpected method " + method)
+
+
+class TestGate(unittest.TestCase):
+    def test_foreign_listener_sends_nothing(self):
+        c = GateFake()
+        with mock.patch.object(au, "check_listener_ownership", return_value="foreign"):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual(code, au.EXIT_UNRECOVERABLE)
+        self.assertEqual(new, None)      # baseline unchanged
+        self.assertEqual(c.calls, [])    # CRUCIAL: no credential ever went on the wire
+
+    def test_unreadable_proc_sends_nothing(self):
+        c = GateFake()
+        with mock.patch.object(au, "check_listener_ownership", return_value="unreadable"):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual(code, au.EXIT_UNRECOVERABLE)
+        self.assertEqual(c.calls, [])
+
+    def test_nothing_listening_is_transient_and_silent(self):
+        c = GateFake()
+        with mock.patch.object(au, "check_listener_ownership", return_value="none"):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual((new, code), (None, au.EXIT_TRANSIENT))
+        self.assertEqual(c.calls, [])
+
+    def test_owned_listener_proceeds_to_unlock(self):
+        c = GateFake()
+        with mock.patch.object(au, "check_listener_ownership", return_value="ours"):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual((new, code), (7, au.EXIT_OK))
+        self.assertIn(("getinfo", []), c.calls)
+        self.assertIn(("walletpassphrase", ["pw", 60, True]), c.calls)
+
+
+class TestGatePlatform(unittest.TestCase):
+    def test_loopback_without_gate_support_refuses_by_default(self):
+        # Simulate Windows: loopback target, platform cannot verify ownership.
+        c = GateFake()  # loopback True, allow_unverified False
+        with mock.patch.object(au, "_platform_can_gate", return_value=False):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual(code, au.EXIT_UNRECOVERABLE)
+        self.assertEqual(c.calls, [])  # fail closed: nothing sent
+
+    def test_loopback_without_gate_support_proceeds_with_flag(self):
+        c = GateFake()
+        c.allow_unverified = True
+        with mock.patch.object(au, "_platform_can_gate", return_value=False):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual((new, code), (7, au.EXIT_OK))
+        self.assertIn(("walletpassphrase", ["pw", 60, True]), c.calls)
+
+    def test_remote_host_skips_gate_even_if_owner_would_be_foreign(self):
+        c = GateFake()
+        c.loopback = False  # remote target: gate cannot apply
+        with mock.patch.object(au, "check_listener_ownership", return_value="foreign"):
+            new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual((new, code), (7, au.EXIT_OK))
+        self.assertIn(("walletpassphrase", ["pw", 60, True]), c.calls)
+
+
+# --- transport / proxy / redaction -------------------------------------------
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+
+    def read(self):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class TestRpcClient(unittest.TestCase):
+    def _client(self):
+        return au.RpcClient({"host": "127.0.0.1", "port": 1, "user": "u", "password": "p"})
+
+    def test_loopback_flag_on_loopback_host(self):
+        self.assertTrue(self._client().loopback)
+
+    def test_loopback_flag_off_remote_host(self):
+        c = au.RpcClient({"host": "10.0.0.2", "port": 1, "user": "u", "password": "p"})
+        self.assertFalse(c.loopback)
+
+    def test_httperror_json_body_yields_code_and_message(self):
+        body = b'{"result": null, "error": {"code": -17, "message": "already unlocked"}}'
+        http_err = urllib.error.HTTPError("http://127.0.0.1:1/", 500,
+                                          "Internal Server Error", {}, io.BytesIO(body))
+        with mock.patch.object(au._OPENER, "open", side_effect=http_err):
+            with self.assertRaises(au.RpcError) as ctx:
+                self._client().call("walletpassphrase", ["p", 60, True])
+        self.assertEqual(ctx.exception.code, -17)
+        self.assertIn("already unlocked", str(ctx.exception))
+
+    def test_http_401_flagged_as_auth_failure(self):
+        http_err = urllib.error.HTTPError("http://127.0.0.1:1/", 401,
+                                          "Unauthorized", {}, io.BytesIO(b""))
+        with mock.patch.object(au._OPENER, "open", side_effect=http_err):
+            with self.assertRaises(au.RpcError) as ctx:
+                self._client().call("getinfo", [])
+        self.assertEqual(ctx.exception.http_status, 401)
+
+    def test_application_error_on_200_yields_code(self):
+        data = b'{"result": null, "error": {"code": -8, "message": "bad param"}}'
+        with mock.patch.object(au._OPENER, "open", return_value=FakeResp(data)):
+            with self.assertRaises(au.RpcError) as ctx:
+                self._client().call("walletpassphrase", ["p", 60, True])
+        self.assertEqual(ctx.exception.code, -8)
+
+    def test_non_object_payload_is_rpcerror_not_crash(self):
+        # A syntactically-valid but non-object 200 body must not raise AttributeError.
+        with mock.patch.object(au._OPENER, "open", return_value=FakeResp(b"5")):
+            with self.assertRaises(au.RpcError):
+                self._client().call("getinfo", [])
+
+    def test_transport_error_has_no_code(self):
+        with mock.patch.object(au._OPENER, "open",
+                               side_effect=urllib.error.URLError("refused")):
+            with self.assertRaises(au.RpcError) as ctx:
+                self._client().call("getinfo", [])
+        self.assertIsNone(ctx.exception.code)
+
+    def test_malformed_http_is_rpcerror_not_crash(self):
+        # http.client.HTTPException (e.g. BadStatusLine) is NOT a URLError/OSError;
+        # it must still be mapped to RpcError so it cannot kill the resident loop.
+        import http.client
+        with mock.patch.object(au._OPENER, "open",
+                               side_effect=http.client.BadStatusLine("garbage")):
+            with self.assertRaises(au.RpcError) as ctx:
+                self._client().call("getinfo", [])
+        self.assertIsNone(ctx.exception.code)
+
+    def test_opener_ignores_env_proxy(self):
+        # The passphrase POST must never be diverted by an inherited http_proxy.
+        with mock.patch.dict(os.environ,
+                             {"http_proxy": "http://evil.example:8080",
+                              "https_proxy": "http://evil.example:8080"}):
+            default = urllib.request.build_opener()  # picks up the env proxy
+            default_proxies = [h.proxies for h in default.handlers
+                               if isinstance(h, urllib.request.ProxyHandler)]
+            self.assertTrue(any(p for p in default_proxies),
+                            "expected the default opener to pick up the env proxy")
+            ours = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+            for h in ours.handlers:
+                if isinstance(h, urllib.request.ProxyHandler):
+                    self.assertFalse(h.proxies)
+        for h in au._OPENER.handlers:
+            if isinstance(h, urllib.request.ProxyHandler):
+                self.assertFalse(h.proxies)
+
+
+class TestRedaction(unittest.TestCase):
+    def setUp(self):
+        self._saved = list(au._SECRETS)
+        au._SECRETS.clear()
+
+    def tearDown(self):
+        au._SECRETS[:] = self._saved
+
+    def test_registered_secret_is_scrubbed(self):
+        au.register_secret("topsecret")
+        self.assertEqual(au.redact("passphrase=topsecret ok"), "passphrase=<REDACTED> ok")
+
+    def test_multiple_secrets_scrubbed(self):
+        au.register_secret("pw123")
+        au.register_secret("rpcpw")
+        self.assertEqual(au.redact("a pw123 b rpcpw c"), "a <REDACTED> b <REDACTED> c")
+
+    def test_empty_secret_is_ignored(self):
+        au.register_secret("")  # must not turn every char into <REDACTED>
+        self.assertEqual(au.redact("abc"), "abc")
+
+    def test_client_registers_auth_token(self):
+        au.RpcClient({"host": "127.0.0.1", "port": 1, "user": "u", "password": "s3cret"})
+        token = au.base64.b64encode(b"u:s3cret").decode()
+        self.assertEqual(au.redact("auth=" + token), "auth=<REDACTED>")
+
+
+# --- CLI / passphrase / conf -------------------------------------------------
 
 class TestCli(unittest.TestCase):
     def test_read_passphrase_strips_trailing_newline(self):
@@ -131,9 +562,38 @@ class TestCli(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_read_passphrase_strips_crlf(self):
+        with tempfile.NamedTemporaryFile("w", newline="", delete=False) as f:
+            f.write("hunter2\r\n")
+            path = f.name
+        try:
+            self.assertEqual(au.read_passphrase(path), "hunter2")
+        finally:
+            os.unlink(path)
+
+    def test_read_passphrase_drops_utf8_bom(self):
+        # Windows Notepad / PowerShell redirection prepend a UTF-8 BOM.
+        with tempfile.NamedTemporaryFile("wb", delete=False) as f:
+            f.write(b"\xef\xbb\xbfhunter2\r\n")
+            path = f.name
+        try:
+            self.assertEqual(au.read_passphrase(path), "hunter2")
+        finally:
+            os.unlink(path)
+
     def test_read_passphrase_rejects_empty(self):
         with tempfile.NamedTemporaryFile("w", delete=False) as f:
             f.write("\n")
+            path = f.name
+        try:
+            with self.assertRaises(ValueError):
+                au.read_passphrase(path)
+        finally:
+            os.unlink(path)
+
+    def test_read_passphrase_rejects_whitespace_only(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("   \t\n")
             path = f.name
         try:
             with self.assertRaises(ValueError):
@@ -173,19 +633,53 @@ class TestCli(unittest.TestCase):
             shutil.rmtree(d)
 
 
-class TestRpcClient(unittest.TestCase):
-    def test_call_surfaces_httperror_json_body(self):
-        import io
-        import urllib.error
-        from unittest import mock
-        client = au.RpcClient({"host": "127.0.0.1", "port": 1, "user": "u", "password": "p"})
-        body = b'{"result": null, "error": {"code": -17, "message": "already unlocked"}}'
-        http_err = urllib.error.HTTPError("http://127.0.0.1:1/", 500,
-                                          "Internal Server Error", {}, io.BytesIO(body))
-        with mock.patch("urllib.request.urlopen", side_effect=http_err):
-            with self.assertRaises(au.RpcError) as ctx:
-                client.call("walletpassphrase", ["p", 60, True])
-        self.assertIn("already unlocked", str(ctx.exception))  # real message, not "HTTP Error 500"
+# --- main() / --once / resident-loop catch-all -------------------------------
+
+class OnceFake:
+    """A well-behaved client for --once: loopback False so the gate is skipped."""
+    loopback = False
+
+    def __init__(self):
+        self.calls = []
+
+    def call(self, method, params):
+        self.calls.append(method)
+        if method == "getinfo":
+            return {"uptime": 5}
+        return None
+
+
+class BoomClient:
+    """Raises a non-RpcError from call() to exercise the resident-loop catch-all."""
+    loopback = False
+
+    def call(self, method, params):
+        raise RuntimeError("kaboom")
+
+
+class TestMain(unittest.TestCase):
+    def _passfile(self, content="pw\n"):
+        f = tempfile.NamedTemporaryFile("w", delete=False)
+        f.write(content)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def _argv(self, pf, *extra):
+        return ["--passphrase-file", pf, "--rpcuser", "u",
+                "--rpcpassword", "p", "--rpcport", "15715", "--once", *extra]
+
+    def test_once_returns_ok_on_successful_unlock(self):
+        pf = self._passfile()
+        with mock.patch.object(au, "RpcClient", return_value=OnceFake()):
+            rc = au.main(self._argv(pf))
+        self.assertEqual(rc, au.EXIT_OK)
+
+    def test_once_catchall_maps_unexpected_exception_to_transient(self):
+        pf = self._passfile()
+        with mock.patch.object(au, "RpcClient", return_value=BoomClient()):
+            rc = au.main(self._argv(pf))  # must NOT raise
+        self.assertEqual(rc, au.EXIT_TRANSIENT)
 
 
 if __name__ == "__main__":

--- a/contrib/wallettools/test_gridcoin_autounlock.py
+++ b/contrib/wallettools/test_gridcoin_autounlock.py
@@ -311,8 +311,9 @@ class ErrClient:
     """getinfo succeeds (fresh instance); walletpassphrase raises a coded RpcError."""
     loopback = False
 
-    def __init__(self, code):
+    def __init__(self, code, http_status=None):
         self._code = code
+        self._http = http_status
         self.calls = []
 
     def call(self, method, params):
@@ -320,8 +321,22 @@ class ErrClient:
         if method == "getinfo":
             return {"uptime": 5}
         if method == "walletpassphrase":
-            raise au.RpcError("boom", code=self._code)
+            raise au.RpcError("boom", code=self._code, http_status=self._http)
         raise AssertionError("unexpected method " + method)
+
+
+class Getinfo401Client:
+    """getinfo itself fails auth (HTTP 401) -- wrong rpcuser/rpcpassword."""
+    loopback = False
+
+    def __init__(self):
+        self.calls = []
+
+    def call(self, method, params):
+        self.calls.append(method)
+        if method == "getinfo":
+            raise au.RpcError("unauthorized", http_status=401)
+        raise AssertionError("should not reach " + method)
 
 
 class TestWalletpassphraseErrors(unittest.TestCase):
@@ -344,6 +359,19 @@ class TestWalletpassphraseErrors(unittest.TestCase):
     def test_unknown_error_is_transient(self):
         c = ErrClient(None)  # transport / unknown -> retry may help
         self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_TRANSIENT))
+
+    def test_walletpassphrase_http_401_is_unrecoverable(self):
+        # 401 has no JSON-RPC code (code=None) but must NOT fall through to transient.
+        c = ErrClient(None, http_status=401)
+        self.assertEqual(au.run_once(c, "pw", 60, None), (5, au.EXIT_UNRECOVERABLE))
+
+    def test_getinfo_http_401_is_unrecoverable(self):
+        # Bad rpcuser/rpcpassword surface on the getinfo probe first; that must be
+        # unrecoverable (park), not transient (retry forever), and send no passphrase.
+        c = Getinfo401Client()
+        new, code = au.run_once(c, "pw", 60, None)
+        self.assertEqual(code, au.EXIT_UNRECOVERABLE)
+        self.assertNotIn("walletpassphrase", c.calls)
 
     def test_helper_never_crashes_on_walletpassphrase_error(self):
         for code in (au.RPC_WALLET_ALREADY_UNLOCKED, au.RPC_WALLET_PASSPHRASE_INCORRECT,
@@ -455,6 +483,14 @@ class TestRpcClient(unittest.TestCase):
     def test_loopback_flag_off_remote_host(self):
         c = au.RpcClient({"host": "10.0.0.2", "port": 1, "user": "u", "password": "p"})
         self.assertFalse(c.loopback)
+
+    def test_ipv6_literal_host_is_bracketed_in_url(self):
+        c = au.RpcClient({"host": "::1", "port": 15715, "user": "u", "password": "p"})
+        self.assertEqual(c._url, "http://[::1]:15715/")
+
+    def test_ipv4_host_url_unbracketed(self):
+        c = au.RpcClient({"host": "127.0.0.1", "port": 15715, "user": "u", "password": "p"})
+        self.assertEqual(c._url, "http://127.0.0.1:15715/")
 
     def test_httperror_json_body_yields_code_and_message(self):
         body = b'{"result": null, "error": {"code": -17, "message": "already unlocked"}}'


### PR DESCRIPTION
Security hardening of the `gridcoin_autounlock.py` helper added in #3247, part of the cross-platform multiprocess "background-core + secure autounlock" work (umbrella #3153; design `~/GridcoinDev/windows_mp_install/DESIGN.md`). It stays **external, opt-in, stake-only** — no wallet-binary change.

## Why

The helper as merged sent `rpcuser:rpcpassword` and then the wallet passphrase to whatever answered `127.0.0.1:<rpcport>`, **with no check on who was listening**. On a normal core start the RPC port is **unbound for minutes** (`LoadBlockIndex` runs long before `StartRPCThreads`) and the RPC port is unprivileged, so any local account can bind it first and harvest both secrets — HTTP Basic authenticates the client to the server, never the reverse. A mainnet-validated prototype had already caught and fixed exactly this; this PR ports those defenses into the shared helper and hardens further after a three-lens adversarial security review (credential-flow, `/proc`-gate correctness, control-flow/test-honesty).

## What changed

**Listener-ownership gate (the core fix).** Before any credential goes on the wire, every LISTEN socket on the port must belong to our own uid (parsed from `/proc/net/tcp` + `/proc/net/tcp6`). Foreign owner ⇒ refuse. A present-but-**unreadable** `/proc` table also fails closed (a foreign listener could hide in the table we couldn't read); `FileNotFound` (address family absent, e.g. IPv6 off) does not. The `getinfo` readiness probe — which also carries credentials — runs only *after* the gate passes.

**Fail closed when the platform can't verify a loopback listener.** On a platform without a POSIX uid model (e.g. Windows), the helper **refuses** to send to a loopback target unless `--allow-unverified-listener` is passed, rather than sending blind. A non-loopback (remote) target legitimately can't be gated and proceeds after a startup warning. → A Windows-native owner check (`GetExtendedTcpTable`) is a follow-up (Plan 5); until then Windows autounlock requires the explicit opt-out on a trusted single-user host.

**Proxy-free opener.** `build_opener(ProxyHandler({}))` so an inherited `http_proxy` can't divert the passphrase POST (body + `Authorization`) off-box in cleartext.

**Redaction + an unkillable resident loop.** Passphrase, `rpcpassword`, and the auth token are scrubbed from every log line; a top-level catch-all maps any unexpected exception (malformed HTTP such as `BadStatusLine`, non-object JSON, `null`/non-numeric `uptime`) to a transient poll instead of a crash or an unredacted traceback.

**Correctness.**
- Structured `RpcError` (JSON-RPC code / HTTP status) → exit-code contract (`0` ok / `1` transient / `2` unrecoverable) so the systemd oneshot can key `RestartPreventExitStatus=2`; `-14`/`-8`/`401`/foreign-listener are unrecoverable.
- `-17` (already unlocked by another path) now **warns** that the stake-only restriction wasn't re-asserted, instead of silently claiming success.
- `parse_conf` now takes the **first** value on a duplicate key, matching the core (`settings.cpp` `reverse_precedence`); `read_passphrase` drops a UTF-8 BOM (`utf-8-sig`) and rejects a whitespace-only file — both silent `-14` sources on the Windows path; `rpcport` is validated as an integer.

## Tests

72 `unittest` cases, including the real `/proc` reader's fail-closed accounting (partial-unreadable ⇒ refuse), the gate sending **nothing** on foreign / unreadable / unverifiable-platform, proxy suppression, redaction, malformed-response survival, and the full exit-code contract. `lint-python` clean.

## Notes / follow-ups

- The resident (`--interval`) mode reacts to core restarts (uptime reset), not to an out-of-band GUI/RPC lock mid-instance. The shipping systemd model is the **oneshot** (`--once`), which re-asserts every run and has no such gap. The oneshot unit itself lands in the next PR (Plan 3).
- Windows-native listener verification is Plan 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
