### PR TITLE
qt: warn pre-encryption wallet backups are a security risk; guide MP users to restart the core

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -112,21 +112,60 @@ void AskPassphraseDialog::accept()
         if(retval == QMessageBox::Yes) {
             if(newpass1 == newpass2) {
                 if(model->setWalletEncrypted(newpass1)) {
-                    QMessageBox::warning(this, tr("Wallet encrypted"),
-                                         "<qt>" +
-                                         tr("Gridcoin will close now to finish the encryption process. "
-                                         "Remember that encrypting your wallet cannot fully protect "
-                                         "your coins from being stolen by malware infecting your computer.") +
-                                         "<br><br><b>" +
-                                         tr("IMPORTANT: Any previous backups you have made of your wallet file "
-                                         "should be replaced with the newly generated, encrypted wallet file. "
-                                         "For security reasons, previous backups of the unencrypted wallet file "
-                                         "will become useless as soon as you start using the new, encrypted wallet.") +
-                                         "</b></qt>");
-                    // The wallet must restart to finish encryption; route the
-                    // shutdown through BitcoinGUI::requestQuit() so it can't be
-                    // vetoed by minimize-on-close on Qt6 (issue #2995).
-                    BitcoinGUI::requestQuit();
+                    // Earlier backups of the pre-encryption wallet are not merely useless
+                    // once the new wallet is in use -- they remain a security risk, because
+                    // they still contain the UNENCRYPTED private keys. This includes the
+                    // automatic backups written to the walletbackups folder. Shown in both
+                    // the monolithic and multiprocess cases (most users do not know this).
+                    const QString backupWarning = "<b>" +
+                                                  tr("IMPORTANT: Any earlier backups of your wallet file are not just "
+                                                     "useless once you use the new encrypted wallet, they are a security "
+                                                     "risk. They still contain your UNENCRYPTED private keys, so anyone who "
+                                                     "obtains one can take your coins even after the live wallet is encrypted. "
+                                                     "This includes the automatic backups Gridcoin writes to the "
+                                                     "\"walletbackups\" folder. After making a fresh backup of the new "
+                                                     "encrypted wallet, securely delete every backup taken before encryption, "
+                                                     "including those in \"walletbackups\".") +
+                                                  "</b>";
+
+                    if (!m_multiprocess) {
+                        // Monolithic: node + wallet + GUI are one process, so restarting the
+                        // application performs the clean reload that finishes the encryption.
+                        QMessageBox::warning(this, tr("Wallet encrypted"),
+                                             "<qt>" +
+                                                 tr("Gridcoin will close now to finish the encryption process. "
+                                                    "Remember that encrypting your wallet cannot fully protect "
+                                                    "your coins from being stolen by malware infecting your computer.") +
+                                                 "<br><br>" + backupWarning + "</qt>");
+                        // The wallet must restart to finish encryption; route the
+                        // shutdown through BitcoinGUI::requestQuit() so it can't be
+                        // vetoed by minimize-on-close on Qt6 (issue #2995).
+                        BitcoinGUI::requestQuit();
+                    } else {
+                        // Multiprocess: the wallet lives in the separate core process, which
+                        // keeps running -- closing this GUI would NOT restart it. The on-disk
+                        // encryption is already complete (the wallet database was rewritten and
+                        // the keypool regenerated in the core); the core just needs a restart to
+                        // drop the pre-encryption database state it still holds in memory and
+                        // reload cleanly. Deliberately no requestQuit() here.
+                        QMessageBox::warning(this, tr("Wallet encrypted - restart the core to finish"),
+                                             "<qt>" +
+                                                 tr("Your wallet is now fully encrypted and has been locked.") +
+                                                 "<br><br>" +
+                                                 tr("You are running in multiprocess mode, so the wallet lives in the "
+                                                    "separate Gridcoin core process, which is still running. To finish the "
+                                                    "encryption cleanly, restart the core process now (the running "
+                                                    "<code>gridcoinresearchd</code>). The encryption on disk is already "
+                                                    "complete; the restart is only so the core drops the pre-encryption "
+                                                    "database state it still holds in memory and reloads the encrypted "
+                                                    "wallet fresh.") +
+                                                 "<br><br>" +
+                                                 tr("Note: closing this window will not restart the core. Only "
+                                                    "stopping and starting the core process does that; stopping it "
+                                                    "will also close this window, so reopen the wallet once the core "
+                                                    "is back up.") +
+                                                 "<br><br>" + backupWarning + "</qt>");
+                    }
                 }
                 else {
                     QMessageBox::critical(this, tr("Wallet encryption failed"),

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -119,13 +119,13 @@ void AskPassphraseDialog::accept()
                     // the monolithic and multiprocess cases (most users do not know this).
                     const QString backupWarning = "<b>" +
                                                   tr("IMPORTANT: Any earlier backups of your wallet file are not just "
-                                                     "useless once you use the new encrypted wallet, they are a security "
+                                                     "useless once you use the new encrypted wallet; they are a security "
                                                      "risk. They still contain your UNENCRYPTED private keys, so anyone who "
                                                      "obtains one can take your coins even after the live wallet is encrypted. "
-                                                     "This includes the automatic backups Gridcoin writes to the "
-                                                     "\"walletbackups\" folder. After making a fresh backup of the new "
-                                                     "encrypted wallet, securely delete every backup taken before encryption, "
-                                                     "including those in \"walletbackups\".") +
+                                                     "This includes the automatic backups Gridcoin writes to the wallet backups "
+                                                     "directory (\"walletbackups\" by default, or the directory set by -backupdir). "
+                                                     "After making a fresh backup of the new encrypted wallet, securely delete "
+                                                     "every backup taken before encryption, including those in that directory.") +
                                                   "</b>";
 
                     if (!m_multiprocess) {

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -30,11 +30,18 @@ public:
 
     void setModel(WalletModel *model);
 
+    //! In the -multiprocess split build the wallet lives in a separate core
+    //! process, so encrypting it does not restart via this GUI (closing the GUI
+    //! leaves the core running). Set from BitcoinGUI (GuiIpcInfo::active) before
+    //! exec() so the Encrypt-completion message can guide the user accordingly.
+    void setMultiprocess(bool multiprocess) { m_multiprocess = multiprocess; }
+
 private:
     Ui::AskPassphraseDialog *ui;
     Mode mode;
     WalletModel *model;
     bool fCapsLock;
+    bool m_multiprocess{false};
 
 private slots:
     void textChanged();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1819,6 +1819,10 @@ void BitcoinGUI::encryptWallet()
     AskPassphraseDialog dlg(AskPassphraseDialog::Encrypt, this);
 
     dlg.setModel(walletModel);
+    // GuiIpcInfo::active is true only in the -multiprocess split build, where the
+    // wallet lives in a separate core process; the dialog uses it to guide the
+    // user to restart the core (this GUI closing would not) after encryption.
+    dlg.setMultiprocess(m_ipc_info.active);
     dlg.exec();
 
     setEncryptionStatus(walletModel->getEncryptionStatus());


### PR DESCRIPTION
Fixes two problems in the **"Wallet encrypted"** dialog (`AskPassphraseDialog`), found while first-encrypting a wallet on a live multiprocess node (umbrella #3153).

## 1. Multiprocess: the "close to finish encryption" restart never happens
Encrypting an unencrypted wallet historically requires a **process restart** to complete (a clean reload after the wallet DB is rewritten). The monolith dialog does this by showing *"Gridcoin will close now to finish the encryption process"* and calling `BitcoinGUI::requestQuit()`.

In **`-multiprocess`** the wallet lives in the separate **core** process. The GUI encrypt goes over IPC → `WalletImpl::encryptWallet` → `CWallet::EncryptWallet` (which does the real work — rewrite + keypool regen + `CDB::Rewrite` — **in the core**), but `requestQuit()` closes **only the GUI**. The core keeps running (by design: "closing the GUI does not stop the daemon"), so the restart that "finishes" the encryption **never happens**, and the *"Gridcoin will close now…"* message is actively misleading. (Note the RPC `encryptwallet` path *does* `StartShutdown()` — `rpcwallet.cpp` — so the two paths diverge in MP.)

**Fix:** branch the dialog on multiprocess mode:
- **Monolith** — unchanged (close + restart the app).
- **MP** — tell the user the wallet is *already fully encrypted and locked*, and to **restart the core process** so it drops the pre-encryption database state and reloads cleanly. **No `requestQuit()`** (a no-op on the core), and it notes that stopping the core will also close the GUI (which quits on connection loss), so reopen the wallet afterward.

> On-disk encryption is unaffected — `EncryptWallet` rewrites the wallet + regenerates the keypool in-process. This is dialog/UX guidance only, no wallet-format change.

## 2. Both modes: pre-encryption backups are a security risk (incl. `walletbackups`)
The old warning only said old backups become "useless." They're worse — they still contain the **unencrypted private keys**, so anyone who obtains one can spend your coins even after the live wallet is encrypted. Critically, most users don't realise this includes the **automatic backups in the `walletbackups` folder**. Both dialogs now say so and advise a fresh encrypted backup + securely deleting the pre-encryption ones (shared `tr()` string).

## Implementation & review
- MP-ness is read from **`GuiIpcInfo::active`** (the GUI's own "connected to a separate core" flag, populated in `main()` and threaded into `BitcoinGUI`), passed to the dialog via a `setMultiprocess()` setter — **not `gArgs`**, which `test/lint/lint-qt-includes.sh` (the Phase-1f interfaces gate) forbids in `src/qt` outside the composition root. There is no generic `getArg` on `interfaces::Node` today; `GuiIpcInfo::active` is the correct existing channel and is set before the event loop, so it's reliable at encrypt time.
- Platform-independent (cross-platform Qt/wallet/IPC code); first hit on Windows but affects any MP first-encryption.
- Builds with `-DUSE_QT6=ON` (`gridcoinresearch` links clean); clang-format + `lint-all` clean.
- Adversarial-reviewed (independent pass): only `Encrypt` creation site is wired; `active` is MP-only and set before any encrypt; monolith behavior byte-preserved; on-disk-complete claim verified against `CWallet::EncryptWallet`. On-screen text is a manual GUI check (dialog strings aren't unit-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)