### PR TITLE
init: oneshot systemd stake-only autounlock unit (multiprocess autounlock, Plan 3)

### DIFF
--- a/contrib/init/gridcoinresearchd-autounlock.service
+++ b/contrib/init/gridcoinresearchd-autounlock.service
@@ -42,6 +42,17 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
+# RemainAfterExit keeps the unit "active (exited)" after the single unlock, so an
+# operator sees success -- a bare oneshot goes "inactive (dead)" on a clean exit,
+# which reads like failure. The trade-off (noted in review): with
+# LoadCredentialEncrypted= below, systemd keeps the decrypted passphrase in the
+# per-unit credentials tmpfs for the unit's active lifetime (~ the core's uptime)
+# instead of tearing it down right after the unlock. Kept deliberately: that file
+# is ramfs (never swapped), mode 0400, owned by THIS service's user -- the same
+# user that runs the core, which already holds the passphrase in its own memory
+# the whole time the wallet is unlocked (readable by that uid via ptrace). So the
+# credential file does not materially widen the attack surface, while the clear
+# "active (exited)" status is worth keeping. Matches the mainnet-validated prototype.
 RemainAfterExit=yes
 User=gridcoin
 Group=gridcoin

--- a/contrib/init/gridcoinresearchd-autounlock.service
+++ b/contrib/init/gridcoinresearchd-autounlock.service
@@ -1,0 +1,113 @@
+# Opt-in stake-only wallet autounlock, companion to gridcoinresearchd.service.
+#
+# It is not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades. Use `systemctl edit` for local changes.
+#
+# This is a SEPARATE unit rather than an ExecStartPost= on the core, deliberately:
+# a non-zero ExecStartPost= would SIGTERM the core (combined with the core's
+# Restart=on-failure, a restart loop on a live staking wallet), a hanging one
+# would wedge the core in "activating" under its TimeoutStartSec=infinity, and it
+# would put the unlock on the boot-critical path. A separate unit keeps a failed
+# unlock from ever touching the core, and gives a hand-runnable re-unlock with
+# real retry. The core unit is never modified: the [Install] WantedBy= below only
+# creates gridcoinresearchd.service.wants/, leaving its hardening untouched.
+#
+# SETUP (opt-in). Encrypt the wallet passphrase once, host/TPM-bound, then enable:
+#
+#   printf '%s' 'YOUR-WALLET-PASSPHRASE' | sudo systemd-creds encrypt \
+#       --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+#   sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
+#   sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
+#   sudo systemctl enable --now gridcoinresearchd-autounlock.service
+#
+# systemd decrypts it to $CREDENTIALS_DIRECTORY/wallet-passphrase (0400, readable
+# only by this service) at start. The passphrase is NEVER stored here or on argv.
+# Rotating the passphrase requires `systemctl restart` (the credential is read at
+# unit start). See doc/multiprocess.md for the full rationale.
+
+[Unit]
+Description=Gridcoin wallet stake-only autounlock
+Documentation=https://github.com/gridcoin-community/Gridcoin-Research/blob/development/doc/multiprocess.md
+After=gridcoinresearchd.service
+BindsTo=gridcoinresearchd.service
+
+# NO start rate limit, deliberately. The limit counts EVERY start of this unit,
+# including the fully successful ones each core start triggers via WantedBy=; a
+# deploy/restart cycle (or a core crash-loop) would exhaust the default burst and
+# leave the core healthy with the wallet silently locked, refusing later starts
+# until `systemctl reset-failed`. Set to 0 (not merely omitted, which inherits the
+# 5-in-10s default) to disable the class. Retries are bounded by exit-status
+# classification instead -- see RestartPreventExitStatus= below.
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=gridcoin
+Group=gridcoin
+
+# Host/TPM-bound wallet passphrase, decrypted to %d/wallet-passphrase at runtime.
+LoadCredentialEncrypted=wallet-passphrase:/etc/gridcoin/wallet-passphrase.cred
+
+# --once: a single unlock attempt driven by systemd's own lifecycle. The core
+# uses -daemonwait, so by the time this unit is ordered After= it, the RPC port
+# is already bound and served -- the helper's listener-ownership gate then only
+# has to confirm the owner (defence in depth). The helper reads rpcuser/rpcpassword
+# /rpcport from the same config the core uses.
+ExecStart=/usr/bin/python3 /usr/share/gridcoin/gridcoin_autounlock.py \
+          --conf=/etc/gridcoin/gridcoin.conf \
+          --passphrase-file=%d/wallet-passphrase \
+          --once
+
+# The helper exits 2 for failures no retry can fix (rejected passphrase -14,
+# rejected parameter -8, HTTP 401 bad RPC credentials, a foreign or unverifiable
+# RPC listener); park those in "failed" where they are visible instead of looping.
+# Exit 1 (transient: core still coming up, RPC momentarily unreachable) retries.
+Restart=on-failure
+RestartSec=30
+RestartPreventExitStatus=2
+
+# Finite, unlike the core (TimeoutStartSec=infinity). The helper's --once worst
+# case is one /proc read plus a getinfo and a walletpassphrase call, each bounded
+# by its 10s HTTP timeout, so two minutes is generous headroom.
+TimeoutStartSec=120
+
+# --- Hardening (mirrors the core unit; tighter where possible -- this helper only
+# opens one loopback TCP socket and reads /etc + the credential). ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+RestrictNamespaces=true
+MemoryDenyWriteExecute=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+CapabilityBoundingSet=
+UMask=0077
+
+# AF_INET/AF_INET6 for the loopback RPC socket; AF_UNIX and AF_NETLINK are what
+# glibc's resolver / interface enumeration reach for. @system-service keeps
+# socket/sendmsg/recvmsg; a denied call returns EPERM rather than SIGSYS.
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+
+# Belt-and-braces around the passphrase POST: the helper already builds a
+# proxy-free urllib opener, but these pin it at the kernel level -- an http_proxy
+# in the manager environment cannot divert the request, and only loopback is
+# reachable at all, regardless of what the code does.
+Environment=no_proxy=*
+IPAddressDeny=any
+IPAddressAllow=localhost
+
+[Install]
+WantedBy=gridcoinresearchd.service

