### PR TITLE
ipc: give multiprocess logging a dedicated BCLog::IPC category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Every `vRPCCommands[]` row in `src/rpc/server.cpp` carries a **mandatory heritag
 
 ## PR Title Prefixes
 
-Use component prefixes: `accrual`, `build`, `consensus`, `contract`, `doc`, `gui`/`qt`, `mining`, `net`/`p2p`, `refactor`, `researcher`, `rpc`, `scraper`, `staking`, `superblock`, `test`/`qa`/`ci`, `voting`, `wallet`, `whitelist`
+Use component prefixes: `accrual`, `build`, `consensus`, `contract`, `doc`, `gui`/`qt`, `ipc`, `mempool`, `mining`, `net`/`p2p`, `refactor`, `researcher`, `rpc`, `scraper`, `staking`, `superblock`, `test`/`qa`/`ci`, `voting`, `wallet`, `whitelist`
 
 ## Key Documentation
 

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -296,6 +296,14 @@ needs for debugging, while -debug=NOISY results in extensive debugging entries.
 The Qt code routes `qDebug()` output to `debug.log` under category "qt": run
 with `-debug=qt` to see it.
 
+Multiprocess (split GUI/node) IPC bookkeeping logs under category "ipc": run with
+`-debug=ipc` to see the per-request libmultiprocess traffic, proxy create/destroy
+and post-disconnect notices. That category carries informational traffic only --
+IPC warnings and errors are deliberately uncategorised (`LogPrintf("WARN: ...")`
+and `error(...)`) so they are always logged rather than hidden behind a debug
+switch. Note "ipc" occupies the bit Bitcoin Core assigns to "cmpctblock", which
+Gridcoin does not implement; see the comment on `BCLog::IPC` in `logging.h`.
+
 ### Testnet mode
 
 If you are testing multi-machine code that needs to operate across the internet,

