### PR TITLE
contrib: Windows DPAPI stake-only wallet autounlock (Plan 5)

### DIFF
--- a/build-aux/cpack/NSIS.template.in
+++ b/build-aux/cpack/NSIS.template.in
@@ -84,6 +84,9 @@ Section -Main SEC0000
     SetOutPath $INSTDIR\doc
     File /oname=COPYING.txt @CPACK_RESOURCE_FILE_LICENSE@
     File /oname=CHANGELOG.md @CPACK_RESOURCE_FILE_CHANGELOG@
+    SetOutPath $INSTDIR\windows
+    File @CPACK_TEMPORARY_DIRECTORY@\daemon\windows\*.ps1
+    File @CPACK_TEMPORARY_DIRECTORY@\daemon\windows\README.md
     SetOutPath $INSTDIR
     WriteRegStr HKLM "${REGKEY}\Components" Main 1
 SectionEnd
@@ -130,6 +133,7 @@ Section /o -un.Main UNSEC0000
     Delete /REBOOTOK $INSTDIR\${GRIDCOIN_GUI_NAME}
     RMDir /r /REBOOTOK $INSTDIR\daemon
     RMDir /r /REBOOTOK $INSTDIR\doc
+    RMDir /r /REBOOTOK $INSTDIR\windows
     DeleteRegValue HKLM "${REGKEY}\Components" Main
 SectionEnd
 

