### PR TITLE
contrib: Windows scripts to run the multiprocess core as a background task (Plan 4)

### DIFF
--- a/contrib/windows/Install-GridcoinCoreTask.ps1
+++ b/contrib/windows/Install-GridcoinCoreTask.ps1
@@ -1,0 +1,164 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Register the Gridcoin multiprocess core as background Scheduled Tasks on Windows.
+
+.DESCRIPTION
+    Registers two discrete, single-purpose tasks under the \Gridcoin\ folder, both
+    run-as the wallet user (never SYSTEM -- the IPC node.sock/ipc.cookie are
+    owner-only NTFS-ACL'd and a SYSTEM core would lock the user's own GUI out):
+
+      Core-Start : boot trigger -> gridcoinresearchd.exe -datadir=<dd> -multiprocess
+                   (with crash restart, the systemd Restart=on-failure analogue).
+      Core-Stop  : gridcoinresearchd.exe -datadir=<dd> stop  (a GRACEFUL RPC stop
+                   that flushes BDB/LevelDB). Runnable on-demand, and best-effort
+                   on the OS-shutdown event (see the SHUTDOWN note).
+
+    SEMANTICS GOTCHA: to stop the core you START the Core-Stop task. NEVER
+    Stop-ScheduledTask the Core-Start task -- Task Scheduler's stop is a hard
+    TerminateProcess (no flush = possible DB corruption).
+
+    SHUTDOWN: the Kernel-General EventID-13 trigger on Core-Stop is BEST-EFFORT
+    only -- Windows does not block shutdown for a scheduled task, so the flush may
+    be cut short. The reliable clean-shutdown primitive is a Group Policy
+    Computer -> Shutdown script (Windows runs it synchronously, bounded by the GP
+    script timeout). Set that up and validate on real hardware; see the README.
+
+    Autounlock (opt-in, DPAPI) is a SEPARATE task added by Set-GridcoinAutounlock.ps1
+    (Plan 5); it is not registered here.
+
+.NOTES
+    Registering a run-as-user task with a stored password typically requires an
+    ELEVATED PowerShell, and the account must hold "Log on as a batch job".
+#>
+[CmdletBinding()]
+param(
+    # Path to gridcoinresearchd.exe. Default: alongside this script's parent (the
+    # install layout is ...\GridcoinResearch\gridcoinresearchd.exe with scripts in
+    # ...\GridcoinResearch\windows\).
+    [string]$CorePath = (Join-Path $PSScriptRoot '..\gridcoinresearchd.exe'),
+
+    # The datadir the core owns (node.sock lives in it). Baked into both the task
+    # and the GUI shortcut so the GUI attaches to the datadir the core is serving.
+    # REQUIRED when -TaskUser is not the current user (see the guard below).
+    [string]$DataDir,
+
+    # The account the tasks run as. Default: the invoking interactive user.
+    # DOMAIN\user or .\user form. "Install as admin, run as walletholder" is
+    # supported by passing -TaskUser explicitly (then -DataDir is also required).
+    [string]$TaskUser = "$env:USERDOMAIN\$env:USERNAME",
+
+    # The TaskUser's *login* password (NOT the wallet passphrase). Required so the
+    # tasks can run at boot with no interactive logon (LogonType=Password). Prompted
+    # securely if omitted.
+    [System.Security.SecureString]$TaskPassword,
+
+    [string]$TaskFolder = 'Gridcoin'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -LiteralPath $CorePath)) {
+    throw "gridcoinresearchd.exe not found at '$CorePath'. Pass -CorePath explicitly."
+}
+$CorePath = (Resolve-Path -LiteralPath $CorePath).Path
+
+# The default datadir (%APPDATA%) is evaluated in the INSTALLER's context. If a
+# different TaskUser was given (install-as-admin, run-as-walletholder), that path
+# points at the installer's profile -- which the TaskUser usually cannot read, so
+# the core would abort or silently build a second, unused datadir. Require an
+# explicit -DataDir in that case.
+$currentUser = "$env:USERDOMAIN\$env:USERNAME"
+if (-not $PSBoundParameters.ContainsKey('DataDir')) {
+    if ($PSBoundParameters.ContainsKey('TaskUser') -and ($TaskUser -ne $currentUser)) {
+        throw "You specified -TaskUser '$TaskUser' (not the current user '$currentUser'), so the " +
+              "default datadir (this user's %APPDATA%) would be wrong. Pass -DataDir explicitly, e.g. " +
+              "-DataDir 'C:\Users\<walletholder>\AppData\Roaming\GridcoinResearch'."
+    }
+    $DataDir = Join-Path $env:APPDATA 'GridcoinResearch'
+}
+if ($DataDir -match '"') {
+    throw "-DataDir must not contain a double-quote character."
+}
+
+if (-not $TaskPassword) {
+    $cred = Get-Credential -UserName $TaskUser `
+        -Message "Enter the Windows password for '$TaskUser' (the account the Gridcoin core will run as). This is NOT the wallet passphrase."
+    $TaskUser = $cred.UserName
+    $TaskPassword = $cred.Password
+}
+
+# Register-ScheduledTask -Password requires the plaintext. NOTE: PtrToStringBSTR
+# materializes a managed System.String, whose contents live on the heap until GC
+# and cannot be zeroed in PS 5.1 (Register-ScheduledTask has no SecureString form);
+# we minimize the BSTR lifetime (ZeroFreeBSTR) but the String residue is
+# unavoidable and equivalent to any -Password cmdlet.
+$plainPw = $null
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($TaskPassword)
+try {
+    $plainPw = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+
+    $ddQuoted = '"' + $DataDir + '"'
+    $startAction = New-ScheduledTaskAction -Execute $CorePath -Argument "-datadir=$ddQuoted -multiprocess"
+    $stopAction  = New-ScheduledTaskAction -Execute $CorePath -Argument "-datadir=$ddQuoted stop"
+
+    # Core-Start: long-running headless daemon, no execution-time limit, restart on
+    # crash (3 tries, 1 min apart) -- the systemd Restart=on-failure analogue. A
+    # graceful stop exits 0 (success) so it is NOT auto-restarted; only a crash is.
+    $startSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew `
+        -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+
+    # Core-Stop: a short-lived action; no restart (a failed stop must not loop).
+    $stopSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable -ExecutionTimeLimit (New-TimeSpan -Minutes 10) -MultipleInstances IgnoreNew
+
+    $startTrigger = New-ScheduledTaskTrigger -AtStartup
+
+    Register-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Core-Start' -Force `
+        -Action $startAction -Trigger $startTrigger -Settings $startSettings `
+        -User $TaskUser -Password $plainPw -RunLevel Limited `
+        -Description 'Start the Gridcoin multiprocess core at boot (run-as the wallet user).' | Out-Null
+
+    # Core-Stop: register first with no trigger, then attach the OS-shutdown event
+    # trigger via XML (New-ScheduledTaskTrigger has no event-trigger form).
+    Register-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Core-Stop' -Force `
+        -Action $stopAction -Settings $stopSettings `
+        -User $TaskUser -Password $plainPw -RunLevel Limited `
+        -Description 'Graceful RPC stop of the Gridcoin core (on-demand; best-effort OS-shutdown). Start this task to stop the core; never hard-kill Core-Start.' | Out-Null
+
+    # System log, Microsoft-Windows-Kernel-General EventID 13 == shutdown initiated.
+    # BEST-EFFORT only (see the SHUTDOWN note above): the OS does not wait for it.
+    $evtXml = @'
+<QueryList><Query Id="0" Path="System"><Select Path="System">*[System[Provider[@Name='Microsoft-Windows-Kernel-General'] and EventID=13]]</Select></Query></QueryList>
+'@
+    $eventTrigger = New-CimInstance -CimClass (
+        Get-CimClass -Namespace 'Root/Microsoft/Windows/TaskScheduler' -ClassName 'MSFT_TaskEventTrigger'
+    ) -ClientOnly
+    $eventTrigger.Enabled = $true
+    $eventTrigger.Subscription = $evtXml
+
+    $stopTask = Get-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Core-Stop'
+    $stopTask.Triggers = @($eventTrigger)
+    Set-ScheduledTask -InputObject $stopTask -User $TaskUser -Password $plainPw | Out-Null
+}
+catch {
+    throw "Failed to register the Gridcoin tasks: $($_.Exception.Message)`n" +
+          "Registering a run-as-user task with a stored password usually needs an ELEVATED " +
+          "PowerShell (Run as administrator), and '$TaskUser' must hold the 'Log on as a batch job' " +
+          "right. Re-run elevated; see contrib/windows/README.md."
+}
+finally {
+    $plainPw = $null
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
+
+Write-Host "Registered \$TaskFolder\Core-Start (boot) and \$TaskFolder\Core-Stop (on-demand + best-effort OS-shutdown), run-as $TaskUser." -ForegroundColor Green
+Write-Host ""
+Write-Host "  Start the core now :  Start-ScheduledTask -TaskPath '\$TaskFolder\' -TaskName 'Core-Start'"
+Write-Host "  Stop the core      :  Start-ScheduledTask -TaskPath '\$TaskFolder\' -TaskName 'Core-Stop'   (graceful; do NOT Stop-ScheduledTask Core-Start)"
+Write-Host "  Attach the GUI     :  .\Start-GridcoinGui.ps1 -DataDir '$DataDir'"
+Write-Host ""
+Write-Host "  For a reliable flush on OS shutdown, also configure a Group Policy" -ForegroundColor Yellow
+Write-Host "  Computer -> Shutdown script that starts the Core-Stop task (see README)." -ForegroundColor Yellow

--- a/contrib/windows/Install-GridcoinCoreTask.ps1
+++ b/contrib/windows/Install-GridcoinCoreTask.ps1
@@ -116,6 +116,16 @@ try {
 
     $startTrigger = New-ScheduledTaskTrigger -AtStartup
 
+    # Ensure the task folder exists first: Register-ScheduledTask -TaskPath does not
+    # reliably create a missing folder on all Windows versions (best-effort -- if
+    # this fails, Register may still create it or surface the clear error below).
+    try {
+        $svc = New-Object -ComObject 'Schedule.Service'
+        $svc.Connect()
+        try { $null = $svc.GetFolder("\$TaskFolder") }
+        catch { $null = $svc.GetFolder('\').CreateFolder($TaskFolder) }
+    } catch { }
+
     Register-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Core-Start' -Force `
         -Action $startAction -Trigger $startTrigger -Settings $startSettings `
         -User $TaskUser -Password $plainPw -RunLevel Limited `

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -33,11 +33,13 @@ The core then autostarts on every boot. To upgrade:
 ## Two things to know
 
 **Run-as the wallet user, never SYSTEM.** The IPC socket (`node.sock`) and cookie
-(`ipc.cookie`) are created **owner-only** in the datadir, and a per-connection
-peer-UID check enforces same-user. A SYSTEM-owned core would lock the wallet user's
-own GUI out. This also means **only that Windows user can attach a GUI** — a
-*different* user running `gridcoinresearch.exe -multiprocess` gets *"could not
-connect to the daemon"*. **That is the access control working, not a bug.**
+(`ipc.cookie`) are created **owner-only** in the datadir (NTFS ACL), so on Windows
+only that user can open them. (The Linux `SO_PEERCRED`/peer-UID check has no Windows
+equivalent — AF_UNIX on Windows exposes no peer credentials — so the ACL is the
+enforcement here.) A SYSTEM-owned core would lock the wallet user's own GUI out.
+This also means **only that Windows user can attach a GUI** — a *different* user
+running `gridcoinresearch.exe -multiprocess` gets *"could not connect to the
+daemon"*. **That is the access control working, not a bug.**
 
 **Graceful stop = start the Core-Stop task.** To stop the core, *start* the
 `Core-Stop` task (`Start-ScheduledTask … Core-Stop`) — it runs `gridcoinresearchd

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -1,0 +1,81 @@
+# Gridcoin multiprocess on Windows — core task scripts
+
+PowerShell scripts to run the split **multiprocess** Gridcoin core as a background
+Scheduled Task on Windows, stop it gracefully, upgrade a locked exe, and launch the
+GUI. See [`doc/multiprocess.md`](../../doc/multiprocess.md) for the split-mode model.
+
+| Script | Purpose |
+|---|---|
+| `Install-GridcoinCoreTask.ps1` | Register the **Core-Start** (boot) and **Core-Stop** (graceful) tasks, run-as the wallet user. |
+| `Uninstall-GridcoinCoreTask.ps1` | Remove them. |
+| `Update-GridcoinCore.ps1` | Graceful upgrade engine for the locked-exe problem. |
+| `Start-GridcoinGui.ps1` | Launch the `-multiprocess` GUI (or drop a Start-Menu shortcut with `-CreateShortcut`). |
+
+Opt-in **autounlock** (DPAPI, stake-only) is separate — `Set-GridcoinAutounlock.ps1` (future).
+
+## Quick start
+
+```powershell
+# From the install directory (…\GridcoinResearch\windows\). Run-as the account that
+# owns the wallet; it will prompt for that account's Windows password.
+.\Install-GridcoinCoreTask.ps1 -DataDir "$env:APPDATA\GridcoinResearch"
+
+Start-ScheduledTask -TaskPath '\Gridcoin\' -TaskName 'Core-Start'   # start the core now
+.\Start-GridcoinGui.ps1                                             # attach the GUI
+```
+
+The core then autostarts on every boot. To upgrade:
+
+```powershell
+.\Update-GridcoinCore.ps1 -NewBinariesDir C:\path\to\new\bin   # graceful stop -> replace -> restart
+```
+
+## Two things to know
+
+**Run-as the wallet user, never SYSTEM.** The IPC socket (`node.sock`) and cookie
+(`ipc.cookie`) are created **owner-only** in the datadir, and a per-connection
+peer-UID check enforces same-user. A SYSTEM-owned core would lock the wallet user's
+own GUI out. This also means **only that Windows user can attach a GUI** — a
+*different* user running `gridcoinresearch.exe -multiprocess` gets *"could not
+connect to the daemon"*. **That is the access control working, not a bug.**
+
+**Graceful stop = start the Core-Stop task.** To stop the core, *start* the
+`Core-Stop` task (`Start-ScheduledTask … Core-Stop`) — it runs `gridcoinresearchd
+… stop`, an RPC stop that flushes the databases. **Never `Stop-ScheduledTask` the
+`Core-Start` task**: Task Scheduler's stop is a hard `TerminateProcess` with no
+flush, which risks database corruption. Shutdown, upgrade, and manual stop all go
+through the one `Core-Stop` task.
+
+## Graceful stop on OS shutdown
+
+The `Core-Stop` task carries a best-effort OS-shutdown trigger (Kernel-General
+EventID 13), but **a scheduled task cannot reliably flush before shutdown**: Windows
+does not wait for an event-triggered task to finish, and the services it depends on
+are being torn down in that window, so the RPC `stop` will often be cut short
+mid-flush. For a **reliable** clean shutdown, configure a Group Policy **Computer →
+Shutdown** script — Windows runs shutdown scripts synchronously and waits for them
+(bounded by *Maximum wait time for Group Policy scripts*, default 600 s):
+
+1. `gpedit.msc` → Computer Configuration → Windows Settings → Scripts → **Shutdown**.
+2. Add a script that starts the stop task and waits for the core to exit — e.g. a
+   `.cmd` running `schtasks /Run /TN "\Gridcoin\Core-Stop"` followed by a short loop
+   on `tasklist | findstr gridcoinresearchd` until it is gone.
+
+Confirming the exact wait-for-flush behavior on real hardware is the top item on the
+validation list.
+
+## Crash recovery
+
+`Core-Start` is registered with restart-on-failure (3 tries, 1 minute apart) — the
+analogue of the Linux unit's `Restart=on-failure`. A *graceful* stop exits 0 and is
+not restarted; only a crash (non-zero exit) triggers a restart.
+
+## Status
+
+New scripts, validated by PowerShell parse-check + inspection; full runtime
+validation on Windows (install → reboot → autostart → upgrade → GUI attach →
+shutdown-flush → different-user connection-refused) is pending on the test box.
+Known items to confirm there: the shutdown-flush mechanism (above); that
+stored-password task registration requires an **elevated** shell and the "Log on as
+a batch job" right for the run-as account; and Microsoft/AzureAD-account principal
+forms.

--- a/contrib/windows/Start-GridcoinGui.ps1
+++ b/contrib/windows/Start-GridcoinGui.ps1
@@ -8,10 +8,12 @@
     core that Core-Start is running on the same datadir. With -CreateShortcut it
     instead writes a per-user Start-Menu shortcut with the same arguments.
 
-    Single-user by design (not a bug to fix): the core's node.sock/ipc.cookie are
-    owner-only NTFS-ACL'd (#3234) and a per-connection SO_PEERCRED/peer-UID check
-    (#3242) enforces same-user, so only the wallet user can attach. A DIFFERENT
-    Windows user gets "could not connect to the daemon" -- that is the ACL working.
+    Single-user by design (not a bug to fix): on Windows the core's node.sock /
+    ipc.cookie are created owner-only (NTFS ACL, #3234), so only the wallet user can
+    open them and attach a GUI. (The SO_PEERCRED/peer-UID check, #3242, is a Linux
+    mechanism -- AF_UNIX on Windows exposes no peer-credential API, so the NTFS ACL
+    is the enforcement here.) A DIFFERENT Windows user gets "could not connect to
+    the daemon" -- that is the access control working, not a bug.
 
     If no core is running, the GUI shows the same connect-failure dialog (the
     datadir chooser is suppressed in -multiprocess, Plan 1); it will not start a
@@ -31,6 +33,10 @@ if (-not (Test-Path -LiteralPath $GuiPath)) {
     throw "gridcoinresearch.exe not found at '$GuiPath'. Pass -GuiPath explicitly."
 }
 $GuiPath = (Resolve-Path -LiteralPath $GuiPath).Path
+
+if ($DataDir -match '"') {
+    throw "-DataDir must not contain a double-quote character."
+}
 
 # One arg string reused for both the direct launch and the shortcut.
 $ddQuoted = '"' + $DataDir + '"'

--- a/contrib/windows/Start-GridcoinGui.ps1
+++ b/contrib/windows/Start-GridcoinGui.ps1
@@ -1,0 +1,56 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Launch the Gridcoin -multiprocess GUI, attaching to the running core.
+
+.DESCRIPTION
+    Starts gridcoinresearch.exe -multiprocess -datadir=<dd>, which connects to the
+    core that Core-Start is running on the same datadir. With -CreateShortcut it
+    instead writes a per-user Start-Menu shortcut with the same arguments.
+
+    Single-user by design (not a bug to fix): the core's node.sock/ipc.cookie are
+    owner-only NTFS-ACL'd (#3234) and a per-connection SO_PEERCRED/peer-UID check
+    (#3242) enforces same-user, so only the wallet user can attach. A DIFFERENT
+    Windows user gets "could not connect to the daemon" -- that is the ACL working.
+
+    If no core is running, the GUI shows the same connect-failure dialog (the
+    datadir chooser is suppressed in -multiprocess, Plan 1); it will not start a
+    core for you.
+#>
+[CmdletBinding()]
+param(
+    [string]$GuiPath = (Join-Path $PSScriptRoot '..\gridcoinresearch.exe'),
+    [string]$DataDir = (Join-Path $env:APPDATA 'GridcoinResearch'),
+    [switch]$CreateShortcut
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -LiteralPath $GuiPath)) {
+    throw "gridcoinresearch.exe not found at '$GuiPath'. Pass -GuiPath explicitly."
+}
+$GuiPath = (Resolve-Path -LiteralPath $GuiPath).Path
+
+# One arg string reused for both the direct launch and the shortcut.
+$ddQuoted = '"' + $DataDir + '"'
+$arguments = "-multiprocess -datadir=$ddQuoted"
+
+if ($CreateShortcut) {
+    $programs = [Environment]::GetFolderPath('Programs')   # per-user Start Menu\Programs
+    $lnkPath = Join-Path $programs 'Gridcoin (multiprocess).lnk'
+    $shell = New-Object -ComObject 'WScript.Shell'
+    $shortcut = $shell.CreateShortcut($lnkPath)
+    $shortcut.TargetPath = $GuiPath
+    $shortcut.Arguments = $arguments
+    $shortcut.WorkingDirectory = (Split-Path -Parent $GuiPath)
+    $shortcut.Description = 'Gridcoin GUI attaching to the running multiprocess core'
+    $shortcut.IconLocation = $GuiPath
+    $shortcut.Save()
+    Write-Host "Created Start-Menu shortcut: $lnkPath" -ForegroundColor Green
+    return
+}
+
+# Launch detached; do not block this shell on the GUI.
+Start-Process -FilePath $GuiPath -ArgumentList $arguments -WorkingDirectory (Split-Path -Parent $GuiPath)
+Write-Host "Launched the Gridcoin GUI (-multiprocess) on datadir '$DataDir'."

--- a/contrib/windows/Uninstall-GridcoinCoreTask.ps1
+++ b/contrib/windows/Uninstall-GridcoinCoreTask.ps1
@@ -27,18 +27,20 @@ foreach ($name in 'Core-Start', 'Core-Stop') {
     }
 }
 
-# Remove the folder only if it is now empty (leaves \Gridcoin alone if the
-# Autounlock task or anything else still lives there). Schedule.Service COM API,
-# since the ScheduledTasks module has no Remove-ScheduledTaskFolder.
+# Remove the folder only if it is now empty (leaves \Gridcoin alone if the Plan-5
+# Autounlock task or anything else still lives there). Enumerate via the COM folder
+# object -- Get-ScheduledTask's -TaskPath does not reliably support wildcards, and a
+# false "empty" result would wrongly delete the folder and its remaining tasks.
 try {
-    $remaining = Get-ScheduledTask -TaskPath "\$TaskFolder\*" -ErrorAction SilentlyContinue
-    if (-not $remaining) {
-        $service = New-Object -ComObject 'Schedule.Service'
-        $service.Connect()
+    $service = New-Object -ComObject 'Schedule.Service'
+    $service.Connect()
+    $folder = $service.GetFolder("\$TaskFolder")
+    $remaining = @($folder.GetTasks(1))   # 1 = TASK_ENUM_HIDDEN (count hidden too)
+    if ($remaining.Count -eq 0) {
         $service.GetFolder('\').DeleteFolder($TaskFolder, 0)
         Write-Host "Removed empty task folder \$TaskFolder"
     } else {
-        Write-Host "Task folder \$TaskFolder still has other tasks; left in place."
+        Write-Host "Task folder \$TaskFolder still has $($remaining.Count) task(s); left in place."
     }
 } catch {
     Write-Host "Task folder \$TaskFolder not removed ($($_.Exception.Message)); left in place."

--- a/contrib/windows/Uninstall-GridcoinCoreTask.ps1
+++ b/contrib/windows/Uninstall-GridcoinCoreTask.ps1
@@ -1,0 +1,45 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Remove the Gridcoin core Scheduled Tasks registered by Install-GridcoinCoreTask.ps1.
+
+.DESCRIPTION
+    Unregisters \Gridcoin\Core-Start and \Gridcoin\Core-Stop and removes the (now
+    empty) \Gridcoin task folder. Tolerant of already-absent tasks (idempotent).
+
+    Does NOT remove the opt-in autounlock task (\Gridcoin\Autounlock) -- that is
+    owned by Set-GridcoinAutounlock.ps1 / its uninstall (Plan 5). It also does not
+    stop a running core; run the Core-Stop task first if you want a graceful stop.
+#>
+[CmdletBinding()]
+param([string]$TaskFolder = 'Gridcoin')
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+foreach ($name in 'Core-Start', 'Core-Stop') {
+    $existing = Get-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName $name -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName $name -Confirm:$false
+        Write-Host "Removed \$TaskFolder\$name"
+    } else {
+        Write-Host "\$TaskFolder\$name not present (ok)"
+    }
+}
+
+# Remove the folder only if it is now empty (leaves \Gridcoin alone if the
+# Autounlock task or anything else still lives there). Schedule.Service COM API,
+# since the ScheduledTasks module has no Remove-ScheduledTaskFolder.
+try {
+    $remaining = Get-ScheduledTask -TaskPath "\$TaskFolder\*" -ErrorAction SilentlyContinue
+    if (-not $remaining) {
+        $service = New-Object -ComObject 'Schedule.Service'
+        $service.Connect()
+        $service.GetFolder('\').DeleteFolder($TaskFolder, 0)
+        Write-Host "Removed empty task folder \$TaskFolder"
+    } else {
+        Write-Host "Task folder \$TaskFolder still has other tasks; left in place."
+    }
+} catch {
+    Write-Host "Task folder \$TaskFolder not removed ($($_.Exception.Message)); left in place."
+}

--- a/contrib/windows/Update-GridcoinCore.ps1
+++ b/contrib/windows/Update-GridcoinCore.ps1
@@ -1,0 +1,124 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Safely upgrade a running Gridcoin multiprocess core (the locked-exe problem).
+
+.DESCRIPTION
+    A running gridcoinresearchd.exe is write-locked by Windows, and the core runs
+    headless. This drives a graceful upgrade:
+
+      1. Detect a running core.
+      2. Graceful stop by STARTING the canonical Core-Stop task (never
+         Stop-ScheduledTask on Core-Start -- that is a hard kill, no flush).
+      3. Wait for the process to exit AND the exe's write-lock to release (a
+         connected -multiprocess GUI also quit on core-stop, releasing its lock).
+      4. Optionally copy new binaries in (or the caller already did).
+      5. Restart via the Core-Start task. Autounlock (Plan 5) self-heals on the
+         fresh instance.
+
+    SAFE BY DEFAULT: graceful-only; on stop/lock-release timeout it ABORTS and
+    leaves the old binary in place -- it never corrupts the datadir to force an
+    upgrade. Idempotent: with no core running it goes straight to replace/restart.
+
+    NOTE: if the install lives under C:\Program Files, replacing binaries needs an
+    ELEVATED PowerShell. When -NewBinariesDir is given, this is checked up front
+    (before stopping the core) so a permission problem aborts cleanly.
+#>
+[CmdletBinding()]
+param(
+    [string]$CorePath = (Join-Path $PSScriptRoot '..\gridcoinresearchd.exe'),
+
+    # Optional: a directory containing the new gridcoinresearch*.exe to copy over
+    # the installed ones once the lock is released. Omit if the caller replaces the
+    # binaries itself between stop and restart.
+    [string]$NewBinariesDir,
+
+    [string]$TaskFolder = 'Gridcoin',
+    [int]$StopTimeoutSec = 120,   # BDB flush can be slow
+    [int]$PollMs = 1000
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -LiteralPath $CorePath)) {
+    throw "gridcoinresearchd.exe not found at '$CorePath'. Pass -CorePath explicitly."
+}
+$CorePath = (Resolve-Path -LiteralPath $CorePath).Path
+$coreDir = Split-Path -Parent $CorePath
+
+function Test-FileWriteLocked {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    try {
+        $fs = [System.IO.File]::Open($Path, 'Open', 'ReadWrite', 'None')
+        $fs.Close()
+        return $false
+    } catch [System.IO.IOException] {
+        # Sharing violation: still held open by the (exiting) core.
+        return $true
+    } catch [System.UnauthorizedAccessException] {
+        # No write permission (e.g. Program Files, non-elevated) -- NOT an in-use
+        # lock. Treated as unlocked here; the up-front writability check reports the
+        # permission problem clearly before any copy is attempted.
+        return $false
+    }
+}
+
+function Get-RunningCore {
+    # Match by image path so we don't touch an unrelated gridcoinresearchd from a
+    # different install. Reading .Path can throw on a process we can't inspect
+    # (another user / bitness); skip those.
+    Get-Process -Name 'gridcoinresearchd' -ErrorAction SilentlyContinue | Where-Object {
+        try { $_.Path -and ($_.Path -ieq $CorePath) } catch { $false }
+    }
+}
+
+# Up-front: if we will copy binaries, confirm the install dir is writable BEFORE
+# stopping the core, so a permission problem aborts without leaving it stopped.
+if ($NewBinariesDir) {
+    if (-not (Test-Path -LiteralPath $NewBinariesDir)) { throw "NewBinariesDir '$NewBinariesDir' not found." }
+    $probe = Join-Path $coreDir ('.grc-update-write-probe-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [System.IO.File]::WriteAllText($probe, '')
+        Remove-Item -LiteralPath $probe -Force
+    } catch {
+        throw "Cannot write to '$coreDir' (needed to replace binaries). Run this from an ELEVATED " +
+              "PowerShell -- Program Files installs require it. The core was NOT stopped."
+    }
+}
+
+# 1-2. Graceful stop.
+if (Get-RunningCore) {
+    Write-Host "Core running; invoking the graceful Core-Stop task..."
+    Start-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Core-Stop'
+
+    # 3. Wait for exit AND write-lock release.
+    $deadline = (Get-Date).AddSeconds($StopTimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Milliseconds $PollMs
+        if (-not (Get-RunningCore) -and -not (Test-FileWriteLocked -Path $CorePath)) { break }
+    }
+    if ((Get-RunningCore) -or (Test-FileWriteLocked -Path $CorePath)) {
+        throw "Core did not stop / '$CorePath' is still write-locked after ${StopTimeoutSec}s. " +
+              "Close any process using it and retry. Binaries were NOT replaced."
+    }
+    Write-Host "Core stopped and the exe lock is released."
+} else {
+    Write-Host "No core running; proceeding to replace/restart."
+}
+
+# 4. Replace binaries (optional convenience).
+if ($NewBinariesDir) {
+    foreach ($exe in 'gridcoinresearchd.exe', 'gridcoinresearch.exe') {
+        $src = Join-Path $NewBinariesDir $exe
+        if (Test-Path -LiteralPath $src) {
+            Copy-Item -LiteralPath $src -Destination (Join-Path $coreDir $exe) -Force
+            Write-Host "Replaced $exe"
+        }
+    }
+}
+
+# 5. Restart.
+Start-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Core-Start'
+Write-Host "Restarted \$TaskFolder\Core-Start. Autounlock (if enabled) self-heals on the new instance." -ForegroundColor Green

--- a/contrib/windows/Update-GridcoinCore.ps1
+++ b/contrib/windows/Update-GridcoinCore.ps1
@@ -78,6 +78,11 @@ function Get-RunningCore {
 # stopping the core, so a permission problem aborts without leaving it stopped.
 if ($NewBinariesDir) {
     if (-not (Test-Path -LiteralPath $NewBinariesDir)) { throw "NewBinariesDir '$NewBinariesDir' not found." }
+    # Refuse a no-op "upgrade" that stops+restarts on the old binaries: the new dir
+    # must actually contain the core exe.
+    if (-not (Test-Path -LiteralPath (Join-Path $NewBinariesDir 'gridcoinresearchd.exe'))) {
+        throw "NewBinariesDir '$NewBinariesDir' does not contain gridcoinresearchd.exe; refusing a no-op upgrade."
+    }
     $probe = Join-Path $coreDir ('.grc-update-write-probe-' + [guid]::NewGuid().ToString('N'))
     try {
         [System.IO.File]::WriteAllText($probe, '')


### PR DESCRIPTION
Plan 4 of the cross-platform multiprocess "background-core + secure autounlock" work (umbrella #3153; the Linux side — Plans 1–3 — is merged and live-validated). Adds `contrib/windows/` PowerShell to run the split `-multiprocess` core as a background **Scheduled Task** on Windows, stop it gracefully, upgrade a locked exe, and launch the GUI.

## Scripts
| Script | Purpose |
|---|---|
| `Install-GridcoinCoreTask.ps1` | Register **Core-Start** (boot, crash-restart) + **Core-Stop** (graceful RPC `stop`, on-demand + best-effort OS-shutdown), run-as the wallet user. |
| `Uninstall-GridcoinCoreTask.ps1` | Remove them (idempotent). |
| `Update-GridcoinCore.ps1` | Locked-exe upgrade engine: start Core-Stop → wait for exit + write-lock release (**abort on timeout, never corrupt the datadir**) → replace → Core-Start. |
| `Start-GridcoinGui.ps1` | Launch the `-multiprocess` GUI (or `-CreateShortcut`). |
| `README.md` | Usage + rationale + caveats. |

## Key design points
- **Run-as the wallet user, never SYSTEM** (`LogonType=Password`, `RunLevel=Limited`): the IPC `node.sock`/`ipc.cookie` are owner-only NTFS-ACL'd (#3234) + `SO_PEERCRED` same-user (#3242); a SYSTEM core would lock the user's own GUI out. This also means a *different* Windows user gets "connection refused" — the ACL working, documented loudly.
- **Graceful stop = *start* the Core-Stop task** (RPC `stop`, flushes DBs). **Never `Stop-ScheduledTask` the start task** (Task Scheduler's stop is a hard `TerminateProcess`). Shutdown / upgrade / manual all invoke the one Core-Stop task.
- **Crash restart** on Core-Start (3× 1 min) = the systemd `Restart=on-failure` analogue; a graceful stop exits 0 so it isn't auto-restarted.
- Autounlock (opt-in DPAPI) is a separate **Plan 5** script, not here.

## Notable caveat (from review)
A scheduled task **cannot block OS shutdown**, so the EventID-13 stop trigger is *best-effort* — the flush may be cut short. The reliable primitive is a **Group Policy Computer → Shutdown** script (Windows runs it synchronously and waits); the README documents setting that up, and confirming the flush behavior is the top W10-1 item.

## Validation status
- **All four scripts parse-check clean on Windows PowerShell 5.1** (run on the W10-1 test box over SSH), and were **adversarially reviewed** (findings folded in: install-as-another-user datadir guard, `UnauthorizedAccessException` handling in the lock probe, up-front elevation check, crash-restart parity, StrictMode/credential hardening).
- **Runtime** validation (install → reboot → autostart → upgrade → GUI attach → shutdown-flush → different-user refused) is a W10-1 session — draft until then. Items to confirm: the shutdown-flush mechanism, elevated/batch-logon registration, and MS/AzureAD principal forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