--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -14,9 +14,9 @@ namespace interfaces {
 
 void LogDroppedNotification(const char* what)
 {
-    // Verbose category only: on a clean shutdown many peers drop at once, so this
-    // can fire repeatedly; it is expected, not an error. Surfaces with -debug=verbose.
-    LogPrint(BCLog::VERBOSE, "IPC: dropped a notification to a disconnected client: %s\n", what);
+    // IPC category only: on a clean shutdown many peers drop at once, so this can
+    // fire repeatedly; it is expected, not an error. Surfaces with -debug=ipc.
+    LogPrint(BCLog::LogFlags::IPC, "IPC: dropped a notification to a disconnected client: %s", what);
 }
 
 namespace {

--- a/src/interfaces/handler.h
+++ b/src/interfaces/handler.h
@@ -37,7 +37,7 @@ std::unique_ptr<Handler> MakeSignalHandler(boost::signals2::connection connectio
 //! Return a Handler that runs a cleanup function on disconnect/destruction.
 std::unique_ptr<Handler> MakeCleanupHandler(std::function<void()> cleanup);
 
-//! Log (at the verbose category) that a one-way notification was dropped because
+//! Log (at the ipc category) that a one-way notification was dropped because
 //! the IPC client had already disconnected. Defined out of line so this header
 //! stays free of the logging dependency; used by GuardNotify below.
 void LogDroppedNotification(const char* what);

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -34,17 +34,62 @@ namespace ipc {
 namespace capnp {
 namespace {
 
-//! Route libmultiprocess log messages into the Gridcoin log. This is high-volume
-//! bookkeeping (per-request send/recv, proxy create/destroy, post-disconnect
-//! "method called after disconnect" notices), so gate it behind the verbose
-//! category -- silent by default, surfaced with -debug=verbose. (Bitcoin Core
-//! gates this behind a dedicated BCLog::IPC category; Gridcoin's LogFlags bits are
-//! all allocated, so it rides the verbose category instead.) Raise-level messages
-//! are still turned into exceptions (mp's convention for a fatal protocol error);
-//! the message survives via the thrown exception if it goes uncaught.
+//! Route libmultiprocess log messages into the Gridcoin log, split by mp's own
+//! severity rather than lumped together.
+//!
+//! Trace/Debug/Info are high-volume bookkeeping (per-request send/recv, proxy
+//! create/destroy), so they go to the dedicated IPC category -- silent by
+//! default, surfaced with -debug=ipc. Warning and Error are real signal, and
+//! burying them in a debug category is how you lose the one message that
+//! mattered in a flood of bookkeeping, so they take the uncategorised WARN /
+//! ERROR forms and are always logged. Raise stays on the quiet category and is
+//! converted to an exception below -- see the case for why it must not be
+//! grouped with Error.
+//!
+//! The switch has no default so -Wswitch flags an mp::Log level that gained no
+//! mapping; the post-switch assert is the runtime backstop, mirroring
+//! ToCoreFlag() in qt/guilog.cpp. The backstop is doing the real work here --
+//! this target is not currently built with -Wall/-Wextra, so the compile-time
+//! half is aspirational. It still logs rather than returning silently: dropping
+//! an mp message outright would be worse than misclassifying one.
+void LogIpcMessage(const mp::LogMessage& message)
+{
+    switch (message.level) {
+    case mp::Log::Trace:
+    case mp::Log::Debug:
+    case mp::Log::Info:
+        LogPrint(BCLog::LogFlags::IPC, "ipc: %s", message.message);
+        return;
+    case mp::Log::Warning:
+        LogPrintf("WARN: ipc: %s", message.message);
+        return;
+    case mp::Log::Error:
+        error("ipc: %s", message.message);
+        return;
+    case mp::Log::Raise:
+        // Deliberately quiet, and NOT grouped with Error. Raise is mp's "turn
+        // this into an exception" level -- IpcLogFn does exactly that below, so
+        // the throw is the signal and this line is only belt-and-braces. It is
+        // not reserved for fatal faults: the dominant Raise in practice is
+        // "IPC client method called after disconnect." (proxy-types.h:721/772),
+        // which fires whenever a one-way notification races a GUI close.
+        // interfaces::GuardNotify swallows that by design and logs its own gated
+        // line, so promoting Raise to error() would stamp an ERROR into the
+        // daemon log for every ordinary GUI shutdown, across every notification
+        // forwarder -- the exact noise this category exists to remove.
+        LogPrint(BCLog::LogFlags::IPC, "ipc: %s", message.message);
+        return;
+    }
+
+    assert(false && "unhandled mp::Log level");
+    LogPrintf("WARN: ipc: (unhandled mp log level %d) %s",
+              static_cast<int>(message.level), message.message);
+}
+
 void IpcLogFn(mp::LogMessage message)
 {
-    LogPrint(BCLog::VERBOSE, "ipc: %s\n", message.message);
+    LogIpcMessage(message);
+
     if (message.level == mp::Log::Raise) {
         throw std::runtime_error(message.message);
     }
@@ -59,9 +104,9 @@ void InvokeDisconnectCb(const std::function<void()>& cb)
     try {
         cb();
     } catch (const std::exception& e) {
-        LogPrintf("ipc: disconnect callback threw: %s\n", e.what());
+        error("ipc: disconnect callback threw: %s", e.what());
     } catch (...) {
-        LogPrintf("ipc: disconnect callback threw a non-standard exception\n");
+        error("ipc: disconnect callback threw a non-standard exception");
     }
 }
 

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -50,8 +50,9 @@ namespace {
 //! mapping; the post-switch assert is the runtime backstop, mirroring
 //! ToCoreFlag() in qt/guilog.cpp. The backstop is doing the real work here --
 //! this target is not currently built with -Wall/-Wextra, so the compile-time
-//! half is aspirational. It still logs rather than returning silently: dropping
-//! an mp message outright would be worse than misclassifying one.
+//! half is aspirational. The fallback logs before it asserts, so the unhandled
+//! level is recorded whether or not asserts are live: dropping an mp message
+//! outright would be worse than misclassifying one.
 void LogIpcMessage(const mp::LogMessage& message)
 {
     switch (message.level) {
@@ -81,9 +82,14 @@ void LogIpcMessage(const mp::LogMessage& message)
         return;
     }
 
-    assert(false && "unhandled mp::Log level");
+    // Log BEFORE asserting. This target compiles with -DNDEBUG followed by
+    // -UNDEBUG, so asserts are live and would abort the process before the
+    // diagnostic was ever written -- leaving no record of the level that went
+    // unhandled, which is the opposite of the intent. In this order the message
+    // survives in both build configurations.
     LogPrintf("WARN: ipc: (unhandled mp log level %d) %s",
               static_cast<int>(message.level), message.message);
+    assert(false && "unhandled mp::Log level");
 }
 
 void IpcLogFn(mp::LogMessage message)

--- a/src/ipc/peercred.cpp
+++ b/src/ipc/peercred.cpp
@@ -26,7 +26,7 @@ bool CheckPeerCredentials(int peer_fd)
     return true;
 #else
     if (peer_fd < 0) {
-        LogPrintf("IPC: WARNING: no peer fd available; skipping peer-credential check\n");
+        LogPrintf("WARN: %s: no peer fd available; skipping peer-credential check", __func__);
         return true;
     }
 
@@ -38,11 +38,11 @@ bool CheckPeerCredentials(int peer_fd)
     struct ucred cred;
     socklen_t len = sizeof(cred);
     if (::getsockopt(peer_fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) != 0) {
-        LogPrintf("IPC: WARNING: SO_PEERCRED failed (errno %d); skipping peer-credential check\n", errno);
+        LogPrintf("WARN: %s: SO_PEERCRED failed (errno %d); skipping peer-credential check", __func__, errno);
         return true;
     }
     if (len != sizeof(cred)) {
-        LogPrintf("IPC: WARNING: SO_PEERCRED returned an unexpected size; skipping peer-credential check\n");
+        LogPrintf("WARN: %s: SO_PEERCRED returned an unexpected size; skipping peer-credential check", __func__);
         return true;
     }
     peer_uid = cred.uid;
@@ -50,15 +50,14 @@ bool CheckPeerCredentials(int peer_fd)
     // *BSD / macOS.
     gid_t peer_gid;
     if (::getpeereid(peer_fd, &peer_uid, &peer_gid) != 0) {
-        LogPrintf("IPC: WARNING: getpeereid failed (errno %d); skipping peer-credential check\n", errno);
+        LogPrintf("WARN: %s: getpeereid failed (errno %d); skipping peer-credential check", __func__, errno);
         return true;
     }
 #endif
 
     if (peer_uid != self_uid) {
-        LogPrintf("IPC: rejecting connection: peer uid %d does not match serving uid %d\n",
-                  static_cast<int>(peer_uid), static_cast<int>(self_uid));
-        return false;
+        return error("%s: rejecting IPC connection: peer uid %d does not match serving uid %d",
+                     __func__, static_cast<int>(peer_uid), static_cast<int>(self_uid));
     }
     return true;
 #endif // WIN32

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -156,7 +156,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::ADDRMAN, "addrman"},
     {BCLog::SELECTCOINS, "selectcoins"},
     {BCLog::REINDEX, "reindex"},
-    {BCLog::CMPCTBLOCK, "cmpctblock"},
+    {BCLog::IPC, "ipc"},
     {BCLog::RAND, "rand"},
     {BCLog::MISC, "misc"},
     {BCLog::PROXY, "proxy"},

--- a/src/logging.h
+++ b/src/logging.h
@@ -60,7 +60,20 @@ namespace BCLog {
         ADDRMAN     = (1 <<  9),
         SELECTCOINS = (1 << 10),
         REINDEX     = (1 << 11),
-        CMPCTBLOCK  = (1 << 12),
+        // Bit 12 is Bitcoin Core's CMPCTBLOCK (BIP152 compact-block relay).
+        // Gridcoin has no compact-block code and the LogFlags bitfield is fully
+        // allocated (NET at bit 0 through NOISY at bit 31), so this bit was
+        // repurposed for the multiprocess IPC category rather than widening the
+        // mask. CMPCTBLOCK was never referenced at a single call site in
+        // Gridcoin's history, and reclaiming it would mean porting BIP152 onto a
+        // net_processing layer that has diverged from Core -- for a chain whose
+        // volume makes the bandwidth saving moot. Note m_categories is a
+        // runtime-only atomic -- built from -debug/-debugexclude, the logging
+        // RPC and a handful of direct EnableCategory() calls, and never written
+        // to disk -- so reusing the bit cannot remap a stored setting. The only
+        // migration cost is an "Unsupported logging category" warning for a
+        // config still carrying -debug=cmpctblock.
+        IPC         = (1 << 12),
         RAND        = (1 << 13),
         MISC        = (1 << 14),
         PROXY       = (1 << 15),

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -368,7 +368,7 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
         settings.setValue(key, token);
         settings.sync();
         if (settings.status() != QSettings::NoError) {
-            GUILogPrintf("IPC: WARNING: could not persist the node-identity binding "
+            GUILogPrintf("WARN: IPC: could not persist the node-identity binding "
                          "(QSettings status %d); the wallet-swap guard is disabled this session",
                          static_cast<int>(settings.status()));
         }
@@ -380,17 +380,18 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
     case ipc::BindOutcome::Match:
         break;
     case ipc::BindOutcome::UnavailableFresh:
-        GUILogPrintf("IPC: the daemon reported no wallet identity (binding unavailable); "
+        GUILogPrintf("WARN: IPC: the daemon reported no wallet identity (binding unavailable); "
                      "proceeding without the wallet-swap guard");
         break;
     case ipc::BindOutcome::FirstSeen:
-        GUILogPrintf("IPC: bound to the daemon's wallet identity for this data directory");
+        GUILogPrint(GUILogCategory::IPC,
+                    "IPC: bound to the daemon's wallet identity for this data directory");
         persist(reported);
         break;
     case ipc::BindOutcome::Mismatch: {
         // A different (non-empty) wallet identity than the one bound here.
         if (autotrust) {
-            GUILogPrintf("IPC: the daemon's wallet identity changed; -autotrustidentity set -> "
+            GUILogPrintf("WARN: IPC: the daemon's wallet identity changed; -autotrustidentity set -> "
                          "re-binding to the new wallet without prompting");
             persist(reported);
             break;
@@ -421,7 +422,7 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
         // under -autotrustidentity (that flag accepts a *changed* wallet, not the
         // loss of the identity we bound to).
         if (autotrust) {
-            GUILogPrintf("IPC: the daemon reports no wallet identity though a binding exists; "
+            GUILogPrintf("WARN: IPC: the daemon reports no wallet identity though a binding exists; "
                          "-autotrustidentity set -> proceeding, keeping the existing binding");
             break;
         }
@@ -445,10 +446,11 @@ static bool ResolveNodeIdentity(const ipc::HandshakeResult& hs)
     // Soft (non-fatal) findings.
     for (const ipc::SoftWarn w : hs.soft) {
         if (w == ipc::SoftWarn::GuiOlderMinor) {
-            GUILogPrintf("IPC: the daemon speaks a newer IPC schema minor than this GUI "
-                         "(forward-compatible; some newer features may be unavailable)");
+            GUILogPrint(GUILogCategory::IPC,
+                        "IPC: the daemon speaks a newer IPC schema minor than this GUI "
+                        "(forward-compatible; some newer features may be unavailable)");
         } else if (w == ipc::SoftWarn::GitCommitMismatch && !gArgs.GetBoolArg("-nobuildwarn", false)) {
-            GUILogPrintf("IPC: WARNING: the GUI (%s) and daemon (%s) were built from different "
+            GUILogPrintf("WARN: IPC: the GUI (%s) and daemon (%s) were built from different "
                          "commits; mixed builds can behave unexpectedly",
                          ipc::GetLocalBuildInfo().git_commit, hs.remote_build.git_commit);
         }
@@ -531,12 +533,12 @@ static void InstallGuiTerminationHandler(QCoreApplication& app)
     // Linux/BSD-only and absent on macOS. Set non-blocking and close-on-exec on
     // both ends explicitly for portability.
     if (::pipe(g_signal_pipe) != 0) {
-        GUILogPrintf("IPC: could not install the GUI termination-signal handler "
+        GUILogPrintf("WARN: IPC: could not install the GUI termination-signal handler "
                      "(pipe failed); SIGTERM/SIGINT will hard-terminate the GUI");
         return;
     }
     if (!SetSelfPipeFdFlags(g_signal_pipe[0]) || !SetSelfPipeFdFlags(g_signal_pipe[1])) {
-        GUILogPrintf("IPC: could not install the GUI termination-signal handler "
+        GUILogPrintf("WARN: IPC: could not install the GUI termination-signal handler "
                      "(fcntl failed); SIGTERM/SIGINT will hard-terminate the GUI");
         ::close(g_signal_pipe[0]);
         ::close(g_signal_pipe[1]);
@@ -915,7 +917,7 @@ int main(int argc, char *argv[])
             });
         if (!node_connection)
         {
-            GUILogPrintf("IPC: could not connect to the Gridcoin daemon: %s", ipc_error);
+            GUIError("IPC: could not connect to the Gridcoin daemon: %s", ipc_error);
             QMessageBox::critical(nullptr, PACKAGE_NAME,
                     QObject::tr("Could not connect to the Gridcoin daemon:\n%1").arg(QString::fromStdString(ipc_error)));
             return EXIT_FAILURE;
@@ -959,7 +961,7 @@ int main(int argc, char *argv[])
 #else
     if (multiprocess)
     {
-        GUILogPrintf("IPC: -multiprocess requested but this build has no multiprocess (IPC) support");
+        GUIError("IPC: -multiprocess requested but this build has no multiprocess (IPC) support");
         QMessageBox::critical(nullptr, PACKAGE_NAME,
                 QObject::tr("This build was compiled without multiprocess (IPC) support."));
         return EXIT_FAILURE;
@@ -998,7 +1000,7 @@ int main(int argc, char *argv[])
         // misleading "lost the daemon connection".
         if (multiprocess)
         {
-            GUILogPrintf("IPC: lost the daemon connection during GUI startup: %s", e.what());
+            GUIError("IPC: lost the daemon connection during GUI startup: %s", e.what());
             QMessageBox::critical(nullptr, PACKAGE_NAME,
                     QObject::tr("Lost connection to the Gridcoin daemon during startup:\n%1")
                         .arg(QString::fromStdString(e.what())));

--- a/src/qt/guilog.cpp
+++ b/src/qt/guilog.cpp
@@ -20,6 +20,7 @@ BCLog::LogFlags ToCoreFlag(GUILogCategory category)
     case GUILogCategory::VOTE:    return BCLog::LogFlags::VOTE;
     case GUILogCategory::SCRAPER: return BCLog::LogFlags::SCRAPER;
     case GUILogCategory::MISC:    return BCLog::LogFlags::MISC;
+    case GUILogCategory::IPC:     return BCLog::LogFlags::IPC;
     case GUILogCategory::VERBOSE: return BCLog::LogFlags::VERBOSE;
     case GUILogCategory::NOISY:   return BCLog::LogFlags::NOISY;
     }

--- a/src/qt/guilog.h
+++ b/src/qt/guilog.h
@@ -35,6 +35,7 @@ enum class GUILogCategory {
     VOTE,
     SCRAPER,
     MISC,
+    IPC,
     VERBOSE,
     NOISY,
 };


### PR DESCRIPTION
## Problem

`IpcLogFn()` routes every libmultiprocess message through a single `LogPrint` under `BCLog::VERBOSE`. That is high-volume bookkeeping — per-request send/recv, proxy create/destroy — so running `-debug=verbose` on a multiprocess node drowns the verbose category, which is exactly the category you reach for when debugging something else. The existing comment in `protocol.cpp` already noted that Bitcoin Core gates this behind a dedicated `BCLog::IPC` and that Gridcoin could not, because the `LogFlags` bits were all allocated.

## Which bit, and why

`LogFlags` is fully packed — `NET` at bit 0 through `NOISY` at bit 31 — so this reclaims one rather than widening the mask.

Twelve categories inherited from Core have **zero** call sites, and `git log -S"BCLog::LogFlags::<X>"` shows none of them was ever referenced at a call site anywhere in Gridcoin's history. Narrowing from there:

- `libevent` and `leveldb` are named by `-debugexclude` in `test/functional/test_framework/test_node.py`, so removing either name would emit `Unsupported logging category` on every functional-test node.
- `selectcoins`, `reindex`, `proxy`, `mempoolrej` and `http` all describe subsystems Gridcoin genuinely has, so any of them could plausibly be wanted later.
- `cmpctblock` is BIP152 compact-block relay. There is no compact-block code in the tree, reclaiming it would mean porting BIP152 onto a `net_processing` layer that has diverged from Core, and the bandwidth win it exists for is meaningless at this chain's volume. It is also the only candidate whose *name* has no plausible alternative meaning in Gridcoin, so it cannot be coveted for something else.

Reuse is safe: `m_categories` is a runtime-only atomic and is never written to disk, so no stored setting can be silently remapped. The only migration cost is an `Unsupported logging category` warning for a config still carrying `-debug=cmpctblock`.

## Beyond the category swap

Sorting the call sites by severity surfaced two things worth fixing in the same pass.

**`IpcLogFn` collapsed all six `mp::Log` levels into one categorised `LogPrint`**, so libmultiprocess's own `Warning` and `Error` messages were hidden behind a debug switch. `Trace/Debug/Info` now go to the IPC category; `Warning` and `Error` take the uncategorised `WARN:` / `error()` forms.

`Raise` deliberately stays on the quiet category rather than joining `Error`. It is not a fatal-fault level here — mp raises `"IPC client method called after disconnect."` at `Log::Raise` (`proxy-types.h:721` and `:772`) whenever a one-way notification races a GUI close, which `interfaces::GuardNotify` swallows by design and logs through its own gated `LogDroppedNotification`. Promoting `Raise` would stamp an `ERROR` into the daemon log on every ordinary GUI shutdown, across every notification forwarder — the precise noise this category exists to remove. `IpcLogFn` still converts `Raise` to an exception, which is the real signal.

The switch has no `default` so `-Wswitch` flags an unmapped level where that warning is on; since this target is not built with `-Wall`, the post-switch `assert` is the actual guard, mirroring `ToCoreFlag()` in `qt/guilog.cpp`. It logs rather than returning silently, so a future `mp::Log` level is misclassified rather than dropped.

**IPC warnings and errors elsewhere were either categorised or used the wrong primitive.** Warnings now take `LogPrintf("WARN: ...")` and errors take `error()` / `GUIError()`, both uncategorised, so they are always logged. The three GUI sites that already ended in `QMessageBox::critical` + `EXIT_FAILURE` become `GUIError`. `peercred`'s uid-mismatch rejection folds into a single `return error(...)`, since `error()` returns `false`.

Lifecycle lines that explain why the GUI closed, and the audit trail of a user's answer to a wallet-identity prompt, are left unconditional on purpose. They are not warnings, but silencing them behind `-debug=ipc` would be worse than the noise they add.

Format strings carrying their own trailing `\n` lose it — Gridcoin's `LogPrintf`/`LogPrint`/`error` all append one, so those sites were emitting a blank line after every entry. Only lines this change already touches are altered.

The Qt layer has its own `GUILogCategory` enum mapped onto `BCLog` in `guilog.cpp`, so it gains a matching `IPC` member and `-debug=ipc` covers both sides of the split.

## Testing

- Full `ENABLE_MULTIPROCESS` + Qt6 `RelWithDebInfo` build: clean, no new warnings; all three test suites pass; `test/lint/lint-all.sh` passes.
- Runtime category list now reads `... reindex, ipc, rand ...` with `cmpctblock` gone.
- Isolated regtest probe: `-debug=ipc` is accepted with no warning, while `-debug=cmpctblock` is rejected exactly like an unknown category.

## Also included

`CLAUDE.md`'s PR-prefix list omitted `ipc`, which this change ran straight into — a correctly-prefixed branch looked non-conforming. `ipc:` has 28 commits since 2026-07-23 across six dates and is the established prefix for this subsystem, so the list was simply stale. `mempool` is added for the same reason: 8 commits over four dates from three different authors, so it is a cross-author convention.

Deliberately not added: `wallettools` and `threading` are single-day, single-author bursts from one series each, and `crypto` is 4 commits spread over two years — incidental labels rather than components anyone reaches for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)