--- a/debian-testnet/control
+++ b/debian-testnet/control
@@ -52,7 +52,8 @@ Depends:
  ${misc:Depends},
  adduser
 Recommends:
- bash-completion
+ bash-completion,
+ python3
 Description: Gridcoin Research testnet daemon
  Gridcoin is a proof-of-stake cryptocurrency that rewards BOINC
  (Berkeley Open Infrastructure for Network Computing) participants

--- a/debian-testnet/not-installed
+++ b/debian-testnet/not-installed
@@ -6,3 +6,5 @@ usr/share/icons/hicolor/48x48/apps/gridcointestnet.png
 usr/share/metainfo/us.gridcoin.GridcoinResearch.metainfo.xml
 usr/share/bash-completion/completions/gridcoinresearchd
 usr/share/bash-completion/completions/gridcoinresearch
+usr/lib/systemd/system/gridcoinresearchd-autounlock.service
+usr/share/gridcoin/gridcoin_autounlock.py

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,8 @@ Depends:
  ${misc:Depends},
  adduser
 Recommends:
- bash-completion
+ bash-completion,
+ python3
 Description: Gridcoin Research daemon
  Gridcoin is a proof-of-stake cryptocurrency that rewards BOINC
  (Berkeley Open Infrastructure for Network Computing) participants

--- a/debian/gridcoinresearchd.install
+++ b/debian/gridcoinresearchd.install
@@ -1,3 +1,5 @@
 usr/bin/gridcoinresearchd
 usr/share/man/man1/gridcoinresearchd.1
 usr/share/bash-completion/completions/gridcoinresearchd