--- a/contrib/windows/Install-GridcoinCoreTask.ps1
+++ b/contrib/windows/Install-GridcoinCoreTask.ps1
@@ -33,10 +33,10 @@
 #>
 [CmdletBinding()]
 param(
-    # Path to gridcoinresearchd.exe. Default: alongside this script's parent (the
-    # install layout is ...\GridcoinResearch\gridcoinresearchd.exe with scripts in
-    # ...\GridcoinResearch\windows\).
-    [string]$CorePath = (Join-Path $PSScriptRoot '..\gridcoinresearchd.exe'),
+    # Path to gridcoinresearchd.exe. Default: resolved below across both known layouts --
+    # the NSIS installer's ...\GridcoinResearch\daemon\gridcoinresearchd.exe (scripts in
+    # ...\GridcoinResearch\windows\), and a build tree where the exe sits one level up.
+    [string]$CorePath,
 
     # The datadir the core owns (node.sock lives in it). Baked into both the task
     # and the GUI shortcut so the GUI attaches to the datadir the core is serving.
@@ -59,8 +59,18 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# Resolve the default core path across both layouts (installer daemon\ subfolder first,
+# then a build tree with the exe one level up). An explicit -CorePath is honored as-is.
+if (-not $CorePath) {
+    $CorePath = @(
+        (Join-Path $PSScriptRoot '..\daemon\gridcoinresearchd.exe'),   # NSIS installer layout
+        (Join-Path $PSScriptRoot '..\gridcoinresearchd.exe')           # exe alongside the scripts' parent
+    ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    if (-not $CorePath) { $CorePath = (Join-Path $PSScriptRoot '..\daemon\gridcoinresearchd.exe') }
+}
 if (-not (Test-Path -LiteralPath $CorePath)) {
-    throw "gridcoinresearchd.exe not found at '$CorePath'. Pass -CorePath explicitly."
+    throw "gridcoinresearchd.exe not found at '$CorePath'. Pass -CorePath explicitly (installer layout: " +
+          "...\GridcoinResearch\daemon\gridcoinresearchd.exe, with these scripts in ...\GridcoinResearch\windows\)."
 }
 $CorePath = (Resolve-Path -LiteralPath $CorePath).Path
 
@@ -162,6 +172,18 @@ catch {
 finally {
     $plainPw = $null
     [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
+
+# Verify both tasks actually registered. Register-ScheduledTask can emit a NON-terminating
+# "Access is denied" (0x80070005) -- a boot-triggered task needs an elevated shell, whereas
+# the on-demand Core-Stop registers without it -- and continue, so confirm rather than trust
+# that we reached here. Otherwise a half-registered install reports false success.
+foreach ($name in 'Core-Start', 'Core-Stop') {
+    if (-not (Get-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName $name -ErrorAction SilentlyContinue)) {
+        throw "Task \$TaskFolder\$name was not registered (likely 'Access is denied'). A boot-triggered " +
+              "run-as task needs an ELEVATED PowerShell (Run as administrator) and the 'Log on as a batch " +
+              "job' right for '$TaskUser'. Re-run elevated; see contrib/windows/README.md."
+    }
 }
 
 Write-Host "Registered \$TaskFolder\Core-Start (boot) and \$TaskFolder\Core-Stop (on-demand + best-effort OS-shutdown), run-as $TaskUser." -ForegroundColor Green

--- a/contrib/windows/Invoke-GridcoinAutounlock.ps1
+++ b/contrib/windows/Invoke-GridcoinAutounlock.ps1
@@ -277,21 +277,29 @@ function Invoke-GridcoinRpc([string]$url, [string]$auth, [string]$method, [objec
     catch [System.Net.WebException] {
         $r = $_.Exception.Response
         if ($null -ne $r) {
-            $status = [int]([System.Net.HttpWebResponse]$r).StatusCode
-            if ($status -eq 401) {
-                return @{ Ok = $false; Code = $null; Http = 401; Msg = 'HTTP 401 Unauthorized: rpcuser/rpcpassword rejected by the daemon' }
-            }
-            # Gridcoin returns JSON-RPC errors with HTTP 500 and the error object in the body.
-            $eo = $null
+            # Always close the error response: HttpWebResponse holds the connection until closed,
+            # and the resident loop can hit repeated HTTP errors -- unclosed responses would leak
+            # handles and exhaust the per-endpoint connection pool. The returns below still run
+            # this finally before the function returns.
             try {
-                $er = New-Object IO.StreamReader($r.GetResponseStream())
-                try { $eb = $er.ReadToEnd() } finally { $er.Close() }
-                $eo = (Get-Prop ($eb | ConvertFrom-Json) 'error')
-            } catch { $eo = $null }
-            if ($eo) {
-                return @{ Ok = $false; Code = (Get-Prop $eo 'code'); Http = $status; Msg = [string](Get-Prop $eo 'message') }
+                $status = [int]([System.Net.HttpWebResponse]$r).StatusCode
+                if ($status -eq 401) {
+                    return @{ Ok = $false; Code = $null; Http = 401; Msg = 'HTTP 401 Unauthorized: rpcuser/rpcpassword rejected by the daemon' }
+                }
+                # Gridcoin returns JSON-RPC errors with HTTP 500 and the error object in the body.
+                $eo = $null
+                try {
+                    $er = New-Object IO.StreamReader($r.GetResponseStream())
+                    try { $eb = $er.ReadToEnd() } finally { $er.Close() }
+                    $eo = (Get-Prop ($eb | ConvertFrom-Json) 'error')
+                } catch { $eo = $null }
+                if ($eo) {
+                    return @{ Ok = $false; Code = (Get-Prop $eo 'code'); Http = $status; Msg = [string](Get-Prop $eo 'message') }
+                }
+                return @{ Ok = $false; Code = $null; Http = $status; Msg = ("HTTP {0} error" -f $status) }
+            } finally {
+                $r.Close()
             }
-            return @{ Ok = $false; Code = $null; Http = $status; Msg = ("HTTP {0} error" -f $status) }
         }
         # Transport-level (connection refused, timeout): no JSON-RPC code; retry may help.
         return @{ Ok = $false; Code = $null; Http = $null; Msg = [string]$_.Exception.Message }

--- a/contrib/windows/Invoke-GridcoinAutounlock.ps1
+++ b/contrib/windows/Invoke-GridcoinAutounlock.ps1
@@ -1,0 +1,435 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Stake-only Gridcoin wallet autounlock helper (Windows-native).
+
+.DESCRIPTION
+    Native PowerShell port of contrib/wallettools/gridcoin_autounlock.py, which is the
+    canonical reference for the security-critical behaviour. Reads RPC connection details
+    from gridcoinresearch.conf (or gridcoin.conf), DPAPI-decrypts the wallet passphrase
+    (CurrentUser), verifies that our own SID owns every LISTEN socket on the RPC port
+    (fail closed), and then sends `walletpassphrase <pass> <timeout> $true` (stake-only)
+    whenever it sees a fresh core instance. Python-3-free; runs on stock Windows.
+
+    Security-critical behaviour (mirrors gridcoin_autounlock.py):
+      * Listener-ownership gate. The RPC port is UNBOUND for minutes during core startup
+        (LoadBlockIndex runs long before the RPC threads) and an unprivileged loopback
+        port can be bound first by any local account. HTTP Basic authenticates the client
+        to the server, not the reverse, so a naive readiness poll would hand
+        rpcuser:rpcpassword (then the passphrase) to whatever answers. Before anything
+        goes on the wire we require that every LISTEN socket on the port is owned by our
+        own SID. A foreign owner, or a listener we cannot attribute, fails closed. On
+        Windows the owner is resolved natively (Get-NetTCPConnection -> Win32_Process
+        GetOwnerSid); this closes the same startup race the Python helper can only refuse
+        on this platform.
+      * Proxy-free request. $req.Proxy = $null so an environment/WinHTTP proxy can never
+        divert the passphrase POST off-box in cleartext.
+      * Redaction. The passphrase, the rpcpassword, and the Basic token are scrubbed from
+        every log line, and a top-level catch keeps the resident loop alive without ever
+        printing an unredacted error.
+
+    Exit status (meaningful in -Once; the resident loop logs and keeps polling instead of
+    exiting on these):
+      0  unlocked, or nothing to do (already unlocked / not encrypted)
+      1  transient; retrying may help (core not up, RPC not bound yet, transport)
+      2  unrecoverable; retrying cannot help (wrong passphrase, HTTP 401, a foreign or
+         unverifiable process holding the RPC port, a bad DPAPI blob)
+
+    See doc/multiprocess.md and contrib/windows/README.md.
+#>
+[CmdletBinding()]
+param(
+    # Data directory holding gridcoinresearch.conf (the wallet/config live here).
+    [string]$DataDir = (Join-Path $env:APPDATA 'GridcoinResearch'),
+
+    # Explicit config path (overrides the -DataDir lookup of gridcoinresearch.conf / gridcoin.conf).
+    [string]$Conf,
+
+    # DPAPI (CurrentUser) passphrase blob written by Set-GridcoinAutounlock.ps1.
+    [string]$CredPath = (Join-Path $DataDir 'autounlock\passphrase.cred'),
+
+    # Redacted log sink (a scheduled task's stdout is not captured anywhere). Defaults
+    # alongside the blob; kept in the owner-only autounlock dir.
+    [string]$LogPath = (Join-Path $DataDir 'autounlock\autounlock.log'),
+
+    # Connection overrides (otherwise taken from the config; see resolve below).
+    [string]$RpcConnect,
+    [int]$RpcPort = 0,           # 0 => use conf rpcport, else DEFAULT_RPC_PORT
+    [string]$RpcUser,
+
+    [int]$Timeout = 99999999,    # walletpassphrase timeout (the node clamps > 100000000)
+    [int]$Interval = 20,         # poll interval seconds
+    [switch]$Once,               # poll once and exit (testing / one-shot)
+
+    # Proceed even when the listener-ownership gate mechanism is unavailable on this host
+    # (e.g. Get-NetTCPConnection missing). INSECURE unless the host is single-user and
+    # trusted: without owner verification the passphrase could go to a process that
+    # squatted the RPC port during core startup.
+    [switch]$AllowUnverifiedListener
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$EXIT_OK = 0
+$EXIT_TRANSIENT = 1
+$EXIT_UNRECOVERABLE = 2
+
+# Mainnet RPC port (CBaseChainParams::MAIN, src/chainparamsbase.cpp). The daemon defaults
+# to this when rpcport is unset and a packaged gridcoinresearch.conf commonly omits it, so
+# default to it too. A non-mainnet node must set rpcport in the config or pass -RpcPort.
+$DEFAULT_RPC_PORT = 15715
+
+# RPC error codes we react to (src/rpc/protocol.h).
+$RPC_INVALID_PARAMETER = -8
+$RPC_WALLET_PASSPHRASE_INCORRECT = -14
+$RPC_WALLET_WRONG_ENC_STATE = -15
+$RPC_WALLET_ALREADY_UNLOCKED = -17
+
+# ---------------------------------------------------------------------------
+# Redaction (mirror register_secret / redact): scrub known secrets from any log line.
+# ---------------------------------------------------------------------------
+$script:Secrets = New-Object System.Collections.Generic.List[string]
+
+function Register-Secret([string]$value) {
+    if ($value) { [void]$script:Secrets.Add($value) }
+}
+
+function Format-Redacted([string]$text) {
+    $out = [string]$text
+    foreach ($s in $script:Secrets) { if ($s) { $out = $out.Replace($s, '<REDACTED>') } }
+    return $out
+}
+
+# Console (for -Once / interactive) AND an owner-only, size-capped log file (for the
+# resident task, whose stdout goes nowhere). Both sinks receive redacted text only.
+function Write-Line([string]$level, [string]$message) {
+    $red = Format-Redacted $message
+    $line = ('gridcoin_autounlock: ' + $(if ($level -eq 'WARNING') { 'WARNING: ' } else { '' }) + $red)
+    if ($level -eq 'WARNING') { [Console]::Error.WriteLine($line) } else { [Console]::Out.WriteLine($line) }
+    if ($LogPath) {
+        try {
+            $dir = Split-Path -Parent $LogPath
+            if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+            # Single-rotation cap so a persistent refusal (logged every poll) cannot grow the file unbounded.
+            if ((Test-Path -LiteralPath $LogPath) -and ((Get-Item -LiteralPath $LogPath).Length -gt 1MB)) {
+                Move-Item -LiteralPath $LogPath -Destination ($LogPath + '.1') -Force
+            }
+            $stamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+            Add-Content -LiteralPath $LogPath -Value ("$stamp $line") -Encoding UTF8
+        } catch { }  # logging must never break the poll
+    }
+}
+
+function Write-Log([string]$m)  { Write-Line 'INFO' $m }
+function Write-Warn([string]$m) { Write-Line 'WARNING' $m }
+
+# StrictMode-safe property read of a ConvertFrom-Json object (missing property -> $null,
+# instead of the StrictMode "property cannot be found" terminating error).
+function Get-Prop($obj, [string]$name) {
+    if ($null -eq $obj) { return $null }
+    $p = $obj.PSObject.Properties[$name]
+    if ($p) { return $p.Value }
+    return $null
+}
+
+# ---------------------------------------------------------------------------
+# Config (mirror parse_conf / _load_conf / resolve_connection).
+# ---------------------------------------------------------------------------
+function ConvertFrom-GridcoinConf([string]$text) {
+    # Strip from the first '#' (drops inline and full-line comments), key=value, and on a
+    # repeated key the FIRST value wins -- matching the core (reverse_precedence,
+    # src/util/settings.cpp). The core disallows '#' in rpcpassword, so this is safe.
+    $conf = @{}
+    foreach ($raw in ($text -split "`n")) {
+        $line = ($raw -split '#', 2)[0].Trim()
+        if (-not $line -or ($line -notmatch '=')) { continue }
+        $idx = $line.IndexOf('=')
+        $k = $line.Substring(0, $idx).Trim()
+        $v = $line.Substring($idx + 1).Trim()
+        if ($k -and -not $conf.ContainsKey($k)) { $conf[$k] = $v }   # first occurrence wins
+    }
+    return $conf
+}
+
+function Get-GridcoinConf {
+    if ($Conf) { $candidates = @($Conf) }
+    elseif ($DataDir) {
+        # Core default is gridcoinresearch.conf; gridcoin.conf is a common packaging alias.
+        $candidates = @((Join-Path $DataDir 'gridcoinresearch.conf'), (Join-Path $DataDir 'gridcoin.conf'))
+    }
+    else { return @{} }
+    foreach ($p in $candidates) {
+        if (Test-Path -LiteralPath $p) { return (ConvertFrom-GridcoinConf ([IO.File]::ReadAllText($p))) }
+    }
+    return @{}
+}
+
+# ---------------------------------------------------------------------------
+# Passphrase at rest: DPAPI CurrentUser (mirror read_passphrase's decode rules).
+# ---------------------------------------------------------------------------
+function Read-DpapiPassphrase([string]$path) {
+    if (-not (Test-Path -LiteralPath $path)) { throw "credential blob not found: $path" }
+    Add-Type -AssemblyName System.Security
+    $blob = [IO.File]::ReadAllBytes($path)
+    $bytes = [Security.Cryptography.ProtectedData]::Unprotect($blob, $null, 'CurrentUser')
+    try {
+        $pw = [Text.Encoding]::UTF8.GetString($bytes)
+        if ($pw.Length -gt 0 -and [int][char]$pw[0] -eq 0xFEFF) { $pw = $pw.Substring(1) }  # drop a BOM
+        $pw = $pw -replace '[\r\n]+$', ''                                                   # trailing CR/LF only
+        if (-not $pw.Trim()) { throw 'decrypted passphrase is empty or whitespace-only' }
+        return $pw
+    } finally {
+        [Array]::Clear($bytes, 0, $bytes.Length)
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Native listener-ownership gate (mirror check_listener_ownership).
+# Returns 'ours' | 'none' | 'foreign' | 'unreadable'.
+# ---------------------------------------------------------------------------
+function Get-ListenerOwnership([int]$port) {
+    $mySid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+    # Get-NetTCPConnection returns the full v4+v6 table; an empty/failed query means
+    # "nothing we can see is listening" -> 'none'. We never send on 'none', so treating a
+    # query miss as 'none' is safe. Per-listener owner attribution is where fail-closed
+    # matters (below): a listener we cannot attribute to ourselves -> 'unreadable' -> refuse.
+    try {
+        $listeners = @(Get-NetTCPConnection -State Listen -LocalPort $port -ErrorAction SilentlyContinue)
+    } catch {
+        return 'none'
+    }
+    if ($listeners.Count -eq 0) { return 'none' }
+    $sawForeign = $false
+    foreach ($l in $listeners) {
+        $ownerSid = $null
+        try {
+            $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$($l.OwningProcess)" -ErrorAction Stop
+            if ($proc) {
+                $res = Invoke-CimMethod -InputObject $proc -MethodName GetOwnerSid -ErrorAction Stop
+                if ((Get-Prop $res 'ReturnValue') -eq 0) { $ownerSid = [string](Get-Prop $res 'Sid') }
+            }
+        } catch {
+            $ownerSid = $null
+        }
+        if ([string]::IsNullOrEmpty($ownerSid)) { return 'unreadable' }  # cannot attribute -> fail closed
+        if ($ownerSid -ne $mySid) { $sawForeign = $true }
+    }
+    if ($sawForeign) { return 'foreign' }
+    return 'ours'
+}
+
+# Run the gate. Returns an EXIT_* code to stop this poll (nothing sent), or $null to proceed.
+function Invoke-Gate([int]$port, [bool]$loopback, [bool]$canGate) {
+    if (-not $loopback) {
+        return $null  # remote target: the ownership gate cannot apply (warned at startup); proceed
+    }
+    if (-not $canGate) {
+        if ($AllowUnverifiedListener) { return $null }
+        Write-Warn ("cannot verify the owner of the loopback RPC port {0} on this host; refusing to send " +
+            "credentials. Use -AllowUnverifiedListener on a trusted single-user host to override." -f $port)
+        return $EXIT_UNRECOVERABLE
+    }
+    switch (Get-ListenerOwnership $port) {
+        'foreign' {
+            Write-Warn ("REFUSING TO SEND CREDENTIALS: a process owned by another user is listening on the " +
+                "RPC port {0}. Either the core runs as a different user than expected, or a local account has " +
+                "bound the RPC port. Investigate before relying on autounlock." -f $port)
+            return $EXIT_UNRECOVERABLE
+        }
+        'unreadable' {
+            Write-Warn ("cannot attribute the owner of a listener on RPC port {0}; refusing to send credentials " +
+                "to an unverified listener." -f $port)
+            return $EXIT_UNRECOVERABLE
+        }
+        'none' { return $EXIT_TRANSIENT }   # nothing listening yet; the core is still coming up
+        default { return $null }            # 'ours': proceed
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Proxy-free JSON-RPC. Returns a discriminated result (no exceptions for RPC-level errors):
+#   @{ Ok = $true;  Result = <object> }
+#   @{ Ok = $false; Code = <jsonrpc code|$null>; Http = <status|$null>; Msg = <string> }
+# ---------------------------------------------------------------------------
+function Invoke-GridcoinRpc([string]$url, [string]$auth, [string]$method, [object[]]$params) {
+    $body = (@{ jsonrpc = '1.0'; id = 'autounlock'; method = $method; params = $params } | ConvertTo-Json -Compress -Depth 6)
+    $bytes = [Text.Encoding]::UTF8.GetBytes($body)
+    try {
+        $req = [System.Net.HttpWebRequest]::Create($url)
+        $req.Proxy = $null                       # proxy-free: never divert the passphrase POST off-box
+        $req.Method = 'POST'
+        $req.ContentType = 'application/json'
+        $req.Timeout = 10000
+        $req.ReadWriteTimeout = 10000
+        $req.KeepAlive = $false
+        $req.Headers['Authorization'] = $auth
+        $req.ContentLength = $bytes.Length
+        $rs = $req.GetRequestStream()
+        try { $rs.Write($bytes, 0, $bytes.Length) } finally { $rs.Close() }
+
+        $resp = $req.GetResponse()
+        try {
+            $sr = New-Object IO.StreamReader($resp.GetResponseStream())
+            try { $text = $sr.ReadToEnd() } finally { $sr.Close() }
+        } finally { $resp.Close() }
+    }
+    catch [System.Net.WebException] {
+        $r = $_.Exception.Response
+        if ($null -ne $r) {
+            $status = [int]([System.Net.HttpWebResponse]$r).StatusCode
+            if ($status -eq 401) {
+                return @{ Ok = $false; Code = $null; Http = 401; Msg = 'HTTP 401 Unauthorized: rpcuser/rpcpassword rejected by the daemon' }
+            }
+            # Gridcoin returns JSON-RPC errors with HTTP 500 and the error object in the body.
+            $eo = $null
+            try {
+                $er = New-Object IO.StreamReader($r.GetResponseStream())
+                try { $eb = $er.ReadToEnd() } finally { $er.Close() }
+                $eo = (Get-Prop ($eb | ConvertFrom-Json) 'error')
+            } catch { $eo = $null }
+            if ($eo) {
+                return @{ Ok = $false; Code = (Get-Prop $eo 'code'); Http = $status; Msg = [string](Get-Prop $eo 'message') }
+            }
+            return @{ Ok = $false; Code = $null; Http = $status; Msg = ("HTTP {0} error" -f $status) }
+        }
+        # Transport-level (connection refused, timeout): no JSON-RPC code; retry may help.
+        return @{ Ok = $false; Code = $null; Http = $null; Msg = [string]$_.Exception.Message }
+    }
+    catch {
+        return @{ Ok = $false; Code = $null; Http = $null; Msg = [string]$_.Exception.Message }
+    }
+
+    $obj = $null
+    try { $obj = $text | ConvertFrom-Json } catch { return @{ Ok = $false; Code = $null; Http = $null; Msg = 'RPC returned a non-JSON body' } }
+    $err = Get-Prop $obj 'error'
+    if ($err) {
+        return @{ Ok = $false; Code = (Get-Prop $err 'code'); Http = $null; Msg = [string](Get-Prop $err 'message') }
+    }
+    return @{ Ok = $true; Result = (Get-Prop $obj 'result') }
+}
+
+# ---------------------------------------------------------------------------
+# One poll (mirror run_once). Returns @{ Uptime = <int|$null>; Code = <EXIT_*> }.
+# ---------------------------------------------------------------------------
+function Invoke-Poll([string]$url, [string]$auth, [int]$port, [bool]$loopback, [bool]$canGate, [string]$passphrase, [int]$timeout, $prevUptime) {
+    $gateCode = Invoke-Gate $port $loopback $canGate
+    if ($null -ne $gateCode) { return @{ Uptime = $prevUptime; Code = $gateCode } }
+
+    $info = Invoke-GridcoinRpc $url $auth 'getinfo' @()
+    if (-not $info.Ok) {
+        if ($info.Http -eq 401) {
+            Write-Warn 'RPC rejected the credentials (HTTP 401): rpcuser/rpcpassword are wrong -- retrying cannot fix this'
+            return @{ Uptime = $prevUptime; Code = $EXIT_UNRECOVERABLE }
+        }
+        return @{ Uptime = $prevUptime; Code = $EXIT_TRANSIENT }   # core down / RPC not bound yet
+    }
+    $u = Get-Prop $info.Result 'uptime'
+    if ($null -eq $u) { return @{ Uptime = $prevUptime; Code = $EXIT_TRANSIENT } }
+    try { $curUptime = [int]$u } catch { return @{ Uptime = $prevUptime; Code = $EXIT_TRANSIENT } }
+
+    # should_unlock: first contact, or the core restarted (uptime went backwards).
+    $needUnlock = ($null -eq $prevUptime) -or ($curUptime -lt $prevUptime)
+    if (-not $needUnlock) { return @{ Uptime = $curUptime; Code = $EXIT_OK } }
+
+    $r = Invoke-GridcoinRpc $url $auth 'walletpassphrase' @($passphrase, $timeout, $true)   # stake-only
+    if ($r.Ok) {
+        Write-Log 'wallet unlocked (stake-only)'
+        return @{ Uptime = $curUptime; Code = $EXIT_OK }
+    }
+    if ($r.Http -eq 401) {
+        Write-Warn 'RPC rejected the credentials (HTTP 401) -- retrying cannot fix this'
+        return @{ Uptime = $curUptime; Code = $EXIT_UNRECOVERABLE }
+    }
+    $code = $r.Code
+    if ($code -eq $RPC_WALLET_ALREADY_UNLOCKED) {
+        # -17 is thrown before the stake-only flag is assigned, so the wallet is unlocked
+        # but by another path and the staking-only restriction was NOT re-asserted -- if
+        # that path was a full GUI unlock it is spendable. No RPC exposes the flag.
+        Write-Warn 'wallet was already unlocked by another path (-17); the staking-only restriction was NOT re-asserted and may not be in effect'
+        return @{ Uptime = $curUptime; Code = $EXIT_OK }
+    }
+    if ($code -eq $RPC_WALLET_WRONG_ENC_STATE) {
+        Write-Warn 'wallet is not encrypted (-15); there is nothing to unlock'
+        return @{ Uptime = $curUptime; Code = $EXIT_OK }
+    }
+    if ($code -eq $RPC_WALLET_PASSPHRASE_INCORRECT -or $code -eq $RPC_INVALID_PARAMETER) {
+        Write-Warn ("walletpassphrase was rejected ({0}): {1} -- retrying cannot fix this" -f $code, $r.Msg)
+        return @{ Uptime = $curUptime; Code = $EXIT_UNRECOVERABLE }
+    }
+    Write-Warn ("walletpassphrase failed: {0}" -f $r.Msg)
+    return @{ Uptime = $curUptime; Code = $EXIT_TRANSIENT }
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+# Note: the local is $cfg, NOT $conf -- the script has a [string]$Conf parameter, and
+# PowerShell variable names are case-insensitive, so assigning the hashtable to $conf would
+# be coerced by that [string] type constraint into the string "System.Collections.Hashtable".
+$cfg = Get-GridcoinConf
+$rpcUser = if ($RpcUser) { $RpcUser } elseif ($cfg.ContainsKey('rpcuser')) { $cfg['rpcuser'] } else { $null }
+$rpcPass = if ($cfg.ContainsKey('rpcpassword')) { $cfg['rpcpassword'] } else { $null }
+$rpcHost = if ($RpcConnect) { $RpcConnect } elseif ($cfg.ContainsKey('rpcconnect')) { $cfg['rpcconnect'] } else { '127.0.0.1' }
+if ($RpcPort -gt 0) {
+    $port = $RpcPort
+} elseif ($cfg.ContainsKey('rpcport')) {
+    $parsedPort = 0
+    if (-not [int]::TryParse([string]$cfg['rpcport'], [ref]$parsedPort)) {
+        Write-Warn ("rpcport in the config is not an integer ('{0}')" -f $cfg['rpcport'])
+        exit $EXIT_UNRECOVERABLE
+    }
+    $port = $parsedPort
+} else {
+    $port = $DEFAULT_RPC_PORT
+}
+
+if (-not $rpcUser -or -not $rpcPass) {
+    Write-Warn 'rpcuser and rpcpassword must be set in the config file (or pass -RpcUser and set rpcpassword in the conf)'
+    exit $EXIT_UNRECOVERABLE
+}
+
+# Decrypt the passphrase ONCE at startup (mirror main()). A bad blob or the wrong user
+# context is unrecoverable -- do not enter the loop.
+try {
+    $passphrase = Read-DpapiPassphrase $CredPath
+} catch {
+    Write-Warn ("could not read the DPAPI passphrase blob: {0}" -f $_.Exception.Message)
+    exit $EXIT_UNRECOVERABLE
+}
+Register-Secret $passphrase
+Register-Secret $rpcPass
+$token = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(("{0}:{1}" -f $rpcUser, $rpcPass)))
+Register-Secret $token
+$auth = "Basic $token"
+
+# Bracket an IPv6 literal host so the URL is valid: http://[::1]:port/, not http://::1:port/.
+$urlHost = if ($rpcHost.Contains(':') -and -not $rpcHost.StartsWith('[')) { "[$rpcHost]" } else { $rpcHost }
+$url = "http://{0}:{1}/" -f $urlHost, $port
+
+# Gate applicability: a loopback target with the gate mechanism (Get-NetTCPConnection) present.
+$loopback = ($rpcHost -in @('127.0.0.1', '::1', 'localhost')) -or $rpcHost.StartsWith('127.')
+$canGate = $false
+if ($loopback) {
+    try { Get-Command Get-NetTCPConnection -ErrorAction Stop | Out-Null; $canGate = $true } catch { $canGate = $false }
+    if (-not $canGate -and -not $AllowUnverifiedListener) {
+        Write-Warn 'the listener-ownership gate is unavailable (Get-NetTCPConnection missing); credentials will NOT be sent until -AllowUnverifiedListener is set on a trusted single-user host'
+    }
+} else {
+    Write-Warn ("RPC target {0} is not loopback; the listener-ownership gate cannot apply and credentials will be sent to the configured host." -f $rpcHost)
+}
+
+$prevUptime = $null
+while ($true) {
+    try {
+        $result = Invoke-Poll $url $auth $port $loopback $canGate $passphrase $Timeout $prevUptime
+        $prevUptime = $result.Uptime
+        $code = $result.Code
+    } catch {
+        # The resident loop must never die and must never print an unredacted error.
+        Write-Warn ("unexpected error during poll: {0}" -f (Format-Redacted ([string]$_.Exception.Message)))
+        $code = $EXIT_TRANSIENT
+    }
+    if ($Once) { exit $code }
+    Start-Sleep -Seconds $Interval
+}

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -2,7 +2,13 @@
 
 PowerShell scripts to run the split **multiprocess** Gridcoin core as a background
 Scheduled Task on Windows, stop it gracefully, upgrade a locked exe, and launch the
-GUI. See [`doc/multiprocess.md`](../../doc/multiprocess.md) for the split-mode model.
+GUI. See [`doc/multiprocess.md`](../../doc/multiprocess.md) for the split-mode model,
+and [`doc/running-unattended.md`](../../doc/running-unattended.md) for the step-by-step
+walkthrough.
+
+The Windows installer **bundles these scripts** into `…\GridcoinResearch\windows\`; run
+them from there in an **elevated** PowerShell. (In a source checkout they live here in
+`contrib/windows/`.)
 
 | Script | Purpose |
 |---|---|

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -10,8 +10,10 @@ GUI. See [`doc/multiprocess.md`](../../doc/multiprocess.md) for the split-mode m
 | `Uninstall-GridcoinCoreTask.ps1` | Remove them. |
 | `Update-GridcoinCore.ps1` | Graceful upgrade engine for the locked-exe problem. |
 | `Start-GridcoinGui.ps1` | Launch the `-multiprocess` GUI (or drop a Start-Menu shortcut with `-CreateShortcut`). |
+| `Set-GridcoinAutounlock.ps1` | **Opt-in**: enable/remove stake-only autounlock (DPAPI secret + resident task). |
+| `Invoke-GridcoinAutounlock.ps1` | The resident autounlock helper the task runs (not called directly). |
 
-Opt-in **autounlock** (DPAPI, stake-only) is separate — `Set-GridcoinAutounlock.ps1` (future).
+Autounlock is **opt-in** and independent of the core tasks — see [Autounlock](#autounlock-opt-in-stake-only-dpapi) below.
 
 ## Quick start
 
@@ -72,12 +74,58 @@ validation list.
 analogue of the Linux unit's `Restart=on-failure`. A *graceful* stop exits 0 and is
 not restarted; only a crash (non-zero exit) triggers a restart.
 
+## Autounlock (opt-in, stake-only, DPAPI)
+
+Unattended **staking** on an encrypted wallet needs the wallet unlocked after every boot
+or restart. This is opt-in and deliberately **external** to the wallet (the in-wallet
+auto-unlock was removed years ago as insecure): the passphrase lives in the OS credential
+store, and the wallet is unlocked over RPC **for staking only** — never for spending. It is
+the Windows analogue of the Linux `gridcoinresearchd-autounlock.service` (systemd
+`LoadCredentialEncrypted`); the security contract mirrors
+[`contrib/wallettools/gridcoin_autounlock.py`](../wallettools/gridcoin_autounlock.py).
+
+Enable it **as the wallet user** (elevated if task registration requires it):
+
+```powershell
+.\Set-GridcoinAutounlock.ps1 -DataDir "$env:APPDATA\GridcoinResearch"
+# Prompts: the WALLET passphrase (twice), then the account's Windows LOGIN password.
+```
+
+What it does:
+
+- **Secret at rest = DPAPI (CurrentUser).** The passphrase is encrypted with
+  `CryptProtectData` and written to `<datadir>\autounlock\passphrase.cred` — decryptable
+  only by **that Windows account on that machine**, and additionally locked owner-only by
+  NTFS ACL. It is never stored in the wallet, on a command line, or in a log. Because DPAPI
+  CurrentUser is per-account, the task **must run as the same user that ran setup** — the
+  script refuses a mismatched `-TaskUser`.
+- **Registers `\Gridcoin\Autounlock`**, a resident task (run-as the wallet user) that runs
+  `Invoke-GridcoinAutounlock.ps1`: it waits for the core, unlocks **stake-only**
+  (`walletpassphrase … true`), and **self-heals** — it re-unlocks after each core restart.
+- **Native listener-ownership gate.** Before any credential goes on the wire it verifies
+  that our own SID owns every LISTEN socket on the RPC port (`Get-NetTCPConnection` →
+  `Win32_Process` owner SID). The RPC port is unbound for minutes during core startup and an
+  unprivileged loopback port can be squatted by a local account first; a **foreign or
+  unverifiable owner makes it refuse** and log — that is the gate working, not a bug.
+
+A running log (redacted — no secrets) is at `<datadir>\autounlock\autounlock.log`. To
+remove everything:
+
+```powershell
+.\Set-GridcoinAutounlock.ps1 -Remove   # unregister the task and delete the DPAPI blob
+```
+
+Note: a `-17 already unlocked` in the log means the wallet was unlocked by another path
+(e.g. a GUI unlock) and the **staking-only restriction was not re-asserted** — it may be
+spendable until the next restart.
+
 ## Status
 
-New scripts, validated by PowerShell parse-check + inspection; full runtime
-validation on Windows (install → reboot → autostart → upgrade → GUI attach →
-shutdown-flush → different-user connection-refused) is pending on the test box.
-Known items to confirm there: the shutdown-flush mechanism (above); that
-stored-password task registration requires an **elevated** shell and the "Log on as
-a batch job" right for the run-as account; and Microsoft/AzureAD-account principal
-forms.
+Validated by PowerShell parse-check + inspection; full runtime validation on Windows is
+pending on the test box. Core tasks: install → reboot → autostart → upgrade → GUI attach →
+shutdown-flush → different-user connection-refused. Autounlock: enable → **DPAPI decrypt
+inside the batch-logon task** (the primary unknown) → cold stake-only unlock → foreign-listener
+refused → self-heal on restart → remove. Known items to confirm there: the shutdown-flush
+mechanism (above); that stored-password task registration requires an **elevated** shell and
+the "Log on as a batch job" right for the run-as account; and Microsoft/AzureAD-account
+principal forms.

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -84,12 +84,16 @@ the Windows analogue of the Linux `gridcoinresearchd-autounlock.service` (system
 `LoadCredentialEncrypted`); the security contract mirrors
 [`contrib/wallettools/gridcoin_autounlock.py`](../wallettools/gridcoin_autounlock.py).
 
-Enable it **as the wallet user** (elevated if task registration requires it):
+Enable it **as the wallet user, from an elevated console** (Run as administrator):
 
 ```powershell
 .\Set-GridcoinAutounlock.ps1 -DataDir "$env:APPDATA\GridcoinResearch"
 # Prompts: the WALLET passphrase (twice), then the account's Windows LOGIN password.
 ```
+
+Run it **at the machine's own console, not over SSH/PSRemoting**: DPAPI CurrentUser encryption
+needs an interactive or batch logon and fails over a network logon (no master key). Elevation is
+needed because the resident task carries a boot trigger.
 
 What it does:
 

--- a/contrib/windows/Set-GridcoinAutounlock.ps1
+++ b/contrib/windows/Set-GridcoinAutounlock.ps1
@@ -19,8 +19,12 @@
     See contrib/windows/README.md and doc/multiprocess.md.
 
 .NOTES
-    Registering a run-as task with a stored login password typically needs an ELEVATED
-    PowerShell and the "Log on as a batch job" right for the account.
+    Run this at an ELEVATED console (Run as administrator). Two reasons: registering the
+    resident run-as task with a stored login password needs elevation and the "Log on as a
+    batch job" right for the account; and DPAPI CurrentUser encryption requires an
+    interactive or batch logon -- it FAILS over a network logon (a key-based SSH / PSRemoting
+    session), where the user's master key is not available. So enable autounlock from the
+    machine's own console, not remotely.
 #>
 [CmdletBinding()]
 param(
@@ -223,6 +227,15 @@ catch {
 finally {
     $plainPw = $null
     [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
+
+# Verify the task actually registered. Register-ScheduledTask can emit a NON-terminating
+# "Access is denied" and continue -- a boot-triggered run-as task needs an elevated shell --
+# so confirm rather than report false success (the DPAPI blob was still written above).
+if (-not (Get-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Autounlock' -ErrorAction SilentlyContinue)) {
+    throw "Task \$TaskFolder\Autounlock was not registered (likely 'Access is denied'). This needs an " +
+          "ELEVATED PowerShell (Run as administrator) and the 'Log on as a batch job' right for '$TaskUser'. " +
+          "The DPAPI blob at $CredPath was written; re-run elevated to register the task, or -Remove to undo."
 }
 
 Write-Host "Registered \$TaskFolder\Autounlock (resident, run-as $TaskUser)." -ForegroundColor Green

--- a/contrib/windows/Set-GridcoinAutounlock.ps1
+++ b/contrib/windows/Set-GridcoinAutounlock.ps1
@@ -1,0 +1,232 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Enable (or remove) opt-in stake-only autounlock for the Windows multiprocess core.
+
+.DESCRIPTION
+    Prompts for the wallet passphrase (SecureString, entered twice), DPAPI-encrypts it
+    (CurrentUser) to an owner-only blob, and registers the resident \Gridcoin\Autounlock
+    scheduled task (run-as the wallet user) that runs Invoke-GridcoinAutounlock.ps1. The
+    passphrase is NEVER on argv, in a log, or in the wallet. -Remove unregisters the task
+    and deletes the blob.
+
+    RUN THIS AS THE WALLET USER. DPAPI CurrentUser is keyed to the account that encrypts
+    the blob, so it can only be decrypted by that same account -- which must therefore be
+    the account the task runs as. This script refuses if -TaskUser resolves to a different
+    account (an admin encrypting a blob a standard walletholder then cannot read). Elevation
+    is fine: an elevated shell still runs as the same user SID.
+
+    See contrib/windows/README.md and doc/multiprocess.md.
+
+.NOTES
+    Registering a run-as task with a stored login password typically needs an ELEVATED
+    PowerShell and the "Log on as a batch job" right for the account.
+#>
+[CmdletBinding()]
+param(
+    [string]$DataDir = (Join-Path $env:APPDATA 'GridcoinResearch'),
+    [string]$CredPath = (Join-Path $DataDir 'autounlock\passphrase.cred'),
+    [string]$HelperPath = (Join-Path $PSScriptRoot 'Invoke-GridcoinAutounlock.ps1'),
+
+    # The account the task runs as. Must be the current user (DPAPI CurrentUser constraint).
+    [string]$TaskUser = "$env:USERDOMAIN\$env:USERNAME",
+
+    # The TaskUser's LOGIN password (NOT the wallet passphrase). Prompted if omitted.
+    [System.Security.SecureString]$TaskPassword,
+
+    [int]$Interval = 20,
+    [int]$Timeout = 99999999,
+    [string]$TaskFolder = 'Gridcoin',
+    [switch]$Remove
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# ---------------------------------------------------------------------------
+# -Remove: unregister the task and delete the blob (idempotent).
+# ---------------------------------------------------------------------------
+if ($Remove) {
+    # Resilient teardown: each step is independent so a failure in one still runs the rest.
+    try {
+        $existing = Get-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Autounlock' -ErrorAction SilentlyContinue
+        if ($existing) {
+            Unregister-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Autounlock' -Confirm:$false
+            Write-Host "Removed \$TaskFolder\Autounlock"
+        } else {
+            Write-Host "\$TaskFolder\Autounlock not present (ok)"
+        }
+    } catch {
+        Write-Host "Could not unregister \$TaskFolder\Autounlock ($($_.Exception.Message)); continuing." -ForegroundColor Yellow
+    }
+    if (Test-Path -LiteralPath $CredPath) {
+        try { Remove-Item -LiteralPath $CredPath -Force; Write-Host "Deleted credential blob $CredPath" }
+        catch { Write-Host "Could not delete $CredPath ($($_.Exception.Message))." -ForegroundColor Yellow }
+    } else {
+        Write-Host "credential blob $CredPath not present (ok)"
+    }
+    # Remove the autounlock dir's logs, then the dir itself if it is now empty.
+    $credDir = Split-Path -Parent $CredPath
+    foreach ($lg in @('autounlock.log', 'autounlock.log.1')) {
+        $lp = Join-Path $credDir $lg
+        if (Test-Path -LiteralPath $lp) { try { Remove-Item -LiteralPath $lp -Force } catch { } }
+    }
+    if ((Test-Path -LiteralPath $credDir) -and -not (Get-ChildItem -LiteralPath $credDir -Force)) {
+        try { Remove-Item -LiteralPath $credDir -Force } catch { }
+    }
+    Write-Host "Autounlock removed. The core tasks (Core-Start / Core-Stop) are untouched."
+    return
+}
+
+if (-not (Test-Path -LiteralPath $HelperPath)) {
+    throw "Invoke-GridcoinAutounlock.ps1 not found at '$HelperPath'. Pass -HelperPath explicitly."
+}
+$HelperPath = (Resolve-Path -LiteralPath $HelperPath).Path
+
+# DPAPI CurrentUser constraint: the blob must be encrypted by the account the task runs as.
+# Refuse if -TaskUser resolves to a different SID than the current user.
+$mySid = ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+$taskSid = $null
+try {
+    $taskSid = (New-Object System.Security.Principal.NTAccount($TaskUser)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+} catch {
+    $taskSid = $null
+}
+if ($taskSid -and ($taskSid -ne $mySid)) {
+    throw ("-TaskUser '$TaskUser' is a different account than the one running this script. DPAPI " +
+           "CurrentUser can only be decrypted by the account that encrypted it, so the autounlock task " +
+           "must run as the SAME user that runs this setup. Re-run this AS '$TaskUser' (elevated if task " +
+           "registration requires it).")
+}
+if (-not $taskSid) {
+    Write-Host ("Note: could not resolve '$TaskUser' to a SID to confirm it matches the current user. The " +
+                "DPAPI blob will only decrypt if the task runs as the same account that runs this setup.") -ForegroundColor Yellow
+}
+
+# ---------------------------------------------------------------------------
+# Prompt the wallet passphrase (twice) and DPAPI-encrypt it.
+# ---------------------------------------------------------------------------
+$p1 = Read-Host -AsSecureString -Prompt 'Enter the WALLET passphrase to store for stake-only autounlock'
+$p2 = Read-Host -AsSecureString -Prompt 'Re-enter the WALLET passphrase'
+
+# Compare + encrypt via short-lived unmanaged buffers. The managed String materialised for
+# UTF-8 encoding is unavoidable residue in PS 5.1 (equivalent to any -Password cmdlet); we
+# minimise its lifetime and zero every buffer we control.
+$b1 = [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($p1)
+$b2 = [Runtime.InteropServices.Marshal]::SecureStringToGlobalAllocUnicode($p2)
+$bytes = $null
+$blob = $null
+try {
+    $s1 = [Runtime.InteropServices.Marshal]::PtrToStringUni($b1)
+    $s2 = [Runtime.InteropServices.Marshal]::PtrToStringUni($b2)
+    if ($s1 -cne $s2) { throw 'the two passphrases do not match.' }
+    if (-not $s1.Trim()) { throw 'the passphrase is empty.' }
+    Add-Type -AssemblyName System.Security
+    $bytes = [Text.Encoding]::UTF8.GetBytes($s1)          # UTF-8, no BOM (the helper tolerates a BOM anyway)
+    $blob = [Security.Cryptography.ProtectedData]::Protect($bytes, $null, [Security.Cryptography.DataProtectionScope]::CurrentUser)
+} finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode($b1)
+    [Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocUnicode($b2)
+    if ($bytes) { [Array]::Clear($bytes, 0, $bytes.Length) }
+}
+
+# ---------------------------------------------------------------------------
+# Write the blob and lock it to the current user (defense in depth; DPAPI already
+# user-binds it, but an owner-only ACL keeps other local users from even reading the blob).
+# ---------------------------------------------------------------------------
+$credDir = Split-Path -Parent $CredPath
+if ($credDir -and -not (Test-Path -LiteralPath $credDir)) {
+    New-Item -ItemType Directory -Path $credDir -Force | Out-Null
+}
+$meAccount = ([Security.Principal.WindowsIdentity]::GetCurrent()).User
+# Lock the whole autounlock dir owner-only, with inheritance, so the (redacted) log the
+# helper writes there is covered too -- not just the blob.
+if ($credDir) {
+    $dacl = New-Object System.Security.AccessControl.DirectorySecurity
+    $dacl.SetAccessRuleProtection($true, $false)   # disable inheritance, drop inherited ACEs
+    $inherit = [System.Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
+    $dacl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+        $meAccount, 'FullControl', $inherit, 'None', 'Allow')))
+    Set-Acl -LiteralPath $credDir -AclObject $dacl
+}
+[IO.File]::WriteAllBytes($CredPath, $blob)
+$acl = New-Object System.Security.AccessControl.FileSecurity
+$acl.SetAccessRuleProtection($true, $false)   # disable inheritance, drop inherited ACEs
+$acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule($meAccount, 'FullControl', 'Allow')))
+Set-Acl -LiteralPath $CredPath -AclObject $acl
+Write-Host "Wrote DPAPI (CurrentUser) passphrase blob: $CredPath (owner-only)."
+
+# ---------------------------------------------------------------------------
+# Register the resident \Gridcoin\Autounlock task, run-as the wallet user.
+# ---------------------------------------------------------------------------
+if (-not $TaskPassword) {
+    $cred = Get-Credential -UserName $TaskUser `
+        -Message "Enter the Windows LOGIN password for '$TaskUser' (the account the autounlock task runs as). This is NOT the wallet passphrase."
+    $TaskUser = $cred.UserName
+    $TaskPassword = $cred.Password
+}
+
+# Re-validate AFTER the prompt: Get-Credential lets the operator edit the username, which
+# would otherwise defeat the pre-prompt SID check and register the task under an account
+# whose DPAPI store cannot decrypt the blob (autounlock would then fail on every start).
+$finalSid = $null
+try {
+    $finalSid = (New-Object System.Security.Principal.NTAccount($TaskUser)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+} catch {
+    $finalSid = $null
+}
+if ($finalSid -and ($finalSid -ne $mySid)) {
+    throw ("The task run-as account '$TaskUser' is a different account than the one running this script. " +
+           "DPAPI CurrentUser can only be decrypted by the account that encrypted the blob, so the task must " +
+           "run as the SAME user that runs this setup. Re-run this AS '$TaskUser' (elevated if needed).")
+}
+
+$ddQuoted = '"' + $DataDir + '"'
+$helperQuoted = '"' + $HelperPath + '"'
+$credQuoted = '"' + $CredPath + '"'
+$psArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File $helperQuoted -DataDir $ddQuoted -CredPath $credQuoted -Interval $Interval -Timeout $Timeout"
+
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $psArgs
+$trigger = New-ScheduledTaskTrigger -AtStartup
+# Resident: no execution-time limit; single instance. The modest crash-restart is a safety
+# net only -- normal operation never exits (the loop logs transient/unrecoverable and keeps
+# polling), so it will not hammer bad credentials.
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew `
+    -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+
+# Ensure \Gridcoin\ exists (Register -TaskPath does not reliably create it on all Windows versions).
+try {
+    $svc = New-Object -ComObject 'Schedule.Service'
+    $svc.Connect()
+    try { $null = $svc.GetFolder("\$TaskFolder") }
+    catch { $null = $svc.GetFolder('\').CreateFolder($TaskFolder) }
+} catch { }
+
+# Register-ScheduledTask -Password needs the plaintext once. Minimise the BSTR lifetime; the
+# managed String residue is unavoidable in PS 5.1 (equivalent to any -Password cmdlet).
+$plainPw = $null
+$bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($TaskPassword)
+try {
+    $plainPw = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    Register-ScheduledTask -TaskPath "\$TaskFolder\" -TaskName 'Autounlock' -Force `
+        -Action $action -Trigger $trigger -Settings $settings `
+        -User $TaskUser -Password $plainPw -RunLevel Limited `
+        -Description 'Stake-only wallet autounlock for the Gridcoin multiprocess core (DPAPI, run-as the wallet user).' | Out-Null
+}
+catch {
+    throw "Failed to register \$TaskFolder\Autounlock: $($_.Exception.Message)`n" +
+          "Registering a run-as task with a stored password usually needs an ELEVATED PowerShell " +
+          "(Run as administrator) and the 'Log on as a batch job' right for '$TaskUser'. Re-run elevated; " +
+          "see contrib/windows/README.md."
+}
+finally {
+    $plainPw = $null
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+}
+
+Write-Host "Registered \$TaskFolder\Autounlock (resident, run-as $TaskUser)." -ForegroundColor Green
+Write-Host ""
+Write-Host "  Start now :  Start-ScheduledTask -TaskPath '\$TaskFolder\' -TaskName 'Autounlock'"
+Write-Host "  Log       :  $(Join-Path (Split-Path -Parent $CredPath) 'autounlock.log')"
+Write-Host "  Remove    :  .\Set-GridcoinAutounlock.ps1 -Remove"

--- a/contrib/windows/Uninstall-GridcoinCoreTask.ps1
+++ b/contrib/windows/Uninstall-GridcoinCoreTask.ps1
@@ -8,8 +8,9 @@
     empty) \Gridcoin task folder. Tolerant of already-absent tasks (idempotent).
 
     Does NOT remove the opt-in autounlock task (\Gridcoin\Autounlock) -- that is
-    owned by Set-GridcoinAutounlock.ps1 / its uninstall (Plan 5). It also does not
-    stop a running core; run the Core-Stop task first if you want a graceful stop.
+    owned by Set-GridcoinAutounlock.ps1 (remove it with `Set-GridcoinAutounlock.ps1
+    -Remove`). It also does not stop a running core; run the Core-Stop task first if
+    you want a graceful stop.
 #>
 [CmdletBinding()]
 param([string]$TaskFolder = 'Gridcoin')

--- a/contrib/windows/Update-GridcoinCore.ps1
+++ b/contrib/windows/Update-GridcoinCore.ps1
@@ -26,7 +26,9 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$CorePath = (Join-Path $PSScriptRoot '..\gridcoinresearchd.exe'),
+    # Default resolved below across both layouts (installer daemon\ subfolder, or a build
+    # tree with the exe one level up). An explicit -CorePath is honored as-is.
+    [string]$CorePath,
 
     # Optional: a directory containing the new gridcoinresearch*.exe to copy over
     # the installed ones once the lock is released. Omit if the caller replaces the
@@ -41,8 +43,16 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+if (-not $CorePath) {
+    $CorePath = @(
+        (Join-Path $PSScriptRoot '..\daemon\gridcoinresearchd.exe'),   # NSIS installer layout
+        (Join-Path $PSScriptRoot '..\gridcoinresearchd.exe')           # exe alongside the scripts' parent
+    ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    if (-not $CorePath) { $CorePath = (Join-Path $PSScriptRoot '..\daemon\gridcoinresearchd.exe') }
+}
 if (-not (Test-Path -LiteralPath $CorePath)) {
-    throw "gridcoinresearchd.exe not found at '$CorePath'. Pass -CorePath explicitly."
+    throw "gridcoinresearchd.exe not found at '$CorePath'. Pass -CorePath explicitly (installer layout: " +
+          "...\GridcoinResearch\daemon\gridcoinresearchd.exe, with these scripts in ...\GridcoinResearch\windows\)."
 }
 $CorePath = (Resolve-Path -LiteralPath $CorePath).Path
 $coreDir = Split-Path -Parent $CorePath

--- a/doc/build.md
+++ b/doc/build.md
@@ -88,7 +88,7 @@ After you build with this script with the appropriate target
 
 Please refer to [Link](cmake-options.md) (cmake-options.md) for a list of cmake configuration options.
 
-To build the **split GUI/node (multiprocess)** variant — where the GUI and daemon run as separate processes that communicate over IPC — add `-DENABLE_MULTIPROCESS=ON` to a native build, or build the depends tree with `MULTIPROCESS=1` for a static/Windows build. See [multiprocess.md](multiprocess.md) for building **and running** in multiprocess mode (including the Windows requirement that the daemon run as the same user as the GUI).
+To build the **split GUI/node (multiprocess)** variant — where the GUI and daemon run as separate processes that communicate over IPC — add `-DENABLE_MULTIPROCESS=ON` to a native build, or build the depends tree with `MULTIPROCESS=1` for a static/Windows build. See [multiprocess.md](multiprocess.md) for building **and running** in multiprocess mode (including the Windows requirement that the daemon run as the same user as the GUI), and [running-unattended.md](running-unattended.md) for running the core as a **background service that stakes unattended** (Linux systemd / Windows Task Scheduler, with optional stake-only autounlock).
 
 Developers may want to use -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache to have ccache cache
 the compilation at the ccache level. In many instances it is required to do an rm -rf of the build directory, and this will speed up

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -240,6 +240,26 @@ gate is defence in depth. While unlocked, the passphrase lives in the core's mem
 requires `systemctl restart gridcoinresearchd-autounlock.service`, as the credential
 is read at unit start.
 
+### Unattended stake-only autounlock (Windows)
+
+The Windows equivalent is a pair of PowerShell scripts in
+[`contrib/windows/`](../contrib/windows/) (no Python needed). Run **as the wallet user**:
+
+```powershell
+.\Set-GridcoinAutounlock.ps1 -DataDir "$env:APPDATA\GridcoinResearch"
+```
+
+It prompts for the wallet passphrase (twice) and the account's login password, encrypts the
+passphrase with **DPAPI (CurrentUser)** to an owner-only `<datadir>\autounlock\passphrase.cred`
+(decryptable only by that account on that machine), and registers a resident
+`\Gridcoin\Autounlock` task that runs `Invoke-GridcoinAutounlock.ps1`. The helper waits for the
+core, unlocks **stake-only**, and self-heals across restarts. Its security contract mirrors the
+Linux helper: a **native listener-ownership gate** (`Get-NetTCPConnection` → owning-PID → owner
+SID) refuses to send credentials unless our own account owns every LISTEN socket on the RPC
+port, closing the same startup-squat race. Because DPAPI CurrentUser is per-account, the task
+must run as the account that ran setup. Remove with `.\Set-GridcoinAutounlock.ps1 -Remove`. See
+[`contrib/windows/README.md`](../contrib/windows/README.md).
+
 ## Troubleshooting
 
 - **"Could not connect to the Gridcoin daemon … node.sock: connection refused."**

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -10,6 +10,9 @@ Multiprocess mode is **opt-in at both build time and run time**:
   [Building with multiprocess support](#building-with-multiprocess-support) below).
 - Each process must be started with the `-multiprocess` flag.
 
+To run the core as an **unattended background service** (boot autostart + optional stake-only
+autounlock) on Linux or Windows, see [running-unattended.md](running-unattended.md).
+
 For the internal architecture, see [multiprocess_design.md](multiprocess_design.md).
 
 ## Why run split?
@@ -242,8 +245,10 @@ is read at unit start.
 
 ### Unattended stake-only autounlock (Windows)
 
-The Windows equivalent is a pair of PowerShell scripts in
-[`contrib/windows/`](../contrib/windows/) (no Python needed). Run **as the wallet user**:
+The Windows equivalent is a pair of PowerShell scripts (no Python needed) that the installer
+bundles into `…\GridcoinResearch\windows\` (source: [`contrib/windows/`](../contrib/windows/)).
+Run **as the wallet user, from an elevated console** (DPAPI needs an interactive logon — it fails
+over a remote/SSH session):
 
 ```powershell
 .\Set-GridcoinAutounlock.ps1 -DataDir "$env:APPDATA\GridcoinResearch"

--- a/doc/running-unattended.md
+++ b/doc/running-unattended.md
@@ -1,0 +1,168 @@
+# Running Gridcoin unattended (background service + stake-only autounlock)
+
+This guide walks through running the Gridcoin **multiprocess** core as a background service that **stakes
+unattended**, on **Linux** (systemd) and **Windows** (Task Scheduler), including the optional **stake-only
+autounlock** for an encrypted wallet.
+
+It is a task-oriented walkthrough. For the underlying model and the full mechanism, see
+[`multiprocess.md`](multiprocess.md); for the Windows script reference, see
+[`../contrib/windows/README.md`](../contrib/windows/README.md).
+
+## Is this for you?
+
+Use this if you want the wallet to **run headless and keep staking** across reboots without leaving the GUI
+open. In multiprocess mode the **core** (`gridcoinresearchd`) runs as a background service and owns the wallet
+and the blockchain; the **GUI** (`gridcoinresearch`) is a separate program you open on demand and it *attaches*
+to the running core. See [`multiprocess.md`](multiprocess.md) for the split model.
+
+Staking on an **encrypted** wallet additionally needs the wallet unlocked after every start. The optional
+autounlock does that **for staking only** — never for spending — with the passphrase held in the OS credential
+store, never in the wallet, on a command line, or in a log. It is opt-in and off by default.
+
+---
+
+## Linux (systemd)
+
+The packaged daemon ships a hardened systemd unit, so this is nearly turnkey.
+
+### 1. Run the core as a service
+
+```bash
+sudo systemctl enable --now gridcoinresearchd.service
+```
+
+That starts the core now and on every boot. Attach the GUI when you want it:
+
+```bash
+gridcoinresearch -multiprocess
+```
+
+### 2. (Optional) Enable stake-only autounlock
+
+Encrypt the wallet passphrase, bound to this host (and its TPM, if present), then enable the companion unit:
+
+```bash
+printf '%s' 'YOUR-WALLET-PASSPHRASE' | sudo systemd-creds encrypt \
+    --name=wallet-passphrase - /etc/gridcoin/wallet-passphrase.cred
+sudo chown gridcoin:gridcoin /etc/gridcoin/wallet-passphrase.cred
+sudo chmod 0400 /etc/gridcoin/wallet-passphrase.cred
+
+sudo systemctl enable --now gridcoinresearchd-autounlock.service
+```
+
+The autounlock unit runs whenever the core starts (boot, restart, upgrade), unlocks **stake-only**, and exits.
+A rejected passphrase or an unverifiable RPC listener leaves it `failed` (visible) rather than looping. Full
+detail — including the listener-ownership gate and the security model — is in
+[`multiprocess.md` → *Unattended stake-only autounlock (Linux)*](multiprocess.md).
+
+The daemon package *Recommends* `python3` (the helper is stdlib-only Python 3); on a minimal install run
+`sudo apt install python3` first.
+
+---
+
+## Windows (Task Scheduler)
+
+On Windows the same roles run as **scheduled tasks**, driven by PowerShell scripts the installer places in
+`…\GridcoinResearch\windows\`. Everything below runs in an **elevated** PowerShell (Run as administrator) — a
+boot-triggered task needs it, and so does DPAPI.
+
+Run-as **your own (the wallet) user, never SYSTEM**: the core's IPC socket is owner-only, so a SYSTEM core would
+lock your own GUI out.
+
+### 1. Install and prepare the session
+
+Run the installer. It lays out `gridcoinresearch.exe` (GUI), `daemon\gridcoinresearchd.exe`, and the helper
+scripts in `windows\`. Then, in an elevated PowerShell:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+cd "C:\Program Files\GridcoinResearch\windows"
+```
+
+> Set the policy in the session like this and call the scripts directly. Do **not** wrap a call in
+> `powershell.exe -ExecutionPolicy Bypass .\script -Arg "C:\Program Files\..."` — the outer shell re-parses and
+> splits the spaced path.
+
+### 2. Run the core as a boot task
+
+```powershell
+.\Install-GridcoinCoreTask.ps1 -DataDir "$env:APPDATA\GridcoinResearch"
+#   enter your Windows LOGIN password at the prompt (so the task can start at boot)
+Start-ScheduledTask -TaskPath '\Gridcoin\' -TaskName 'Core-Start'
+```
+
+This registers **Core-Start** (boot) and **Core-Stop** (graceful), then starts the core headless. Attach the
+GUI with `.\Start-GridcoinGui.ps1` (or `.\Start-GridcoinGui.ps1 -CreateShortcut` for a Start-Menu entry).
+
+> **First-start note:** the *first* multiprocess-capable start does a one-time `wallet.dat` rewrite and may
+> exit. If `Get-Process gridcoinresearchd` shows nothing right after, run the `Start-ScheduledTask … Core-Start`
+> line once more.
+
+**To stop the core, start the Core-Stop task** — `Start-ScheduledTask -TaskPath '\Gridcoin\' -TaskName
+'Core-Stop'`. Never `Stop-ScheduledTask` the Core-Start task: that is a hard kill with no database flush.
+
+For a reliable flush on OS shutdown, also configure a Group Policy Computer → Shutdown script (a scheduled task
+alone cannot block shutdown) — see [`../contrib/windows/README.md` → *Graceful stop on OS
+shutdown*](../contrib/windows/README.md).
+
+### 3. (Optional) Enable stake-only autounlock
+
+Run this **at the machine's own console** (elevated) — DPAPI encryption needs an interactive logon and fails
+over a remote (SSH/PSRemoting) session:
+
+```powershell
+.\Set-GridcoinAutounlock.ps1 -DataDir "$env:APPDATA\GridcoinResearch"
+#   prompts: the WALLET passphrase (twice), then your Windows LOGIN password
+Start-ScheduledTask -TaskPath '\Gridcoin\' -TaskName 'Autounlock'
+```
+
+This encrypts the passphrase with **DPAPI (CurrentUser)** to an owner-only
+`…\GridcoinResearch\autounlock\passphrase.cred` and registers a resident task that unlocks **stake-only** and
+re-unlocks after each core restart. It refuses to send anything if a *foreign* process owns the RPC port (the
+listener-ownership gate). Detail: [`../contrib/windows/README.md` →
+*Autounlock*](../contrib/windows/README.md).
+
+---
+
+## Upgrading
+
+- **Linux:** upgrade the package, then `sudo systemctl restart gridcoinresearchd.service`. Autounlock re-runs on
+  the fresh instance.
+- **Windows:** with the core running, from the `windows\` folder:
+  ```powershell
+  .\Update-GridcoinCore.ps1 -NewBinariesDir C:\path\to\new\bin
+  ```
+  It gracefully stops the core, waits for the exe lock to release, copies the new binaries, and restarts. If the
+  stop times out it aborts and leaves the old binary in place (safe by default).
+
+## Verifying it works
+
+- The core is up: `gridcoinresearchd getinfo` (Linux) / `& "…\daemon\gridcoinresearchd.exe" -datadir=… getinfo`
+  (Windows) returns.
+- Autounlock is working and **stake-only**: `getwalletinfo` shows the wallet unlocked, and a spend-path command
+  is refused —
+  ```
+  dumpprivkey <one of your addresses>
+  → error code -13: "Wallet is unlocked for staking only."
+  ```
+- Logs: Linux → `journalctl -u gridcoinresearchd-autounlock.service`; Windows →
+  `…\GridcoinResearch\autounlock\autounlock.log` (redacted — never contains the passphrase).
+
+## Turning it off
+
+- **Linux:** `sudo systemctl disable --now gridcoinresearchd-autounlock.service` (autounlock) and/or
+  `gridcoinresearchd.service` (the core).
+- **Windows:** `.\Set-GridcoinAutounlock.ps1 -Remove` (removes the task + deletes the DPAPI blob), and
+  `.\Uninstall-GridcoinCoreTask.ps1` (removes Core-Start/Core-Stop).
+
+## Troubleshooting
+
+- **GUI says "could not connect to the daemon."** The core isn't running, wasn't started with `-multiprocess`,
+  uses a different `-datadir`, or (Windows) is running as a different user. See
+  [`multiprocess.md` → *Troubleshooting*](multiprocess.md).
+- **Windows: "Access is denied" registering a task.** Use an **elevated** PowerShell; a boot-triggered task
+  needs it, and the account needs the "Log on as a batch job" right.
+- **Autounlock log shows "REFUSING TO SEND CREDENTIALS."** A process owned by another user is listening on the
+  RPC port — investigate before relying on autounlock; this is the gate working, not a bug.
+- **Autounlock log shows "-17 already unlocked."** The wallet was unlocked by another path (e.g. a GUI unlock)
+  and the staking-only restriction was not re-asserted — it may be spendable until the next restart.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -425,6 +425,24 @@ if(ENABLE_DAEMON)
             RUNTIME DESTINATION bin
             BUNDLE  DESTINATION "."
         )
+        if(WIN32)
+            # Bundle the PowerShell helpers that run the multiprocess core as a background
+            # scheduled task and provide opt-in stake-only autounlock. They install into the
+            # package's windows\ folder (NSIS.template.in Files them into $INSTDIR\windows);
+            # from there the scripts resolve the daemon at ..\daemon\gridcoinresearchd.exe and
+            # the GUI at ..\gridcoinresearch.exe, matching the installed layout.
+            install(FILES
+                "${CMAKE_SOURCE_DIR}/contrib/windows/Install-GridcoinCoreTask.ps1"
+                "${CMAKE_SOURCE_DIR}/contrib/windows/Uninstall-GridcoinCoreTask.ps1"
+                "${CMAKE_SOURCE_DIR}/contrib/windows/Update-GridcoinCore.ps1"
+                "${CMAKE_SOURCE_DIR}/contrib/windows/Start-GridcoinGui.ps1"
+                "${CMAKE_SOURCE_DIR}/contrib/windows/Set-GridcoinAutounlock.ps1"
+                "${CMAKE_SOURCE_DIR}/contrib/windows/Invoke-GridcoinAutounlock.ps1"
+                "${CMAKE_SOURCE_DIR}/contrib/windows/README.md"
+                COMPONENT daemon
+                DESTINATION windows
+            )
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Opt-in, stake-only wallet autounlock for the **Windows** multiprocess core — the DPAPI/PowerShell analogue of the Linux `gridcoinresearchd-autounlock.service` (Plan 3, systemd `LoadCredentialEncrypted`). Part of the multiprocess background-service feature (umbrella #3153); follows Plan 4 (#3254, Windows core tasks).

**No Python on Windows.** Stock Windows has no Python (only the Store alias stub), and requiring/bundling it was rejected, so this is a *native PowerShell* reimplementation. `contrib/wallettools/gridcoin_autounlock.py` remains the Linux implementation and the **canonical reference** for the security-critical contract; the two are behaviourally equivalent and platform-separate.

### Scripts (`contrib/windows/`)
- **`Set-GridcoinAutounlock.ps1`** — prompts the wallet passphrase (twice), DPAPI-encrypts it (`CurrentUser`) to an owner-ACL'd `<datadir>\autounlock\passphrase.cred`, and registers the resident `\Gridcoin\Autounlock` task run-as the wallet user. `-Remove` tears down task + blob. Refuses a `-TaskUser` whose SID differs from the current user (DPAPI CurrentUser is per-account, re-checked **after** the credential prompt).
- **`Invoke-GridcoinAutounlock.ps1`** — the resident helper the task runs: waits for the core, unlocks **stake-only** (`walletpassphrase … $true`), and self-heals across restarts via `getinfo.uptime`.

### Security model (mirrors the Python contract case-for-case)
- **Secret at rest = DPAPI CurrentUser**, owner-only ACL, never in the wallet / argv / logs.
- **Native listener-ownership gate** — before any credential goes on the wire, verifies our own SID owns *every* LISTEN socket on the RPC port (`Get-NetTCPConnection` → `Win32_Process` `GetOwnerSid`), failing closed on a foreign or unattributable owner. This closes the RPC-port-squat race during core startup that the Python helper can only *refuse* on Windows (no `os.getuid`) — the concrete security win of going native.
- Exit codes 0/1/2; RPC handling `401→2`, `-17→0`+warn, `-15→0`, `-14`/`-8`→2; proxy-free request; redaction of passphrase/rpcpassword/token from every sink; resident loop never dies / never prints an unredacted trace.

### Review + validation
- **Adversarial security review** (opus/high) run before push; the security core (gate fail-closed on every path, no secret leak, proxy-free, exit classification, StrictMode-safety, loop liveness) verified clean. Findings fixed: a post-prompt SID-guard bypass (HIGH), remote-target gate divergence + misleading messages (MEDIUM), UTF-8 vs ASCII token, dir/log ACL, `-Remove` resilience, guarded `rpcport` parse.
- **Runtime-tested on Windows PowerShell 5.1** (functional smoke, no core): scripts parse-clean; DPAPI encrypt→decrypt round-trip; conf parse; gate `ours`/`none` against a real self-owned listener; exit codes for bad-blob / missing-creds; **no plaintext secret in any output file**. (Caught a real `[string]$Conf`-vs-`$conf` case-insensitive type-coercion bug that a static review missed.)

### Still pending — fresh-install VM runtime test
DPAPI `CurrentUser` decrypt inside a **batch-logon** (non-interactive) task is the primary unknown; also cold stake-only unlock after reboot, `foreign`/`unreadable` gate paths (second local user), and self-heal on restart. Docs are Plan 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)