+usr/lib/systemd/system/gridcoinresearchd-autounlock.service
+usr/share/gridcoin/gridcoin_autounlock.py

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -204,6 +204,10 @@ removed years ago as insecure); it uses only the standard
 `walletpassphrase <pass> <timeout> true` RPC via the
 [`gridcoin_autounlock.py`](../contrib/wallettools/gridcoin_autounlock.py) helper.
 
+The helper is Python 3 (standard library only). The daemon package *Recommends*
+`python3` rather than depending on it, so on a minimal install
+(`apt --no-install-recommends`) install it first: `sudo apt install python3`.
+
 Set it up once, then enable:
 
 ```bash

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -191,6 +191,51 @@ confinement (no `execve` of a shell, no new socket families for exfiltration, no
 `ptrace` into sibling processes) with the policy maintained by the OS instead of by
 this project.
 
+### Unattended stake-only autounlock (Linux)
+
+An encrypted wallet must be unlocked after every start before it can stake, and
+there is no native way to supply a passphrase at daemon startup. A packaged install
+ships an **opt-in** companion unit,
+[`contrib/init/gridcoinresearchd-autounlock.service`](../contrib/init/gridcoinresearchd-autounlock.service),
+that keeps the wallet unlocked **for staking only**, with the passphrase held
+host/TPM-bound in `systemd-creds` — never in a file the daemon reads, the unit, or
+on a command line. It stays **external** to the wallet (the in-wallet auto-unlock was
+removed years ago as insecure); it uses only the standard
+`walletpassphrase <pass> <timeout> true` RPC via the
+[`gridcoin_autounlock.py`](../contrib/wallettools/gridcoin_autounlock.py) helper.
+
+Set it up once, then enable:
+
+```bash
+# Encrypt the wallet passphrase, bound to this host (and its TPM, if present):
+printf '%s' 'YOUR-WALLET-PASSPHRASE' | sudo systemd-creds encrypt \
+    --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
+sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
+
+sudo systemctl enable --now gridcoinresearchd-autounlock.service
+```
+
+`systemctl enable` links the unit into `gridcoinresearchd.service.wants/`, so it runs
+whenever the core starts (boot, restart, deploy) without modifying the core unit;
+`BindsTo=` re-triggers it on every core restart. It runs as `gridcoin`, unlocks
+stake-only (`walletpassphrase … true`, which still permits staking **and** automatic
+beacon renewal but blocks spends), and exits — a `Type=oneshot`, not a resident poll.
+A rejected passphrase, bad RPC credentials, or an unverifiable RPC listener park the
+unit in `failed` (`RestartPreventExitStatus=2`) where they are visible, rather than
+looping silently over a locked wallet.
+
+**Security model.** Only a principal that can already run as the `gridcoin` user on
+this host can recover the passphrase — the same bar as reading the wallet's own files.
+Before sending anything, the helper verifies (via `/proc/net/tcp{,6}`) that the RPC
+listener is owned by its own uid, so credentials are never handed to a local process
+that squatted the RPC port during startup; because the core uses `-daemonwait`, the
+port is already bound and served by the time the unit is ordered `After=` it, so this
+gate is defence in depth. While unlocked, the passphrase lives in the core's memory
+(unavoidable for unattended staking). Rotating the passphrase (or `rpcpassword`)
+requires `systemctl restart gridcoinresearchd-autounlock.service`, as the credential
+is read at unit start.
+
 ## Troubleshooting
 
 - **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -407,6 +407,15 @@ if(ENABLE_DAEMON)
         install(FILES "${CMAKE_SOURCE_DIR}/contrib/init/gridcoinresearchd.service" COMPONENT daemon
             DESTINATION "lib/systemd/system"
         )
+        install(FILES "${CMAKE_SOURCE_DIR}/contrib/init/gridcoinresearchd-autounlock.service" COMPONENT daemon
+            DESTINATION "lib/systemd/system"
+        )
+        # The stake-only autounlock helper the unit above runs. install(PROGRAMS ...)
+        # sets the executable bit; share/gridcoin is portable (share == share on
+        # every distro), matching the unit's ExecStart path.
+        install(PROGRAMS "${CMAKE_SOURCE_DIR}/contrib/wallettools/gridcoin_autounlock.py" COMPONENT daemon
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/gridcoin"
+        )
         install(FILES "${CMAKE_SOURCE_DIR}/contrib/completions/bash/gridcoinresearchd.bash" COMPONENT daemon
             DESTINATION "${CMAKE_INSTALL_DATADIR}/bash-completion/completions"
             RENAME "gridcoinresearchd"


### PR DESCRIPTION
The Linux systemd side of the cross-platform multiprocess "background-core + secure autounlock" work (umbrella #3153; design `~/GridcoinDev/windows_mp_install/DESIGN.md`). Ships an **opt-in, external, stake-only** autounlock unit driven by the hardened helper — no wallet-binary change.

> Builds on the hardened `gridcoin_autounlock.py` helper merged in **#3248**. This PR is now a single commit on `development` (the helper landed with #3248) — it adds the systemd unit that drives that helper, its install rules, and docs.

## What this adds

`contrib/init/gridcoinresearchd-autounlock.service` — a companion to the packaged core unit that keeps the wallet unlocked **for staking only**, with the passphrase held host/TPM-bound in `systemd-creds` (`LoadCredentialEncrypted=`, decrypted to `%d/wallet-passphrase` at runtime) — never in a file the daemon reads, the unit, or on argv. It runs the `gridcoin_autounlock.py` helper with `--once`.

Design mirrors the maintainer's mainnet-validated prototype:

- **`Type=oneshot` + `RemainAfterExit`**, run per core start. `After=`/`BindsTo=`/`WantedBy=gridcoinresearchd.service` ties it to the core (re-runs on every restart) **without modifying the core unit** — `WantedBy=` only creates `gridcoinresearchd.service.wants/`.
- **`StartLimitIntervalSec=0`** — the start rate limit counts the *successful* starts each core start triggers via `WantedBy=`, so a deploy/restart cycle would otherwise exhaust the default burst and leave the wallet silently locked (requiring `reset-failed`). Retries are bounded by exit-status classification instead: **`RestartPreventExitStatus=2`** parks a rejected passphrase / bad RPC creds / unverifiable listener in `failed` where they're visible.
- **Finite `TimeoutStartSec`** (the helper's `--once` worst case is bounded), unlike the core's `TimeoutStartSec=infinity`.
- **Hardening** mirrors the core unit, tighter where possible (one loopback TCP socket): full `Protect*`/`Restrict*` suite, `SystemCallFilter=@system-service`, `CapabilityBoundingSet=`. `Environment=no_proxy=*` + `IPAddressDeny=any`/`IPAddressAllow=localhost` pin the passphrase POST to loopback at the kernel level.

Because the packaged core uses **`-daemonwait`**, `After=` ordering means the RPC port is already bound and served by the time this unit runs — so the helper's `/proc` listener-ownership gate is **defence in depth** here rather than the primary race guard.

## Packaging & docs

- `cmake --install` now installs the unit to `lib/systemd/system` and the helper (executable) to `share/gridcoin` — the path the unit's `ExecStart` references.
- The daemon `.deb` now **Recommends `python3`** (the helper is stdlib-only Python 3; opt-in feature, hence Recommends not Depends) — `debian/control` + `debian-testnet/control`.
- `doc/multiprocess.md` documents the opt-in `systemd-creds` setup and the security model.

## Validation

`systemd-analyze verify` clean; `cmake` configure places both install rules (`src/cmake_install.cmake`) with the helper as `TYPE PROGRAM`. `%d` confirmed as the credentials-directory specifier on the target (systemd 257). Full runtime validation (encrypt cred → `enable --now` → wallet unlocks stake-only, survives a core restart) is a manual deploy — I'll run it on the maintainer's mainnet node as the live test after merge, and report back.

## Follow-ups

Windows core tasks (Plan 4) and Windows DPAPI autounlock + native listener gate (Plan 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)